### PR TITLE
fix: rename perfectId to perfectName in users schema

### DIFF
--- a/drizzle/migrations/0003_rename_perfect_id.sql
+++ b/drizzle/migrations/0003_rename_perfect_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" RENAME COLUMN "perfect_id" TO "perfect_name";

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778263091081,
       "tag": "0002_fair_ikaris",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1747008000000,
+      "tag": "0003_rename_perfect_id",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -62,7 +62,7 @@ export async function submitRegistration(input: RegistrationFormData) {
       steam64: data.steam64,
       qq: data.qq,
       studentId: data.studentId,
-      perfectId: data.perfectId,
+      perfectName: data.perfectName,
       steamName: data.steamName,
       steamProfileUrl: data.steamProfileUrl,
     };

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -163,13 +163,13 @@ export function RegistrationForm({
             </div>
           </div>
 
-          {/* 完美 ID */}
+          {/* 完美昵称 */}
           <div>
-            <Label htmlFor="perfectId" className="text-[var(--text-secondary)] mb-1.5 block">
-              完美平台 ID <Required />
+            <Label htmlFor="perfectName" className="text-[var(--text-secondary)] mb-1.5 block">
+              完美平台昵称 <Required />
             </Label>
-            <Input id="perfectId" placeholder="完美对战平台 ID" className={inputCls} {...register("perfectId")} />
-            <FieldError name="perfectId" />
+            <Input id="perfectName" placeholder="完美对战平台昵称" className={inputCls} {...register("perfectName")} />
+            <FieldError name="perfectName" />
           </div>
 
           {/* Steam 昵称 + Steam64 */}

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -16,7 +16,7 @@ export const users = pgTable("users", {
   // 基础信息（跨赛季持久）
   studentId: text("student_id"),          // 学号，毕业生填"毕业年份+学院"
   qq: text("qq"),
-  perfectId: text("perfect_id"),          // 完美平台 ID
+  perfectName: text("perfect_name"),       // 完美平台昵称
   steamName: text("steam_name"),          // Steam 昵称
   steam64: text("steam64"),               // Steam 64 位 ID
   steamProfileUrl: text("steam_profile_url"), // Steam 个人资料链接

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -110,7 +110,7 @@ export async function seed() {
         userRows.push({
           email: `seed-p${String(idx).padStart(2, "0")}@rivalhu.b`,
           steamName: `${TEAM_NAMES[t]}_${TEAM_POSITIONS[p].toUpperCase()}_${idx}`,
-          perfectId: `PW${100000 + idx}`,
+          perfectName: `${TEAM_NAMES[t]}_${TEAM_POSITIONS[p].toUpperCase()}`,
         });
       }
     }

--- a/src/lib/validators/registration.ts
+++ b/src/lib/validators/registration.ts
@@ -43,9 +43,9 @@ export const registrationSchema = z
       .min(1, "请填写 QQ 号")
       .regex(/^\d{5,12}$/, "请输入有效的 QQ 号（5-12 位数字）"),
 
-    perfectId: z
+    perfectName: z
       .string()
-      .min(1, "请填写完美平台 ID"),
+      .min(1, "请填写完美平台昵称"),
 
     steamName: z
       .string()


### PR DESCRIPTION
## 改动内容

`users` 表 `perfect_id` 列重命名为 `perfect_name`，含义从"完美平台账号 ID"改为"完美平台昵称"。

- `src/db/schema/users.ts`：字段 `perfectId → perfectName`，列名 `perfect_id → perfect_name`
- `src/lib/validators/registration.ts`：字段名 + 错误提示改为"完美平台昵称"
- `src/components/register/RegistrationForm.tsx`：label 和 placeholder 改为"完美平台昵称"
- `src/actions/register.ts`：写库字段名同步更新
- `src/db/seed.ts`：seed 数据改为真实昵称格式（如 `Nova_IGL`）
- `drizzle/migrations/0003_rename_perfect_id.sql`：手写迁移，`ALTER TABLE RENAME COLUMN`

## 应用迁移

```bash
pnpm db:push
```