### PR TITLE
[phase-5] 修复 admin typedRoutes 类型检查

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit",
+    "type-check": "next typegen && tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
## Summary
- Refresh Next.js generated route types before TypeScript checks by running `next typegen` inside `pnpm type-check`.
- Fix stale typedRoutes failures for Phase 5 admin routes such as `/admin/invites`, `/admin/users`, and `/admin/settings`.

## Why
Phase 5 added new admin pages, but `tsc --noEmit` can read stale `.next/types` output when route types have not been regenerated. This makes the type-check script deterministic before Phase 6 work starts.

## Test Plan
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test`
- [x] `pnpm type-check`
