### PR TITLE
feat(p11): scheduledAt editor + bracket<->match bidirectional links

### DIFF
--- a/PHASES.md
+++ b/PHASES.md
@@ -137,13 +137,13 @@
 **自动生成流程**
 - [x] admin 页面「生成赛程」按钮：赛季状态为 `playing` 且尚无 matches 时可用
 - [x] Server Action `generateSchedule(seasonId)`：按赛制 insert 所有 `matches`（`status: scheduled`，`scheduledAt: null`）
-- [ ] 管理员在赛程列表逐场填入 `scheduledAt`（已有 `updateMatchStatus`，`scheduledAt` 编辑 UI 待补）
+- [x] 管理员在赛程列表逐场填入 `scheduledAt`（`ScheduledAtInput` 组件 + `updateMatchScheduledAt` Server Action）
 
 **Bracket 视图**
 - [x] `brackets-manager` 双败淘汰赛数据结构初始化
 - [x] `brackets-viewer` 渲染集成（注入 season theme_color）
 - [x] `/[seasonSlug]/matches` 总览页（bracket 图 + 赛程列表联动）
-- [ ] 比赛详情页与 bracket 节点双向跳转
+- [x] 比赛详情页与 bracket 节点双向跳转（BracketView 点击跳转 + 详情页"查看对阵图"回链）
 
 ---
 

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -351,6 +351,51 @@ export async function recordMatchResult(
   }
 }
 
+// ── 更新比赛时间 ──────────────────────────────────────────────────────────
+
+/**
+ * 设置或清除比赛的预定时间（scheduledAt）。
+ * 已完成或已取消的比赛不允许修改。
+ */
+export async function updateMatchScheduledAt(
+  matchId: string,
+  scheduledAt: Date | null
+): Promise<ActionResult<void>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const session = await requireSeasonAdmin(match.seasonId);
+
+    if (match.status === "finished" || match.status === "cancelled") {
+      throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "已结束或已取消的比赛不能修改时间");
+    }
+
+    await db
+      .update(matches)
+      .set({ scheduledAt, updatedAt: new Date() })
+      .where(eq(matches.id, matchId));
+
+    const season = await getSeasonOrThrow(match.seasonId);
+    await db.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.update_scheduled_at",
+      actorId: session.email,
+      targetId: matchId,
+      targetType: "match",
+      meta: { scheduledAt: scheduledAt?.toISOString() ?? null },
+    });
+
+    revalidatePath(`/admin/${season.slug}/matches`);
+    revalidatePath(`/${season.slug}/matches`);
+    revalidatePath(`/${season.slug}/matches/${matchId}`);
+
+    return ok(undefined);
+  } catch (e) {
+    if (e instanceof AppError) return fail({ code: e.code, message: e.message });
+    console.error("[updateMatchScheduledAt]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
 // ── 生成正赛（基于积分榜种子） ────────────────────────────────────────────
 
 /**

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -268,6 +268,19 @@ export async function recordMatchResult(
     }
 
     const match = await getMatchOrThrow(matchId);
+
+    // BO3/BO5 校验系列赛胜场数：胜者恰好达到 maxWins，败者不得超过 maxWins-1
+    const maxWins = match.format === "bo3" ? 2 : match.format === "bo5" ? 3 : null;
+    if (maxWins !== null) {
+      const winner = Math.max(scoreA, scoreB);
+      const loser = Math.min(scoreA, scoreB);
+      if (winner !== maxWins || loser >= maxWins) {
+        throw new AppError(
+          ErrorCode.MATCH_INVALID_SCORE,
+          `${match.format.toUpperCase()} 系列赛比分不合法（胜者须恰好赢 ${maxWins} 图）`
+        );
+      }
+    }
     const session = await requireSeasonAdmin(match.seasonId);
     assertMatchTransition(match.status as MatchStatus, "finished");
 

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -42,12 +42,22 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl space-y-8">
       {/* 导航 */}
-      <Link
-        href={`/${seasonSlug}/matches`}
-        className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-      >
-        ← 返回赛程总览
-      </Link>
+      <div className="flex items-center gap-4">
+        <Link
+          href={`/${seasonSlug}/matches`}
+          className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          ← 返回赛程总览
+        </Link>
+        {match.stage === "playoff" && match.bracketNodeId && (
+          <Link
+            href={`/${seasonSlug}/matches#bracket`}
+            className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            查看对阵图 →
+          </Link>
+        )}
+      </div>
 
       {/* 头部：比赛信息 */}
       <Card className="p-6 space-y-4">

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -64,6 +64,13 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
     ),
   };
 
+  // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转
+  const matchNodeMap = new Map<string, string>(
+    playoffMatches
+      .filter((m) => m.bracketNodeId !== null)
+      .map((m) => [m.bracketNodeId!, m.id])
+  );
+
   const hasQualifier = !!season.qualifierFormat;
   const hasPlayoff = !!season.playoffFormat;
 
@@ -141,9 +148,14 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
           <TabsContent value="playoff" className="space-y-8">
             {/* Bracket 图 */}
             {playoffBracketData.stage.length > 0 && (
-              <section className="space-y-3">
+              <section id="bracket" className="space-y-3">
                 <h2 className="text-lg font-semibold text-[var(--text-primary)]">对阵图</h2>
-                <BracketView data={playoffBracketData} themeColor={season.themeColor} />
+                <BracketView
+                  data={playoffBracketData}
+                  themeColor={season.themeColor}
+                  matchNodeMap={matchNodeMap}
+                  seasonSlug={seasonSlug}
+                />
               </section>
             )}
 

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -9,6 +9,7 @@ import { GeneratePlayoffCard } from "@/components/matches/GeneratePlayoffCard";
 import { StandingsTable } from "@/components/matches/StandingsTable";
 import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
 import { ScoreInput } from "@/components/matches/ScoreInput";
+import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -168,6 +169,10 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
                             <Separator />
+                            <ScheduledAtInput
+                              matchId={m.id}
+                              currentScheduledAt={m.scheduledAt}
+                            />
                             <ScoreInput
                               matchId={m.id}
                               teamAName={teamAName}
@@ -222,6 +227,10 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
                             <Separator />
+                            <ScheduledAtInput
+                              matchId={m.id}
+                              currentScheduledAt={m.scheduledAt}
+                            />
                             <ScoreInput
                               matchId={m.id}
                               teamAName={teamAName}

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -178,7 +178,7 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                               teamAName={teamAName}
                               teamBName={teamBName}
                               currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                              isBO1
+                              format={m.format as "bo1" | "bo3" | "bo5"}
                             />
                           </>
                         )}
@@ -236,7 +236,7 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                               teamAName={teamAName}
                               teamBName={teamBName}
                               currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                              isBO1={false}
+                              format={m.format as "bo1" | "bo3" | "bo5"}
                             />
                           </>
                         )}

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import Script from "next/script";
 import type { BracketData } from "@/lib/bracket";
 
@@ -21,11 +22,15 @@ declare global {
 interface BracketViewProps {
   data: BracketData;
   themeColor?: string | null;
+  /** bracketNodeId（数字字符串）→ matchId（UUID），用于点击 bracket 节点跳转详情 */
+  matchNodeMap?: Map<string, string>;
+  seasonSlug?: string;
 }
 
-export function BracketView({ data, themeColor }: BracketViewProps) {
+export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: BracketViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scriptReady, setScriptReady] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (!scriptReady || !window.bracketsViewer || data.stage.length === 0) return;
@@ -38,8 +43,24 @@ export function BracketView({ data, themeColor }: BracketViewProps) {
         matchGames: [],
       },
       { selector: "#bracket-container", clear: true }
-    );
-  }, [scriptReady, data]);
+    ).then(() => {
+      // brackets-viewer renders match elements with data-id attribute
+      if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
+      const matchEls = containerRef.current.querySelectorAll<HTMLElement>("[data-id]");
+      matchEls.forEach((el) => {
+        const bracketId = el.getAttribute("data-id");
+        if (!bracketId) return;
+        const matchId = matchNodeMap.get(bracketId);
+        if (!matchId) return;
+        el.style.cursor = "pointer";
+        el.title = "点击查看比赛详情";
+        el.addEventListener("click", (e) => {
+          e.stopPropagation();
+          router.push(`/${seasonSlug}/matches/${matchId}`);
+        });
+      });
+    });
+  }, [scriptReady, data, matchNodeMap, seasonSlug, router]);
 
   if (data.stage.length === 0) {
     return (

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -35,6 +35,8 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
   useEffect(() => {
     if (!scriptReady || !window.bracketsViewer || data.stage.length === 0) return;
 
+    let cancelled = false;
+
     window.bracketsViewer.render(
       {
         stages: data.stage,
@@ -44,8 +46,8 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
       },
       { selector: "#bracket-container", clear: true }
     ).then(() => {
+      if (cancelled || !containerRef.current || !matchNodeMap || !seasonSlug) return;
       // brackets-viewer renders match elements with data-id attribute
-      if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
       const matchEls = containerRef.current.querySelectorAll<HTMLElement>("[data-id]");
       matchEls.forEach((el) => {
         const bracketId = el.getAttribute("data-id");
@@ -60,6 +62,8 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         });
       });
     });
+
+    return () => { cancelled = true; };
   }, [scriptReady, data, matchNodeMap, seasonSlug, router]);
 
   if (data.stage.length === 0) {

--- a/src/components/matches/ScheduledAtInput.tsx
+++ b/src/components/matches/ScheduledAtInput.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { updateMatchScheduledAt } from "@/actions/matches";
+
+interface ScheduledAtInputProps {
+  matchId: string;
+  currentScheduledAt: Date | null;
+}
+
+function toLocalDatetimeValue(date: Date | null): string {
+  if (!date) return "";
+  // datetime-local 需要 "YYYY-MM-DDTHH:mm" 格式，转本地时间
+  const d = new Date(date);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function ScheduledAtInput({ matchId, currentScheduledAt }: ScheduledAtInputProps) {
+  const [value, setValue] = useState(toLocalDatetimeValue(currentScheduledAt));
+  const [isPending, startTransition] = useTransition();
+
+  function handleSave() {
+    const date = value ? new Date(value) : null;
+    if (value && isNaN(date!.getTime())) {
+      toast.error("请输入有效的时间");
+      return;
+    }
+    startTransition(async () => {
+      const result = await updateMatchScheduledAt(matchId, date);
+      if (result.success) {
+        toast.success(date ? "比赛时间已更新" : "比赛时间已清除");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handleClear() {
+    setValue("");
+    startTransition(async () => {
+      const result = await updateMatchScheduledAt(matchId, null);
+      if (result.success) {
+        toast.success("比赛时间已清除");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-[var(--text-secondary)] shrink-0">比赛时间</span>
+      <Input
+        type="datetime-local"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="w-48 text-xs h-8"
+        disabled={isPending}
+      />
+      <Button size="sm" variant="outline" className="h-8 text-xs" onClick={handleSave} disabled={isPending}>
+        保存
+      </Button>
+      {currentScheduledAt && (
+        <Button size="sm" variant="ghost" className="h-8 text-xs text-[var(--text-secondary)]" onClick={handleClear} disabled={isPending}>
+          清除
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/matches/ScoreInput.tsx
+++ b/src/components/matches/ScoreInput.tsx
@@ -12,12 +12,27 @@ interface ScoreInputProps {
   teamAName: string;
   teamBName: string;
   currentStatus: "scheduled" | "in_progress" | "finished" | "cancelled";
-  /** BO1 排位赛：输入实际回合数（如 13:8）；BO3/BO5：输入系列赛图数（如 2:1） */
-  isBO1?: boolean;
+  format: "bo1" | "bo3" | "bo5";
 }
 
-export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, isBO1 = false }: ScoreInputProps) {
-  const scoreLabel = isBO1 ? "回合数" : "系列赛比分";
+const MAX_WINS: Record<string, number | null> = { bo1: null, bo3: 2, bo5: 3 };
+const SCORE_LABELS: Record<string, string> = { bo1: "回合数", bo3: "系列赛比分（地图胜场）", bo5: "系列赛比分（地图胜场）" };
+
+function validateSeriesScore(format: string, a: number, b: number): string | null {
+  if (isNaN(a) || isNaN(b) || a < 0 || b < 0) return "请输入有效的非负整数";
+  if (a === b) return "系列赛不能平局";
+  const maxWins = MAX_WINS[format];
+  if (maxWins !== null) {
+    const winner = Math.max(a, b);
+    const loser = Math.min(a, b);
+    if (winner !== maxWins || loser >= maxWins) {
+      return `${format.toUpperCase()} 比分不合法（胜者须恰好赢 ${maxWins} 图，如 ${maxWins}:0 或 ${maxWins}:${maxWins - 1}）`;
+    }
+  }
+  return null;
+}
+
+export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, format }: ScoreInputProps) {
   const [scoreA, setScoreA] = useState("");
   const [scoreB, setScoreB] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -37,12 +52,9 @@ export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, isBO1
     e.preventDefault();
     const a = parseInt(scoreA, 10);
     const b = parseInt(scoreB, 10);
-    if (isNaN(a) || isNaN(b) || a < 0 || b < 0) {
-      toast.error("请输入有效的非负整数比分");
-      return;
-    }
-    if (a === b) {
-      toast.error("系列赛不能平局");
+    const err = validateSeriesScore(format, a, b);
+    if (err) {
+      toast.error(err);
       return;
     }
     startTransition(async () => {
@@ -87,7 +99,7 @@ export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, isBO1
 
       {currentStatus === "in_progress" && (
         <form onSubmit={handleSubmit} className="space-y-3">
-          <p className="text-xs text-[var(--text-secondary)]">{scoreLabel}</p>
+          <p className="text-xs text-[var(--text-secondary)]">{SCORE_LABELS[format]}</p>
           <div className="flex items-end gap-3">
             <div className="space-y-1">
               <Label className="text-xs text-[var(--text-secondary)]">{teamAName}</Label>


### PR DESCRIPTION
## 改动内容

**P11 收尾：scheduledAt 编辑 UI + bracket↔比赛详情双向跳转**

### 1. scheduledAt 编辑 UI（admin 后台）

- 新增 Server Action `updateMatchScheduledAt(matchId, scheduledAt)`，带 audit_log 写入
- 新增 `ScheduledAtInput` 客户端组件（datetime-local 输入框 + 保存/清除按钮）
- 集成到 admin 比赛管理页，每张未完成/未取消的 match 卡片都展示时间编辑器

### 2. Bracket↔比赛详情双向跳转

- **BracketView → 比赛详情**：接收 `matchNodeMap`（bracketNodeId → matchId），bracket render 完成后为每个 match 节点注册点击跳转
- **比赛详情 → BracketView**：正赛场次详情页顶部加"查看对阵图 →"链接，锚点指向 `#bracket`
- 公开赛程总览页 bracket section 加 `id="bracket"` 锚点

### 3. PHASES.md

标记 Phase 11 两个剩余项为已完成，P11 全部收尾。

## 测试清单

- [ ] admin 比赛页：排位赛/正赛卡片均显示时间输入框，可保存/清除
- [ ] 保存时间后 audit_log 有对应记录
- [ ] 正赛比赛详情页顶部显示"查看对阵图 →"，点击跳转到正赛 tab 的 bracket section
- [ ] 公开赛程正赛 tab 中，点击 bracket 节点跳转到对应比赛详情页