### PR TITLE
[phase-5] 修复 admin typedRoutes 类型检查

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit",
+    "type-check": "next typegen && tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
## Summary
- 在 `pnpm type-check` 中先运行 `next typegen`，再执行 `tsc --noEmit`。
- 避免 Phase 5 新增 admin 路由后 `.next/types` 过期，导致 `/admin/invites`、`/admin/users`、`/admin/settings` 等 typedRoutes 报错。

## Why
README 约定功能开发应从 `dev` 分支开 feature branch，并 PR 回 `dev`。这次修复是 Phase 5 后台路由的基线类型检查问题，先把检查命令稳定下来，避免后续 Phase 6 开发被旧的 generated route types 阻塞。

## Test Plan
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test`
- [x] `pnpm type-check`
