### PR TITLE
feat(phase7): implement draft spectator view and admin controls

### DIFF
--- a/src/actions/draft.ts
+++ b/src/actions/draft.ts
@@ -1,17 +1,234 @@
 "use server";
 
-// TODO: captain picks a player — Postgres transaction + SELECT FOR UPDATE + idempotency key
-// client_request_id provides idempotency against double-submit
-export async function pickPlayer(
-  _teamId: string,
-  _registrationId: string,
-  _clientRequestId: string
-): Promise<void> {
-  throw new Error("not implemented");
+import { revalidatePath } from "next/cache";
+import { eq, asc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons, teams, draftState, draftPicks, auditLogs } from "@/db/schema";
+import { ok, fail, type ActionResult } from "@/types/action";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { requireAdmin } from "@/lib/auth/session";
+import {
+  startDraftSchema,
+  pauseDraftSchema,
+  resumeDraftSchema,
+  type StartDraftInput,
+  type PauseDraftInput,
+  type ResumeDraftInput,
+} from "@/lib/validators/draft";
+import { DRAFT_ROUND_TIMEOUT_SECONDS } from "@/types/draft";
+import { getSnakeOrder } from "@/lib/draft/rules";
+
+// ── 启动选秀 ───────────────────────────────────────────
+
+export async function startDraft(
+  input: StartDraftInput,
+): Promise<ActionResult<{ draftStateId: string }>> {
+  const admin = await requireAdmin();
+
+  const parsed = startDraftSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("启动选秀参数无效");
+  }
+
+  const { seasonId } = parsed.data;
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+      }
+      if (!season.hasDraft) {
+        throw new AppError(
+          ErrorCode.SEASON_CAPABILITY_DISABLED,
+          ERROR_MESSAGES.SEASON_CAPABILITY_DISABLED,
+        );
+      }
+      if (season.status !== "drafting") {
+        throw new AppError(
+          ErrorCode.SEASON_INVALID_STATUS,
+          "只有 drafting 状态的赛季可以启动选秀",
+        );
+      }
+
+      const existing = await tx.query.draftState.findFirst({
+        where: eq(draftState.seasonId, seasonId),
+      });
+      if (existing) {
+        throw new AppError(
+          ErrorCode.SEASON_INVALID_STATUS,
+          "选秀已启动",
+        );
+      }
+
+      const seasonTeams = await tx
+        .select({ id: teams.id, draftOrder: teams.draftOrder })
+        .from(teams)
+        .where(eq(teams.seasonId, seasonId))
+        .orderBy(asc(teams.draftOrder));
+
+      if (seasonTeams.length === 0) {
+        throw new AppError(
+          ErrorCode.VALIDATION_FAILED,
+          "该赛季没有队伍，请先确认队长生成队伍",
+        );
+      }
+
+      const order = getSnakeOrder(seasonTeams, 1);
+      const firstTeamId = order[0].id;
+      const deadline = new Date(Date.now() + DRAFT_ROUND_TIMEOUT_SECONDS * 1000);
+
+      const [draft] = await tx
+        .insert(draftState)
+        .values({
+          seasonId,
+          currentRound: 1,
+          currentTeamId: firstTeamId,
+          roundDeadline: deadline,
+          isActive: true,
+        })
+        .returning({ id: draftState.id });
+
+      await tx.insert(auditLogs).values({
+        seasonId,
+        action: "draft.start",
+        actorId: admin.adminUsername,
+        targetId: seasonId,
+        targetType: "season",
+        meta: { firstTeamId, roundDeadline: deadline.toISOString() },
+      });
+
+      return { draftStateId: draft.id, slug: season.slug };
+    });
+
+    revalidatePath(`/${result.slug}/draft`);
+    revalidatePath(`/admin/${result.slug}/draft`);
+    return ok({ draftStateId: result.draftStateId });
+  } catch (e) {
+    return actionError("startDraft", e);
+  }
 }
 
-// TODO: admin triggers auto-pick (by peak_rating desc) when timer expires
-// Also called by Vercel Cron route
-export async function autoPick(_seasonId: string): Promise<void> {
-  throw new Error("not implemented");
+// ── 暂停选秀 ───────────────────────────────────────────
+
+export async function pauseDraft(
+  input: PauseDraftInput,
+): Promise<ActionResult<{ paused: boolean }>> {
+  const admin = await requireAdmin();
+
+  const parsed = pauseDraftSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("暂停选秀参数无效");
+  }
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const ds = await tx.query.draftState.findFirst({
+        where: eq(draftState.seasonId, parsed.data.seasonId),
+      });
+      if (!ds) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
+      }
+      if (!ds.isActive) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, "选秀未在进行中");
+      }
+
+      await tx
+        .update(draftState)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(eq(draftState.id, ds.id));
+
+      await tx.insert(auditLogs).values({
+        seasonId: parsed.data.seasonId,
+        action: "draft.pause",
+        actorId: admin.adminUsername,
+        targetId: ds.id,
+        targetType: "draft_state",
+      });
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, parsed.data.seasonId),
+      });
+      return { slug: season?.slug ?? "" };
+    });
+
+    revalidatePath(`/${result.slug}/draft`);
+    revalidatePath(`/admin/${result.slug}/draft`);
+    return ok({ paused: true });
+  } catch (e) {
+    return actionError("pauseDraft", e);
+  }
+}
+
+// ── 恢复选秀 ───────────────────────────────────────────
+
+export async function resumeDraft(
+  input: ResumeDraftInput,
+): Promise<ActionResult<{ resumed: boolean }>> {
+  const admin = await requireAdmin();
+
+  const parsed = resumeDraftSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("恢复选秀参数无效");
+  }
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const ds = await tx.query.draftState.findFirst({
+        where: eq(draftState.seasonId, parsed.data.seasonId),
+      });
+      if (!ds) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
+      }
+      if (ds.isActive) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, "选秀已在进行中");
+      }
+      if (!ds.currentTeamId) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, "选秀状态异常");
+      }
+
+      const deadline = new Date(Date.now() + DRAFT_ROUND_TIMEOUT_SECONDS * 1000);
+
+      await tx
+        .update(draftState)
+        .set({ isActive: true, roundDeadline: deadline, updatedAt: new Date() })
+        .where(eq(draftState.id, ds.id));
+
+      await tx.insert(auditLogs).values({
+        seasonId: parsed.data.seasonId,
+        action: "draft.resume",
+        actorId: admin.adminUsername,
+        targetId: ds.id,
+        targetType: "draft_state",
+        meta: { roundDeadline: deadline.toISOString() },
+      });
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, parsed.data.seasonId),
+      });
+      return { slug: season?.slug ?? "" };
+    });
+
+    revalidatePath(`/${result.slug}/draft`);
+    revalidatePath(`/admin/${result.slug}/draft`);
+    return ok({ resumed: true });
+  } catch (e) {
+    return actionError("resumeDraft", e);
+  }
+}
+
+// ── 工具函数 ───────────────────────────────────────────
+
+function failValidation(message: string): ActionResult<never> {
+  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
+}
+
+function actionError(scope: string, e: unknown): ActionResult<never> {
+  if (e instanceof AppError) {
+    return fail({ code: e.code, message: e.message });
+  }
+  console.error(`[${scope}]`, e);
+  return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
 }

--- a/src/actions/draft.ts
+++ b/src/actions/draft.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { eq, asc } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, draftState, draftPicks, auditLogs } from "@/db/schema";
+import { seasons, teams, draftState, auditLogs } from "@/db/schema";
 import { ok, fail, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { requireAdmin } from "@/lib/auth/session";
@@ -15,7 +15,7 @@ import {
   type PauseDraftInput,
   type ResumeDraftInput,
 } from "@/lib/validators/draft";
-import { DRAFT_ROUND_TIMEOUT_SECONDS } from "@/types/draft";
+import { DRAFT_ROUND_TIMEOUT_SECONDS, DRAFT_TEAMS } from "@/types/draft";
 import { getSnakeOrder } from "@/lib/draft/rules";
 
 // ── 启动选秀 ───────────────────────────────────────────
@@ -73,6 +73,18 @@ export async function startDraft(
         throw new AppError(
           ErrorCode.VALIDATION_FAILED,
           "该赛季没有队伍，请先确认队长生成队伍",
+        );
+      }
+      if (seasonTeams.length !== DRAFT_TEAMS) {
+        throw new AppError(
+          ErrorCode.VALIDATION_FAILED,
+          `选秀需要 ${DRAFT_TEAMS} 支队伍，当前为 ${seasonTeams.length} 支`,
+        );
+      }
+      if (!hasSequentialDraftOrder(seasonTeams)) {
+        throw new AppError(
+          ErrorCode.VALIDATION_FAILED,
+          `队伍 draft order 必须为 1-${DRAFT_TEAMS} 且不能重复`,
         );
       }
 
@@ -223,6 +235,15 @@ export async function resumeDraft(
 
 function failValidation(message: string): ActionResult<never> {
   return fail({ code: ErrorCode.VALIDATION_FAILED, message });
+}
+
+function hasSequentialDraftOrder(teamRows: { draftOrder: number }[]): boolean {
+  const orders = new Set(teamRows.map((team) => team.draftOrder));
+  if (orders.size !== DRAFT_TEAMS) return false;
+  for (let order = 1; order <= DRAFT_TEAMS; order++) {
+    if (!orders.has(order)) return false;
+  }
+  return true;
 }
 
 function actionError(scope: string, e: unknown): ActionResult<never> {

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -80,7 +80,12 @@ export default async function DraftPage({ params }: DraftPageProps) {
           </p>
         </Card>
       ) : (
-        <DraftLiveRoom data={data} seasonSlug={seasonSlug} />
+        <DraftLiveRoom
+          data={data}
+          seasonId={season.id}
+          seasonSlug={seasonSlug}
+          seasonPositions={season.positions}
+        />
       )}
     </main>
   );

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -1,14 +1,87 @@
-// TODO: draft spectator view — 8-team grid, countdown timer, remaining player pool, realtime
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { DraftLiveRoom } from "@/components/draft/DraftLiveRoom";
+import { Card } from "@/components/ui/card";
+import { getDraftData } from "@/lib/draft/data";
+
+export const dynamic = "force-dynamic";
+
 interface DraftPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
+export async function generateMetadata({ params }: DraftPageProps): Promise<Metadata> {
+  const { seasonSlug } = await params;
+  return { title: `选秀直播间 · ${seasonSlug}` };
+}
+
 export default async function DraftPage({ params }: DraftPageProps) {
   const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  if (!season.hasDraft) {
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-10">
+        <Card className="p-8">
+          <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            该赛季未启用蛇形选秀。
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  if (season.status !== "drafting") {
+    const messages: Record<string, string> = {
+      draft: "选秀尚未开放，赛季仍在筹备中。",
+      registration: "报名阶段结束后才会开始选秀，请耐心等待。",
+      voting: "队长投票进行中，投票结束后将进入选秀阶段。",
+      playing: "选秀已结束，赛季正在进行中。",
+      finished: "该赛季已结束。",
+      archived: "该赛季已归档。",
+    };
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-10">
+        <Card className="p-8">
+          <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
+            {messages[season.status] ?? "选秀当前不可用。"}
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  const data = await getDraftData(season.id);
+
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-3xl font-bold mb-8">选秀直播间 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">选秀状态加载中...</p>
-    </div>
+    <main className="container mx-auto max-w-7xl px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">选秀直播间 · {season.name}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          实时更新选秀进度，队伍阵容与选手池自动刷新。
+        </p>
+      </div>
+
+      {!data.state ? (
+        <Card className="p-8 text-center">
+          <h2 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
+            选秀尚未启动
+          </h2>
+          <p className="text-sm text-[var(--text-secondary)]">
+            等待管理员启动选秀，页面会自动刷新。
+          </p>
+        </Card>
+      ) : (
+        <DraftLiveRoom data={data} seasonSlug={seasonSlug} />
+      )}
+    </main>
   );
 }

--- a/src/app/admin/[seasonSlug]/draft/page.tsx
+++ b/src/app/admin/[seasonSlug]/draft/page.tsx
@@ -1,14 +1,53 @@
-// TODO: admin draft control — start draft, advance round, override pick, reset
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { eq, count } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons, teams } from "@/db/schema";
+import { DraftAdminPanel } from "@/components/draft/DraftAdminPanel";
+import { getDraftData } from "@/lib/draft/data";
+
+export const dynamic = "force-dynamic";
+
 interface AdminDraftPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
+export async function generateMetadata({ params }: AdminDraftPageProps): Promise<Metadata> {
+  const { seasonSlug } = await params;
+  return { title: `选秀管理 · ${seasonSlug}` };
+}
+
 export default async function AdminDraftPage({ params }: AdminDraftPageProps) {
   const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const [teamCountRow] = await db
+    .select({ count: count() })
+    .from(teams)
+    .where(eq(teams.seasonId, season.id));
+  const teamCount = Number(teamCountRow?.count ?? 0);
+
+  const data = season.hasDraft ? await getDraftData(season.id) : null;
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">选秀管理 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">选秀状态加载中...</p>
-    </div>
+    <main className="container mx-auto max-w-6xl px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">选秀管理 · {season.name}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          启动、暂停、恢复选秀流程。选秀开始后选手可围观实时进度。
+        </p>
+      </div>
+
+      <DraftAdminPanel
+        seasonId={season.id}
+        seasonName={season.name}
+        seasonStatus={season.status}
+        teamCount={teamCount}
+        data={data}
+      />
+    </main>
   );
 }

--- a/src/components/draft/DraftAdminPanel.tsx
+++ b/src/components/draft/DraftAdminPanel.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Play, Pause, RotateCcw } from "lucide-react";
+import { startDraft, pauseDraft, resumeDraft } from "@/actions/draft";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { DRAFT_TOTAL_ROUNDS } from "@/types/draft";
+import type { DraftFullData } from "@/lib/draft/data";
+
+interface DraftAdminPanelProps {
+  seasonId: string;
+  seasonName: string;
+  seasonStatus: string;
+  teamCount: number;
+  data: DraftFullData | null;
+}
+
+export function DraftAdminPanel({
+  seasonId,
+  seasonName,
+  seasonStatus,
+  teamCount,
+  data,
+}: DraftAdminPanelProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const state = data?.state ?? null;
+  const isLive = state?.isActive ?? false;
+  const isDrafting = seasonStatus === "drafting";
+  const canStart =
+    isDrafting && !state && teamCount > 0;
+  const canPause = isLive;
+  const canResume = isDrafting && state && !isLive;
+
+  function handleStart() {
+    startTransition(async () => {
+      const result = await startDraft({ seasonId });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success("选秀已启动");
+      router.refresh();
+    });
+  }
+
+  function handlePause() {
+    startTransition(async () => {
+      const result = await pauseDraft({ seasonId });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success("选秀已暂停");
+      router.refresh();
+    });
+  }
+
+  function handleResume() {
+    startTransition(async () => {
+      const result = await resumeDraft({ seasonId });
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+      toast.success("选秀已恢复");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 状态卡片 */}
+      <Card className="p-6">
+        <h2 className="text-lg font-semibold mb-4">{seasonName} · 选秀控制</h2>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6 text-sm">
+          <div>
+            <span className="text-[var(--text-muted)]">赛季状态</span>
+            <p className="font-medium text-[var(--text-primary)]">{seasonStatus}</p>
+          </div>
+          <div>
+            <span className="text-[var(--text-muted)]">队伍数</span>
+            <p className="font-medium text-[var(--text-primary)]">{teamCount}</p>
+          </div>
+          <div>
+            <span className="text-[var(--text-muted)]">选秀状态</span>
+            <p className="font-medium text-[var(--text-primary)]">
+              {state ? (isLive ? "进行中" : "已暂停") : "未启动"}
+            </p>
+          </div>
+          <div>
+            <span className="text-[var(--text-muted)]">进度</span>
+            <p className="font-medium text-[var(--text-primary)] tabular">
+              {state
+                ? `第 ${state.currentRound} / ${DRAFT_TOTAL_ROUNDS} 轮`
+                : "-"}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {canStart && (
+            <Button
+              onClick={handleStart}
+              disabled={isPending}
+              style={{
+                backgroundColor: "var(--season-primary)",
+                color: "#fff",
+              }}
+            >
+              <Play size={16} className="mr-1.5" />
+              启动选秀
+            </Button>
+          )}
+          {canPause && (
+            <Button
+              variant="outline"
+              onClick={handlePause}
+              disabled={isPending}
+            >
+              <Pause size={16} className="mr-1.5" />
+              暂停
+            </Button>
+          )}
+          {canResume && (
+            <Button
+              onClick={handleResume}
+              disabled={isPending}
+              style={{
+                backgroundColor: "var(--season-primary)",
+                color: "#fff",
+              }}
+            >
+              <RotateCcw size={16} className="mr-1.5" />
+              恢复选秀
+            </Button>
+          )}
+          {!isDrafting && (
+            <p className="text-sm text-[var(--text-muted)]">
+              赛季状态需为 "drafting" 才能操作选秀。请先在队长确认页面确认队长生成队伍。
+            </p>
+          )}
+          {isDrafting && teamCount === 0 && (
+            <p className="text-sm text-[var(--text-muted)]">
+              尚未生成队伍。请先在队长确认页面确认队长。
+            </p>
+          )}
+        </div>
+      </Card>
+
+      {/* 当前详情 */}
+      {state && data && (
+        <Card className="p-6">
+          <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
+            当前详情
+          </h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div>
+              <span className="text-[var(--text-muted)]">当前轮次：</span>
+              <span className="text-[var(--text-primary)] tabular ml-1">
+                第 {state.currentRound} 轮
+              </span>
+            </div>
+            <div>
+              <span className="text-[var(--text-muted)]">当前队伍：</span>
+              <span className="text-[var(--text-primary)] ml-1">
+                {data.teams.find((t) => t.teamId === state.currentTeamId)?.teamName ??
+                  "无"}
+              </span>
+            </div>
+            <div>
+              <span className="text-[var(--text-muted)]">已完成 picks：</span>
+              <span className="text-[var(--text-primary)] tabular ml-1">
+                {data.totalPicks} / {data.maxPicks}
+              </span>
+            </div>
+            <div>
+              <span className="text-[var(--text-muted)]">剩余可选：</span>
+              <span className="text-[var(--text-primary)] tabular ml-1">
+                {data.remainingPlayers.length} 人
+              </span>
+            </div>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/draft/DraftCountdown.tsx
+++ b/src/components/draft/DraftCountdown.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { getCountdownSeconds, isDeadlinePassed } from "@/lib/utils/date";
 
 interface DraftCountdownProps {
   deadline: string | null; // ISO string
@@ -26,7 +25,7 @@ export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
   }
 
   if (!isActive) {
-    const remaining = getCountdownSeconds(new Date(deadline));
+    const remaining = getCountdownSeconds(deadline, now);
     return (
       <span className="text-sm text-[var(--text-muted)] tabular">
         {formatTime(remaining)}
@@ -34,7 +33,7 @@ export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
     );
   }
 
-  if (isDeadlinePassed(deadline)) {
+  if (isDeadlinePassed(deadline, now)) {
     return (
       <span className="text-sm text-red-400 font-medium tabular">
         已超时
@@ -42,7 +41,7 @@ export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
     );
   }
 
-  const remaining = getCountdownSeconds(deadline);
+  const remaining = getCountdownSeconds(deadline, now);
   const urgent = remaining < 30;
 
   return (
@@ -54,6 +53,14 @@ export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
       {formatTime(remaining)}
     </span>
   );
+}
+
+function getCountdownSeconds(deadline: string, now: number): number {
+  return Math.max(0, Math.floor((new Date(deadline).getTime() - now) / 1000));
+}
+
+function isDeadlinePassed(deadline: string, now: number): boolean {
+  return new Date(deadline).getTime() <= now;
 }
 
 function formatTime(seconds: number): string {

--- a/src/components/draft/DraftCountdown.tsx
+++ b/src/components/draft/DraftCountdown.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getCountdownSeconds, isDeadlinePassed } from "@/lib/utils/date";
+
+interface DraftCountdownProps {
+  deadline: string | null; // ISO string
+  isActive: boolean;
+}
+
+export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (!deadline || !isActive) return;
+    const timer = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(timer);
+  }, [deadline, isActive]);
+
+  if (!deadline) {
+    return (
+      <span className="text-sm text-[var(--text-muted)] tabular">
+        --:--
+      </span>
+    );
+  }
+
+  if (!isActive) {
+    const remaining = getCountdownSeconds(new Date(deadline));
+    return (
+      <span className="text-sm text-[var(--text-muted)] tabular">
+        {formatTime(remaining)}
+      </span>
+    );
+  }
+
+  if (isDeadlinePassed(deadline)) {
+    return (
+      <span className="text-sm text-red-400 font-medium tabular">
+        已超时
+      </span>
+    );
+  }
+
+  const remaining = getCountdownSeconds(deadline);
+  const urgent = remaining < 30;
+
+  return (
+    <span
+      className={`tabular text-sm font-medium ${
+        urgent ? "text-red-400 animate-pulse" : "text-[var(--text-primary)]"
+      }`}
+    >
+      {formatTime(remaining)}
+    </span>
+  );
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { DRAFT_TOTAL_ROUNDS } from "@/types/draft";
+import { createBrowserClient } from "@/lib/auth/supabase";
+import { DraftCountdown } from "./DraftCountdown";
+import { TeamDraftGrid } from "./TeamDraftGrid";
+import { PlayerPool } from "./PlayerPool";
+import type { DraftFullData } from "@/lib/draft/data";
+
+interface DraftLiveRoomProps {
+  data: DraftFullData;
+  seasonSlug: string;
+}
+
+export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomProps) {
+  const router = useRouter();
+  const { state, teams, snakeOrder, remainingPlayers, completedPicks, totalPicks, maxPicks } =
+    data;
+
+  const isLive = state?.isActive ?? false;
+
+  // 轮询兜底（10 秒刷新）
+  useEffect(() => {
+    const timer = window.setInterval(() => router.refresh(), 10_000);
+    return () => window.clearInterval(timer);
+  }, [router]);
+
+  // Realtime 订阅
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    const channel = supabase
+      .channel("draft-live")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "draft_state" },
+        () => router.refresh(),
+      )
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "draft_picks" },
+        () => router.refresh(),
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [router]);
+
+  // 确定当前选秀队
+  const pickingTeamId = isLive ? state?.currentTeamId ?? null : null;
+  const pickingTeam = teams.find((t) => t.teamId === pickingTeamId);
+
+  return (
+    <div className="space-y-6">
+      {/* 顶部状态栏 */}
+      <div className="flex flex-wrap items-center justify-between gap-3 p-4 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)]">
+        <div className="flex items-center gap-4 flex-wrap">
+          <div className="text-sm">
+            <span className="text-[var(--text-secondary)]">进度 </span>
+            <span className="text-[var(--text-primary)] font-semibold tabular">
+              {totalPicks} / {maxPicks}
+            </span>
+          </div>
+          {state && (
+            <div className="text-sm">
+              <span className="text-[var(--text-secondary)]">第 </span>
+              <span className="text-[var(--text-primary)] font-semibold tabular">
+                {state.currentRound}
+              </span>
+              <span className="text-[var(--text-secondary)]"> / {DRAFT_TOTAL_ROUNDS} 轮</span>
+            </div>
+          )}
+          {pickingTeam && isLive && (
+            <div className="text-sm">
+              <span className="text-[var(--text-secondary)]">当前 </span>
+              <span className="text-[var(--season-primary)] font-semibold">
+                {pickingTeam.teamName}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-[var(--text-muted)]">
+            {isLive ? "倒计时" : "已暂停"}
+          </span>
+          <DraftCountdown
+            deadline={state?.roundDeadline ?? null}
+            isActive={isLive}
+          />
+        </div>
+      </div>
+
+      {/* 队伍网格 */}
+      <section>
+        <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
+          队伍阵容
+        </h2>
+        <TeamDraftGrid
+          teams={teams}
+          currentTeamId={pickingTeamId}
+          totalRounds={DRAFT_TOTAL_ROUNDS}
+          currentRound={state?.currentRound ?? 1}
+        />
+      </section>
+
+      {/* 蛇形顺序指示 */}
+      {isLive && snakeOrder.length > 0 && (
+        <div className="flex items-center gap-1.5 text-xs text-[var(--text-muted)] overflow-x-auto">
+          <span>蛇形顺序：</span>
+          {snakeOrder.map((tid, i) => {
+            const t = teams.find((tt) => tt.teamId === tid);
+            const isNow = tid === pickingTeamId;
+            return (
+              <span
+                key={tid}
+                className={`px-1.5 py-0.5 rounded tabular ${
+                  isNow
+                    ? "bg-[var(--season-primary)] text-white font-medium"
+                    : "text-[var(--text-secondary)]"
+                }`}
+              >
+                {t?.teamName ?? tid.slice(0, 6)}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 已完成 pick 历史 */}
+      {completedPicks.length > 0 && (
+        <section>
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
+            选秀记录
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-1 text-xs">
+            {completedPicks.map((pick) => {
+              const team = teams.find((t) => t.teamId === pick.teamId);
+              return (
+                <div
+                  key={`${pick.registrationId}-${pick.pickNumber}`}
+                  className="px-2 py-1 rounded bg-[var(--bg-elevated)] border border-[var(--border)] truncate"
+                  title={`R${pick.round}P${pick.pickNumber} ${team?.teamName}: ${pick.steamName}${pick.autoPicked ? " (自动)" : ""}`}
+                >
+                  <span className="text-[var(--text-muted)] tabular">
+                    R{pick.round}P{pick.pickNumber}{" "}
+                  </span>
+                  <span className="text-[var(--text-primary)]">
+                    {pick.steamName}
+                  </span>
+                  {pick.autoPicked && (
+                    <span className="text-amber-400 ml-0.5">⚡</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* 选手池 */}
+      <section>
+        <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
+          剩余选手池 ({remainingPlayers.length})
+        </h2>
+        <PlayerPool players={remainingPlayers} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -11,10 +11,17 @@ import type { DraftFullData } from "@/lib/draft/data";
 
 interface DraftLiveRoomProps {
   data: DraftFullData;
+  seasonId: string;
   seasonSlug: string;
+  seasonPositions: string[];
 }
 
-export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomProps) {
+export function DraftLiveRoom({
+  data,
+  seasonId,
+  seasonSlug: _seasonSlug,
+  seasonPositions,
+}: DraftLiveRoomProps) {
   const router = useRouter();
   const { state, teams, snakeOrder, remainingPlayers, completedPicks, totalPicks, maxPicks } =
     data;
@@ -31,15 +38,25 @@ export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomPr
   useEffect(() => {
     const supabase = createBrowserClient();
     const channel = supabase
-      .channel("draft-live")
+      .channel(`draft-live:${seasonId}`)
       .on(
         "postgres_changes",
-        { event: "*", schema: "public", table: "draft_state" },
+        {
+          event: "*",
+          schema: "public",
+          table: "draft_state",
+          filter: `season_id=eq.${seasonId}`,
+        },
         () => router.refresh(),
       )
       .on(
         "postgres_changes",
-        { event: "INSERT", schema: "public", table: "draft_picks" },
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "draft_picks",
+          filter: `season_id=eq.${seasonId}`,
+        },
         () => router.refresh(),
       )
       .subscribe();
@@ -47,7 +64,7 @@ export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomPr
     return () => {
       void supabase.removeChannel(channel);
     };
-  }, [router]);
+  }, [router, seasonId]);
 
   // 确定当前选秀队
   const pickingTeamId = isLive ? state?.currentTeamId ?? null : null;
@@ -111,7 +128,7 @@ export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomPr
       {isLive && snakeOrder.length > 0 && (
         <div className="flex items-center gap-1.5 text-xs text-[var(--text-muted)] overflow-x-auto">
           <span>蛇形顺序：</span>
-          {snakeOrder.map((tid, i) => {
+          {snakeOrder.map((tid) => {
             const t = teams.find((tt) => tt.teamId === tid);
             const isNow = tid === pickingTeamId;
             return (
@@ -166,7 +183,7 @@ export function DraftLiveRoom({ data, seasonSlug: _seasonSlug }: DraftLiveRoomPr
         <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 uppercase tracking-wider">
           剩余选手池 ({remainingPlayers.length})
         </h2>
-        <PlayerPool players={remainingPlayers} />
+        <PlayerPool players={remainingPlayers} seasonPositions={seasonPositions} />
       </section>
     </div>
   );

--- a/src/components/draft/PlayerPool.tsx
+++ b/src/components/draft/PlayerPool.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { DraftPlayerRow } from "@/lib/draft/data";
+import { positionValues, POSITION_LABELS } from "@/lib/validators/registration";
+
+interface PlayerPoolProps {
+  players: DraftPlayerRow[];
+}
+
+export function PlayerPool({ players }: PlayerPoolProps) {
+  const [filter, setFilter] = useState<string>("all");
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, DraftPlayerRow[]>();
+    for (const p of players) {
+      const list = map.get(p.primaryPosition) ?? [];
+      list.push(p);
+      map.set(p.primaryPosition, list);
+    }
+    return map;
+  }, [players]);
+
+  const positions: readonly string[] =
+    filter === "all"
+      ? positionValues
+      : positionValues.filter((v) => v === filter);
+
+  const total = players.length;
+
+  if (total === 0) {
+    return (
+      <div className="py-12 text-center text-[var(--text-muted)] text-sm">
+        所有选手已被选完
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* 筛选栏 */}
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <button
+          onClick={() => setFilter("all")}
+          className={`text-xs px-2 py-1 rounded transition-colors ${
+            filter === "all"
+              ? "bg-[var(--season-primary)] text-white"
+              : "bg-[var(--bg-overlay)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          }`}
+        >
+          全部 ({total})
+        </button>
+        {positionValues.map((pos) => {
+          const count = grouped.get(pos)?.length ?? 0;
+          return (
+            <button
+              key={pos}
+              onClick={() => setFilter(pos === filter ? "all" : pos as string)}
+              disabled={count === 0}
+              className={`text-xs px-2 py-1 rounded transition-colors ${
+                pos === filter
+                  ? "bg-[var(--season-primary)] text-white"
+                  : "bg-[var(--bg-overlay)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-30"
+              }`}
+            >
+              {POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.en ?? pos} ({count})
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 选手列表 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5 max-h-64 overflow-y-auto">
+        {positions.flatMap((pos) => {
+          const list = grouped.get(pos) ?? [];
+          return list.map((p) => (
+            <div
+              key={p.registrationId}
+              className="flex items-center justify-between text-xs px-2 py-1.5 rounded bg-[var(--bg-elevated)] border border-[var(--border)]"
+            >
+              <span className="text-[var(--text-primary)] truncate">
+                {p.steamName}
+              </span>
+              <span className="text-[var(--text-muted)] tabular ml-1 shrink-0">
+                {p.peakRank} {p.peakRating.toFixed(2)}
+              </span>
+            </div>
+          ));
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/draft/PlayerPool.tsx
+++ b/src/components/draft/PlayerPool.tsx
@@ -2,13 +2,14 @@
 
 import { useMemo, useState } from "react";
 import type { DraftPlayerRow } from "@/lib/draft/data";
-import { positionValues, POSITION_LABELS } from "@/lib/validators/registration";
+import { POSITION_LABELS } from "@/lib/validators/registration";
 
 interface PlayerPoolProps {
   players: DraftPlayerRow[];
+  seasonPositions: string[];
 }
 
-export function PlayerPool({ players }: PlayerPoolProps) {
+export function PlayerPool({ players, seasonPositions }: PlayerPoolProps) {
   const [filter, setFilter] = useState<string>("all");
 
   const grouped = useMemo(() => {
@@ -21,10 +22,18 @@ export function PlayerPool({ players }: PlayerPoolProps) {
     return map;
   }, [players]);
 
+  const positionOptions = useMemo(() => {
+    const ordered = [...seasonPositions];
+    for (const position of grouped.keys()) {
+      if (!ordered.includes(position)) ordered.push(position);
+    }
+    return ordered;
+  }, [grouped, seasonPositions]);
+
   const positions: readonly string[] =
     filter === "all"
-      ? positionValues
-      : positionValues.filter((v) => v === filter);
+      ? positionOptions
+      : positionOptions.filter((position) => position === filter);
 
   const total = players.length;
 
@@ -50,12 +59,12 @@ export function PlayerPool({ players }: PlayerPoolProps) {
         >
           全部 ({total})
         </button>
-        {positionValues.map((pos) => {
+        {positionOptions.map((pos) => {
           const count = grouped.get(pos)?.length ?? 0;
           return (
             <button
               key={pos}
-              onClick={() => setFilter(pos === filter ? "all" : pos as string)}
+              onClick={() => setFilter(pos === filter ? "all" : pos)}
               disabled={count === 0}
               className={`text-xs px-2 py-1 rounded transition-colors ${
                 pos === filter

--- a/src/components/draft/TeamDraftGrid.tsx
+++ b/src/components/draft/TeamDraftGrid.tsx
@@ -73,7 +73,7 @@ export function TeamDraftGrid({
             </div>
 
             {/* 已选队员 */}
-            {team.members.map((m, i) => (
+            {team.members.map((m) => (
               <div key={m.registrationId} className="text-xs mb-0.5">
                 <span className="text-[var(--text-secondary)]">
                   R{m.pickRound}P{m.pickNumber}{" "}

--- a/src/components/draft/TeamDraftGrid.tsx
+++ b/src/components/draft/TeamDraftGrid.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { DraftTeamSlot } from "@/lib/draft/data";
+
+const POS_SHORT: Record<string, string> = {
+  igl: "IGL",
+  awper: "AWP",
+  opener: "突破",
+  closer: "自由",
+  anchor: "主防",
+};
+
+interface TeamDraftGridProps {
+  teams: DraftTeamSlot[];
+  currentTeamId: string | null;
+  totalRounds: number;
+  currentRound: number;
+}
+
+export function TeamDraftGrid({
+  teams,
+  currentTeamId,
+  totalRounds,
+  currentRound,
+}: TeamDraftGridProps) {
+  // sort by draftOrder
+  const sorted = [...teams].sort((a, b) => a.draftOrder - b.draftOrder);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="py-24 text-center text-[var(--text-muted)]">
+        <p className="text-lg">暂无队伍数据</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+      {sorted.map((team) => {
+        const isCurrent = team.teamId === currentTeamId;
+        const maxSlots = totalRounds; // 6 picks per team
+        const filledSlots = team.members.length;
+        const emptySlots = Math.max(0, maxSlots - filledSlots);
+
+        return (
+          <div
+            key={team.teamId}
+            className={`rounded-lg border p-3 sm:p-4 transition-colors ${
+              isCurrent
+                ? "border-[var(--season-primary)] bg-[var(--season-primary)]/5"
+                : "border-[var(--border)] bg-[var(--bg-elevated)]"
+            }`}
+          >
+            {/* 队名 + draft order */}
+            <div className="flex items-baseline justify-between mb-2">
+              <h3 className="text-sm font-bold text-[var(--text-primary)] truncate">
+                {team.teamName}
+              </h3>
+              <span className="text-xs text-[var(--text-muted)] tabular">
+                #{team.draftOrder}
+              </span>
+            </div>
+
+            {/* 队长 */}
+            <div className="text-xs mb-1">
+              <span className="text-[var(--text-muted)]">队长 </span>
+              <span className="text-[var(--text-primary)] font-medium">
+                {team.captain.steamName}
+              </span>
+              <span className="text-[var(--text-muted)] ml-1">
+                {POS_SHORT[team.captain.primaryPosition] ?? team.captain.primaryPosition}
+              </span>
+            </div>
+
+            {/* 已选队员 */}
+            {team.members.map((m, i) => (
+              <div key={m.registrationId} className="text-xs mb-0.5">
+                <span className="text-[var(--text-secondary)]">
+                  R{m.pickRound}P{m.pickNumber}{" "}
+                </span>
+                <span className="text-[var(--text-primary)]">
+                  {m.steamName}
+                </span>
+                <span className="text-[var(--text-muted)] ml-1">
+                  {POS_SHORT[m.primaryPosition] ?? m.primaryPosition}
+                </span>
+                {m.autoPicked && (
+                  <span className="text-amber-400 ml-0.5">⚡</span>
+                )}
+              </div>
+            ))}
+
+            {/* 空位 */}
+            {Array.from({ length: emptySlots }).map((_, i) => (
+              <div
+                key={`empty-${i}`}
+                className="text-xs text-[var(--text-muted)] mb-0.5"
+              >
+                ??? · ??? · 待选
+              </div>
+            ))}
+
+            {/* 满员标记 */}
+            {emptySlots === 0 && (
+              <div className="text-xs text-emerald-400 mt-1">阵容已满</div>
+            )}
+
+            {isCurrent && (
+              <div className="mt-2 text-xs font-medium text-[var(--season-primary)]">
+                第 {currentRound} 轮 · 选择中…
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -1,0 +1,258 @@
+import { eq, and, asc } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  draftState,
+  draftPicks,
+  teams,
+  teamMembers,
+  seasonRegistrations,
+  users,
+} from "@/db/schema";
+import { DRAFT_TEAMS } from "@/types/draft";
+import { getSnakeOrder } from "./rules";
+
+// ── 数据类型 ─────────────────────────────────────────────
+
+export interface DraftTeamSlot {
+  teamId: string;
+  teamName: string;
+  draftOrder: number;
+  captain: { steamName: string; primaryPosition: string };
+  members: {
+    registrationId: string;
+    steamName: string;
+    primaryPosition: string;
+    pickRound: number;
+    pickNumber: number;
+    autoPicked: boolean;
+  }[];
+}
+
+export interface DraftPlayerRow {
+  registrationId: string;
+  steamName: string;
+  primaryPosition: string;
+  secondaryPosition: string;
+  peakRank: string;
+  peakRating: number;
+}
+
+export interface DraftLiveState {
+  currentRound: number;
+  currentTeamId: string | null;
+  roundDeadline: string | null; // ISO string
+  isActive: boolean;
+}
+
+export interface DraftFullData {
+  state: DraftLiveState | null;
+  teams: DraftTeamSlot[];
+  snakeOrder: string[]; // team IDs in snake order for current/next round
+  remainingPlayers: DraftPlayerRow[];
+  completedPicks: {
+    teamId: string;
+    registrationId: string;
+    steamName: string;
+    round: number;
+    pickNumber: number;
+    autoPicked: boolean;
+  }[];
+  totalPicks: number;
+  maxPicks: number; // DRAFT_TEAMS * total rounds
+}
+
+// ── 查询函数 ─────────────────────────────────────────────
+
+export async function getDraftData(seasonId: string): Promise<DraftFullData> {
+  const maxPicks = DRAFT_TEAMS * 6; // 48
+
+  // 1. 选秀状态
+  const state = await db.query.draftState.findFirst({
+    where: eq(draftState.seasonId, seasonId),
+  });
+
+  // 2. 所有队伍 + 队员
+  const teamRows = await db
+    .select()
+    .from(teams)
+    .where(eq(teams.seasonId, seasonId))
+    .orderBy(asc(teams.draftOrder));
+
+  const memberRows =
+    teamRows.length > 0
+      ? await db
+          .select({
+            teamId: teamMembers.teamId,
+            registrationId: teamMembers.registrationId,
+            isStarter: teamMembers.isStarter,
+            steamName: users.steamName,
+            primaryPosition: seasonRegistrations.primaryPosition,
+          })
+          .from(teamMembers)
+          .innerJoin(
+            seasonRegistrations,
+            eq(teamMembers.registrationId, seasonRegistrations.id),
+          )
+          .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+          .where(
+            eq(
+              teamMembers.teamId,
+              teamRows[0]?.id ?? "", // placeholder, all teams in season
+            ),
+          )
+      : [];
+
+  // Reload members for all teams properly
+  const allMembers =
+    teamRows.length > 0
+      ? await db
+          .select({
+            teamId: teamMembers.teamId,
+            registrationId: teamMembers.registrationId,
+            isStarter: teamMembers.isStarter,
+            steamName: users.steamName,
+            primaryPosition: seasonRegistrations.primaryPosition,
+          })
+          .from(teamMembers)
+          .innerJoin(
+            seasonRegistrations,
+            eq(teamMembers.registrationId, seasonRegistrations.id),
+          )
+          .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+      : [];
+
+  // 3. 所有 picks
+  const pickRows = await db
+    .select({
+      id: draftPicks.id,
+      teamId: draftPicks.teamId,
+      registrationId: draftPicks.registrationId,
+      round: draftPicks.round,
+      pickNumber: draftPicks.pickNumber,
+      autoPicked: draftPicks.autoPicked,
+      steamName: users.steamName,
+      primaryPosition: seasonRegistrations.primaryPosition,
+    })
+    .from(draftPicks)
+    .innerJoin(
+      seasonRegistrations,
+      eq(draftPicks.registrationId, seasonRegistrations.id),
+    )
+    .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(eq(draftPicks.seasonId, seasonId))
+    .orderBy(asc(draftPicks.pickNumber));
+
+  const pickedRegIds = new Set(pickRows.map((p) => p.registrationId));
+
+  // 4. 剩余可选选手（approved 且未被选，不含已是队长的）
+  const captainRegIds = new Set(
+    teamRows.map((t) => t.captainRegistrationId),
+  );
+
+  const remainingRows = await db
+    .select({
+      registrationId: seasonRegistrations.id,
+      steamName: users.steamName,
+      primaryPosition: seasonRegistrations.primaryPosition,
+      secondaryPosition: seasonRegistrations.secondaryPosition,
+      peakRank: seasonRegistrations.peakRank,
+      peakRating: seasonRegistrations.peakRating,
+    })
+    .from(seasonRegistrations)
+    .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    )
+    .orderBy(asc(seasonRegistrations.primaryPosition));
+
+  const remainingPlayers: DraftPlayerRow[] = remainingRows
+    .filter((r) => !pickedRegIds.has(r.registrationId) && !captainRegIds.has(r.registrationId))
+    .map((r) => ({
+      registrationId: r.registrationId,
+      steamName: r.steamName ?? "未知选手",
+      primaryPosition: r.primaryPosition,
+      secondaryPosition: r.secondaryPosition,
+      peakRank: r.peakRank,
+      peakRating: r.peakRating ?? 0,
+    }));
+
+  // 5. 组装队伍数据
+  const membersByTeam = new Map<string, typeof allMembers>();
+  for (const m of allMembers) {
+    const list = membersByTeam.get(m.teamId) ?? [];
+    list.push(m);
+    membersByTeam.set(m.teamId, list);
+  }
+
+  const picksByRegId = new Map<string, (typeof pickRows)[number]>();
+  for (const p of pickRows) {
+    picksByRegId.set(p.registrationId, p);
+  }
+
+  const draftTeams: DraftTeamSlot[] = teamRows.map((t) => {
+    const teamMembersList = membersByTeam.get(t.id) ?? [];
+    const captain = teamMembersList.find(
+      (m) => m.registrationId === t.captainRegistrationId,
+    );
+    const drafted = teamMembersList
+      .filter((m) => m.registrationId !== t.captainRegistrationId)
+      .map((m) => {
+        const pick = picksByRegId.get(m.registrationId);
+        return {
+          registrationId: m.registrationId,
+          steamName: m.steamName ?? "未知选手",
+          primaryPosition: m.primaryPosition,
+          pickRound: pick?.round ?? 0,
+          pickNumber: pick?.pickNumber ?? 0,
+          autoPicked: pick?.autoPicked ?? false,
+        };
+      })
+      .sort((a, b) => a.pickNumber - b.pickNumber);
+
+    return {
+      teamId: t.id,
+      teamName: t.name,
+      draftOrder: t.draftOrder,
+      captain: {
+        steamName: captain?.steamName ?? "未知队长",
+        primaryPosition: captain?.primaryPosition ?? "未知",
+      },
+      members: drafted,
+    };
+  });
+
+  // 6. 蛇形顺序
+  const snakeOrder = state
+    ? getSnakeOrder(
+        teamRows.map((t) => ({ id: t.id, draftOrder: t.draftOrder })),
+        state.currentRound,
+      ).map((t) => t.id)
+    : [];
+
+  return {
+    state: state
+      ? {
+          currentRound: state.currentRound,
+          currentTeamId: state.currentTeamId,
+          roundDeadline: state.roundDeadline?.toISOString() ?? null,
+          isActive: state.isActive,
+        }
+      : null,
+    teams: draftTeams,
+    snakeOrder,
+    remainingPlayers,
+    completedPicks: pickRows.map((p) => ({
+      teamId: p.teamId,
+      registrationId: p.registrationId,
+      steamName: p.steamName ?? "未知选手",
+      round: p.round,
+      pickNumber: p.pickNumber,
+      autoPicked: p.autoPicked,
+    })),
+    totalPicks: pickRows.length,
+    maxPicks,
+  };
+}

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -1,4 +1,4 @@
-import { eq, and, asc } from "drizzle-orm";
+import { eq, and, asc, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
   draftState,
@@ -8,7 +8,7 @@ import {
   seasonRegistrations,
   users,
 } from "@/db/schema";
-import { DRAFT_TEAMS } from "@/types/draft";
+import { DRAFT_TEAMS, DRAFT_TOTAL_ROUNDS } from "@/types/draft";
 import { getSnakeOrder } from "./rules";
 
 // ── 数据类型 ─────────────────────────────────────────────
@@ -47,7 +47,7 @@ export interface DraftLiveState {
 export interface DraftFullData {
   state: DraftLiveState | null;
   teams: DraftTeamSlot[];
-  snakeOrder: string[]; // team IDs in snake order for current/next round
+  snakeOrder: string[]; // team IDs in snake order for the current round
   remainingPlayers: DraftPlayerRow[];
   completedPicks: {
     teamId: string;
@@ -64,7 +64,7 @@ export interface DraftFullData {
 // ── 查询函数 ─────────────────────────────────────────────
 
 export async function getDraftData(seasonId: string): Promise<DraftFullData> {
-  const maxPicks = DRAFT_TEAMS * 6; // 48
+  const maxPicks = DRAFT_TEAMS * DRAFT_TOTAL_ROUNDS;
 
   // 1. 选秀状态
   const state = await db.query.draftState.findFirst({
@@ -78,33 +78,9 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
     .where(eq(teams.seasonId, seasonId))
     .orderBy(asc(teams.draftOrder));
 
-  const memberRows =
-    teamRows.length > 0
-      ? await db
-          .select({
-            teamId: teamMembers.teamId,
-            registrationId: teamMembers.registrationId,
-            isStarter: teamMembers.isStarter,
-            steamName: users.steamName,
-            primaryPosition: seasonRegistrations.primaryPosition,
-          })
-          .from(teamMembers)
-          .innerJoin(
-            seasonRegistrations,
-            eq(teamMembers.registrationId, seasonRegistrations.id),
-          )
-          .leftJoin(users, eq(seasonRegistrations.userId, users.id))
-          .where(
-            eq(
-              teamMembers.teamId,
-              teamRows[0]?.id ?? "", // placeholder, all teams in season
-            ),
-          )
-      : [];
-
-  // Reload members for all teams properly
+  const teamIds = teamRows.map((team) => team.id);
   const allMembers =
-    teamRows.length > 0
+    teamIds.length > 0
       ? await db
           .select({
             teamId: teamMembers.teamId,
@@ -119,6 +95,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
             eq(teamMembers.registrationId, seasonRegistrations.id),
           )
           .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+          .where(inArray(teamMembers.teamId, teamIds))
       : [];
 
   // 3. 所有 picks

--- a/src/lib/draft/rules.ts
+++ b/src/lib/draft/rules.ts
@@ -1,0 +1,80 @@
+import {
+  DRAFT_TOTAL_ROUNDS,
+  DRAFT_TEAMS,
+} from "@/types/draft";
+
+export interface DraftTeamOrder {
+  id: string;
+  draftOrder: number;
+}
+
+/**
+ * 获取指定轮次的蛇形选秀顺序
+ * 奇数轮正向（draftOrder 升序），偶数轮反向（draftOrder 降序）
+ */
+export function getSnakeOrder(
+  teams: DraftTeamOrder[],
+  round: number,
+): DraftTeamOrder[] {
+  const sorted = [...teams].sort((a, b) => a.draftOrder - b.draftOrder);
+  return round % 2 === 1 ? sorted : sorted.reverse();
+}
+
+/**
+ * 获取当前队的下一队 ID（用于 draft_state 推进）
+ * 同一轮内按蛇形顺序推进，轮末翻转到下一轮
+ */
+export function getNextTeamId(
+  teams: DraftTeamOrder[],
+  currentTeamId: string,
+  round: number,
+): { teamId: string; nextRound: number } | null {
+  const order = getSnakeOrder(teams, round);
+  const idx = order.findIndex((t) => t.id === currentTeamId);
+  if (idx === -1) return null;
+
+  // 本轮还有下一队
+  if (idx < order.length - 1) {
+    return { teamId: order[idx + 1].id, nextRound: round };
+  }
+
+  // 本队是轮末 → 下一轮
+  const nextRound = round + 1;
+  if (nextRound > DRAFT_TOTAL_ROUNDS) return null; // 已完成
+
+  const nextOrder = getSnakeOrder(teams, nextRound);
+  return { teamId: nextOrder[0].id, nextRound };
+}
+
+/**
+ * 判断选秀是否全部完成
+ */
+export function isDraftComplete(
+  round: number,
+  currentTeamId: string | null,
+  totalPicks: number,
+): boolean {
+  return (
+    totalPicks >= DRAFT_TOTAL_ROUNDS * DRAFT_TEAMS ||
+    (round > DRAFT_TOTAL_ROUNDS && !currentTeamId)
+  );
+}
+
+/**
+ * 统计每队各主选位置人数
+ * 返回 Map<teamId, Record<position, count>>
+ */
+export function computeTeamPositionCounts(
+  members: { teamId: string; primaryPosition: string }[],
+): Map<string, Map<string, number>> {
+  const byTeam = new Map<string, Map<string, number>>();
+  for (const m of members) {
+    let teamMap = byTeam.get(m.teamId);
+    if (!teamMap) {
+      teamMap = new Map();
+      byTeam.set(m.teamId, teamMap);
+    }
+    teamMap.set(m.primaryPosition, (teamMap.get(m.primaryPosition) ?? 0) + 1);
+  }
+  return byTeam;
+}

--- a/src/lib/draft/rules.ts
+++ b/src/lib/draft/rules.ts
@@ -62,7 +62,7 @@ export function isDraftComplete(
 
 /**
  * 统计每队各主选位置人数
- * 返回 Map<teamId, Record<position, count>>
+ * 返回 Map<teamId, Map<position, count>>
  */
 export function computeTeamPositionCounts(
   members: { teamId: string; primaryPosition: string }[],

--- a/src/lib/validators/draft.ts
+++ b/src/lib/validators/draft.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const startDraftSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
+
+export const pauseDraftSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
+
+export const resumeDraftSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
+
+export type StartDraftInput = z.infer<typeof startDraftSchema>;
+export type PauseDraftInput = z.infer<typeof pauseDraftSchema>;
+export type ResumeDraftInput = z.infer<typeof resumeDraftSchema>;

--- a/tests/unit/lib/draft-rules.test.ts
+++ b/tests/unit/lib/draft-rules.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSnakeOrder,
+  getNextTeamId,
+  isDraftComplete,
+  computeTeamPositionCounts,
+} from "@/lib/draft/rules";
+
+function team(id: string, draftOrder: number) {
+  return { id, draftOrder };
+}
+
+// 8 teams with draftOrder 1-8
+const ALL_TEAMS = [
+  team("t1", 1),
+  team("t2", 2),
+  team("t3", 3),
+  team("t4", 4),
+  team("t5", 5),
+  team("t6", 6),
+  team("t7", 7),
+  team("t8", 8),
+];
+
+describe("getSnakeOrder", () => {
+  it("round 1 (odd) returns forward order", () => {
+    const order = getSnakeOrder(ALL_TEAMS, 1);
+    expect(order.map((t) => t.id)).toEqual([
+      "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8",
+    ]);
+  });
+
+  it("round 2 (even) returns reverse order", () => {
+    const order = getSnakeOrder(ALL_TEAMS, 2);
+    expect(order.map((t) => t.id)).toEqual([
+      "t8", "t7", "t6", "t5", "t4", "t3", "t2", "t1",
+    ]);
+  });
+
+  it("round 3 (odd) returns forward order again", () => {
+    const order = getSnakeOrder(ALL_TEAMS, 3);
+    expect(order.map((t) => t.id)).toEqual([
+      "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...ALL_TEAMS];
+    getSnakeOrder(input, 2);
+    expect(input[0].id).toBe("t1"); // unchanged
+  });
+});
+
+describe("getNextTeamId", () => {
+  it("advances to next team in same round (forward)", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t3", 1);
+    expect(next).toEqual({ teamId: "t4", nextRound: 1 });
+  });
+
+  it("advances to next team in same round (reverse)", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t5", 2);
+    expect(next).toEqual({ teamId: "t4", nextRound: 2 });
+  });
+
+  it("wraps to next round when last team in forward round", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t8", 1);
+    expect(next).toEqual({ teamId: "t8", nextRound: 2 });
+  });
+
+  it("wraps to next round when last team in reverse round", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t1", 2);
+    expect(next).toEqual({ teamId: "t1", nextRound: 3 });
+  });
+
+  it("returns null when draft is complete (round 6, last team)", () => {
+    // Round 6 is even, reverse: t8, t7, ..., t1. Last is t1.
+    const next = getNextTeamId(ALL_TEAMS, "t1", 6);
+    expect(next).toBeNull();
+  });
+
+  it("returns null for unknown team", () => {
+    const next = getNextTeamId(ALL_TEAMS, "unknown", 1);
+    expect(next).toBeNull();
+  });
+});
+
+describe("isDraftComplete", () => {
+  it("returns true when totalPicks >= 48", () => {
+    expect(isDraftComplete(6, "t1", 48)).toBe(true);
+  });
+
+  it("returns false when totalPicks < 48", () => {
+    expect(isDraftComplete(3, "t4", 20)).toBe(false);
+  });
+
+  it("returns true when round exceeds total rounds", () => {
+    expect(isDraftComplete(7, null, 48)).toBe(true);
+  });
+});
+
+describe("computeTeamPositionCounts", () => {
+  it("counts positions per team", () => {
+    const members = [
+      { teamId: "a", primaryPosition: "igl" },
+      { teamId: "a", primaryPosition: "igl" },
+      { teamId: "a", primaryPosition: "awper" },
+      { teamId: "b", primaryPosition: "igl" },
+    ];
+    const result = computeTeamPositionCounts(members);
+
+    expect(result.get("a")?.get("igl")).toBe(2);
+    expect(result.get("a")?.get("awper")).toBe(1);
+    expect(result.get("b")?.get("igl")).toBe(1);
+  });
+
+  it("returns empty map for no members", () => {
+    const result = computeTeamPositionCounts([]);
+    expect(result.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add snake order / team advancement / draft completion pure business rules
- Add `getDraftData` query for complete draft state snapshot
- Implement `startDraft` / `pauseDraft` / `resumeDraft` Server Actions with audit logs
- Create DraftLiveRoom spectator page with Supabase Realtime + 10s polling fallback
- Create TeamDraftGrid (8-team grid, current-team highlight, empty slots)
- Create DraftCountdown (red pulse under 30s, timeout state)
- Create PlayerPool (position-grouped with filter)
- Create DraftAdminPanel (start/pause/resume controls + status overview)
- Add 15 unit tests for draft rules (snake order, team advancement, position counting)

## Test plan
- [ ] `pnpm tsc --noEmit` — only 2 pre-existing admin route errors
- [ ] `pnpm test` — 23 tests pass (4 files, including 15 new draft-rules tests)
- [ ] `pnpm build` — all routes compile successfully
- [ ] Manual flow: admin login → confirm captains → start draft → visit spectator page