### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm tsc --noEmit
+
+      - run: pnpm test
+
+      - run: pnpm build


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/ci.yml`，在每个 PR 和 push 时自动运行三步检查：`tsc --noEmit` → `vitest` → `next build`
- 触发条件：push 或 PR 目标为 `main` / `dev`
- 无需数据库连接，Phase 1 完全可以通过

## Test plan

- [ ] 提交后确认 Actions tab 中 CI 跑通
- [ ] 在 GitHub Settings → Branches 中，将 `ci` job 设为 required status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)