### PR TITLE
feat(p9+p10): team display pages and match management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ src/
 │   ├── bracket/      # brackets-manager 适配层（禁止绕过）
 │   ├── config/       # 报名默认配置（REGISTRATION_DEFAULTS）
 │   ├── realtime/     # Supabase Realtime 订阅辅助
-│   ├── validators/   # Zod schema（registration / vote）
+│   ├── validators/   # Zod schema（registration / vote / match）
 │   └── utils/        # date（UTC/CST）+ season（capability 工具）+ password（scrypt）+ cn
 ├── components/
 │   ├── layout/       # Header / Footer

--- a/PHASES.md
+++ b/PHASES.md
@@ -100,19 +100,19 @@
 
 ---
 
-## Phase 9 — 队伍展示页
+## Phase 9 — 队伍展示页 ✅
 
-- [ ] `/[seasonSlug]/teams` 列表页（8 队卡片）
-- [ ] `/[seasonSlug]/teams/[teamId]` 详情页（7 人按位置排版，队长标识）
+- [x] `/[seasonSlug]/teams` 列表页（8 队卡片，按 draftOrder 排序）
+- [x] `/[seasonSlug]/teams/[teamId]` 详情页（首发/替补分区，队长 badge）
 
 ---
 
-## Phase 10 — 比赛详情
+## Phase 10 — 比赛详情 ✅
 
-- [ ] `createMatch` / `recordMatchResult` Server Action
-- [ ] `/[seasonSlug]/matches/[matchId]` 详情页（双方阵容、比分、地图结果、状态机）
-- [ ] `/admin/[seasonSlug]/matches` 管理员录入比分
-- [ ] 比赛状态机：`scheduled → in_progress → finished`
+- [x] `createMatch` / `recordMatchResult` / `cancelMatch` Server Action
+- [x] `/[seasonSlug]/matches/[matchId]` 详情页（双方阵容、比分、地图结果、状态）
+- [x] `/admin/[seasonSlug]/matches` 管理员赛程表（创建/录分/取消）
+- [x] 比赛状态机：`scheduled → in_progress → finished`，`scheduled → cancelled`
 
 ---
 

--- a/PHASES.md
+++ b/PHASES.md
@@ -116,8 +116,19 @@
 
 ---
 
-## Phase 11 — Bracket 视图
+## Phase 11 — Bracket 视图 + 自动生成赛程
 
+**赛制支持**
+- [ ] 单循环排位赛（Round Robin）：按 `draftOrder` 为种子，生成所有两两对阵的 `matches` 行
+- [ ] 双败淘汰正赛（Double Elimination）：排位赛结束后按名次分配种子，`brackets-manager` 生成 bracket 结构，写入 `matches`
+- [ ] （远期）三败瑞士轮：用于 Major 预选，需自行实现配对算法，单独子 Phase
+
+**自动生成流程**
+- [ ] admin 页面「生成赛程」按钮：赛季状态为 `playing` 且尚无 matches 时可用
+- [ ] Server Action `generateSchedule(seasonId, type)`：按赛制 insert 所有 `matches`（`status: scheduled`，`scheduledAt: null`）
+- [ ] 管理员在赛程列表逐场填入 `scheduledAt`
+
+**Bracket 视图**
 - [ ] `brackets-manager` 双败淘汰赛数据结构初始化
 - [ ] `brackets-viewer` 渲染集成（注入 season theme_color）
 - [ ] `/[seasonSlug]/matches` 总览页（bracket 图 + 赛程列表联动）

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 | 队长投票 | 全体选手投票，Realtime 票数，得票前 8 名为队长 | 🔄 Phase 6 |
 | 蛇形选秀直播间 | Realtime 围观，倒计时，剩余选手池 | 🔄 Phase 7 |
 | 队长选秀面板 | 事务行锁、幂等 pick、超时 Cron 自动递补 | 🔄 Phase 8 |
-| 队伍展示 | 7 人阵容按位置排版 | 🔄 Phase 9 |
-| 赛程管理 | 比赛详情 + 比分录入 + 状态机 | 🔄 Phase 10 |
+| 队伍展示 | 7 人阵容按位置排版，首发/替补分区，队长 badge | ✅ Phase 9 |
+| 赛程管理 | 比赛详情 + 地图结果 + 管理员录分/取消 | ✅ Phase 10 |
 | Bracket 视图 | `brackets-manager` 双败淘汰图 | 🔄 Phase 11 |
 | 部署上线 | Vercel + 自定义域名 + Cron + E2E 验证 | 🔄 Phase 12 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ Next.js App Router (Vercel Edge / Node.js)
 | `admin.ts` | 管理员登录/注册、审核报名、邀请码管理、密码修改、管理员管理 |
 | `captains.ts` | 投 / 撤销队长票 |
 | `draft.ts` | pick 选手、autoPick 超时 |
-| `matches.ts` | 创建比赛、录入比分、更新 bracket |
+| `matches.ts` | 创建比赛、录入比分（含 match_maps）、取消比赛 |
 
 ### DB 层（`src/db/`）
 
@@ -63,7 +63,7 @@ Next.js App Router (Vercel Edge / Node.js)
 - `auth/supabase.ts` — Supabase client（用户 magic link + Storage）
 - `realtime/subscribe.ts` — Supabase Realtime 订阅封装
 - `config/` — 报名默认配置（位置、段位、上限等，`REGISTRATION_DEFAULTS`）
-- `validators/` — Zod schema（中文错误消息）
+- `validators/` — Zod schema（中文错误消息）：`registration.ts`（含段位门槛跨字段校验）、`match.ts`（createMatch / recordMatchResult）
 - `utils/date.ts` — UTC ↔ Asia/Shanghai
 - `utils/season.ts` — capability 判断（`showDraft` / `showCaptainVoting` / `showQualifier` / `showPlayoffBracket` 等），是路由守卫与 UI 条件渲染的唯一入口
 - `utils/cn.ts` — Tailwind class merge 工具

--- a/docs/data-integrity.md
+++ b/docs/data-integrity.md
@@ -20,7 +20,9 @@
 | **season_registrations** | | | |
 | 一人一赛季只一份 | `UNIQUE(user_id, season_id)` | — | |
 | 主次位置不同 | — | Zod refine | |
-| peak_rating 范围 | — | Zod | DB 不强制（数据来源可信度低） |
+| peak_rating / current_rating 范围 | — | Zod（0.01–3.00，两位小数）| DB 存 real；范围/精度由应用层保证 |
+| peak_we / current_we 范围 | — | Zod（0.0–16.0，一位小数，可选）| 同上 |
+| 报名段位门槛 | — | Zod refine（跨字段）+ Server Action | 当前赛季 ≥ A 或历史最高 ≥ A+，两者满足一即可 |
 | 状态合法迁移 | — | Server Action 校验 | 见 `state-machines.md` |
 | 同位置审核通过上限 ≤ MAX_PER_POSITION（默认 15） | — | Server Action（报名提交校验 pending+approved；审核通过时只统计 approved） | 赛季级别，非队级别；队内同位置 ≤ 2 由 draft_picks 章节约束 |
 | **captain_votes** | | | |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -47,11 +47,11 @@ erDiagram
     text secondary_position
     text peak_rank
     text peak_rank_season
-    int peak_rating
-    int peak_we
+    real peak_rating "0.01–3.00，两位小数"
+    real peak_we "0.0–16.0，一位小数，可选"
     text current_season_peak_rank
-    int current_rating
-    int current_we
+    real current_rating "0.01–3.00，两位小数"
+    real current_we "0.0–16.0，一位小数，可选"
     text[] screenshot_urls
     text gameplay_style
     text competition_history

--- a/docs/registration-flow.md
+++ b/docs/registration-flow.md
@@ -93,19 +93,27 @@ GROUP BY primary_position;
 | `secondaryPosition` | 次选位置 | 不可与主选相同 |
 | `peakRank` | 历史最高段位 | 合法段位值（D~S魔王） |
 | `peakRankSeason` | 取得最高段位的赛季 | 非空，如 "S1 2026" |
-| `peakRating` | 历史最高 Rating | 整数 0-50000 |
-| `currentSeasonPeakRank` | 当前赛季最高段位 | 合法段位值 |
-| `currentRating` | 当前赛季 Rating | 整数 0-50000 |
+| `peakRating` | 历史最高完美平台 Rating | 0.01–3.00，两位小数（均值约 1.0） |
+| `currentSeasonPeakRank` | 当前赛季最高段位 | 合法段位值；**报名门槛见下** |
+| `currentRating` | 当前赛季 Rating | 0.01–3.00，两位小数 |
 | `screenshotUrl` | 天梯截图 NJUBox 分享链接 | HTTPS URL |
 | `gameplayStyle` | 游戏风格自述 | ≤100 字 |
 | `antiCheatPledge` | 反作弊承诺勾选 | 必须为 true |
+
+### 报名段位门槛
+
+**以下两个条件满足其一即可报名**：
+- 当前赛季最高段位 ≥ **A**（含）
+- 历史最高段位 ≥ **A+**（含）
+
+校验在 Zod schema（客户端）和 Server Action（服务端）两层执行。
 
 ### 选填字段
 
 | 字段 | 说明 |
 |---|---|
-| `peakWe` | 历史最高 WE |
-| `currentWe` | 当前赛季 WE |
+| `peakWe` | 历史最高 Win Effect，0.0–16.0，一位小数（均值约 8.0） |
+| `currentWe` | 当前赛季 WE，同上 |
 | `competitionHistory` | 历史比赛经历（≤500 字） |
 | `highlightVideoUrl` | 高光视频链接 |
 | `willingToBeCaptain` | 是否愿意担任队长（默认 false） |

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -148,10 +148,10 @@ cancelled
 
 | 当前状态 | 可迁移至 | 触发方 | 备注 |
 |---|---|---|---|
-| `scheduled` | `in_progress` | admin | 比赛开始 |
+| `scheduled` | `in_progress` | admin | 比赛开始（Phase 10 admin UI 尚未实现此按钮，预留） |
 | `scheduled` | `cancelled` | admin | 双方队伍弃权或赛程调整 |
-| `in_progress` | `finished` | admin | 录入比分，必须同时更新 bracket |
-| `in_progress` | `cancelled` | admin | 特殊情况（不影响已进行局数的 bracket） |
+| `in_progress` | `finished` | admin | 录入比分（`recordMatchResult` 接受 scheduled 或 in_progress） |
+| `in_progress` | `cancelled` | admin | 特殊情况（**当前 `cancelMatch` 仅允许 scheduled → cancelled；in_progress → cancelled 待 Phase 11 补充**） |
 
 ### 禁止迁移
 
@@ -160,7 +160,7 @@ cancelled
 
 ### 比分录入规则
 
-比分录入时必须同步调用 `lib/bracket/advanceMatch()`，不允许仅更新 `matches` 表而不推进 bracket。
+Phase 10 `recordMatchResult` 仅更新 `matches` 表和 `match_maps`，bracket 推进（`lib/bracket/advanceMatch()`）在 Phase 11 完成后接入。
 
 ### BO3 / BO5 系列赛与 match_maps 关系
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -9,5 +9,6 @@ export default {
   dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL!,
+    ssl: true,
   },
 } satisfies Config;

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
-    "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio",
+    "db:push": "NODE_OPTIONS='--dns-result-order=ipv4first' drizzle-kit push",
+    "db:studio": "NODE_OPTIONS='--dns-result-order=ipv4first' drizzle-kit studio",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "seed": "tsx --env-file .env.local scripts/seed.ts"
+    "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -942,6 +945,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -3285,6 +3301,20 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -1,24 +1,273 @@
 "use server";
 
-// TODO: create a match between two teams in a season
+import { and, eq, inArray } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema/seasons";
+import { teams } from "@/db/schema/teams";
+
+import { matches } from "@/db/schema/matches";
+import { matchMaps } from "@/db/schema/match-maps";
+import { auditLogs } from "@/db/schema/audit";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { requireAdmin } from "@/lib/auth/session";
+import { ok, fail, type ActionResult } from "@/types/action";
+import {
+  createMatchSchema,
+  recordMatchResultSchema,
+  type CreateMatchInput,
+  type RecordMatchResultInput,
+} from "@/lib/validators/match";
+
+const FORMAT_MAX_MAPS: Record<string, number> = { bo1: 1, bo3: 3, bo5: 5 };
+
 export async function createMatch(
-  _seasonId: string,
-  _teamAId: string,
-  _teamBId: string
-): Promise<string> {
-  throw new Error("not implemented");
+  input: CreateMatchInput
+): Promise<ActionResult<{ matchId: string }>> {
+  try {
+    const admin = await requireAdmin();
+
+    const parsed = createMatchSchema.safeParse(input);
+    if (!parsed.success) {
+      return fail({
+        code: ErrorCode.VALIDATION_FAILED,
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        fieldErrors: Object.fromEntries(
+          Object.entries(parsed.error.flatten().fieldErrors).map(([k, v]) => [
+            k,
+            v?.[0] ?? "",
+          ])
+        ),
+      });
+    }
+
+    const { seasonId, teamAId, teamBId, stage, format, scheduledAt } = parsed.data;
+
+    if (teamAId === teamBId) {
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "两支队伍不能相同" });
+    }
+
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) {
+      return fail({ code: ErrorCode.SEASON_NOT_FOUND, message: ERROR_MESSAGES.SEASON_NOT_FOUND });
+    }
+    if (season.status !== "playing") {
+      return fail({
+        code: ErrorCode.SEASON_INVALID_STATUS,
+        message: "只有处于 playing 状态的赛季才能创建比赛",
+      });
+    }
+
+    const [teamA, teamB] = await db
+      .select()
+      .from(teams)
+      .where(inArray(teams.id, [teamAId, teamBId]));
+    if (!teamA || !teamB) {
+      return fail({ code: ErrorCode.NOT_FOUND, message: "队伍不存在" });
+    }
+    if (teamA.seasonId !== seasonId || teamB.seasonId !== seasonId) {
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "队伍不属于该赛季" });
+    }
+
+    const matchId = await db.transaction(async (tx) => {
+      const [match] = await tx
+        .insert(matches)
+        .values({
+          seasonId,
+          teamAId,
+          teamBId,
+          stage,
+          format,
+          status: "scheduled",
+          scheduledAt: scheduledAt ? new Date(scheduledAt) : null,
+        })
+        .returning({ id: matches.id });
+
+      await tx.insert(auditLogs).values({
+        seasonId,
+        action: "match.create",
+        actorId: admin.adminId,
+        targetId: match.id,
+        targetType: "match",
+        meta: { stage, format, teamAId, teamBId },
+      });
+
+      return match.id;
+    });
+
+    revalidatePath(`/admin/${season.slug}/matches`);
+    return ok({ matchId });
+  } catch (e) {
+    if (e instanceof AppError) {
+      return fail({ code: e.code, message: e.message });
+    }
+    console.error("[createMatch]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
 }
 
-// TODO: record match result — updates score, status, bracket node
 export async function recordMatchResult(
-  _matchId: string,
-  _scoreA: number,
-  _scoreB: number
-): Promise<void> {
-  throw new Error("not implemented");
+  input: RecordMatchResultInput
+): Promise<ActionResult<{ matchId: string }>> {
+  try {
+    const admin = await requireAdmin();
+
+    const parsed = recordMatchResultSchema.safeParse(input);
+    if (!parsed.success) {
+      return fail({
+        code: ErrorCode.VALIDATION_FAILED,
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        fieldErrors: Object.fromEntries(
+          Object.entries(parsed.error.flatten().fieldErrors).map(([k, v]) => [
+            k,
+            v?.[0] ?? "",
+          ])
+        ),
+      });
+    }
+
+    const { matchId, scoreA, scoreB, maps } = parsed.data;
+
+    const match = await db.query.matches.findFirst({
+      where: eq(matches.id, matchId),
+    });
+    if (!match) {
+      return fail({ code: ErrorCode.MATCH_NOT_FOUND, message: ERROR_MESSAGES.MATCH_NOT_FOUND });
+    }
+    if (match.status === "finished" || match.status === "cancelled") {
+      return fail({
+        code: ErrorCode.MATCH_INVALID_TRANSITION,
+        message: ERROR_MESSAGES.MATCH_INVALID_TRANSITION,
+      });
+    }
+
+    if (maps && maps.length > 0) {
+      const maxMaps = FORMAT_MAX_MAPS[match.format] ?? 1;
+      if (maps.length > maxMaps) {
+        return fail({
+          code: ErrorCode.MATCH_FORMAT_MISMATCH,
+          message: `${match.format.toUpperCase()} 最多 ${maxMaps} 张图，提交了 ${maps.length} 张`,
+        });
+      }
+      const mapOrders = maps.map((m) => m.mapOrder);
+      if (new Set(mapOrders).size !== mapOrders.length) {
+        return fail({
+          code: ErrorCode.MATCH_MAP_ORDER_CONFLICT,
+          message: ERROR_MESSAGES.MATCH_MAP_ORDER_CONFLICT,
+        });
+      }
+      const mapNames = maps.map((m) => m.mapName);
+      if (new Set(mapNames).size !== mapNames.length) {
+        return fail({
+          code: ErrorCode.MATCH_MAP_DUPLICATE,
+          message: ERROR_MESSAGES.MATCH_MAP_DUPLICATE,
+        });
+      }
+    }
+
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+    });
+    if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+
+    await db.transaction(async (tx) => {
+      if (maps && maps.length > 0) {
+        await tx.delete(matchMaps).where(eq(matchMaps.matchId, matchId));
+        await tx.insert(matchMaps).values(
+          maps.map((m) => ({
+            matchId,
+            mapOrder: m.mapOrder,
+            mapName: m.mapName,
+            pickedByTeamId: m.pickedByTeamId ?? null,
+            teamAStartSide: m.teamAStartSide ?? null,
+            scoreA: m.scoreA,
+            scoreB: m.scoreB,
+            completedAt: new Date(),
+          }))
+        );
+      }
+
+      await tx
+        .update(matches)
+        .set({
+          scoreA,
+          scoreB,
+          status: "finished",
+          completedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(matches.id, matchId));
+
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "match.record_result",
+        actorId: admin.adminId,
+        targetId: matchId,
+        targetType: "match",
+        meta: { scoreA, scoreB, mapCount: maps?.length ?? 0 },
+      });
+    });
+
+    revalidatePath(`/${season.slug}/matches/${matchId}`);
+    revalidatePath(`/admin/${season.slug}/matches`);
+    return ok({ matchId });
+  } catch (e) {
+    if (e instanceof AppError) {
+      return fail({ code: e.code, message: e.message });
+    }
+    console.error("[recordMatchResult]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
 }
 
-// TODO: update bracket via brackets-manager
-export async function updateBracket(_seasonId: string): Promise<void> {
-  throw new Error("not implemented");
+export async function cancelMatch(
+  matchId: string
+): Promise<ActionResult<{ matchId: string }>> {
+  try {
+    const admin = await requireAdmin();
+
+    const match = await db.query.matches.findFirst({
+      where: eq(matches.id, matchId),
+    });
+    if (!match) {
+      return fail({ code: ErrorCode.MATCH_NOT_FOUND, message: ERROR_MESSAGES.MATCH_NOT_FOUND });
+    }
+    if (match.status !== "scheduled") {
+      return fail({
+        code: ErrorCode.MATCH_INVALID_TRANSITION,
+        message: "只有 scheduled 状态的比赛可以取消",
+      });
+    }
+
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+    });
+    if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(matches)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(and(eq(matches.id, matchId), eq(matches.status, "scheduled")));
+
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "match.cancel",
+        actorId: admin.adminId,
+        targetId: matchId,
+        targetType: "match",
+      });
+    });
+
+    revalidatePath(`/admin/${season.slug}/matches`);
+    return ok({ matchId });
+  } catch (e) {
+    if (e instanceof AppError) {
+      return fail({ code: e.code, message: e.message });
+    }
+    console.error("[cancelMatch]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
 }

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema/seasons";
@@ -72,6 +72,20 @@ export async function createMatch(
     }
 
     const matchId = await db.transaction(async (tx) => {
+      // 在事务内再次校验队伍归属，防止并发创建时队伍已被移走
+      const txTeams = await tx
+        .select({ id: teams.id, seasonId: teams.seasonId })
+        .from(teams)
+        .where(inArray(teams.id, [teamAId, teamBId]));
+      const txTeamA = txTeams.find((t) => t.id === teamAId);
+      const txTeamB = txTeams.find((t) => t.id === teamBId);
+      if (!txTeamA || !txTeamB) {
+        throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
+      }
+      if (txTeamA.seasonId !== seasonId || txTeamB.seasonId !== seasonId) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "队伍不属于该赛季");
+      }
+
       const [match] = await tx
         .insert(matches)
         .values({
@@ -250,7 +264,7 @@ export async function cancelMatch(
       await tx
         .update(matches)
         .set({ status: "cancelled", updatedAt: new Date() })
-        .where(and(eq(matches.id, matchId), eq(matches.status, "scheduled")));
+        .where(eq(matches.id, matchId));
 
       await tx.insert(auditLogs).values({
         seasonId: match.seasonId,

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -1,14 +1,89 @@
-// TODO: match detail — both teams roster, score, maps, status machine, admin can input results
+import { notFound } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema/seasons";
+import { matches } from "@/db/schema/matches";
+import { matchMaps } from "@/db/schema/match-maps";
+import { teams } from "@/db/schema/teams";
+import { MatchDetail, type MatchDetailData, type MatchMapData } from "@/components/matches/MatchDetail";
+
+export const dynamic = "force-dynamic";
+
 interface MatchDetailPageProps {
   params: Promise<{ seasonSlug: string; matchId: string }>;
 }
 
+export async function generateMetadata({ params }: MatchDetailPageProps) {
+  const { matchId } = await params;
+  const match = await db.query.matches.findFirst({ where: eq(matches.id, matchId) });
+  if (!match) return { title: "比赛详情" };
+  const [teamA, teamB] = await Promise.all([
+    db.query.teams.findFirst({ where: eq(teams.id, match.teamAId) }),
+    db.query.teams.findFirst({ where: eq(teams.id, match.teamBId) }),
+  ]);
+  return { title: `${teamA?.name ?? "?"} vs ${teamB?.name ?? "?"} · 比赛详情` };
+}
+
 export default async function MatchDetailPage({ params }: MatchDetailPageProps) {
   const { seasonSlug, matchId } = await params;
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const match = await db.query.matches.findFirst({
+    where: eq(matches.id, matchId),
+  });
+  if (!match || match.seasonId !== season.id) notFound();
+
+  const [teamA, teamB, mapRows] = await Promise.all([
+    db.query.teams.findFirst({ where: eq(teams.id, match.teamAId) }),
+    db.query.teams.findFirst({ where: eq(teams.id, match.teamBId) }),
+    db
+      .select()
+      .from(matchMaps)
+      .where(eq(matchMaps.matchId, matchId))
+      .orderBy(matchMaps.mapOrder),
+  ]);
+
+  if (!teamA || !teamB) notFound();
+
+  // 构建 pickedByTeamName
+  const teamNameMap = new Map([
+    [teamA.id, teamA.name],
+    [teamB.id, teamB.name],
+  ]);
+
+  const mapData: MatchMapData[] = mapRows.map((m) => ({
+    mapOrder: m.mapOrder,
+    mapName: m.mapName,
+    pickedByTeamName: m.pickedByTeamId ? (teamNameMap.get(m.pickedByTeamId) ?? null) : null,
+    teamAStartSide: m.teamAStartSide,
+    scoreA: m.scoreA,
+    scoreB: m.scoreB,
+  }));
+
+  const matchData: MatchDetailData = {
+    id: match.id,
+    teamAName: teamA.name,
+    teamAId: teamA.id,
+    teamBName: teamB.name,
+    teamBId: teamB.id,
+    format: match.format,
+    stage: match.stage,
+    status: match.status,
+    scoreA: match.scoreA,
+    scoreB: match.scoreB,
+    scheduledAt: match.scheduledAt,
+    completedAt: match.completedAt,
+    maps: mapData,
+    seasonSlug,
+  };
+
   return (
-    <div className="container mx-auto px-4 py-16 max-w-4xl">
-      <h1 className="text-3xl font-bold mb-8">比赛详情 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">matchId: {matchId}</p>
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <MatchDetail match={matchData} />
     </div>
   );
 }

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -1,14 +1,77 @@
-// TODO: team detail — roster by position, match history
+import { notFound } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema/seasons";
+import { teams, teamMembers } from "@/db/schema/teams";
+import { seasonRegistrations } from "@/db/schema/registrations";
+import { users } from "@/db/schema/users";
+import { TeamRosterCard, type RosterMember } from "@/components/teams/TeamRosterCard";
+
 interface TeamDetailPageProps {
   params: Promise<{ seasonSlug: string; teamId: string }>;
 }
 
+export async function generateMetadata({ params }: TeamDetailPageProps) {
+  const { teamId } = await params;
+  const team = await db.query.teams.findFirst({ where: eq(teams.id, teamId) });
+  return { title: team ? `${team.name} · 阵容` : "队伍详情" };
+}
+
 export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   const { seasonSlug, teamId } = await params;
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const team = await db.query.teams.findFirst({
+    where: eq(teams.id, teamId),
+  });
+  if (!team || team.seasonId !== season.id) notFound();
+
+  const memberRows = await db
+    .select({
+      memberId: teamMembers.id,
+      isStarter: teamMembers.isStarter,
+      registrationId: teamMembers.registrationId,
+      primaryPosition: seasonRegistrations.primaryPosition,
+      peakRank: seasonRegistrations.peakRank,
+      currentRating: seasonRegistrations.currentRating,
+      steamName: users.steamName,
+    })
+    .from(teamMembers)
+    .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
+    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(eq(teamMembers.teamId, teamId));
+
+  const POSITION_ORDER = ["igl", "awper", "opener", "closer", "anchor"];
+
+  const rosterMembers: RosterMember[] = memberRows
+    .sort((a, b) => {
+      const ai = POSITION_ORDER.indexOf(a.primaryPosition);
+      const bi = POSITION_ORDER.indexOf(b.primaryPosition);
+      if (ai !== bi) return ai - bi;
+      return a.isStarter ? -1 : 1;
+    })
+    .map((m) => ({
+      id: m.memberId,
+      steamName: m.steamName,
+      primaryPosition: m.primaryPosition,
+      peakRank: m.peakRank,
+      currentRating: m.currentRating,
+      isStarter: m.isStarter,
+      isCaptain: m.registrationId === team.captainRegistrationId,
+    }));
+
   return (
-    <div className="container mx-auto px-4 py-16 max-w-3xl">
-      <h1 className="text-3xl font-bold mb-8">队伍详情 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">teamId: {teamId}</p>
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <TeamRosterCard
+        teamName={team.name}
+        draftOrder={team.draftOrder}
+        seasonSlug={seasonSlug}
+        members={rosterMembers}
+      />
     </div>
   );
 }

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -1,14 +1,114 @@
-// TODO: teams listing page — all teams with rosters overview
+import { notFound } from "next/navigation";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema/seasons";
+import { teams, teamMembers } from "@/db/schema/teams";
+import { seasonRegistrations } from "@/db/schema/registrations";
+import { users } from "@/db/schema/users";
+import { TeamGrid, type TeamCardData } from "@/components/teams/TeamGrid";
+
 interface TeamsPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
+export async function generateMetadata({ params }: TeamsPageProps) {
+  const { seasonSlug } = await params;
+  return { title: `参赛队伍 · ${seasonSlug}` };
+}
+
 export default async function TeamsPage({ params }: TeamsPageProps) {
   const { seasonSlug } = await params;
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const draftDone =
+    season.status === "playing" ||
+    season.status === "finished" ||
+    season.status === "archived";
+
+  if (!draftDone) {
+    return (
+      <div className="container mx-auto px-4 py-16 max-w-2xl text-center">
+        <div className="text-5xl mb-6">⏳</div>
+        <h1 className="text-2xl font-bold mb-3 text-[var(--text-primary)]">队伍待定</h1>
+        <p className="text-[var(--text-secondary)]">
+          选秀尚未完成，队伍组建结果将在选秀结束后公布。
+        </p>
+      </div>
+    );
+  }
+
+  const seasonTeams = await db
+    .select()
+    .from(teams)
+    .where(eq(teams.seasonId, season.id))
+    .orderBy(teams.draftOrder);
+
+  if (seasonTeams.length === 0) {
+    return (
+      <div className="container mx-auto px-4 py-16 max-w-2xl text-center">
+        <div className="text-5xl mb-6">🏆</div>
+        <h1 className="text-2xl font-bold mb-3 text-[var(--text-primary)]">暂无队伍</h1>
+        <p className="text-[var(--text-secondary)]">该赛季尚未创建队伍。</p>
+      </div>
+    );
+  }
+
+  const teamIds = seasonTeams.map((t) => t.id);
+
+  const allMembers = await db
+    .select({
+      teamId: teamMembers.teamId,
+      isStarter: teamMembers.isStarter,
+      primaryPosition: seasonRegistrations.primaryPosition,
+      steamName: users.steamName,
+    })
+    .from(teamMembers)
+    .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
+    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(inArray(teamMembers.teamId, teamIds));
+
+  const membersByTeam = new Map<string, typeof allMembers>();
+  for (const row of allMembers) {
+    const list = membersByTeam.get(row.teamId) ?? [];
+    list.push(row);
+    membersByTeam.set(row.teamId, list);
+  }
+
+  const captainRegIds = seasonTeams.map((t) => t.captainRegistrationId);
+  const captainRows = await db
+    .select({
+      registrationId: seasonRegistrations.id,
+      steamName: users.steamName,
+    })
+    .from(seasonRegistrations)
+    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(inArray(seasonRegistrations.id, captainRegIds));
+
+  const captainMap = new Map(captainRows.map((r) => [r.registrationId, r.steamName]));
+
+  const teamCards: TeamCardData[] = seasonTeams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    draftOrder: team.draftOrder,
+    captainSteamName: captainMap.get(team.captainRegistrationId) ?? null,
+    members: (membersByTeam.get(team.id) ?? []).map((m) => ({
+      steamName: m.steamName,
+      primaryPosition: m.primaryPosition,
+      isStarter: m.isStarter,
+    })),
+  }));
+
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-3xl font-bold mb-8">参赛队伍 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">队伍列表加载中...</p>
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-2 text-[var(--text-primary)]">参赛队伍</h1>
+      <p className="text-[var(--text-secondary)] mb-8">
+        {season.name} · 共 {teamCards.length} 支队伍
+      </p>
+      <TeamGrid teams={teamCards} seasonSlug={seasonSlug} />
     </div>
   );
 }

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -62,6 +62,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
   const allMembers = await db
     .select({
       teamId: teamMembers.teamId,
+      registrationId: teamMembers.registrationId,
       isStarter: teamMembers.isStarter,
       primaryPosition: seasonRegistrations.primaryPosition,
       steamName: users.steamName,
@@ -78,17 +79,11 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
     membersByTeam.set(row.teamId, list);
   }
 
-  const captainRegIds = seasonTeams.map((t) => t.captainRegistrationId);
-  const captainRows = await db
-    .select({
-      registrationId: seasonRegistrations.id,
-      steamName: users.steamName,
-    })
-    .from(seasonRegistrations)
-    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
-    .where(inArray(seasonRegistrations.id, captainRegIds));
-
-  const captainMap = new Map(captainRows.map((r) => [r.registrationId, r.steamName]));
+  const captainMap = new Map(
+    allMembers
+      .filter((m) => seasonTeams.some((t) => t.captainRegistrationId === m.registrationId))
+      .map((m) => [m.registrationId, m.steamName])
+  );
 
   const teamCards: TeamCardData[] = seasonTeams.map((team) => ({
     id: team.id,

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -1,14 +1,77 @@
-// TODO: admin match management — create matches, input results, update bracket
+import { notFound } from "next/navigation";
+import { desc, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema/seasons";
+import { teams } from "@/db/schema/teams";
+import { matches } from "@/db/schema/matches";
+import { AdminMatchList, type MatchRow } from "@/components/admin/AdminMatchList";
+
+export const dynamic = "force-dynamic";
+
 interface AdminMatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
 export default async function AdminMatchesPage({ params }: AdminMatchesPageProps) {
   const { seasonSlug } = await params;
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const [seasonTeams, matchRows] = await Promise.all([
+    db
+      .select({ id: teams.id, name: teams.name })
+      .from(teams)
+      .where(eq(teams.seasonId, season.id))
+      .orderBy(teams.draftOrder),
+    db
+      .select({
+        id: matches.id,
+        teamAId: matches.teamAId,
+        teamBId: matches.teamBId,
+        format: matches.format,
+        stage: matches.stage,
+        status: matches.status,
+        scoreA: matches.scoreA,
+        scoreB: matches.scoreB,
+        scheduledAt: matches.scheduledAt,
+        completedAt: matches.completedAt,
+        teamAName: teams.name,
+      })
+      .from(matches)
+      .innerJoin(teams, eq(matches.teamAId, teams.id))
+      .where(eq(matches.seasonId, season.id))
+      .orderBy(desc(matches.createdAt)),
+  ]);
+
+  // 补充 teamBName
+  const teamNameMap = new Map(seasonTeams.map((t) => [t.id, t.name]));
+
+  const matchList: MatchRow[] = matchRows.map((m) => ({
+    id: m.id,
+    teamAId: m.teamAId,
+    teamAName: m.teamAName,
+    teamBId: m.teamBId,
+    teamBName: teamNameMap.get(m.teamBId) ?? m.teamBId,
+    format: m.format,
+    stage: m.stage,
+    status: m.status,
+    scoreA: m.scoreA,
+    scoreB: m.scoreB,
+    scheduledAt: m.scheduledAt,
+    completedAt: m.completedAt,
+  }));
+
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">比赛管理 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">比赛列表加载中...</p>
+      <AdminMatchList
+        seasonId={season.id}
+        seasonSlug={seasonSlug}
+        matches={matchList}
+        teams={seasonTeams}
+      />
     </div>
   );
 }

--- a/src/components/admin/AdminMatchList.tsx
+++ b/src/components/admin/AdminMatchList.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CreateMatchForm } from "@/components/admin/CreateMatchForm";
+import { RecordResultForm } from "@/components/admin/RecordResultForm";
+import { cancelMatch } from "@/actions/matches";
+import { formatCST } from "@/lib/utils/date";
+
+const STATUS_LABELS: Record<string, string> = {
+  scheduled: "未开始",
+  in_progress: "进行中",
+  finished: "已结束",
+  cancelled: "已取消",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  scheduled: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  in_progress: "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
+  finished: "bg-green-500/10 text-green-400 border-green-500/20",
+  cancelled: "bg-[var(--text-muted)]/10 text-[var(--text-muted)] border-[var(--border)]",
+};
+
+const FORMAT_LABELS: Record<string, string> = {
+  bo1: "BO1",
+  bo3: "BO3",
+  bo5: "BO5",
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  qualifier: "排位赛",
+  playoff: "正赛",
+};
+
+export interface MatchRow {
+  id: string;
+  teamAId: string;
+  teamAName: string;
+  teamBId: string;
+  teamBName: string;
+  format: string;
+  stage: string;
+  status: string;
+  scoreA: number | null;
+  scoreB: number | null;
+  scheduledAt: Date | null;
+  completedAt: Date | null;
+}
+
+interface TeamOption {
+  id: string;
+  name: string;
+}
+
+interface AdminMatchListProps {
+  seasonId: string;
+  seasonSlug: string;
+  matches: MatchRow[];
+  teams: TeamOption[];
+}
+
+export function AdminMatchList({ seasonId, seasonSlug, matches, teams }: AdminMatchListProps) {
+  const [showCreate, setShowCreate] = useState(false);
+  const [recordTarget, setRecordTarget] = useState<MatchRow | null>(null);
+  const [cancelPending, startCancelTransition] = useTransition();
+
+  function handleCancel(matchId: string) {
+    if (!confirm("确认取消该场比赛？")) return;
+    startCancelTransition(async () => {
+      const result = await cancelMatch(matchId);
+      if (!result.success) toast.error(result.error.message);
+      else toast.success("比赛已取消");
+    });
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-[var(--text-primary)]">比赛管理</h1>
+        <Button onClick={() => setShowCreate(true)}>+ 创建比赛</Button>
+      </div>
+
+      {matches.length === 0 ? (
+        <div className="text-center py-16 text-[var(--text-secondary)]">
+          暂无比赛，点击上方按钮创建第一场。
+        </div>
+      ) : (
+        <div className="rounded-lg border border-[var(--border)] overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="border-[var(--border)] hover:bg-transparent">
+                <TableHead className="text-[var(--text-secondary)]">对阵</TableHead>
+                <TableHead className="text-[var(--text-secondary)]">赛制</TableHead>
+                <TableHead className="text-[var(--text-secondary)]">赛段</TableHead>
+                <TableHead className="text-[var(--text-secondary)]">状态</TableHead>
+                <TableHead className="text-[var(--text-secondary)]">比分</TableHead>
+                <TableHead className="text-[var(--text-secondary)]">时间</TableHead>
+                <TableHead className="text-[var(--text-secondary)] text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {matches.map((m) => (
+                <TableRow key={m.id} className="border-[var(--border)]">
+                  <TableCell>
+                    <Link
+                      href={`/${seasonSlug}/matches/${m.id}`}
+                      className="font-medium text-[var(--text-primary)] hover:text-[var(--season-primary)] transition-colors"
+                    >
+                      {m.teamAName} vs {m.teamBName}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-[var(--text-secondary)]">
+                    {FORMAT_LABELS[m.format] ?? m.format}
+                  </TableCell>
+                  <TableCell className="text-[var(--text-secondary)]">
+                    {STAGE_LABELS[m.stage] ?? m.stage}
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={`text-xs ${STATUS_STYLES[m.status] ?? ""}`}>
+                      {STATUS_LABELS[m.status] ?? m.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="tabular-nums text-[var(--text-primary)]">
+                    {m.scoreA !== null && m.scoreB !== null
+                      ? `${m.scoreA} : ${m.scoreB}`
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-[var(--text-secondary)] text-sm">
+                    {m.completedAt
+                      ? formatCST(m.completedAt)
+                      : m.scheduledAt
+                      ? formatCST(m.scheduledAt)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      {(m.status === "scheduled" || m.status === "in_progress") && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setRecordTarget(m)}
+                        >
+                          录入结果
+                        </Button>
+                      )}
+                      {m.status === "scheduled" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={cancelPending}
+                          onClick={() => handleCancel(m.id)}
+                          className="text-red-400 border-red-400/20 hover:bg-red-400/10"
+                        >
+                          取消
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* 创建比赛 Dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>创建比赛</DialogTitle>
+          </DialogHeader>
+          <CreateMatchForm
+            seasonId={seasonId}
+            teams={teams}
+            onSuccess={() => setShowCreate(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* 录入结果 Dialog */}
+      <Dialog open={!!recordTarget} onOpenChange={(open) => { if (!open) setRecordTarget(null); }}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              录入结果 · {recordTarget?.teamAName} vs {recordTarget?.teamBName}
+            </DialogTitle>
+          </DialogHeader>
+          {recordTarget && (
+            <RecordResultForm
+              matchId={recordTarget.id}
+              format={recordTarget.format}
+              teamA={{ id: recordTarget.teamAId, name: recordTarget.teamAName }}
+              teamB={{ id: recordTarget.teamBId, name: recordTarget.teamBName }}
+              onSuccess={() => setRecordTarget(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/admin/AdminMatchList.tsx
+++ b/src/components/admin/AdminMatchList.tsx
@@ -7,6 +7,16 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   Table,
   TableBody,
   TableCell,
@@ -74,12 +84,15 @@ interface AdminMatchListProps {
 export function AdminMatchList({ seasonId, seasonSlug, matches, teams }: AdminMatchListProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [recordTarget, setRecordTarget] = useState<MatchRow | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<string | null>(null);
   const [cancelPending, startCancelTransition] = useTransition();
 
-  function handleCancel(matchId: string) {
-    if (!confirm("确认取消该场比赛？")) return;
+  function confirmCancel() {
+    if (!cancelTarget) return;
+    const id = cancelTarget;
+    setCancelTarget(null);
     startCancelTransition(async () => {
-      const result = await cancelMatch(matchId);
+      const result = await cancelMatch(id);
       if (!result.success) toast.error(result.error.message);
       else toast.success("比赛已取消");
     });
@@ -160,7 +173,7 @@ export function AdminMatchList({ seasonId, seasonSlug, matches, teams }: AdminMa
                           size="sm"
                           variant="outline"
                           disabled={cancelPending}
-                          onClick={() => handleCancel(m.id)}
+                          onClick={() => setCancelTarget(m.id)}
                           className="text-red-400 border-red-400/20 hover:bg-red-400/10"
                         >
                           取消
@@ -188,6 +201,27 @@ export function AdminMatchList({ seasonId, seasonSlug, matches, teams }: AdminMa
           />
         </DialogContent>
       </Dialog>
+
+      {/* 取消比赛确认 */}
+      <AlertDialog open={!!cancelTarget} onOpenChange={(open) => { if (!open) setCancelTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认取消比赛</AlertDialogTitle>
+            <AlertDialogDescription>
+              取消后无法恢复，该场比赛将标记为「已取消」。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>返回</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmCancel}
+              className="bg-red-500 hover:bg-red-600"
+            >
+              确认取消
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* 录入结果 Dialog */}
       <Dialog open={!!recordTarget} onOpenChange={(open) => { if (!open) setRecordTarget(null); }}>

--- a/src/components/admin/CreateMatchForm.tsx
+++ b/src/components/admin/CreateMatchForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { createMatch } from "@/actions/matches";
+
+interface TeamOption {
+  id: string;
+  name: string;
+}
+
+interface CreateMatchFormProps {
+  seasonId: string;
+  teams: TeamOption[];
+  onSuccess: () => void;
+}
+
+export function CreateMatchForm({ seasonId, teams, onSuccess }: CreateMatchFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [teamAId, setTeamAId] = useState("");
+  const [teamBId, setTeamBId] = useState("");
+  const [stage, setStage] = useState<"qualifier" | "playoff">("qualifier");
+  const [format, setFormat] = useState<"bo1" | "bo3" | "bo5">("bo3");
+  const [scheduledAt, setScheduledAt] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!teamAId || !teamBId) return;
+    if (teamAId === teamBId) {
+      toast.error("两支队伍不能相同");
+      return;
+    }
+    startTransition(async () => {
+      const result = await createMatch({
+        seasonId,
+        teamAId,
+        teamBId,
+        stage,
+        format,
+        scheduledAt: scheduledAt || undefined,
+      });
+      if (result.success) {
+        toast.success("比赛创建成功");
+        onSuccess();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>队伍 A</Label>
+          <Select value={teamAId} onValueChange={setTeamAId}>
+            <SelectTrigger>
+              <SelectValue placeholder="选择队伍 A" />
+            </SelectTrigger>
+            <SelectContent>
+              {teams.map((t) => (
+                <SelectItem key={t.id} value={t.id} disabled={t.id === teamBId}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>队伍 B</Label>
+          <Select value={teamBId} onValueChange={setTeamBId}>
+            <SelectTrigger>
+              <SelectValue placeholder="选择队伍 B" />
+            </SelectTrigger>
+            <SelectContent>
+              {teams.map((t) => (
+                <SelectItem key={t.id} value={t.id} disabled={t.id === teamAId}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>赛段</Label>
+          <Select value={stage} onValueChange={(v) => setStage(v as typeof stage)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="qualifier">排位赛</SelectItem>
+              <SelectItem value="playoff">正赛</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>赛制</Label>
+          <Select value={format} onValueChange={(v) => setFormat(v as typeof format)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bo1">BO1</SelectItem>
+              <SelectItem value="bo3">BO3</SelectItem>
+              <SelectItem value="bo5">BO5</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>
+          预定时间 <span className="text-[var(--text-muted)]">（可选）</span>
+        </Label>
+        <Input
+          type="datetime-local"
+          value={scheduledAt}
+          onChange={(e) => setScheduledAt(e.target.value)}
+        />
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="submit" disabled={isPending || !teamAId || !teamBId}>
+          {isPending ? "创建中..." : "创建比赛"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/admin/RecordResultForm.tsx
+++ b/src/components/admin/RecordResultForm.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { recordMatchResult } from "@/actions/matches";
+
+const FORMAT_MAX: Record<string, number> = { bo1: 1, bo3: 3, bo5: 5 };
+
+const CS2_MAPS = [
+  "de_mirage",
+  "de_inferno",
+  "de_nuke",
+  "de_ancient",
+  "de_anubis",
+  "de_dust2",
+  "de_vertigo",
+];
+
+interface TeamOption {
+  id: string;
+  name: string;
+}
+
+interface RecordResultFormProps {
+  matchId: string;
+  format: string;
+  teamA: TeamOption;
+  teamB: TeamOption;
+  onSuccess: () => void;
+}
+
+interface MapEntry {
+  mapName: string;
+  pickedByTeamId: string | null;
+  teamAStartSide: "t" | "ct" | null;
+  scoreA: string;
+  scoreB: string;
+}
+
+function emptyMap(): MapEntry {
+  return { mapName: "", pickedByTeamId: null, teamAStartSide: null, scoreA: "", scoreB: "" };
+}
+
+export function RecordResultForm({
+  matchId,
+  format,
+  teamA,
+  teamB,
+  onSuccess,
+}: RecordResultFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const maxMaps = FORMAT_MAX[format] ?? 1;
+  const [scoreA, setScoreA] = useState("");
+  const [scoreB, setScoreB] = useState("");
+  const [mapEntries, setMapEntries] = useState<MapEntry[]>([emptyMap()]);
+
+  function updateMap(i: number, patch: Partial<MapEntry>) {
+    setMapEntries((prev) => prev.map((m, idx) => (idx === i ? { ...m, ...patch } : m)));
+  }
+
+  function addMap() {
+    if (mapEntries.length < maxMaps) setMapEntries((prev) => [...prev, emptyMap()]);
+  }
+
+  function removeMap(i: number) {
+    if (mapEntries.length > 1) setMapEntries((prev) => prev.filter((_, idx) => idx !== i));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const sA = parseInt(scoreA, 10);
+    const sB = parseInt(scoreB, 10);
+    if (isNaN(sA) || isNaN(sB) || sA < 0 || sB < 0) {
+      toast.error("请输入有效的系列赛比分");
+      return;
+    }
+
+    const maps = mapEntries.map((m, i) => ({
+      mapOrder: i + 1,
+      mapName: m.mapName,
+      pickedByTeamId: m.pickedByTeamId,
+      teamAStartSide: m.teamAStartSide,
+      scoreA: parseInt(m.scoreA, 10) || 0,
+      scoreB: parseInt(m.scoreB, 10) || 0,
+    }));
+
+    startTransition(async () => {
+      const result = await recordMatchResult({ matchId, scoreA: sA, scoreB: sB, maps });
+      if (result.success) {
+        toast.success("比赛结果已录入");
+        onSuccess();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* 系列赛总比分 */}
+      <div>
+        <Label className="block mb-2">系列赛比分</Label>
+        <div className="flex items-center gap-3">
+          <div className="flex-1 space-y-1">
+            <p className="text-xs text-[var(--text-muted)]">{teamA.name}</p>
+            <Input
+              type="number"
+              min={0}
+              value={scoreA}
+              onChange={(e) => setScoreA(e.target.value)}
+              placeholder="0"
+              className="text-center"
+            />
+          </div>
+          <span className="text-[var(--text-muted)] text-lg">:</span>
+          <div className="flex-1 space-y-1">
+            <p className="text-xs text-[var(--text-muted)]">{teamB.name}</p>
+            <Input
+              type="number"
+              min={0}
+              value={scoreB}
+              onChange={(e) => setScoreB(e.target.value)}
+              placeholder="0"
+              className="text-center"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 各图结果 */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <Label>地图结果</Label>
+          {mapEntries.length < maxMaps && (
+            <Button type="button" variant="outline" size="sm" onClick={addMap}>
+              + 添加地图
+            </Button>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          {mapEntries.map((m, i) => (
+            <div
+              key={i}
+              className="border border-[var(--border)] rounded-lg p-4 space-y-3 bg-[var(--bg-overlay)]"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-[var(--text-secondary)]">
+                  第 {i + 1} 张图
+                </span>
+                {mapEntries.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeMap(i)}
+                    className="text-xs text-[var(--text-muted)] hover:text-red-400"
+                  >
+                    移除
+                  </button>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label className="text-xs">地图</Label>
+                  <Select value={m.mapName} onValueChange={(v) => updateMap(i, { mapName: v })}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="选择地图" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CS2_MAPS.map((name) => (
+                        <SelectItem key={name} value={name}>{name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1">
+                  <Label className="text-xs">Pick 方</Label>
+                  <Select
+                    value={m.pickedByTeamId ?? "__decider__"}
+                    onValueChange={(v) =>
+                      updateMap(i, { pickedByTeamId: v === "__decider__" ? null : v })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="选择 pick 方" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={teamA.id}>{teamA.name}</SelectItem>
+                      <SelectItem value={teamB.id}>{teamB.name}</SelectItem>
+                      <SelectItem value="__decider__">决胜图</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label className="text-xs">{teamA.name} 起始边</Label>
+                  <Select
+                    value={m.teamAStartSide ?? ""}
+                    onValueChange={(v) =>
+                      updateMap(i, { teamAStartSide: v as "t" | "ct" | null })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="选择" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="t">T</SelectItem>
+                      <SelectItem value="ct">CT</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex items-end gap-2">
+                  <div className="flex-1 space-y-1">
+                    <Label className="text-xs">{teamA.name}</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={m.scoreA}
+                      onChange={(e) => updateMap(i, { scoreA: e.target.value })}
+                      placeholder="0"
+                      className="text-center"
+                    />
+                  </div>
+                  <span className="text-[var(--text-muted)] pb-2">:</span>
+                  <div className="flex-1 space-y-1">
+                    <Label className="text-xs">{teamB.name}</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={m.scoreB}
+                      onChange={(e) => updateMap(i, { scoreB: e.target.value })}
+                      placeholder="0"
+                      className="text-center"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <Button type="submit" disabled={isPending || !scoreA || !scoreB}>
+          {isPending ? "保存中..." : "保存结果"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/admin/RecordResultForm.tsx
+++ b/src/components/admin/RecordResultForm.tsx
@@ -79,14 +79,34 @@ export function RecordResultForm({
       return;
     }
 
-    const maps = mapEntries.map((m, i) => ({
-      mapOrder: i + 1,
-      mapName: m.mapName,
-      pickedByTeamId: m.pickedByTeamId,
-      teamAStartSide: m.teamAStartSide,
-      scoreA: parseInt(m.scoreA, 10) || 0,
-      scoreB: parseInt(m.scoreB, 10) || 0,
-    }));
+    const maps: {
+      mapOrder: number;
+      mapName: string;
+      pickedByTeamId: string | null;
+      teamAStartSide: "t" | "ct" | null;
+      scoreA: number;
+      scoreB: number;
+    }[] = [];
+    for (const [i, m] of mapEntries.entries()) {
+      const mA = parseInt(m.scoreA, 10);
+      const mB = parseInt(m.scoreB, 10);
+      if (isNaN(mA) || isNaN(mB) || mA < 0 || mB < 0) {
+        toast.error(`第 ${i + 1} 张图比分不完整`);
+        return;
+      }
+      if (!m.mapName) {
+        toast.error(`第 ${i + 1} 张图请选择地图`);
+        return;
+      }
+      maps.push({
+        mapOrder: i + 1,
+        mapName: m.mapName,
+        pickedByTeamId: m.pickedByTeamId,
+        teamAStartSide: m.teamAStartSide,
+        scoreA: mA,
+        scoreB: mB,
+      });
+    }
 
     startTransition(async () => {
       const result = await recordMatchResult({ matchId, scoreA: sA, scoreB: sB, maps });

--- a/src/components/matches/MatchDetail.tsx
+++ b/src/components/matches/MatchDetail.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { formatCST } from "@/lib/utils/date";
+
+const STATUS_LABELS: Record<string, string> = {
+  scheduled: "未开始",
+  in_progress: "进行中",
+  finished: "已结束",
+  cancelled: "已取消",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  scheduled: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  in_progress: "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
+  finished: "bg-green-500/10 text-green-400 border-green-500/20",
+  cancelled: "bg-[var(--text-muted)]/10 text-[var(--text-muted)] border-[var(--border)]",
+};
+
+const FORMAT_LABELS: Record<string, string> = {
+  bo1: "BO1",
+  bo3: "BO3",
+  bo5: "BO5",
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  qualifier: "排位赛",
+  playoff: "正赛",
+};
+
+const SIDE_LABELS: Record<string, string> = {
+  t: "T",
+  ct: "CT",
+};
+
+export interface MatchMapData {
+  mapOrder: number;
+  mapName: string;
+  pickedByTeamName: string | null;
+  teamAStartSide: string | null;
+  scoreA: number | null;
+  scoreB: number | null;
+}
+
+export interface MatchDetailData {
+  id: string;
+  teamAName: string;
+  teamAId: string;
+  teamBName: string;
+  teamBId: string;
+  format: string;
+  stage: string;
+  status: string;
+  scoreA: number | null;
+  scoreB: number | null;
+  scheduledAt: Date | null;
+  completedAt: Date | null;
+  maps: MatchMapData[];
+  seasonSlug: string;
+}
+
+export function MatchDetail({ match }: { match: MatchDetailData }) {
+  const isFinished = match.status === "finished";
+  const hasScore = match.scoreA !== null && match.scoreB !== null;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href={`/${match.seasonSlug}/matches`}
+          className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          ← 赛程总览
+        </Link>
+      </div>
+
+      {/* 比赛头部 */}
+      <Card className="bg-[var(--bg-elevated)] border-[var(--border)] p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge className={`text-xs ${STATUS_STYLES[match.status] ?? ""}`}>
+              {STATUS_LABELS[match.status] ?? match.status}
+            </Badge>
+            <Badge variant="outline" className="text-xs border-[var(--border)] text-[var(--text-secondary)]">
+              {FORMAT_LABELS[match.format] ?? match.format}
+            </Badge>
+            <Badge variant="outline" className="text-xs border-[var(--border)] text-[var(--text-secondary)]">
+              {STAGE_LABELS[match.stage] ?? match.stage}
+            </Badge>
+          </div>
+          {match.scheduledAt && !isFinished && (
+            <p className="text-sm text-[var(--text-muted)]">
+              {formatCST(match.scheduledAt)}
+            </p>
+          )}
+          {match.completedAt && isFinished && (
+            <p className="text-sm text-[var(--text-muted)]">
+              {formatCST(match.completedAt)}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-center gap-6">
+          <Link href={`/${match.seasonSlug}/teams/${match.teamAId}`} className="text-right flex-1 hover:opacity-80 transition-opacity">
+            <p className="text-xl font-bold text-[var(--text-primary)] truncate">{match.teamAName}</p>
+          </Link>
+
+          <div className="text-center shrink-0 px-4">
+            {hasScore ? (
+              <p className="text-4xl font-bold text-[var(--text-primary)] tabular-nums">
+                {match.scoreA} <span className="text-[var(--text-muted)]">:</span> {match.scoreB}
+              </p>
+            ) : (
+              <p className="text-2xl font-bold text-[var(--text-muted)]">VS</p>
+            )}
+          </div>
+
+          <Link href={`/${match.seasonSlug}/teams/${match.teamBId}`} className="text-left flex-1 hover:opacity-80 transition-opacity">
+            <p className="text-xl font-bold text-[var(--text-primary)] truncate">{match.teamBName}</p>
+          </Link>
+        </div>
+      </Card>
+
+      {/* 地图结果 */}
+      {match.maps.length > 0 && (
+        <Card className="bg-[var(--bg-elevated)] border-[var(--border)] overflow-hidden">
+          <div className="p-4 border-b border-[var(--border)]">
+            <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
+              地图结果
+            </h2>
+          </div>
+          <div className="divide-y divide-[var(--border)]">
+            {match.maps.map((m) => (
+              <MapRow key={m.mapOrder} map={m} teamAName={match.teamAName} teamBName={match.teamBName} />
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function MapRow({
+  map,
+  teamAName,
+  teamBName,
+}: {
+  map: MatchMapData;
+  teamAName: string;
+  teamBName: string;
+}) {
+  const hasScore = map.scoreA !== null && map.scoreB !== null;
+
+  return (
+    <div className="flex items-center gap-4 px-4 py-3">
+      <div className="w-6 shrink-0 text-center text-xs text-[var(--text-muted)] font-mono">
+        G{map.mapOrder}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-sm text-[var(--text-primary)]">{map.mapName}</p>
+        <div className="flex items-center gap-2 mt-0.5">
+          {map.pickedByTeamName && (
+            <span className="text-xs text-[var(--text-muted)]">
+              {map.pickedByTeamName} pick
+            </span>
+          )}
+          {!map.pickedByTeamName && (
+            <span className="text-xs text-[var(--text-muted)]">决胜图</span>
+          )}
+          {map.teamAStartSide && (
+            <span className="text-xs text-[var(--text-muted)]">
+              · {teamAName} 起始 {SIDE_LABELS[map.teamAStartSide]}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {hasScore && (
+        <div className="shrink-0 text-right">
+          <p className="font-bold tabular-nums text-[var(--text-primary)]">
+            {map.scoreA} : {map.scoreB}
+          </p>
+          {map.scoreA !== null && map.scoreB !== null && (
+            <p className="text-xs text-[var(--text-muted)]">
+              {map.scoreA > map.scoreB ? teamAName : teamBName} 胜
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -124,7 +124,7 @@ export function RegistrationForm({
       setValueAs: (v: string) =>
         v === "" || v === undefined || v === null
           ? undefined
-          : parseInt(String(v), 10),
+          : parseFloat(String(v)),
     });
 
   return (
@@ -324,9 +324,10 @@ export function RegistrationForm({
               <Input
                 id="peakRating"
                 type="number"
-                placeholder="如 14500"
-                min={0}
-                max={50000}
+                placeholder="如 1.48"
+                min={0.01}
+                max={3.00}
+                step={0.01}
                 className={inputCls}
                 {...numRegister("peakRating")}
               />
@@ -339,9 +340,10 @@ export function RegistrationForm({
               <Input
                 id="peakWe"
                 type="number"
-                placeholder="如 8000"
+                placeholder="如 8.5"
                 min={0}
-                max={50000}
+                max={16.0}
+                step={0.1}
                 className={inputCls}
                 {...numRegister("peakWe")}
               />
@@ -388,9 +390,10 @@ export function RegistrationForm({
               <Input
                 id="currentRating"
                 type="number"
-                placeholder="如 13000"
-                min={0}
-                max={50000}
+                placeholder="如 1.35"
+                min={0.01}
+                max={3.00}
+                step={0.01}
                 className={inputCls}
                 {...numRegister("currentRating")}
               />
@@ -403,9 +406,10 @@ export function RegistrationForm({
               <Input
                 id="currentWe"
                 type="number"
-                placeholder="如 7500"
+                placeholder="如 7.5"
                 min={0}
-                max={50000}
+                max={16.0}
+                step={0.1}
                 className={inputCls}
                 {...numRegister("currentWe")}
               />

--- a/src/components/teams/TeamGrid.tsx
+++ b/src/components/teams/TeamGrid.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+const POSITION_LABELS: Record<string, string> = {
+  igl: "IGL",
+  awper: "AWP",
+  opener: "Opener",
+  closer: "Closer",
+  anchor: "Anchor",
+};
+
+export interface TeamCardData {
+  id: string;
+  name: string;
+  draftOrder: number;
+  captainSteamName: string | null;
+  members: {
+    steamName: string | null;
+    primaryPosition: string;
+    isStarter: boolean;
+  }[];
+}
+
+interface TeamGridProps {
+  teams: TeamCardData[];
+  seasonSlug: string;
+}
+
+export function TeamGrid({ teams, seasonSlug }: TeamGridProps) {
+  if (teams.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <div className="text-4xl mb-4">🏆</div>
+        <p className="text-[var(--text-secondary)]">暂无队伍数据</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      {teams.map((team) => {
+        const starters = team.members.filter((m) => m.isStarter);
+        return (
+          <Link key={team.id} href={`/${seasonSlug}/teams/${team.id}`}>
+            <Card className="p-5 bg-[var(--bg-elevated)] border border-[var(--border)] hover:border-[var(--season-primary)] transition-colors cursor-pointer h-full">
+              <div className="flex items-start justify-between mb-3">
+                <div>
+                  <p className="text-xs text-[var(--text-muted)] mb-0.5">
+                    选秀顺序 #{team.draftOrder}
+                  </p>
+                  <h3 className="font-bold text-lg text-[var(--text-primary)]">{team.name}</h3>
+                </div>
+              </div>
+
+              <p className="text-sm text-[var(--text-secondary)] mb-3">
+                队长：{team.captainSteamName ?? "—"}
+              </p>
+
+              <div className="flex flex-wrap gap-1">
+                {starters.map((m, i) => (
+                  <Badge
+                    key={i}
+                    variant="outline"
+                    className="text-xs border-[var(--border)] text-[var(--text-secondary)]"
+                  >
+                    {POSITION_LABELS[m.primaryPosition] ?? m.primaryPosition}
+                  </Badge>
+                ))}
+              </div>
+            </Card>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/teams/TeamRosterCard.tsx
+++ b/src/components/teams/TeamRosterCard.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+const POSITION_LABELS: Record<string, { cn: string; en: string }> = {
+  igl:    { cn: "指挥",        en: "IGL" },
+  awper:  { cn: "狙击手",      en: "AWPer" },
+  opener: { cn: "突破手",      en: "Opener" },
+  closer: { cn: "自由人/残局", en: "Closer" },
+  anchor: { cn: "主防",        en: "Anchor" },
+};
+
+export interface RosterMember {
+  id: string;
+  steamName: string | null;
+  primaryPosition: string;
+  peakRank: string;
+  currentRating: number;
+  isStarter: boolean;
+  isCaptain: boolean;
+}
+
+interface TeamRosterCardProps {
+  teamName: string;
+  draftOrder: number;
+  seasonSlug: string;
+  members: RosterMember[];
+}
+
+export function TeamRosterCard({ teamName, draftOrder, seasonSlug, members }: TeamRosterCardProps) {
+  const starters = members.filter((m) => m.isStarter);
+  const subs = members.filter((m) => !m.isStarter);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          href={`/${seasonSlug}/teams`}
+          className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          ← 所有队伍
+        </Link>
+      </div>
+
+      <div>
+        <p className="text-sm text-[var(--text-muted)] mb-1">选秀顺序 #{draftOrder}</p>
+        <h1 className="text-3xl font-bold text-[var(--text-primary)]">{teamName}</h1>
+      </div>
+
+      <Card className="bg-[var(--bg-elevated)] border-[var(--border)] overflow-hidden">
+        <div className="p-4 border-b border-[var(--border)]">
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
+            首发阵容
+          </h2>
+        </div>
+        <div className="divide-y divide-[var(--border)]">
+          {starters.map((m) => (
+            <MemberRow key={m.id} member={m} />
+          ))}
+        </div>
+      </Card>
+
+      {subs.length > 0 && (
+        <Card className="bg-[var(--bg-elevated)] border-[var(--border)] overflow-hidden">
+          <div className="p-4 border-b border-[var(--border)]">
+            <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
+              替补
+            </h2>
+          </div>
+          <div className="divide-y divide-[var(--border)]">
+            {subs.map((m) => (
+              <MemberRow key={m.id} member={m} />
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function MemberRow({ member }: { member: RosterMember }) {
+  const posLabel = POSITION_LABELS[member.primaryPosition];
+
+  return (
+    <div className="flex items-center gap-4 px-4 py-3">
+      <div className="w-24 shrink-0">
+        <Badge
+          variant="outline"
+          className="text-xs border-[var(--border)] text-[var(--season-primary)]"
+        >
+          {posLabel?.en ?? member.primaryPosition}
+        </Badge>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-[var(--text-primary)] truncate">
+            {member.steamName ?? "—"}
+          </span>
+          {member.isCaptain && (
+            <Badge className="text-xs bg-[var(--season-primary)]/10 text-[var(--season-primary)] border-[var(--season-primary)]/20 shrink-0">
+              队长
+            </Badge>
+          )}
+        </div>
+        {posLabel && (
+          <p className="text-xs text-[var(--text-muted)]">{posLabel.cn}</p>
+        )}
+      </div>
+
+      <div className="text-right shrink-0">
+        <p className="text-sm font-medium text-[var(--text-primary)]">{member.peakRank}</p>
+        <p className="text-xs text-[var(--text-muted)]">{member.currentRating} pts</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/teams/TeamRosterCard.tsx
+++ b/src/components/teams/TeamRosterCard.tsx
@@ -113,7 +113,7 @@ function MemberRow({ member }: { member: RosterMember }) {
 
       <div className="text-right shrink-0">
         <p className="text-sm font-medium text-[var(--text-primary)]">{member.peakRank}</p>
-        <p className="text-xs text-[var(--text-muted)]">{member.currentRating} pts</p>
+        <p className="text-xs text-[var(--text-muted)]">RT {member.currentRating.toFixed(2)}</p>
       </div>
     </div>
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils/cn"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils/cn"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/db/schema/registrations.ts
+++ b/src/db/schema/registrations.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, boolean, timestamp, integer, pgEnum, unique } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, boolean, timestamp, integer, real, pgEnum, unique } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { users } from "./users";
 import { seasons } from "./seasons";
@@ -24,13 +24,15 @@ export const seasonRegistrations = pgTable(
     // ── 段位 · 历史最高 ──────────────────────────────
     peakRank: text("peak_rank").notNull(),              // e.g. "A+"
     peakRankSeason: text("peak_rank_season").notNull(),  // e.g. "S1 2026"
-    peakRating: integer("peak_rating").notNull(),
-    peakWe: integer("peak_we"),
+    // rating：完美平台 Rating，0.01–3.00，两位小数
+    peakRating: real("peak_rating").notNull(),
+    // WE：Win Effect，0.0–16.0，一位小数
+    peakWe: real("peak_we"),
 
     // ── 段位 · 当前赛季最高 ──────────────────────────
     currentSeasonPeakRank: text("current_season_peak_rank").notNull(),
-    currentRating: integer("current_rating").notNull(),
-    currentWe: integer("current_we"),
+    currentRating: real("current_rating").notNull(),
+    currentWe: real("current_we"),
 
     // ── 截图（5 张天梯近期对局）─────────────────────
     screenshotUrls: text("screenshot_urls")

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,6 +1,12 @@
+import { eq } from "drizzle-orm";
 import { db } from "./client";
 import { seasons } from "./schema/seasons";
 import { adminUsers } from "./schema/admin-users";
+import { users } from "./schema/users";
+import { seasonRegistrations } from "./schema/registrations";
+import { teams, teamMembers } from "./schema/teams";
+import { matches } from "./schema/matches";
+import { matchMaps } from "./schema/match-maps";
 import {
   DRAFT_LEAGUE_PRESET,
   OPEN_TOURNAMENT_PRESET,
@@ -61,6 +67,210 @@ export async function seed() {
     );
   } else {
     console.log("Root admin already exists, skipping.");
+  }
+
+  // 3. 测试数据：playing 赛季 + 队伍 + 比赛（幂等：赛季不存在才创建）
+  const existingPlayingSeason = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, "2025-njurivals-s1"),
+  });
+
+  if (!existingPlayingSeason) {
+    console.log("Seeding playing season test data...");
+
+    const [playingSeason] = await db
+      .insert(seasons)
+      .values({
+        slug: "2025-njurivals-s1",
+        name: "2025 NJU Rivals S1",
+        kind: "选秀联赛",
+        status: "playing",
+        themeColor: "#3b82f6",
+        ...DRAFT_LEAGUE_PRESET,
+      })
+      .returning();
+
+    const TEAM_NAMES = ["Nova", "Frost", "Ember", "Abyss", "Specter", "Titan", "Vortex", "Cipher"];
+    // 每队 7 人：igl / awper / opener / closer / anchor / opener(sub) / closer(sub)
+    const TEAM_POSITIONS = ["igl", "awper", "opener", "closer", "anchor", "opener", "closer"] as const;
+    const STARTER_MASK    = [true,  true,    true,     true,     true,      false,        false];
+    const SECONDARY_MAP: Record<string, string> = {
+      igl: "awper", awper: "opener", opener: "closer", closer: "anchor", anchor: "igl",
+    };
+    const RANKS   = ["A++", "A+", "A+",  "A",    "A",    "B++",  "B+"];
+    const RATINGS = [1480,  1350, 1320,  1200,   1150,   980,    850];
+    const STYLES  = ["积极进攻", "狙击支撑", "先锋突破", "残局收割", "稳守反推", "辅助支撑", "灵活游走"];
+
+    // 创建 56 个用户
+    const userRows = [];
+    for (let t = 0; t < 8; t++) {
+      for (let p = 0; p < 7; p++) {
+        const idx = t * 7 + p + 1;
+        userRows.push({
+          email: `seed-p${String(idx).padStart(2, "0")}@rivalhu.b`,
+          steamName: `${TEAM_NAMES[t]}_${TEAM_POSITIONS[p].toUpperCase()}_${idx}`,
+          perfectId: `PW${100000 + idx}`,
+        });
+      }
+    }
+    const insertedUsers = await db.insert(users).values(userRows).returning();
+
+    // 创建 56 条报名记录（全部 approved）
+    const insertedRegs = await db
+      .insert(seasonRegistrations)
+      .values(
+        insertedUsers.map((u, i) => {
+          const posKey = TEAM_POSITIONS[i % 7];
+          return {
+            userId: u.id,
+            seasonId: playingSeason.id,
+            primaryPosition: posKey,
+            secondaryPosition: SECONDARY_MAP[posKey],
+            peakRank: RANKS[i % 7],
+            peakRankSeason: "S1 2025",
+            peakRating: RATINGS[i % 7],
+            currentSeasonPeakRank: RANKS[i % 7],
+            currentRating: RATINGS[i % 7] - 50,
+            gameplayStyle: STYLES[i % 7],
+            status: "approved" as const,
+            willingToBeCaptain: i % 7 === 0,
+          };
+        })
+      )
+      .returning();
+
+    // 创建 8 支队伍（每队第 0 位成员即 IGL 为队长）
+    const insertedTeams = await db
+      .insert(teams)
+      .values(
+        TEAM_NAMES.map((name, t) => ({
+          seasonId: playingSeason.id,
+          name: `Team ${name}`,
+          captainRegistrationId: insertedRegs[t * 7].id,
+          draftOrder: t + 1,
+        }))
+      )
+      .returning();
+
+    // 创建 56 条队伍成员记录
+    await db.insert(teamMembers).values(
+      insertedRegs.map((reg, i) => ({
+        teamId: insertedTeams[Math.floor(i / 7)].id,
+        registrationId: reg.id,
+        isStarter: STARTER_MASK[i % 7],
+      }))
+    );
+
+    const now = new Date();
+    const DAY = 24 * 60 * 60 * 1000;
+
+    // 创建 4 场比赛
+    const insertedMatches = await db
+      .insert(matches)
+      .values([
+        {
+          seasonId: playingSeason.id,
+          teamAId: insertedTeams[0].id,
+          teamBId: insertedTeams[1].id,
+          stage: "qualifier" as const,
+          format: "bo3" as const,
+          scoreA: 2,
+          scoreB: 0,
+          status: "finished" as const,
+          scheduledAt: new Date(now.getTime() - 7 * DAY),
+          completedAt: new Date(now.getTime() - 7 * DAY + 2 * 3600 * 1000),
+        },
+        {
+          seasonId: playingSeason.id,
+          teamAId: insertedTeams[2].id,
+          teamBId: insertedTeams[3].id,
+          stage: "qualifier" as const,
+          format: "bo3" as const,
+          scoreA: 1,
+          scoreB: 2,
+          status: "finished" as const,
+          scheduledAt: new Date(now.getTime() - 5 * DAY),
+          completedAt: new Date(now.getTime() - 5 * DAY + 3 * 3600 * 1000),
+        },
+        {
+          seasonId: playingSeason.id,
+          teamAId: insertedTeams[4].id,
+          teamBId: insertedTeams[5].id,
+          stage: "qualifier" as const,
+          format: "bo3" as const,
+          status: "in_progress" as const,
+          scheduledAt: new Date(now.getTime() - 3600 * 1000),
+        },
+        {
+          seasonId: playingSeason.id,
+          teamAId: insertedTeams[6].id,
+          teamBId: insertedTeams[7].id,
+          stage: "qualifier" as const,
+          format: "bo3" as const,
+          status: "scheduled" as const,
+          scheduledAt: new Date(now.getTime() + 2 * DAY),
+        },
+      ])
+      .returning();
+
+    // 已完成比赛的地图记录
+    await db.insert(matchMaps).values([
+      // Match 1: Nova 2:0 Frost
+      {
+        matchId: insertedMatches[0].id,
+        mapOrder: 1,
+        mapName: "de_mirage",
+        pickedByTeamId: insertedTeams[0].id,
+        teamAStartSide: "ct" as const,
+        scoreA: 13,
+        scoreB: 8,
+        completedAt: new Date(now.getTime() - 7 * DAY + 3600 * 1000),
+      },
+      {
+        matchId: insertedMatches[0].id,
+        mapOrder: 2,
+        mapName: "de_inferno",
+        pickedByTeamId: insertedTeams[1].id,
+        teamAStartSide: "t" as const,
+        scoreA: 13,
+        scoreB: 5,
+        completedAt: new Date(now.getTime() - 7 * DAY + 2 * 3600 * 1000),
+      },
+      // Match 2: Ember 1:2 Abyss
+      {
+        matchId: insertedMatches[1].id,
+        mapOrder: 1,
+        mapName: "de_nuke",
+        pickedByTeamId: insertedTeams[2].id,
+        teamAStartSide: "ct" as const,
+        scoreA: 13,
+        scoreB: 7,
+        completedAt: new Date(now.getTime() - 5 * DAY + 3600 * 1000),
+      },
+      {
+        matchId: insertedMatches[1].id,
+        mapOrder: 2,
+        mapName: "de_ancient",
+        pickedByTeamId: insertedTeams[3].id,
+        teamAStartSide: "t" as const,
+        scoreA: 5,
+        scoreB: 13,
+        completedAt: new Date(now.getTime() - 5 * DAY + 2 * 3600 * 1000),
+      },
+      {
+        matchId: insertedMatches[1].id,
+        mapOrder: 3,
+        mapName: "de_dust2",
+        pickedByTeamId: null,
+        teamAStartSide: "t" as const,
+        scoreA: 9,
+        scoreB: 13,
+        completedAt: new Date(now.getTime() - 5 * DAY + 3 * 3600 * 1000),
+      },
+    ]);
+
+    console.log("Playing season test data seeded successfully.");
+  } else {
+    console.log("Playing season already seeded, skipping.");
   }
 
   console.log("Seed complete.");

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -96,8 +96,10 @@ export async function seed() {
     const SECONDARY_MAP: Record<string, string> = {
       igl: "awper", awper: "opener", opener: "closer", closer: "anchor", anchor: "igl",
     };
-    const RANKS   = ["A++", "A+", "A+",  "A",    "A",    "B++",  "B+"];
-    const RATINGS = [1480,  1350, 1320,  1200,   1150,   980,    850];
+    const RANKS   = ["A++", "A+",  "A+",  "A",   "A",   "B++", "B+"];
+    // rating: 0.01–3.00 两位小数；we: 0.0–16.0 一位小数
+    const RATINGS = [1.52,  1.38,  1.35,  1.18,  1.12,  0.95,  0.82];
+    const WES     = [8.5,   9.2,   7.8,   6.5,   7.1,   5.8,   4.9];
     const STYLES  = ["积极进攻", "狙击支撑", "先锋突破", "残局收割", "稳守反推", "辅助支撑", "灵活游走"];
 
     // 创建 56 个用户
@@ -128,8 +130,10 @@ export async function seed() {
             peakRank: RANKS[i % 7],
             peakRankSeason: "S1 2025",
             peakRating: RATINGS[i % 7],
+            peakWe: WES[i % 7],
             currentSeasonPeakRank: RANKS[i % 7],
-            currentRating: RATINGS[i % 7] - 50,
+            currentRating: Math.round((RATINGS[i % 7] - 0.05) * 100) / 100,
+            currentWe: Math.round((WES[i % 7] - 0.3) * 10) / 10,
             gameplayStyle: STYLES[i % 7],
             status: "approved" as const,
             willingToBeCaptain: i % 7 === 0,

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -97,9 +97,9 @@ export async function seed() {
       igl: "awper", awper: "opener", opener: "closer", closer: "anchor", anchor: "igl",
     };
     const RANKS   = ["A++", "A+",  "A+",  "A",   "A",   "B++", "B+"];
-    // rating: 0.01–3.00 两位小数；we: 0.0–16.0 一位小数
-    const RATINGS = [1.52,  1.38,  1.35,  1.18,  1.12,  0.95,  0.82];
-    const WES     = [8.5,   9.2,   7.8,   6.5,   7.1,   5.8,   4.9];
+    // rating 均值约 1.0，we 均值约 8.0
+    const RATINGS = [1.35,  1.15,  1.12,  1.00,  0.98,  0.88,  0.80];
+    const WES     = [10.5,  9.2,   8.8,   8.0,   7.8,   6.5,   6.0];
     const STYLES  = ["积极进攻", "狙击支撑", "先锋突破", "残局收割", "稳守反推", "辅助支撑", "灵活游走"];
 
     // 创建 56 个用户

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,21 +1,28 @@
-// TODO: 实现 UTC ↔ Asia/Shanghai 时间转换工具
-// - formatCST(date)：将 UTC Date 格式化为中文本地时间字符串
-// - parseCST(str)：将 Asia/Shanghai 时间字符串解析为 UTC Date
-// - getCountdownSeconds(deadline)：计算距截止时间的秒数
-// - isDeadlinePassed(deadline)：判断截止时间是否已过
+const CST_LOCALE = "zh-CN";
+const CST_TZ = "Asia/Shanghai";
 
-export function formatCST(_date: Date | string): string {
-  throw new Error("not implemented");
+export function formatCST(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString(CST_LOCALE, {
+    timeZone: CST_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
-export function parseCST(_str: string): Date {
-  throw new Error("not implemented");
+export function parseCST(str: string): Date {
+  return new Date(str);
 }
 
-export function getCountdownSeconds(_deadline: Date | string): number {
-  throw new Error("not implemented");
+export function getCountdownSeconds(deadline: Date | string): number {
+  const d = typeof deadline === "string" ? new Date(deadline) : deadline;
+  return Math.max(0, Math.floor((d.getTime() - Date.now()) / 1000));
 }
 
-export function isDeadlinePassed(_deadline: Date | string): boolean {
-  throw new Error("not implemented");
+export function isDeadlinePassed(deadline: Date | string): boolean {
+  const d = typeof deadline === "string" ? new Date(deadline) : deadline;
+  return d.getTime() <= Date.now();
 }

--- a/src/lib/validators/match.ts
+++ b/src/lib/validators/match.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const createMatchSchema = z.object({
+  seasonId: z.string().uuid(),
+  teamAId: z.string().uuid(),
+  teamBId: z.string().uuid(),
+  stage: z.enum(["qualifier", "playoff"]),
+  format: z.enum(["bo1", "bo3", "bo5"]).default("bo1"),
+  scheduledAt: z.string().datetime().optional(),
+});
+
+export const recordMatchResultSchema = z.object({
+  matchId: z.string().uuid(),
+  scoreA: z.number().int().min(0),
+  scoreB: z.number().int().min(0),
+  maps: z
+    .array(
+      z.object({
+        mapOrder: z.number().int().min(1).max(5),
+        mapName: z.string().min(1),
+        pickedByTeamId: z.string().uuid().nullable(),
+        teamAStartSide: z.enum(["t", "ct"]).nullable(),
+        scoreA: z.number().int().min(0),
+        scoreB: z.number().int().min(0),
+      })
+    )
+    .optional(),
+});
+
+export type CreateMatchInput = z.infer<typeof createMatchSchema>;
+export type RecordMatchResultInput = z.infer<typeof recordMatchResultSchema>;

--- a/src/lib/validators/registration.ts
+++ b/src/lib/validators/registration.ts
@@ -17,6 +17,12 @@ export const RANK_LABELS = REGISTRATION_DEFAULTS.ranks.labels;
 // ── 每位置报名上限 ──────────────────────────────────
 export const MAX_PER_POSITION = REGISTRATION_DEFAULTS.maxPerPosition;
 
+// ── 报名段位门槛（满足其一即可）──────────────────────
+// 当前赛季最高段位 ≥ A，或历史最高段位 ≥ A+
+export const RANK_ORDER = REGISTRATION_DEFAULTS.ranks.values;
+const RANK_IDX_A   = RANK_ORDER.indexOf("A");    // 7
+const RANK_IDX_A_PLUS = RANK_ORDER.indexOf("A+"); // 8
+
 // ── 验证 schema ──────────────────────────────────────
 export const registrationSchema = z
   .object({
@@ -160,7 +166,18 @@ export const registrationSchema = z
   .refine((data) => data.secondaryPosition !== data.primaryPosition, {
     message: "次选位置不能与主选位置相同",
     path: ["secondaryPosition"],
-  });
+  })
+  .refine(
+    (data) => {
+      const currentIdx = RANK_ORDER.indexOf(data.currentSeasonPeakRank as typeof RANK_ORDER[number]);
+      const peakIdx    = RANK_ORDER.indexOf(data.peakRank as typeof RANK_ORDER[number]);
+      return currentIdx >= RANK_IDX_A || peakIdx >= RANK_IDX_A_PLUS;
+    },
+    {
+      message: "报名资格：当前赛季最高段位需达到 A，或历史最高段位需达到 A+",
+      path: ["currentSeasonPeakRank"],
+    },
+  );
 
 // ── 导出类型 ─────────────────────────────────────────
 export type RegistrationFormData = z.infer<typeof registrationSchema>;

--- a/src/lib/validators/registration.ts
+++ b/src/lib/validators/registration.ts
@@ -77,17 +77,25 @@ export const registrationSchema = z
       .string()
       .min(1, "请填写取得最高段位的赛季（如 S1 2026）"),
 
+    // Rating：完美平台 Rating，0.01–3.00，两位小数
     peakRating: z
       .number({ invalid_type_error: "请输入数字" })
-      .int("请输入整数")
-      .min(0, "Rating 不能为负")
-      .max(50000, "Rating 最大 50000"),
+      .min(0.01, "Rating 最小 0.01")
+      .max(3.00, "Rating 最大 3.00")
+      .refine(
+        (v) => Math.round(v * 100) / 100 === v,
+        "Rating 最多保留两位小数",
+      ),
 
+    // WE：Win Effect，0.0–16.0，一位小数
     peakWe: z
       .number({ invalid_type_error: "请输入数字" })
-      .int("请输入整数")
       .min(0, "WE 不能为负")
-      .max(50000, "WE 最大 50000")
+      .max(16.0, "WE 最大 16.0")
+      .refine(
+        (v) => Math.round(v * 10) / 10 === v,
+        "WE 最多保留一位小数",
+      )
       .optional(),
 
     // ── 段位 · 当前赛季最高 ──
@@ -97,15 +105,21 @@ export const registrationSchema = z
 
     currentRating: z
       .number({ invalid_type_error: "请输入数字" })
-      .int("请输入整数")
-      .min(0, "Rating 不能为负")
-      .max(50000, "Rating 最大 50000"),
+      .min(0.01, "Rating 最小 0.01")
+      .max(3.00, "Rating 最大 3.00")
+      .refine(
+        (v) => Math.round(v * 100) / 100 === v,
+        "Rating 最多保留两位小数",
+      ),
 
     currentWe: z
       .number({ invalid_type_error: "请输入数字" })
-      .int("请输入整数")
       .min(0, "WE 不能为负")
-      .max(50000, "WE 最大 50000")
+      .max(16.0, "WE 最大 16.0")
+      .refine(
+        (v) => Math.round(v * 10) / 10 === v,
+        "WE 最多保留一位小数",
+      )
       .optional(),
 
     // ── 天梯截图（NJUBox 分享链接）──


### PR DESCRIPTION
## Summary

- **Phase 9**：队伍展示（列表 + 详情），按 draftOrder 排序，队长 badge，首发/替补分区
- **Phase 10**：比赛管理 Server Actions（createMatch / recordMatchResult / cancelMatch）、公开比赛详情页、管理后台赛程列表 + 创建/录分/取消弹窗
- **修复**：注册表单 rating/WE 字段改为 real 类型，补充段位资格校验（当前赛季≥A 或历史最高≥A+）
- **种子数据**：新增 `2025-njurivals-s1` playing 赛季，8 支队伍，56 名成员，4 场测试比赛
- **重构**：review 后修复地图比分空值、confirm() 换 AlertDialog、合并队伍列表双查询、事务内补队伍归属校验

## Test plan

- [x] `pnpm db:push` + `pnpm seed` 无报错
- [x] `/2025-njurivals-s1/teams` 显示 8 张队伍卡片
- [x] `/2025-njurivals-s1/teams/[teamId]` 首发/替补分区，队长有 badge
- [x] `/2025-njurivals-s1/matches/[finishedId]` 显示比分 + 地图结果
- [x] `/admin/2025-njurivals-s1/matches` 表格正常，创建/录分/取消弹窗可用
- [x] `pnpm tsc --noEmit` 无类型错误