### PR TITLE
feat(player-stats): OCR scoreboard ingestion with admin review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # 申请地址：https://steamcommunity.com/dev/apikey（免费，域名填 localhost 即可）
 # 未配置时选手头像显示姓名首字母占位符
 STEAM_API_KEY=your-steam-api-key-here
+
+# SiliconFlow OCR（玩家数据截图识别）
+# 申请地址：https://cloud.siliconflow.cn/account/ak
+SILICONFLOW_API_KEY=your-siliconflow-api-key-here

--- a/PHASES.md
+++ b/PHASES.md
@@ -147,6 +147,19 @@
 
 ---
 
+## Phase 11.5 — 玩家数据展示（player-stats 录入已完成，展示待做）
+
+OCR 录入流程已完成（PR #28），数据保存在 `match_player_stats` 表。待补展示侧：
+
+- [ ] **比赛详情页数据表**：`/[seasonSlug]/matches/[matchId]` 每张地图下方加 K/D/A、ADR、RWS、Rating、WE 数据表格（Server Component，读 `getPlayerStatsByMap`）
+- [ ] **个人统计聚合**：用户主页展示跨地图赛事数据（场均 K/D/A、Rating 等，按赛季分组）
+- [ ] **赛季排行榜**：`/[seasonSlug]/stats` 页面，按 Rating/ADR/KD 等指标排名（类似 HLTV Stats 页）
+- [ ] **队伍聚合统计**：队伍场均数据（团队 ADR、胜率等）
+
+> 以上均为 v1 拓展功能，可按需推进，不阻塞 Phase 12 部署。
+
+---
+
 ## Phase 12 — 部署上线
 
 - [ ] Vercel 环境变量配置

--- a/drizzle/migrations/0004_player_stats.sql
+++ b/drizzle/migrations/0004_player_stats.sql
@@ -22,4 +22,5 @@ CREATE TABLE "match_player_stats" (
 --> statement-breakpoint
 ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_match_id_matches_id_fk" FOREIGN KEY ("match_id") REFERENCES "public"."matches"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_map_id_match_maps_id_fk" FOREIGN KEY ("map_id") REFERENCES "public"."match_maps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_map_id_perfect_name_unique" UNIQUE("map_id","perfect_name");

--- a/drizzle/migrations/0004_player_stats.sql
+++ b/drizzle/migrations/0004_player_stats.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "match_player_stats" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"match_id" uuid NOT NULL,
+	"map_id" uuid NOT NULL,
+	"perfect_name" text NOT NULL,
+	"user_id" uuid,
+	"kills" integer,
+	"deaths" integer,
+	"assists" integer,
+	"hs_percent" integer,
+	"first_kills" integer,
+	"multi_kills" integer,
+	"clutches" integer,
+	"adr" real,
+	"rws" real,
+	"rating_pro" real,
+	"we" real,
+	"verified_by_admin" text,
+	"verified_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_match_id_matches_id_fk" FOREIGN KEY ("match_id") REFERENCES "public"."matches"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_map_id_match_maps_id_fk" FOREIGN KEY ("map_id") REFERENCES "public"."match_maps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "match_player_stats" ADD CONSTRAINT "match_player_stats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1747008000000,
       "tag": "0003_rename_perfect_id",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1746806400000,
+      "tag": "0004_player_stats",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,11 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   serverExternalPackages: ["pg"],
   typedRoutes: true,
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -1,0 +1,158 @@
+"use server";
+
+import { eq, and } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matchMaps } from "@/db/schema/match-maps";
+import { matches } from "@/db/schema/matches";
+import { matchPlayerStats } from "@/db/schema/player-stats";
+import { users } from "@/db/schema/users";
+import { seasonRegistrations } from "@/db/schema/registrations";
+import { ok, fail } from "@/types/action";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { extractScoreboardFromBase64 } from "@/lib/ocr/scoreboard";
+import type { PlayerRowOCR } from "@/lib/ocr/scoreboard";
+import { requireAdmin, auditActorId } from "@/lib/auth/session";
+
+export type PlayerStatsDraft = PlayerRowOCR & {
+  userId: string | null;
+};
+
+export type PlayerOption = {
+  userId: string;
+  perfectName: string;
+};
+
+/**
+ * 从截图 base64 提取记分板数据（不写库），返回草稿供管理员确认。
+ * 同时返回赛季中所有已匹配玩家列表供下拉选择。
+ */
+export async function extractStatsFromScreenshot(
+  mapId: string,
+  base64Image: string,
+  mimeType: "image/jpeg" | "image/png" | "image/webp" = "image/jpeg"
+) {
+  try {
+    await requireAdmin();
+
+    const map = await db.query.matchMaps.findFirst({
+      where: eq(matchMaps.id, mapId),
+    });
+    if (!map) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
+
+    const match = await db.query.matches.findFirst({
+      where: eq(matches.id, map.matchId),
+    });
+    if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛记录不存在");
+
+    // 赛季中所有 approved 选手（用于精确昵称匹配 + 下拉选择）
+    const seasonPlayers = await db
+      .select({
+        userId: users.id,
+        perfectName: users.perfectName,
+      })
+      .from(users)
+      .innerJoin(seasonRegistrations, eq(seasonRegistrations.userId, users.id))
+      .where(
+        and(
+          eq(seasonRegistrations.seasonId, match.seasonId),
+          eq(seasonRegistrations.status, "approved")
+        )
+      );
+
+    const nameToUserId = new Map<string, string>();
+    for (const p of seasonPlayers) {
+      if (p.perfectName) {
+        nameToUserId.set(p.perfectName.toLowerCase(), p.userId);
+      }
+    }
+
+    const ocrResult = await extractScoreboardFromBase64(base64Image, mimeType);
+
+    const drafts: PlayerStatsDraft[] = ocrResult.players.map((row) => {
+      const name = row.perfectName as string;
+      return {
+        ...row,
+        perfectName: name,
+        userId: nameToUserId.get(name.toLowerCase()) ?? null,
+      };
+    });
+
+    const playerOptions: PlayerOption[] = seasonPlayers.map((p) => ({
+      userId: p.userId,
+      perfectName: p.perfectName ?? "(未填写昵称)",
+    }));
+
+    return ok({ drafts, playerOptions });
+  } catch (e) {
+    if (e instanceof AppError) {
+      return fail({ code: e.code, message: e.message });
+    }
+    console.error("[extractStatsFromScreenshot]", e);
+    const msg = e instanceof Error ? e.message : ERROR_MESSAGES.INTERNAL_ERROR;
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: msg });
+  }
+}
+
+/**
+ * 保存管理员确认后的玩家数据（幂等：先删同 mapId 旧数据，再批量插入）。
+ */
+export async function savePlayerStats(
+  mapId: string,
+  stats: PlayerStatsDraft[]
+) {
+  try {
+    const session = await requireAdmin();
+    const actor = auditActorId(session);
+
+    const map = await db.query.matchMaps.findFirst({
+      where: eq(matchMaps.id, mapId),
+    });
+    if (!map) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
+
+    await db.transaction(async (tx) => {
+      await tx.delete(matchPlayerStats).where(eq(matchPlayerStats.mapId, mapId));
+
+      if (stats.length === 0) return;
+
+      await tx.insert(matchPlayerStats).values(
+        stats.map((s) => ({
+          matchId: map.matchId,
+          mapId,
+          perfectName: s.perfectName as string,
+          userId: s.userId ?? undefined,
+          kills: s.kills ?? undefined,
+          deaths: s.deaths ?? undefined,
+          assists: s.assists ?? undefined,
+          hsPercent: s.hsPercent ?? undefined,
+          firstKills: s.firstKills ?? undefined,
+          multiKills: s.multiKills ?? undefined,
+          clutches: s.clutches ?? undefined,
+          adr: s.adr ?? undefined,
+          rws: s.rws ?? undefined,
+          ratingPro: s.ratingPro ?? undefined,
+          we: s.we ?? undefined,
+          verifiedByAdmin: actor,
+          verifiedAt: new Date(),
+        }))
+      );
+    });
+
+    return ok({ saved: stats.length });
+  } catch (e) {
+    if (e instanceof AppError) {
+      return fail({ code: e.code, message: e.message });
+    }
+    console.error("[savePlayerStats]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
+/**
+ * 查询某张地图已保存的玩家数据
+ */
+export async function getPlayerStatsByMap(mapId: string) {
+  return db.query.matchPlayerStats.findMany({
+    where: eq(matchPlayerStats.mapId, mapId),
+    orderBy: (t, { desc }) => [desc(t.ratingPro)],
+  });
+}

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -5,6 +5,7 @@ import { db } from "@/db/client";
 import { matchMaps } from "@/db/schema/match-maps";
 import { matches } from "@/db/schema/matches";
 import { matchPlayerStats } from "@/db/schema/player-stats";
+import { auditLogs } from "@/db/schema/audit";
 import { users } from "@/db/schema/users";
 import { seasonRegistrations } from "@/db/schema/registrations";
 import { ok, fail } from "@/types/action";
@@ -88,8 +89,7 @@ export async function extractStatsFromScreenshot(
       return fail({ code: e.code, message: e.message });
     }
     console.error("[extractStatsFromScreenshot]", e);
-    const msg = e instanceof Error ? e.message : ERROR_MESSAGES.INTERNAL_ERROR;
-    return fail({ code: ErrorCode.INTERNAL_ERROR, message: msg });
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: "OCR 识别失败，请检查截图格式后重试" });
   }
 }
 
@@ -109,32 +109,46 @@ export async function savePlayerStats(
     });
     if (!map) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
 
+    const match = await db.query.matches.findFirst({
+      where: eq(matches.id, map.matchId),
+    });
+    if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛记录不存在");
+
     await db.transaction(async (tx) => {
       await tx.delete(matchPlayerStats).where(eq(matchPlayerStats.mapId, mapId));
 
-      if (stats.length === 0) return;
+      if (stats.length > 0) {
+        await tx.insert(matchPlayerStats).values(
+          stats.map((s) => ({
+            matchId: map.matchId,
+            mapId,
+            perfectName: s.perfectName as string,
+            userId: s.userId ?? undefined,
+            kills: s.kills ?? undefined,
+            deaths: s.deaths ?? undefined,
+            assists: s.assists ?? undefined,
+            hsPercent: s.hsPercent ?? undefined,
+            firstKills: s.firstKills ?? undefined,
+            multiKills: s.multiKills ?? undefined,
+            clutches: s.clutches ?? undefined,
+            adr: s.adr ?? undefined,
+            rws: s.rws ?? undefined,
+            ratingPro: s.ratingPro ?? undefined,
+            we: s.we ?? undefined,
+            verifiedByAdmin: actor,
+            verifiedAt: new Date(),
+          }))
+        );
+      }
 
-      await tx.insert(matchPlayerStats).values(
-        stats.map((s) => ({
-          matchId: map.matchId,
-          mapId,
-          perfectName: s.perfectName as string,
-          userId: s.userId ?? undefined,
-          kills: s.kills ?? undefined,
-          deaths: s.deaths ?? undefined,
-          assists: s.assists ?? undefined,
-          hsPercent: s.hsPercent ?? undefined,
-          firstKills: s.firstKills ?? undefined,
-          multiKills: s.multiKills ?? undefined,
-          clutches: s.clutches ?? undefined,
-          adr: s.adr ?? undefined,
-          rws: s.rws ?? undefined,
-          ratingPro: s.ratingPro ?? undefined,
-          we: s.we ?? undefined,
-          verifiedByAdmin: actor,
-          verifiedAt: new Date(),
-        }))
-      );
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "match.save_player_stats",
+        actorId: actor,
+        targetId: mapId,
+        targetType: "match_map",
+        meta: { playerCount: stats.length, matchId: map.matchId },
+      });
     });
 
     return ok({ saved: stats.length });

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -11,6 +11,7 @@ import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
 import { ScoreInput } from "@/components/matches/ScoreInput";
 import { MapByMapInput } from "@/components/matches/MapByMapInput";
 import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
+import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -65,6 +66,24 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
   const teamMap = new Map(allTeams.map((t) => [t.id, t.name]));
   const qualifierMatches = allMatches.filter((m) => m.stage === "qualifier");
   const playoffMatches = allMatches.filter((m) => m.stage === "playoff");
+
+  // 已完成比赛的地图列表（用于 OCR 录入面板）
+  const finishedMatchIds = allMatches
+    .filter((m) => m.status === "finished")
+    .map((m) => m.id);
+  const allMaps =
+    finishedMatchIds.length > 0
+      ? await db.query.matchMaps.findMany({
+          where: inArray(matchMaps.matchId, finishedMatchIds),
+          orderBy: (t, { asc }) => [asc(t.mapOrder)],
+        })
+      : [];
+  const mapsByMatch = new Map<string, typeof allMaps>();
+  for (const map of allMaps) {
+    const arr = mapsByMatch.get(map.matchId) ?? [];
+    arr.push(map);
+    mapsByMatch.set(map.matchId, arr);
+  }
 
   const matchCount = allMatches.length;
   const qualifierCount = qualifierMatches.length;
@@ -200,6 +219,12 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                             />
                           </>
                         )}
+                        {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
+                          <div key={map.id}>
+                            <Separator />
+                            <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                          </div>
+                        ))}
                       </Card>
                     );
                   })}
@@ -277,6 +302,12 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
                             )}
                           </>
                         )}
+                        {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
+                          <div key={map.id}>
+                            <Separator />
+                            <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                          </div>
+                        ))}
                       </Card>
                     );
                   })}

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  extractStatsFromScreenshot,
+  savePlayerStats,
+  type PlayerStatsDraft,
+  type PlayerOption,
+} from "@/actions/player-stats";
+
+interface Props {
+  mapId: string;
+  mapName: string;
+}
+
+type DraftRow = PlayerStatsDraft;
+
+const NUM_FIELDS = [
+  { key: "kills",      label: "K"   },
+  { key: "deaths",     label: "D"   },
+  { key: "assists",    label: "A"   },
+  { key: "hsPercent",  label: "HS%" },
+  { key: "firstKills", label: "FK"  },
+  { key: "multiKills", label: "MK"  },
+  { key: "clutches",   label: "残局" },
+  { key: "adr",        label: "ADR" },
+  { key: "rws",        label: "RWS" },
+  { key: "ratingPro",  label: "Rating" },
+  { key: "we",         label: "WE"  },
+] as const;
+
+type NumFieldKey = typeof NUM_FIELDS[number]["key"];
+
+export function StatsOCRPanel({ mapId, mapName }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [drafts, setDrafts] = useState<DraftRow[]>([]);
+  const [playerOptions, setPlayerOptions] = useState<PlayerOption[]>([]);
+  const [extracting, setExtracting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function handleExtract() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      setError("请先选择截图文件");
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setError("文件大小不超过 10MB");
+      return;
+    }
+
+    setError(null);
+    setExtracting(true);
+    setSaved(false);
+
+    try {
+      const base64 = await fileToBase64(file);
+      const mimeType = file.type as "image/jpeg" | "image/png" | "image/webp";
+      const result = await extractStatsFromScreenshot(mapId, base64, mimeType);
+
+      if (!result.success) {
+        setError(result.error.message);
+        return;
+      }
+
+      setDrafts(result.data.drafts);
+      setPlayerOptions(result.data.playerOptions);
+    } finally {
+      setExtracting(false);
+    }
+  }
+
+  function handleNumChange(idx: number, field: NumFieldKey, raw: string) {
+    const val = raw === "" ? null : Number(raw);
+    setDrafts((prev) =>
+      prev.map((row, i) =>
+        i === idx ? { ...row, [field]: isNaN(val as number) ? null : val } : row
+      )
+    );
+  }
+
+  function handleNameChange(idx: number, value: string) {
+    setDrafts((prev) =>
+      prev.map((row, i) => (i === idx ? { ...row, perfectName: value } : row))
+    );
+  }
+
+  function handleUserChange(idx: number, userId: string) {
+    setDrafts((prev) =>
+      prev.map((row, i) =>
+        i === idx ? { ...row, userId: userId === "__none__" ? null : userId } : row
+      )
+    );
+  }
+
+  function handleDeleteRow(idx: number) {
+    setDrafts((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    const result = await savePlayerStats(mapId, drafts);
+    setSaving(false);
+
+    if (!result.success) {
+      setError(result.error.message);
+      return;
+    }
+    setSaved(true);
+  }
+
+  return (
+    <div className="mt-4 space-y-4">
+      <h4 className="font-semibold text-sm">
+        {mapName} — 玩家数据录入（OCR 识别）
+      </h4>
+
+      <div className="flex gap-2 items-center">
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          className="text-sm"
+        />
+        <Button
+          size="sm"
+          onClick={handleExtract}
+          disabled={extracting}
+        >
+          {extracting ? "识别中…" : "识别截图"}
+        </Button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+
+      {drafts.length > 0 && (
+        <>
+          <div className="overflow-x-auto rounded border">
+            <Table className="text-xs">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-36">昵称</TableHead>
+                  <TableHead className="w-40">匹配用户</TableHead>
+                  {NUM_FIELDS.map((f) => (
+                    <TableHead key={f.key} className="w-16 text-center">
+                      {f.label}
+                    </TableHead>
+                  ))}
+                  <TableHead className="w-10" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {drafts.map((row, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>
+                      <Input
+                        className="h-7 text-xs"
+                        value={row.perfectName as string}
+                        onChange={(e) => handleNameChange(idx, e.target.value)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        value={row.userId ?? "__none__"}
+                        onValueChange={(v) => handleUserChange(idx, v)}
+                      >
+                        <SelectTrigger className="h-7 text-xs">
+                          <SelectValue placeholder="未匹配" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none__">— 未匹配 —</SelectItem>
+                          {playerOptions.map((p) => (
+                            <SelectItem key={p.userId} value={p.userId}>
+                              {p.perfectName}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    {NUM_FIELDS.map((f) => (
+                      <TableCell key={f.key} className="text-center p-1">
+                        <Input
+                          className="h-7 text-xs text-center w-14"
+                          type="number"
+                          value={(row[f.key] as number | null) ?? ""}
+                          onChange={(e) =>
+                            handleNumChange(idx, f.key, e.target.value)
+                          }
+                        />
+                      </TableCell>
+                    ))}
+                    <TableCell className="p-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0 text-red-400"
+                        onClick={() => handleDeleteRow(idx)}
+                        title="删除此行"
+                      >
+                        ×
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex gap-2 items-center">
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? "保存中…" : "确认保存"}
+            </Button>
+            {saved && (
+              <span className="text-sm text-green-600">已保存 {drafts.length} 条数据</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // 去掉 data:image/xxx;base64, 前缀
+      resolve(result.split(",")[1]);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -9,3 +9,4 @@ export * from "./match-maps";
 export * from "./audit";
 export * from "./admin-users";
 export * from "./admin-invites";
+export * from "./player-stats";

--- a/src/db/schema/player-stats.ts
+++ b/src/db/schema/player-stats.ts
@@ -1,0 +1,38 @@
+import { pgTable, uuid, integer, real, text, timestamp } from "drizzle-orm/pg-core";
+import { matches } from "./matches";
+import { matchMaps } from "./match-maps";
+import { users } from "./users";
+
+export const matchPlayerStats = pgTable("match_player_stats", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  matchId: uuid("match_id").notNull().references(() => matches.id),
+  mapId: uuid("map_id").notNull().references(() => matchMaps.id),
+
+  // 记分板上的完美昵称（原始值，用于审核和兜底显示）
+  perfectName: text("perfect_name").notNull(),
+  // 映射到系统用户（可为 null：未匹配或手动留空）
+  userId: uuid("user_id").references(() => users.id),
+
+  // 统计数据（整数类）
+  kills: integer("kills"),
+  deaths: integer("deaths"),
+  assists: integer("assists"),
+  hsPercent: integer("hs_percent"),   // 0–100
+  firstKills: integer("first_kills"),
+  multiKills: integer("multi_kills"),
+  clutches: integer("clutches"),
+
+  // 统计数据（小数类）
+  adr: real("adr"),           // ≥ 0
+  rws: real("rws"),           // 两位小数
+  ratingPro: real("rating_pro"), // 两位小数
+  we: real("we"),             // 一位小数，0–16
+
+  // 审核信息
+  verifiedByAdmin: text("verified_by_admin"),
+  verifiedAt: timestamp("verified_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type MatchPlayerStat = typeof matchPlayerStats.$inferSelect;
+export type NewMatchPlayerStat = typeof matchPlayerStats.$inferInsert;

--- a/src/db/schema/player-stats.ts
+++ b/src/db/schema/player-stats.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, integer, real, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, uuid, integer, real, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { matches } from "./matches";
 import { matchMaps } from "./match-maps";
 import { users } from "./users";
@@ -32,7 +32,9 @@ export const matchPlayerStats = pgTable("match_player_stats", {
   verifiedByAdmin: text("verified_by_admin"),
   verifiedAt: timestamp("verified_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
+}, (t) => ({
+  uniqueMapPlayer: unique().on(t.mapId, t.perfectName),
+}));
 
 export type MatchPlayerStat = typeof matchPlayerStats.$inferSelect;
 export type NewMatchPlayerStat = typeof matchPlayerStats.$inferInsert;

--- a/src/lib/ocr/scoreboard.ts
+++ b/src/lib/ocr/scoreboard.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+const SF_API_URL = "https://api.siliconflow.cn/v1/chat/completions";
+const SF_MODEL = "Qwen/Qwen2.5-VL-72B-Instruct";
+
+const playerRowSchema = z.object({
+  perfectName: z.string(),
+  kills: z.number().int().nonnegative().nullable().default(null),
+  deaths: z.number().int().nonnegative().nullable().default(null),
+  assists: z.number().int().nonnegative().nullable().default(null),
+  hsPercent: z.number().int().min(0).max(100).nullable().default(null),
+  firstKills: z.number().int().nonnegative().nullable().default(null),
+  multiKills: z.number().int().nonnegative().nullable().default(null),
+  clutches: z.number().int().nonnegative().nullable().default(null),
+  adr: z.number().nonnegative().nullable().default(null),
+  rws: z.number().nonnegative().nullable().default(null),
+  ratingPro: z.number().nonnegative().nullable().default(null),
+  we: z.number().min(0).max(16).nullable().default(null),
+});
+
+const ocrResponseSchema = z.object({
+  players: z.array(playerRowSchema).min(1).max(20),
+});
+
+export type PlayerRowOCR = z.infer<typeof playerRowSchema>;
+export type ScoreboardOCRResult = z.infer<typeof ocrResponseSchema>;
+
+const SYSTEM_PROMPT = `你是一个电竞赛事数据录入助手。用户会发送一张完美平台（Perfect World）CS2 赛后记分板截图。
+请精确识别截图中所有玩家的统计数据，以 JSON 格式返回，不要添加任何解释文字。
+
+输出格式（严格遵守）：
+{
+  "players": [
+    {
+      "perfectName": "玩家昵称（与截图完全一致）",
+      "kills": 数字或null,
+      "deaths": 数字或null,
+      "assists": 数字或null,
+      "hsPercent": 0-100整数或null,
+      "firstKills": 整数或null,
+      "multiKills": 整数或null,
+      "clutches": 整数或null,
+      "adr": 小数或null,
+      "rws": 两位小数或null,
+      "ratingPro": 两位小数或null,
+      "we": 0.0-16.0一位小数或null
+    }
+  ]
+}
+
+规则：
+- perfectName 必须与截图中显示的完美平台昵称完全一致
+- 整数字段（kills/deaths/assists/hsPercent/firstKills/multiKills/clutches）无上限，保持整数
+- adr 可以为 0，保留一位或两位小数
+- rws 保留两位小数
+- we 范围 0.0–16.0，保留一位小数
+- 如果某个格子无法识别或为空，填 null
+- 不要推断或捏造任何数据`;
+
+export async function extractScoreboardFromBase64(
+  base64Image: string,
+  mimeType: "image/jpeg" | "image/png" | "image/webp" = "image/jpeg"
+): Promise<ScoreboardOCRResult> {
+  const apiKey = process.env.SILICONFLOW_API_KEY;
+  if (!apiKey) {
+    throw new Error("SILICONFLOW_API_KEY 未配置");
+  }
+
+  const response = await fetch(SF_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: SF_MODEL,
+      messages: [
+        {
+          role: "system",
+          content: SYSTEM_PROMPT,
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: {
+                url: `data:${mimeType};base64,${base64Image}`,
+              },
+            },
+            {
+              type: "text",
+              text: "请识别并返回这张完美平台记分板截图中所有玩家的数据。",
+            },
+          ],
+        },
+      ],
+      response_format: { type: "json_object" },
+      max_tokens: 2048,
+      temperature: 0,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`SiliconFlow API 错误 ${response.status}: ${text}`);
+  }
+
+  const json = await response.json();
+  const content = json?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("SiliconFlow API 返回为空");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error(`无法解析 API 返回的 JSON: ${content.slice(0, 200)}`);
+  }
+
+  const validated = ocrResponseSchema.safeParse(parsed);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => i.message).join("; ");
+    throw new Error(`OCR 结果格式校验失败: ${issues}`);
+  }
+
+  return validated.data;
+}


### PR DESCRIPTION
## Summary

- New `match_player_stats` table storing per-map K/D/A, HS%, FK, MK, clutch, ADR, RWS, Rating Pro, WE
- SiliconFlow Qwen-VL vision model integration with `response_format: json_object` + Zod validation to prevent hallucination
- Three Server Actions: `extractStatsFromScreenshot`, `savePlayerStats`, `getPlayerStatsByMap`
- `StatsOCRPanel` client component: upload screenshot -> OCR -> editable review table with player matching dropdown -> confirm & save
- Admin matches page now shows OCR panel for each completed map on finished matches
- Player name auto-matched against season approved registrations by `perfectName`
- No screenshots stored; base64 passed directly to API, discarded after extraction

## Test plan

- [ ] Set `SILICONFLOW_API_KEY` in `.env.local`
- [ ] Run `pnpm db:push` to apply migration 0004
- [ ] Seed DB and finish a match so maps appear
- [ ] Upload a PW scoreboard screenshot in admin matches page -> verify OCR extracts player rows
- [ ] Edit/correct any misread fields in review table
- [ ] Confirm save -> verify data written to `match_player_stats`
- [ ] Test OCR failure path (wrong image type) -> verify error message shown