### PR TITLE
[phase-6] 实现队长投票

### DIFF
--- a/PHASES.md
+++ b/PHASES.md
@@ -74,10 +74,10 @@
 
 ## Phase 6 — 队长投票
 
-- [ ] `castVote` / `retractVote` Server Action（每人最多 3 票，幂等约束）
-- [ ] `/[seasonSlug]/captains` 投票页（Realtime 实时票数）
-- [ ] `/admin/[seasonSlug]/captains` 确认前 8 名队长、生成 teams + draft_order
-- [ ] 投票结果公示
+- [x] `castVote` / `retractVote` Server Action（每人最多 3 票，幂等约束）
+- [x] `/[seasonSlug]/captains` 投票页（Realtime 实时票数 + 轮询兜底）
+- [x] `/admin/[seasonSlug]/captains` 确认前 8 名队长、生成 teams + draft_order
+- [x] 投票结果公示
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | 多赛事抽象 | capability 驱动多赛事共存，路由前缀 `/[seasonSlug]/` | ✅ 架构就绪 |
 | 玩家报名 | Zod 校验、位置满员检测、NJUBox 截图链接、Magic Link 邮件 | ✅ Phase 4 基本完成 |
 | 管理员审核 | 通过 / 拒绝 / 等待名单 + audit log + 邀请码管理 + 管理员账户管理 | ✅ Phase 5 |
-| 队长投票 | 全体选手投票，Realtime 票数，得票前 8 名为队长 | 🔄 Phase 6 |
+| 队长投票 | 全体选手投票，Realtime 票数，得票前 8 名为队长 | ✅ Phase 6 |
 | 蛇形选秀直播间 | Realtime 围观，倒计时，剩余选手池 | 🔄 Phase 7 |
 | 队长选秀面板 | 事务行锁、幂等 pick、超时 Cron 自动递补 | 🔄 Phase 8 |
 | 队伍展示 | 7 人阵容按位置排版 | 🔄 Phase 9 |

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["pg"],
-  experimental: {
-    typedRoutes: true,
-  },
+  typedRoutes: true,
   images: {
     remotePatterns: [
       {

--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -1,11 +1,306 @@
 "use server";
 
-// TODO: cast a captain vote (max 3 per voter per season)
-export async function castVote(_voterRegistrationId: string, _candidateRegistrationId: string): Promise<void> {
-  throw new Error("not implemented");
+import { revalidatePath } from "next/cache";
+import { and, count, eq, inArray } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  auditLogs,
+  captainVotes,
+  seasonRegistrations,
+  seasons,
+  teamMembers,
+  teams,
+  users,
+} from "@/db/schema";
+import { fail, ok, type ActionResult } from "@/types/action";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { requireAdmin } from "@/lib/auth/session";
+import {
+  castVoteSchema,
+  confirmCaptainsSchema,
+  retractVoteSchema,
+  type CastVoteInput,
+  type ConfirmCaptainsInput,
+  type RetractVoteInput,
+} from "@/lib/validators/vote";
+import {
+  CAPTAIN_TEAM_COUNT,
+  selectCaptainSeeds,
+  validateCaptainVote,
+} from "@/lib/captains/rules";
+
+export async function castVote(
+  input: CastVoteInput,
+): Promise<ActionResult<{ voteId: string }>> {
+  const parsed = castVoteSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("投票参数无效");
+  }
+
+  try {
+    const voteId = await db.transaction(async (tx) => {
+      const voter = await tx.query.seasonRegistrations.findFirst({
+        where: eq(seasonRegistrations.id, parsed.data.voterRegistrationId),
+      });
+      const candidate = await tx.query.seasonRegistrations.findFirst({
+        where: eq(seasonRegistrations.id, parsed.data.candidateRegistrationId),
+      });
+      if (!voter || !candidate) {
+        throw new AppError(ErrorCode.NOT_FOUND, "报名记录不存在");
+      }
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, voter.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+      }
+
+      const [voteCountRow] = await tx
+        .select({ count: count() })
+        .from(captainVotes)
+        .where(eq(captainVotes.voterRegistrationId, voter.id));
+      const existingVote = await tx.query.captainVotes.findFirst({
+        where: and(
+          eq(captainVotes.voterRegistrationId, voter.id),
+          eq(captainVotes.candidateRegistrationId, candidate.id),
+        ),
+      });
+
+      const errorCode = validateCaptainVote({
+        season,
+        voter,
+        candidate,
+        existingVoteCount: Number(voteCountRow?.count ?? 0),
+        alreadyVotedForCandidate: Boolean(existingVote),
+      });
+      if (errorCode) {
+        throw new AppError(errorCode, ERROR_MESSAGES[errorCode]);
+      }
+
+      const [vote] = await tx
+        .insert(captainVotes)
+        .values({
+          voterRegistrationId: voter.id,
+          candidateRegistrationId: candidate.id,
+        })
+        .returning({ id: captainVotes.id });
+      return vote.id;
+    });
+
+    await revalidateCaptainPaths(parsed.data.voterRegistrationId);
+    return ok({ voteId });
+  } catch (e) {
+    return actionError("castVote", e);
+  }
 }
 
-// TODO: retract a captain vote
-export async function retractVote(_voterRegistrationId: string, _candidateRegistrationId: string): Promise<void> {
-  throw new Error("not implemented");
+export async function retractVote(
+  input: RetractVoteInput,
+): Promise<ActionResult<{ removed: boolean }>> {
+  const parsed = retractVoteSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("撤回投票参数无效");
+  }
+
+  try {
+    await db.transaction(async (tx) => {
+      const voter = await tx.query.seasonRegistrations.findFirst({
+        where: eq(seasonRegistrations.id, parsed.data.voterRegistrationId),
+      });
+      const candidate = await tx.query.seasonRegistrations.findFirst({
+        where: eq(seasonRegistrations.id, parsed.data.candidateRegistrationId),
+      });
+      if (!voter || !candidate) {
+        throw new AppError(ErrorCode.NOT_FOUND, "报名记录不存在");
+      }
+      if (voter.seasonId !== candidate.seasonId) {
+        throw new AppError(ErrorCode.CAPTAIN_NOT_ELIGIBLE, ERROR_MESSAGES.CAPTAIN_NOT_ELIGIBLE);
+      }
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, voter.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+      }
+      if (!season.hasCaptainVoting || season.status !== "voting") {
+        throw new AppError(ErrorCode.VOTING_CLOSED, ERROR_MESSAGES.VOTING_CLOSED);
+      }
+
+      await tx
+        .delete(captainVotes)
+        .where(
+          and(
+            eq(captainVotes.voterRegistrationId, voter.id),
+            eq(captainVotes.candidateRegistrationId, candidate.id),
+          ),
+        );
+    });
+
+    await revalidateCaptainPaths(parsed.data.voterRegistrationId);
+    return ok({ removed: true });
+  } catch (e) {
+    return actionError("retractVote", e);
+  }
+}
+
+export async function confirmCaptains(
+  input: ConfirmCaptainsInput,
+): Promise<ActionResult<{ teamIds: string[] }>> {
+  const parsed = confirmCaptainsSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("确认队长参数无效");
+  }
+
+  try {
+    const admin = await requireAdmin();
+    const result = await db.transaction(async (tx) => {
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, parsed.data.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+      }
+      if (!season.hasCaptainVoting || !season.hasDraft) {
+        throw new AppError(
+          ErrorCode.SEASON_CAPABILITY_DISABLED,
+          ERROR_MESSAGES.SEASON_CAPABILITY_DISABLED,
+        );
+      }
+      if (season.status !== "voting") {
+        throw new AppError(ErrorCode.SEASON_INVALID_STATUS, ERROR_MESSAGES.SEASON_INVALID_STATUS);
+      }
+
+      const [existingTeamCount] = await tx
+        .select({ count: count() })
+        .from(teams)
+        .where(eq(teams.seasonId, season.id));
+      if (Number(existingTeamCount?.count ?? 0) > 0) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "该赛季已生成队伍");
+      }
+
+      const candidates = await tx
+        .select({
+          registrationId: seasonRegistrations.id,
+          peakRating: seasonRegistrations.peakRating,
+          createdAt: seasonRegistrations.createdAt,
+          steamName: users.steamName,
+          email: users.email,
+        })
+        .from(seasonRegistrations)
+        .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+        .where(
+          and(
+            eq(seasonRegistrations.seasonId, season.id),
+            eq(seasonRegistrations.status, "approved"),
+            eq(seasonRegistrations.willingToBeCaptain, true),
+          ),
+        );
+      if (candidates.length < CAPTAIN_TEAM_COUNT) {
+        throw new AppError(
+          ErrorCode.CAPTAIN_NOT_ELIGIBLE,
+          `至少需要 ${CAPTAIN_TEAM_COUNT} 名已通过且愿意担任队长的候选人`,
+        );
+      }
+
+      const candidateIds = candidates.map((candidate) => candidate.registrationId);
+      const voteRows = await tx
+        .select({ candidateRegistrationId: captainVotes.candidateRegistrationId })
+        .from(captainVotes)
+        .where(inArray(captainVotes.candidateRegistrationId, candidateIds));
+      const voteCounts = new Map<string, number>();
+      for (const vote of voteRows) {
+        voteCounts.set(
+          vote.candidateRegistrationId,
+          (voteCounts.get(vote.candidateRegistrationId) ?? 0) + 1,
+        );
+      }
+
+      const seeds = selectCaptainSeeds(
+        candidates.map((candidate) => ({
+          ...candidate,
+          voteCount: voteCounts.get(candidate.registrationId) ?? 0,
+        })),
+      );
+
+      const createdTeamIds: string[] = [];
+      for (const [index, captain] of seeds.entries()) {
+        const captainName = captain.steamName ?? captain.email ?? `队长 ${index + 1}`;
+        const [team] = await tx
+          .insert(teams)
+          .values({
+            seasonId: season.id,
+            name: `${captainName} 队`,
+            captainRegistrationId: captain.registrationId,
+            draftOrder: index + 1,
+          })
+          .returning({ id: teams.id });
+        createdTeamIds.push(team.id);
+
+        await tx.insert(teamMembers).values({
+          teamId: team.id,
+          registrationId: captain.registrationId,
+          isStarter: true,
+        });
+      }
+
+      await tx
+        .update(seasons)
+        .set({ status: "drafting", updatedAt: new Date() })
+        .where(eq(seasons.id, season.id));
+
+      await tx.insert(auditLogs).values({
+        seasonId: season.id,
+        action: "captains.confirm",
+        actorId: admin.adminUsername,
+        targetId: season.id,
+        targetType: "season",
+        meta: {
+          captainRegistrationIds: seeds.map((seed) => seed.registrationId),
+          teamIds: createdTeamIds,
+        },
+      });
+
+      return { seasonSlug: season.slug, teamIds: createdTeamIds };
+    });
+
+    revalidatePath(`/${result.seasonSlug}/captains`);
+    revalidatePath(`/${result.seasonSlug}/teams`);
+    revalidatePath(`/${result.seasonSlug}/draft`);
+    revalidatePath(`/admin/${result.seasonSlug}/captains`);
+    revalidatePath(`/admin/${result.seasonSlug}/draft`);
+    return ok({ teamIds: result.teamIds });
+  } catch (e) {
+    return actionError("confirmCaptains", e);
+  }
+}
+
+async function revalidateCaptainPaths(registrationId: string) {
+  const registration = await db.query.seasonRegistrations.findFirst({
+    where: eq(seasonRegistrations.id, registrationId),
+    columns: { seasonId: true },
+  });
+  if (!registration) return;
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.id, registration.seasonId),
+    columns: { slug: true },
+  });
+  if (!season) return;
+
+  revalidatePath(`/${season.slug}/captains`);
+  revalidatePath(`/admin/${season.slug}/captains`);
+}
+
+function failValidation(message: string): ActionResult<never> {
+  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
+}
+
+function actionError(scope: string, e: unknown): ActionResult<never> {
+  if (e instanceof AppError) {
+    return fail({ code: e.code, message: e.message });
+  }
+  console.error(`[${scope}]`, e);
+  return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
 }

--- a/src/app/[seasonSlug]/captains/page.tsx
+++ b/src/app/[seasonSlug]/captains/page.tsx
@@ -1,14 +1,55 @@
-// TODO: captain candidates list with realtime vote counts
+import { notFound } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { CaptainVotingPanel } from "@/components/captains/CaptainVotingPanel";
+import { Card } from "@/components/ui/card";
+import { getCaptainVotingData } from "@/lib/captains/data";
+
+export const dynamic = "force-dynamic";
+
 interface CaptainsPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
 export default async function CaptainsPage({ params }: CaptainsPageProps) {
   const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  if (!season.hasCaptainVoting) {
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-10">
+        <Card className="p-8">
+          <h1 className="text-2xl font-bold">队长投票 · {season.name}</h1>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            该赛季未启用队长投票。
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  const data = await getCaptainVotingData(season.id);
+
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-3xl font-bold mb-8">队长投票 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">候选人列表加载中...</p>
-    </div>
+    <main className="container mx-auto max-w-6xl px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">队长投票 · {season.name}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          公开票数与当前前 8 会定时刷新；赛季进入 drafting 后本页保留最终结果。
+        </p>
+      </div>
+
+      <CaptainVotingPanel
+        seasonName={season.name}
+        seasonStatus={season.status}
+        voters={data.voters}
+        candidates={data.candidates}
+        votes={data.votes}
+      />
+    </main>
   );
 }

--- a/src/app/admin/[seasonSlug]/captains/page.tsx
+++ b/src/app/admin/[seasonSlug]/captains/page.tsx
@@ -1,14 +1,57 @@
-// TODO: admin captain confirmation — view vote results, confirm top-8, generate teams + draft_order
+import { notFound } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { CaptainConfirmPanel } from "@/components/captains/CaptainConfirmPanel";
+import { Card } from "@/components/ui/card";
+import { getCaptainVotingData, getSeasonTeamCount } from "@/lib/captains/data";
+
+export const dynamic = "force-dynamic";
+
 interface AdminCaptainsPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
 export default async function AdminCaptainsPage({ params }: AdminCaptainsPageProps) {
   const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  if (!season.hasCaptainVoting) {
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-8">
+        <Card className="p-8">
+          <h1 className="text-2xl font-bold">队长确认 · {season.name}</h1>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            该赛季未启用队长投票。
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  const [data, teamCount] = await Promise.all([
+    getCaptainVotingData(season.id),
+    getSeasonTeamCount(season.id),
+  ]);
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">队长确认 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">投票结果加载中...</p>
-    </div>
+    <main className="container mx-auto max-w-6xl px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">队长确认 · {season.name}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          查看票数排序，确认前 8 名后自动生成队伍与 draft order。
+        </p>
+      </div>
+
+      <CaptainConfirmPanel
+        seasonId={season.id}
+        seasonStatus={season.status}
+        teamCount={teamCount}
+        candidates={data.candidates}
+      />
+    </main>
   );
 }

--- a/src/components/captains/CaptainConfirmPanel.tsx
+++ b/src/components/captains/CaptainConfirmPanel.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useTransition } from "react";
+import { CheckCircle2, ShieldCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { confirmCaptains } from "@/actions/captains";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { CAPTAIN_TEAM_COUNT } from "@/lib/captains/rules";
+import { POSITION_LABELS } from "@/lib/validators/registration";
+import type { CaptainCandidateRow } from "@/lib/captains/data";
+
+interface CaptainConfirmPanelProps {
+  seasonId: string;
+  seasonStatus: string;
+  teamCount: number;
+  candidates: CaptainCandidateRow[];
+}
+
+export function CaptainConfirmPanel({
+  seasonId,
+  seasonStatus,
+  teamCount,
+  candidates,
+}: CaptainConfirmPanelProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const seeds = candidates.slice(0, CAPTAIN_TEAM_COUNT);
+  const canConfirm =
+    seasonStatus === "voting" &&
+    teamCount === 0 &&
+    seeds.length === CAPTAIN_TEAM_COUNT;
+
+  function handleConfirm() {
+    startTransition(async () => {
+      const result = await confirmCaptains({ seasonId });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success(`已生成 ${result.data.teamIds.length} 支队伍`);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-xl font-semibold">当前前 {CAPTAIN_TEAM_COUNT} 队长</h2>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+            排序规则：票数优先，其次历史最高 Rating，再按报名时间。
+          </p>
+        </div>
+
+        {seeds.length === 0 ? (
+          <Card className="p-8 text-center text-sm text-[var(--text-secondary)]">
+            暂无可确认的候选人
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {seeds.map((candidate, index) => (
+              <Card key={candidate.id} className="p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="default">#{index + 1}</Badge>
+                      <h3 className="font-semibold">{candidate.displayName}</h3>
+                    </div>
+                    <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                      {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRating} ·
+                      Current {candidate.currentRating}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-4 text-sm">
+                    <div className="text-right">
+                      <div className="text-lg font-semibold tabular">{candidate.voteCount}</div>
+                      <div className="text-xs text-[var(--text-secondary)]">票</div>
+                    </div>
+                    <ShieldCheck className="size-5 text-[var(--season-primary)]" />
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <aside className="space-y-4">
+        <Card className="p-4">
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-base font-semibold">确认操作</h2>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                确认后会生成队伍、写入队长成员，并将赛季推进到 drafting。
+              </p>
+            </div>
+
+            <div className="space-y-2 rounded-md border border-[var(--border)] p-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-[var(--text-secondary)]">赛季状态</span>
+                <span>{seasonStatus}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-[var(--text-secondary)]">候选人数</span>
+                <span>{candidates.length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-[var(--text-secondary)]">已生成队伍</span>
+                <span>{teamCount}</span>
+              </div>
+            </div>
+
+            <Button
+              type="button"
+              className="w-full"
+              disabled={!canConfirm || isPending}
+              onClick={handleConfirm}
+            >
+              <CheckCircle2 />
+              确认前 {CAPTAIN_TEAM_COUNT}
+            </Button>
+
+            {!canConfirm && (
+              <p className="text-xs text-[var(--text-secondary)]">
+                仅可在 voting 状态、尚未生成队伍且候选人不少于 {CAPTAIN_TEAM_COUNT} 人时确认。
+              </p>
+            )}
+          </div>
+        </Card>
+      </aside>
+    </div>
+  );
+}
+
+function positionLabel(key: string): string {
+  return POSITION_LABELS[key as keyof typeof POSITION_LABELS]?.cn ?? key;
+}

--- a/src/components/captains/CaptainVotingPanel.tsx
+++ b/src/components/captains/CaptainVotingPanel.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { RefreshCw, Undo2, Vote } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { castVote, retractVote } from "@/actions/captains";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { createBrowserClient } from "@/lib/auth/supabase";
+import { MAX_CAPTAIN_VOTES } from "@/lib/captains/rules";
+import { POSITION_LABELS } from "@/lib/validators/registration";
+import type {
+  CaptainCandidateRow,
+  CaptainVoteRecord,
+  CaptainVoterOption,
+} from "@/lib/captains/data";
+
+interface CaptainVotingPanelProps {
+  seasonName: string;
+  seasonStatus: string;
+  voters: CaptainVoterOption[];
+  candidates: CaptainCandidateRow[];
+  votes: CaptainVoteRecord[];
+}
+
+export function CaptainVotingPanel({
+  seasonName,
+  seasonStatus,
+  voters,
+  candidates,
+  votes,
+}: CaptainVotingPanelProps) {
+  const router = useRouter();
+  const [selectedVoterId, setSelectedVoterId] = useState<string>(voters[0]?.id ?? "");
+  const [isPending, startTransition] = useTransition();
+  const isVotingOpen = seasonStatus === "voting";
+
+  useEffect(() => {
+    if (!isVotingOpen) return;
+    const timer = window.setInterval(() => router.refresh(), 10_000);
+    return () => window.clearInterval(timer);
+  }, [isVotingOpen, router]);
+
+  const selectedVotes = useMemo(
+    () => votes.filter((vote) => vote.voterRegistrationId === selectedVoterId),
+    [selectedVoterId, votes],
+  );
+  const selectedCandidateIds = new Set(
+    selectedVotes.map((vote) => vote.candidateRegistrationId),
+  );
+  const maxVotes = Math.max(1, ...candidates.map((candidate) => candidate.voteCount));
+
+  useEffect(() => {
+    if (!isVotingOpen) return;
+    const supabase = createBrowserClient();
+    const channel = supabase
+      .channel("captain-votes")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "captain_votes" },
+        () => router.refresh(),
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [isVotingOpen, router]);
+
+  function handleCast(candidateId: string) {
+    if (!selectedVoterId) {
+      toast.error("请选择投票身份");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await castVote({
+        voterRegistrationId: selectedVoterId,
+        candidateRegistrationId: candidateId,
+      });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success("投票成功");
+      router.refresh();
+    });
+  }
+
+  function handleRetract(candidateId: string) {
+    startTransition(async () => {
+      const result = await retractVote({
+        voterRegistrationId: selectedVoterId,
+        candidateRegistrationId: candidateId,
+      });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success("已撤回投票");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
+      <aside className="space-y-4">
+        <Card className="p-4">
+          <div className="space-y-3">
+            <div>
+              <h2 className="text-base font-semibold">投票身份</h2>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                每名已通过报名的选手最多投 {MAX_CAPTAIN_VOTES} 票。
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="voter">选择选手</Label>
+              <Select value={selectedVoterId} onValueChange={setSelectedVoterId}>
+                <SelectTrigger id="voter">
+                  <SelectValue placeholder="选择报名身份" />
+                </SelectTrigger>
+                <SelectContent>
+                  {voters.map((voter) => (
+                    <SelectItem key={voter.id} value={voter.id}>
+                      {voter.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="rounded-md border border-[var(--border)] p-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-[var(--text-secondary)]">已投</span>
+                <span className="font-medium">
+                  {selectedVotes.length} / {MAX_CAPTAIN_VOTES}
+                </span>
+              </div>
+              <div className="mt-2 h-2 rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-[var(--season-primary)] transition-all"
+                  style={{ width: `${(selectedVotes.length / MAX_CAPTAIN_VOTES) * 100}%` }}
+                />
+              </div>
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => router.refresh()}
+            >
+              <RefreshCw />
+              刷新票数
+            </Button>
+          </div>
+        </Card>
+      </aside>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-semibold">{seasonName} 队长候选</h2>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              当前状态：{seasonStatus}
+            </p>
+          </div>
+          <Badge variant={isVotingOpen ? "default" : "secondary"}>
+            {isVotingOpen ? "投票开放" : "结果展示"}
+          </Badge>
+        </div>
+
+        {candidates.length === 0 ? (
+          <Card className="p-8 text-center text-sm text-[var(--text-secondary)]">
+            暂无符合条件的队长候选人
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {candidates.map((candidate, index) => {
+              const hasVoted = selectedCandidateIds.has(candidate.id);
+              const voteDisabled =
+                !isVotingOpen ||
+                isPending ||
+                !selectedVoterId ||
+                selectedVoterId === candidate.id ||
+                (!hasVoted && selectedVotes.length >= MAX_CAPTAIN_VOTES);
+
+              return (
+                <Card key={candidate.id} className="p-4">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={index < 8 ? "default" : "outline"}>
+                          #{index + 1}
+                        </Badge>
+                        <h3 className="font-semibold">{candidate.displayName}</h3>
+                        {index < 8 && (
+                          <Badge variant="secondary" className="text-xs">
+                            当前前 8
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                        {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRating} ·
+                        Current {candidate.currentRating}
+                      </p>
+                      <div className="mt-3 h-2 rounded-full bg-muted">
+                        <div
+                          className="h-2 rounded-full bg-[var(--season-primary)] transition-all"
+                          style={{ width: `${(candidate.voteCount / maxVotes) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-3 sm:shrink-0">
+                      <div className="w-14 text-right">
+                        <div className="text-lg font-semibold">{candidate.voteCount}</div>
+                        <div className="text-xs text-[var(--text-secondary)]">票</div>
+                      </div>
+                      {hasVoted ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={!isVotingOpen || isPending}
+                          onClick={() => handleRetract(candidate.id)}
+                        >
+                          <Undo2 />
+                          撤回
+                        </Button>
+                      ) : (
+                        <Button
+                          type="button"
+                          disabled={voteDisabled}
+                          onClick={() => handleCast(candidate.id)}
+                        >
+                          <Vote />
+                          投票
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function positionLabel(key: string): string {
+  return POSITION_LABELS[key as keyof typeof POSITION_LABELS]?.cn ?? key;
+}

--- a/src/components/captains/README.md
+++ b/src/components/captains/README.md
@@ -1,16 +1,14 @@
 # components/captains
 
-队长投票 UI 组件。
-
-## 规划组件
+Phase 6 队长投票 UI 组件。
 
 | 组件 | 说明 |
 |---|---|
-| `CaptainLeaderboard` | 实时票数排行榜（Realtime 订阅 captain_votes） |
-| `VoteButton` | 投票 / 撤票按钮（含 optimistic update） |
-| `MyVotes` | 当前用户已投票状态（最多 3 票提示） |
-| `CaptainConfirmPanel` | 管理员确认前 8 名面板（admin only） |
+| `CaptainVotingPanel` | 公共投票与结果页：候选人排序、投票 / 撤票、Realtime 订阅 `captain_votes`，并用 10 秒轮询兜底刷新 |
+| `CaptainConfirmPanel` | 管理员确认前 8 名面板：生成 `teams`、写入队长 `team_members`、推进赛季到 `drafting` |
 
-## 实装阶段
+## 当前约束
 
-Phase 6：队长投票
+- Phase 6 仍沿用现有报名记录身份输入，公共页面通过报名身份选择器调用 `castVote` / `retractVote`。
+- 后续接入完整用户 session 后，应从登录态推导 `voterRegistrationId`，移除公共选择器。
+- 排序规则与 Server Action 共用 `src/lib/captains/rules.ts`：票数降序、历史最高 Rating 降序、报名时间升序。

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -2,12 +2,14 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema";
 
-// Supabase direct connection requires SSL
-// Production: use Supabase Transaction Pooler URL for connection pooling
+const connectionString = process.env.DATABASE_URL;
+
+// Supabase direct connection requires SSL; local Docker/Postgres does not.
+// Production: use Supabase Transaction Pooler URL for connection pooling.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const pgConfig: any = {
-  connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
+  connectionString,
+  ssl: shouldUseSsl(connectionString) ? { rejectUnauthorized: false } : undefined,
   family: 4, // force IPv4 to avoid DNS resolution issues with Supabase
 };
 const pool = new Pool(pgConfig);
@@ -15,3 +17,11 @@ const pool = new Pool(pgConfig);
 export const db = drizzle(pool, { schema });
 
 export type DB = typeof db;
+
+function shouldUseSsl(databaseUrl?: string): boolean {
+  if (!databaseUrl) return false;
+
+  const url = new URL(databaseUrl);
+  if (url.searchParams.get("sslmode") === "disable") return false;
+  return !["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+}

--- a/src/lib/captains/data.ts
+++ b/src/lib/captains/data.ts
@@ -1,0 +1,113 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { db } from "@/db/client";
+import { captainVotes, seasonRegistrations, users, teams } from "@/db/schema";
+import { compareCaptainSeedCandidates, selectCaptainSeeds } from "@/lib/captains/rules";
+
+export interface CaptainVoterOption {
+  id: string;
+  displayName: string;
+  email: string;
+  primaryPosition: string;
+  peakRating: number;
+}
+
+export interface CaptainCandidateRow extends CaptainVoterOption {
+  registrationId: string;
+  voteCount: number;
+  currentRating: number;
+  createdAt: string;
+}
+
+export interface CaptainVoteRecord {
+  voterRegistrationId: string;
+  candidateRegistrationId: string;
+}
+
+export interface CaptainVotingData {
+  voters: CaptainVoterOption[];
+  candidates: CaptainCandidateRow[];
+  votes: CaptainVoteRecord[];
+}
+
+export async function getCaptainVotingData(seasonId: string): Promise<CaptainVotingData> {
+  const registrations = await db
+    .select({
+      id: seasonRegistrations.id,
+      primaryPosition: seasonRegistrations.primaryPosition,
+      peakRating: seasonRegistrations.peakRating,
+      currentRating: seasonRegistrations.currentRating,
+      willingToBeCaptain: seasonRegistrations.willingToBeCaptain,
+      createdAt: seasonRegistrations.createdAt,
+      email: users.email,
+      steamName: users.steamName,
+    })
+    .from(seasonRegistrations)
+    .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    )
+    .orderBy(asc(seasonRegistrations.createdAt));
+
+  const registrationIds = registrations.map((r) => r.id);
+  const voteRows =
+    registrationIds.length === 0
+      ? []
+      : await db
+          .select({
+            voterRegistrationId: captainVotes.voterRegistrationId,
+            candidateRegistrationId: captainVotes.candidateRegistrationId,
+          })
+          .from(captainVotes)
+          .where(inArray(captainVotes.candidateRegistrationId, registrationIds));
+
+  const voteCounts = new Map<string, number>();
+  for (const vote of voteRows) {
+    voteCounts.set(
+      vote.candidateRegistrationId,
+      (voteCounts.get(vote.candidateRegistrationId) ?? 0) + 1,
+    );
+  }
+
+  const voters: CaptainVoterOption[] = registrations.map((r) => ({
+    id: r.id,
+    displayName: r.steamName ?? r.email ?? "未命名选手",
+    email: r.email ?? "",
+    primaryPosition: r.primaryPosition,
+    peakRating: r.peakRating,
+  }));
+
+  const candidateRows: CaptainCandidateRow[] = registrations
+    .filter((r) => r.willingToBeCaptain)
+    .map((r) => ({
+      id: r.id,
+      registrationId: r.id,
+      displayName: r.steamName ?? r.email ?? "未命名选手",
+      email: r.email ?? "",
+      primaryPosition: r.primaryPosition,
+      peakRating: r.peakRating,
+      currentRating: r.currentRating,
+      createdAt: r.createdAt.toISOString(),
+      voteCount: voteCounts.get(r.id) ?? 0,
+    }));
+
+  const seedRows = selectCaptainSeeds(candidateRows);
+  const sortedCandidates = seedRows.concat(
+    candidateRows
+      .filter((candidate) => !seedRows.some((seed) => seed.registrationId === candidate.registrationId))
+      .sort(compareCaptainSeedCandidates),
+  );
+
+  return {
+    voters,
+    candidates: sortedCandidates,
+    votes: voteRows,
+  };
+}
+
+export async function getSeasonTeamCount(seasonId: string): Promise<number> {
+  const rows = await db.select({ id: teams.id }).from(teams).where(eq(teams.seasonId, seasonId));
+  return rows.length;
+}

--- a/src/lib/captains/rules.ts
+++ b/src/lib/captains/rules.ts
@@ -1,0 +1,85 @@
+import { ErrorCode, type ErrorCode as ErrorCodeValue } from "@/lib/errors";
+
+export const MAX_CAPTAIN_VOTES = 3;
+export const CAPTAIN_TEAM_COUNT = 8;
+
+export interface CaptainVoteSeason {
+  status: string;
+  hasCaptainVoting: boolean;
+}
+
+export interface CaptainVoteRegistration {
+  id: string;
+  seasonId: string;
+  status: string;
+  willingToBeCaptain: boolean;
+}
+
+export interface ValidateCaptainVoteInput {
+  season: CaptainVoteSeason;
+  voter: CaptainVoteRegistration;
+  candidate: CaptainVoteRegistration;
+  existingVoteCount: number;
+  alreadyVotedForCandidate: boolean;
+}
+
+export interface CaptainSeedCandidate {
+  registrationId: string;
+  voteCount: number;
+  peakRating: number;
+  createdAt: Date | string;
+}
+
+export function validateCaptainVote({
+  season,
+  voter,
+  candidate,
+  existingVoteCount,
+  alreadyVotedForCandidate,
+}: ValidateCaptainVoteInput): ErrorCodeValue | null {
+  if (!season.hasCaptainVoting || season.status !== "voting") {
+    return ErrorCode.VOTING_CLOSED;
+  }
+  if (voter.seasonId !== candidate.seasonId) {
+    return ErrorCode.CAPTAIN_NOT_ELIGIBLE;
+  }
+  if (voter.status !== "approved") {
+    return ErrorCode.UNAUTHORIZED;
+  }
+  if (candidate.status !== "approved" || !candidate.willingToBeCaptain) {
+    return ErrorCode.CAPTAIN_NOT_ELIGIBLE;
+  }
+  if (voter.id === candidate.id) {
+    return ErrorCode.VOTE_SELF;
+  }
+  if (existingVoteCount >= MAX_CAPTAIN_VOTES) {
+    return ErrorCode.VOTE_LIMIT_REACHED;
+  }
+  if (alreadyVotedForCandidate) {
+    return ErrorCode.VOTE_DUPLICATE;
+  }
+  return null;
+}
+
+export function selectCaptainSeeds<T extends CaptainSeedCandidate>(candidates: T[]): T[] {
+  return [...candidates]
+    .sort((a, b) => {
+      if (b.voteCount !== a.voteCount) return b.voteCount - a.voteCount;
+      if (b.peakRating !== a.peakRating) return b.peakRating - a.peakRating;
+      return createdAtTime(a.createdAt) - createdAtTime(b.createdAt);
+    })
+    .slice(0, CAPTAIN_TEAM_COUNT);
+}
+
+export function compareCaptainSeedCandidates(
+  a: CaptainSeedCandidate,
+  b: CaptainSeedCandidate,
+): number {
+  if (b.voteCount !== a.voteCount) return b.voteCount - a.voteCount;
+  if (b.peakRating !== a.peakRating) return b.peakRating - a.peakRating;
+  return createdAtTime(a.createdAt) - createdAtTime(b.createdAt);
+}
+
+function createdAtTime(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}

--- a/src/lib/validators/vote.ts
+++ b/src/lib/validators/vote.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-// TODO: 完善校验（每人最多 3 票的应用层限制在 Server Action 中附加校验）
-
 export const castVoteSchema = z.object({
   voterRegistrationId: z.string().uuid(),
   candidateRegistrationId: z.string().uuid(),
@@ -12,5 +10,10 @@ export const retractVoteSchema = z.object({
   candidateRegistrationId: z.string().uuid(),
 });
 
+export const confirmCaptainsSchema = z.object({
+  seasonId: z.string().uuid(),
+});
+
 export type CastVoteInput = z.infer<typeof castVoteSchema>;
 export type RetractVoteInput = z.infer<typeof retractVoteSchema>;
+export type ConfirmCaptainsInput = z.infer<typeof confirmCaptainsSchema>;

--- a/tests/unit/lib/captain-rules.test.ts
+++ b/tests/unit/lib/captain-rules.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+import {
+  MAX_CAPTAIN_VOTES,
+  selectCaptainSeeds,
+  validateCaptainVote,
+} from "@/lib/captains/rules";
+
+describe("captain voting rules", () => {
+  it("rejects voting outside the voting phase", () => {
+    expect(
+      validateCaptainVote({
+        season: { status: "registration", hasCaptainVoting: true },
+        voter: approvedRegistration("voter"),
+        candidate: captainCandidate("candidate"),
+        existingVoteCount: 0,
+        alreadyVotedForCandidate: false,
+      }),
+    ).toBe(ErrorCode.VOTING_CLOSED);
+  });
+
+  it("rejects self votes, duplicate votes, ineligible candidates, and over-limit votes", () => {
+    const voter = approvedRegistration("same");
+    const candidate = captainCandidate("same");
+
+    expect(
+      validateCaptainVote({
+        season: { status: "voting", hasCaptainVoting: true },
+        voter,
+        candidate,
+        existingVoteCount: 0,
+        alreadyVotedForCandidate: false,
+      }),
+    ).toBe(ErrorCode.VOTE_SELF);
+
+    expect(
+      validateCaptainVote({
+        season: { status: "voting", hasCaptainVoting: true },
+        voter: approvedRegistration("voter"),
+        candidate: { ...captainCandidate("candidate"), willingToBeCaptain: false },
+        existingVoteCount: 0,
+        alreadyVotedForCandidate: false,
+      }),
+    ).toBe(ErrorCode.CAPTAIN_NOT_ELIGIBLE);
+
+    expect(
+      validateCaptainVote({
+        season: { status: "voting", hasCaptainVoting: true },
+        voter: approvedRegistration("voter"),
+        candidate: captainCandidate("candidate"),
+        existingVoteCount: MAX_CAPTAIN_VOTES,
+        alreadyVotedForCandidate: false,
+      }),
+    ).toBe(ErrorCode.VOTE_LIMIT_REACHED);
+
+    expect(
+      validateCaptainVote({
+        season: { status: "voting", hasCaptainVoting: true },
+        voter: approvedRegistration("voter"),
+        candidate: captainCandidate("candidate"),
+        existingVoteCount: 1,
+        alreadyVotedForCandidate: true,
+      }),
+    ).toBe(ErrorCode.VOTE_DUPLICATE);
+  });
+
+  it("allows a valid vote", () => {
+    expect(
+      validateCaptainVote({
+        season: { status: "voting", hasCaptainVoting: true },
+        voter: approvedRegistration("voter"),
+        candidate: captainCandidate("candidate"),
+        existingVoteCount: 2,
+        alreadyVotedForCandidate: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("selects eight captain seeds by votes, then rating, then registration time", () => {
+    const seeds = selectCaptainSeeds([
+      seed("low", 2, 2600, "2026-01-01"),
+      seed("high", 4, 2200, "2026-01-02"),
+      seed("rating-tie-break", 4, 2800, "2026-01-03"),
+      seed("early-tie-break", 4, 2800, "2026-01-01"),
+      seed("fifth", 1, 3000, "2026-01-01"),
+      seed("sixth", 1, 2500, "2026-01-01"),
+      seed("seventh", 0, 2900, "2026-01-01"),
+      seed("eighth", 0, 2400, "2026-01-01"),
+      seed("ninth", 0, 1200, "2026-01-01"),
+    ]);
+
+    expect(seeds.map((s) => s.registrationId)).toEqual([
+      "early-tie-break",
+      "rating-tie-break",
+      "high",
+      "low",
+      "fifth",
+      "sixth",
+      "seventh",
+      "eighth",
+    ]);
+  });
+});
+
+function approvedRegistration(id: string) {
+  return {
+    id,
+    seasonId: "season-a",
+    status: "approved",
+    willingToBeCaptain: false,
+  } as const;
+}
+
+function captainCandidate(id: string) {
+  return {
+    id,
+    seasonId: "season-a",
+    status: "approved",
+    willingToBeCaptain: true,
+  } as const;
+}
+
+function seed(
+  registrationId: string,
+  voteCount: number,
+  peakRating: number,
+  createdAt: string,
+) {
+  return {
+    registrationId,
+    voteCount,
+    peakRating,
+    createdAt: new Date(createdAt),
+  };
+}


### PR DESCRIPTION
## Summary
- Implement Phase 6 captain voting actions with validation, vote limits, retract support, admin captain confirmation, team generation, and audit logs.
- Add public captain voting/results UI and admin captain confirmation UI backed by real season data.
- Sync Phase 6 docs/status and fix local Postgres SSL handling plus Next typedRoutes config.

## Why
Phase 6 needed to replace placeholders with the voting workflow required by PHASES.md: players can vote for captain candidates, admins can confirm the top 8, and the system can advance into draft setup. The local DB client also needed to support non-SSL localhost Postgres while preserving SSL for Supabase.

## Test Plan
- pnpm tsc --noEmit
- pnpm test
- pnpm type-check
- pnpm build
- Local smoke: http://localhost:3000/2026-nju-rivals/captains returned 200 after pnpm db:push and pnpm seed against local Postgres.