### PR TITLE
fix(captains): 队长投票安全加固与错误修正（PR #16 review 问题修复）

### DIFF
--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -14,7 +14,7 @@ import {
 } from "@/db/schema";
 import { fail, ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
-import { requireSeasonAdmin } from "@/lib/auth/session";
+import { requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
 import {
   castVoteSchema,
   confirmCaptainsSchema,
@@ -38,6 +38,7 @@ export async function castVote(
   }
 
   try {
+    const session = await requireAuth();
     const voteId = await db.transaction(async (tx) => {
       const voter = await tx.query.seasonRegistrations.findFirst({
         where: eq(seasonRegistrations.id, parsed.data.voterRegistrationId),
@@ -47,6 +48,9 @@ export async function castVote(
       });
       if (!voter || !candidate) {
         throw new AppError(ErrorCode.NOT_FOUND, "报名记录不存在");
+      }
+      if (voter.userId !== session.userId) {
+        throw new AppError(ErrorCode.FORBIDDEN, ERROR_MESSAGES.FORBIDDEN);
       }
 
       const season = await tx.query.seasons.findFirst({
@@ -91,6 +95,9 @@ export async function castVote(
     await revalidateCaptainPaths(parsed.data.voterRegistrationId);
     return ok({ voteId });
   } catch (e) {
+    if (isPgUniqueViolation(e)) {
+      return fail({ code: ErrorCode.VOTE_DUPLICATE, message: ERROR_MESSAGES.VOTE_DUPLICATE });
+    }
     return actionError("castVote", e);
   }
 }
@@ -104,6 +111,7 @@ export async function retractVote(
   }
 
   try {
+    const session = await requireAuth();
     await db.transaction(async (tx) => {
       const voter = await tx.query.seasonRegistrations.findFirst({
         where: eq(seasonRegistrations.id, parsed.data.voterRegistrationId),
@@ -113,6 +121,9 @@ export async function retractVote(
       });
       if (!voter || !candidate) {
         throw new AppError(ErrorCode.NOT_FOUND, "报名记录不存在");
+      }
+      if (voter.userId !== session.userId) {
+        throw new AppError(ErrorCode.FORBIDDEN, ERROR_MESSAGES.FORBIDDEN);
       }
       if (voter.seasonId !== candidate.seasonId) {
         throw new AppError(ErrorCode.CAPTAIN_NOT_ELIGIBLE, ERROR_MESSAGES.CAPTAIN_NOT_ELIGIBLE);
@@ -303,4 +314,8 @@ function actionError(scope: string, e: unknown): ActionResult<never> {
   }
   console.error(`[${scope}]`, e);
   return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+}
+
+function isPgUniqueViolation(e: unknown): boolean {
+  return typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "23505";
 }

--- a/src/app/[seasonSlug]/captains/page.tsx
+++ b/src/app/[seasonSlug]/captains/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons } from "@/db/schema";
+import { seasonRegistrations, seasons } from "@/db/schema";
 import { CaptainVotingPanel } from "@/components/captains/CaptainVotingPanel";
 import { Card } from "@/components/ui/card";
 import { getCaptainVotingData } from "@/lib/captains/data";
+import { getUserSession } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
@@ -32,7 +33,28 @@ export default async function CaptainsPage({ params }: CaptainsPageProps) {
     );
   }
 
-  const data = await getCaptainVotingData(season.id);
+  const [data, session] = await Promise.all([
+    getCaptainVotingData(season.id),
+    getUserSession(),
+  ]);
+
+  let currentVoter = data.voters.find(() => false) ?? null; // typed as CaptainVoterOption | null
+  let currentVotes = data.votes.filter(() => false);
+
+  if (session) {
+    const reg = await db.query.seasonRegistrations.findFirst({
+      where: and(
+        eq(seasonRegistrations.userId, session.userId),
+        eq(seasonRegistrations.seasonId, season.id),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+      columns: { id: true },
+    });
+    if (reg) {
+      currentVoter = data.voters.find((v) => v.id === reg.id) ?? null;
+      currentVotes = data.votes.filter((v) => v.voterRegistrationId === reg.id);
+    }
+  }
 
   return (
     <main className="container mx-auto max-w-6xl px-4 py-10">
@@ -46,9 +68,9 @@ export default async function CaptainsPage({ params }: CaptainsPageProps) {
       <CaptainVotingPanel
         seasonName={season.name}
         seasonStatus={season.status}
-        voters={data.voters}
+        currentVoter={currentVoter}
         candidates={data.candidates}
-        votes={data.votes}
+        votes={currentVotes}
       />
     </main>
   );

--- a/src/components/captains/CaptainVotingPanel.tsx
+++ b/src/components/captains/CaptainVotingPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useTransition } from "react";
 import { RefreshCw, Undo2, Vote } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -8,14 +8,6 @@ import { castVote, retractVote } from "@/actions/captains";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { createBrowserClient } from "@/lib/auth/supabase";
 import { MAX_CAPTAIN_VOTES } from "@/lib/captains/rules";
 import { POSITION_LABELS } from "@/lib/validators/registration";
@@ -28,7 +20,7 @@ import type {
 interface CaptainVotingPanelProps {
   seasonName: string;
   seasonStatus: string;
-  voters: CaptainVoterOption[];
+  currentVoter: CaptainVoterOption | null;
   candidates: CaptainCandidateRow[];
   votes: CaptainVoteRecord[];
 }
@@ -36,12 +28,11 @@ interface CaptainVotingPanelProps {
 export function CaptainVotingPanel({
   seasonName,
   seasonStatus,
-  voters,
+  currentVoter,
   candidates,
   votes,
 }: CaptainVotingPanelProps) {
   const router = useRouter();
-  const [selectedVoterId, setSelectedVoterId] = useState<string>(voters[0]?.id ?? "");
   const [isPending, startTransition] = useTransition();
   const isVotingOpen = seasonStatus === "voting";
 
@@ -51,13 +42,8 @@ export function CaptainVotingPanel({
     return () => window.clearInterval(timer);
   }, [isVotingOpen, router]);
 
-  const selectedVotes = useMemo(
-    () => votes.filter((vote) => vote.voterRegistrationId === selectedVoterId),
-    [selectedVoterId, votes],
-  );
-  const selectedCandidateIds = new Set(
-    selectedVotes.map((vote) => vote.candidateRegistrationId),
-  );
+  // votes 已在服务端按当前用户过滤
+  const votedCandidateIds = new Set(votes.map((vote) => vote.candidateRegistrationId));
   const maxVotes = Math.max(1, ...candidates.map((candidate) => candidate.voteCount));
 
   useEffect(() => {
@@ -78,14 +64,14 @@ export function CaptainVotingPanel({
   }, [isVotingOpen, router]);
 
   function handleCast(candidateId: string) {
-    if (!selectedVoterId) {
-      toast.error("请选择投票身份");
+    if (!currentVoter) {
+      toast.error("请先登录并完成报名审核");
       return;
     }
 
     startTransition(async () => {
       const result = await castVote({
-        voterRegistrationId: selectedVoterId,
+        voterRegistrationId: currentVoter.id,
         candidateRegistrationId: candidateId,
       });
       if (!result.success) {
@@ -98,9 +84,10 @@ export function CaptainVotingPanel({
   }
 
   function handleRetract(candidateId: string) {
+    if (!currentVoter) return;
     startTransition(async () => {
       const result = await retractVote({
-        voterRegistrationId: selectedVoterId,
+        voterRegistrationId: currentVoter.id,
         candidateRegistrationId: candidateId,
       });
       if (!result.success) {
@@ -118,42 +105,41 @@ export function CaptainVotingPanel({
         <Card className="p-4">
           <div className="space-y-3">
             <div>
-              <h2 className="text-base font-semibold">投票身份</h2>
+              <h2 className="text-base font-semibold">我的投票</h2>
               <p className="mt-1 text-sm text-[var(--text-secondary)]">
                 每名已通过报名的选手最多投 {MAX_CAPTAIN_VOTES} 票。
               </p>
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="voter">选择选手</Label>
-              <Select value={selectedVoterId} onValueChange={setSelectedVoterId}>
-                <SelectTrigger id="voter">
-                  <SelectValue placeholder="选择报名身份" />
-                </SelectTrigger>
-                <SelectContent>
-                  {voters.map((voter) => (
-                    <SelectItem key={voter.id} value={voter.id}>
-                      {voter.displayName}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {currentVoter ? (
+              <>
+                <div className="rounded-md border border-[var(--border)] p-3 text-sm">
+                  <p className="font-medium">{currentVoter.displayName}</p>
+                  <p className="mt-0.5 text-[var(--text-secondary)]">
+                    {positionLabel(currentVoter.primaryPosition)} · Peak {currentVoter.peakRating}
+                  </p>
+                </div>
 
-            <div className="rounded-md border border-[var(--border)] p-3 text-sm">
-              <div className="flex items-center justify-between">
-                <span className="text-[var(--text-secondary)]">已投</span>
-                <span className="font-medium">
-                  {selectedVotes.length} / {MAX_CAPTAIN_VOTES}
-                </span>
-              </div>
-              <div className="mt-2 h-2 rounded-full bg-muted">
-                <div
-                  className="h-2 rounded-full bg-[var(--season-primary)] transition-all"
-                  style={{ width: `${(selectedVotes.length / MAX_CAPTAIN_VOTES) * 100}%` }}
-                />
-              </div>
-            </div>
+                <div className="rounded-md border border-[var(--border)] p-3 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[var(--text-secondary)]">已投</span>
+                    <span className="font-medium">
+                      {votes.length} / {MAX_CAPTAIN_VOTES}
+                    </span>
+                  </div>
+                  <div className="mt-2 h-2 rounded-full bg-muted">
+                    <div
+                      className="h-2 rounded-full bg-[var(--season-primary)] transition-all"
+                      style={{ width: `${(votes.length / MAX_CAPTAIN_VOTES) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p className="rounded-md border border-[var(--border)] p-3 text-sm text-[var(--text-secondary)]">
+                请先登录并通过报名审核后方可投票。
+              </p>
+            )}
 
             <Button
               type="button"
@@ -188,13 +174,13 @@ export function CaptainVotingPanel({
         ) : (
           <div className="space-y-3">
             {candidates.map((candidate, index) => {
-              const hasVoted = selectedCandidateIds.has(candidate.id);
+              const hasVoted = votedCandidateIds.has(candidate.id);
               const voteDisabled =
                 !isVotingOpen ||
                 isPending ||
-                !selectedVoterId ||
-                selectedVoterId === candidate.id ||
-                (!hasVoted && selectedVotes.length >= MAX_CAPTAIN_VOTES);
+                !currentVoter ||
+                currentVoter.id === candidate.id ||
+                (!hasVoted && votes.length >= MAX_CAPTAIN_VOTES);
 
               return (
                 <Card key={candidate.id} className="p-4">

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -29,7 +29,12 @@ export type DB = typeof db;
 function shouldUseSsl(databaseUrl?: string): boolean {
   if (!databaseUrl) return false;
 
-  const url = new URL(databaseUrl);
-  if (url.searchParams.get("sslmode") === "disable") return false;
-  return !["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  try {
+    const url = new URL(databaseUrl);
+    if (url.searchParams.get("sslmode") === "disable") return false;
+    return !["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  } catch {
+    console.error("[db] malformed DATABASE_URL, defaulting to SSL enabled");
+    return true;
+  }
 }

--- a/src/lib/captains/data.ts
+++ b/src/lib/captains/data.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, count, eq, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { captainVotes, seasonRegistrations, users, teams } from "@/db/schema";
 import { compareCaptainSeedCandidates, selectCaptainSeeds } from "@/lib/captains/rules";
@@ -108,6 +108,6 @@ export async function getCaptainVotingData(seasonId: string): Promise<CaptainVot
 }
 
 export async function getSeasonTeamCount(seasonId: string): Promise<number> {
-  const rows = await db.select({ id: teams.id }).from(teams).where(eq(teams.seasonId, seasonId));
-  return rows.length;
+  const [row] = await db.select({ count: count() }).from(teams).where(eq(teams.seasonId, seasonId));
+  return Number(row?.count ?? 0);
 }

--- a/src/lib/captains/rules.ts
+++ b/src/lib/captains/rules.ts
@@ -44,7 +44,7 @@ export function validateCaptainVote({
     return ErrorCode.CAPTAIN_NOT_ELIGIBLE;
   }
   if (voter.status !== "approved") {
-    return ErrorCode.UNAUTHORIZED;
+    return ErrorCode.FORBIDDEN;
   }
   if (candidate.status !== "approved" || !candidate.willingToBeCaptain) {
     return ErrorCode.CAPTAIN_NOT_ELIGIBLE;
@@ -62,13 +62,7 @@ export function validateCaptainVote({
 }
 
 export function selectCaptainSeeds<T extends CaptainSeedCandidate>(candidates: T[]): T[] {
-  return [...candidates]
-    .sort((a, b) => {
-      if (b.voteCount !== a.voteCount) return b.voteCount - a.voteCount;
-      if (b.peakRating !== a.peakRating) return b.peakRating - a.peakRating;
-      return createdAtTime(a.createdAt) - createdAtTime(b.createdAt);
-    })
-    .slice(0, CAPTAIN_TEAM_COUNT);
+  return [...candidates].sort(compareCaptainSeedCandidates).slice(0, CAPTAIN_TEAM_COUNT);
 }
 
 export function compareCaptainSeedCandidates(


### PR DESCRIPTION
## Summary
修复 PR #16 review 指出的 7 个安全与正确性问题（#1–#4, #6–#7），涉及 6 个文件。

## Changes

| # | 文件 | 修改 |
|---|------|------|
| #4 安全 | `captains.ts` + `page.tsx` + `CaptainVotingPanel.tsx` | `castVote`/`retractVote` 加 `requireAuth()` + 校验 `voter.userId === session.userId`；UI 移除手动选择投票者下拉框，改为服务端派生的身份卡片；votes 在 page 侧按当前用户过滤 |
| #3 并发 | `captains.ts` | 捕获 PG unique violation（23505）→ 返回 `VOTE_DUPLICATE` 而非 `INTERNAL_ERROR` |
| #1 错误码 | `rules.ts` | 未通过审核的 voter 返回 `FORBIDDEN`（"权限不足"）而非 `UNAUTHORIZED`（"请先登录"） |
| #2 重复逻辑 | `rules.ts` | `selectCaptainSeeds` 复用 `compareCaptainSeedCandidates` |
| #6 SQL | `data.ts` | `getSeasonTeamCount` 用 `COUNT()` 替代全表取回再 `.length` |
| #7 崩溃 | `db/client.ts` | `shouldUseSsl` 的 `new URL()` 加 try/catch |

## Not addressed
- **#5**（`confirmCaptains` 竞态）— admin 操作，后续 PR 单独处理
- **#8**（Realtime 无赛季过滤）— v2 前再改

## Test plan
- [ ] 已登录用户可正常投票/撤票
- [ ] 未登录用户访问投票页看到提示，无法操作
- [ ] 重复投票返回友好错误提示（而非 500）
- [ ] 数据库 URL 格式异常时服务不崩溃
- [ ] `getSeasonTeamCount` 返回正确的队伍数

🤖 Generated with [Claude Code](https://claude.com/claude-code)