### PR TITLE
refactor: replace mock data with DB queries in entry pages

### DIFF
--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -1,41 +1,11 @@
 import Link from "next/link";
-import { UserPlus, Vote, Users, Swords } from "lucide-react";
 import { notFound } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { UserPlus, Vote, Users, Swords, Shuffle } from "lucide-react";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
 import { SEASON_STATUS_LABELS } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
-
-// Mock season data — replaced with DB query in Phase 4+
-const MOCK_SEASONS: Record<string, {
-  name: string;
-  kind: string;
-  status: string;
-  description: string;
-  themeColor: string;
-  schedule: string;
-}> = {
-  "2026-nju-rivals": {
-    name: "2026 NJU Rivals",
-    kind: "选秀联赛",
-    status: "registration",
-    description: "南京大学 CS2 社群选秀联赛，56 选手 · 8 队伍 · 双败淘汰。报名开放至 2026 春季。",
-    themeColor: "#f97316",
-    schedule: "2026 年春季",
-  },
-};
-
-interface QuickLink {
-  href: string;
-  label: string;
-  description: string;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-}
-
-const QUICK_LINKS: QuickLink[] = [
-  { href: "register", label: "立即报名",  description: "提交报名信息",    icon: UserPlus },
-  { href: "captains", label: "队长投票",  description: "为心仪队长投票",  icon: Vote },
-  { href: "teams",    label: "队伍阵容",  description: "8 队选手分布",    icon: Users },
-  { href: "matches",  label: "赛程对决",  description: "Bracket + 战报", icon: Swords },
-];
 
 interface SeasonPageProps {
   params: Promise<{ seasonSlug: string }>;
@@ -43,12 +13,52 @@ interface SeasonPageProps {
 
 export default async function SeasonPage({ params }: SeasonPageProps) {
   const { seasonSlug } = await params;
-  const season = MOCK_SEASONS[seasonSlug];
+
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
   if (!season) notFound();
+
+  const quickLinks = [
+    {
+      href: `/${seasonSlug}/register`,
+      label: "立即报名",
+      description: "提交报名信息",
+      icon: UserPlus,
+      show: true,
+    },
+    {
+      href: `/${seasonSlug}/captains`,
+      label: "队长投票",
+      description: "为心仪队长投票",
+      icon: Vote,
+      show: season.hasCaptainVoting,
+    },
+    {
+      href: `/${seasonSlug}/draft`,
+      label: "选秀直播间",
+      description: "实时观看选秀进度",
+      icon: Shuffle,
+      show: season.hasDraft,
+    },
+    {
+      href: `/${seasonSlug}/teams`,
+      label: "队伍阵容",
+      description: "查看各队选手分布",
+      icon: Users,
+      show: true,
+    },
+    {
+      href: `/${seasonSlug}/matches`,
+      label: "赛程对决",
+      description: "Bracket + 战报",
+      icon: Swords,
+      show: season.qualifierFormat !== null || season.playoffFormat !== null,
+    },
+  ].filter((l) => l.show);
 
   return (
     <div className="container mx-auto px-4 py-10">
-      {/* Hero with theme glow */}
       <div className="season-glow relative mb-12 pt-6">
         <div className="flex items-center gap-3 mb-4 text-xs uppercase tracking-wider">
           <span
@@ -62,24 +72,17 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
             {SEASON_STATUS_LABELS[season.status as SeasonStatus] ?? season.status}
           </span>
           <span className="text-[var(--text-muted)]">{season.kind}</span>
-          <span className="text-[var(--text-muted)]">·</span>
-          <span className="text-[var(--text-muted)] tabular">{season.schedule}</span>
         </div>
-
         <h1 className="text-4xl sm:text-5xl font-bold text-[var(--text-primary)] mb-4 leading-tight">
           {season.name}
         </h1>
-        <p className="text-[var(--text-secondary)] text-base sm:text-lg max-w-2xl leading-relaxed">
-          {season.description}
-        </p>
       </div>
 
-      {/* Quick links */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-        {QUICK_LINKS.map(({ href, label, description, icon: Icon }) => (
+        {quickLinks.map(({ href, label, description, icon: Icon }) => (
           <Link
             key={href}
-            href={`/${seasonSlug}/${href}` as never}
+            href={href as never}
             className="card-elevated group flex flex-col gap-2 p-5 rounded-lg border border-[var(--border)]"
           >
             <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { APP_BRAND } from "@/lib/branding";
 import { SEASON_STATUS_LABELS } from "@/types/season";
 import { StatusDot } from "@/components/ui/status-dot";
 import type { Season } from "@/db/schema/seasons";
-import type { SeasonStatus } from "@/types/season";
 
 export default async function HomePage() {
   const allSeasons = await db
@@ -17,8 +16,8 @@ export default async function HomePage() {
   const activeSeasons = allSeasons.filter(
     (s) => s.status !== "archived" && s.status !== "draft"
   );
-  const featured = activeSeasons[0] as Season | undefined;
-  const others = activeSeasons.slice(1) as Season[];
+  const featured = activeSeasons[0];
+  const others = activeSeasons.slice(1);
 
   return (
     <div className="container mx-auto px-4 py-16 sm:py-24">
@@ -77,9 +76,9 @@ function FeaturedSeasonCard({ season }: { season: Season }) {
       <div className="p-6 sm:p-8 grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-6 items-center">
         <div>
           <div className="flex items-center gap-2 mb-3 text-xs">
-            <StatusDot status={season.status as SeasonStatus} />
+            <StatusDot status={season.status} />
             <span className="text-[var(--text-secondary)] uppercase tracking-wider">
-              {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+              {SEASON_STATUS_LABELS[season.status]}
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-[var(--text-muted)]">{season.kind}</span>
@@ -112,9 +111,9 @@ function CompactSeasonCard({ season }: { season: Season }) {
       <div className="h-0.5 w-full" style={{ backgroundColor: season.themeColor ?? "#f97316" }} />
       <div className="p-5">
         <div className="flex items-center gap-2 mb-2 text-xs">
-          <StatusDot status={season.status as SeasonStatus} />
+          <StatusDot status={season.status} />
           <span className="text-[var(--text-secondary)]">
-            {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+            {SEASON_STATUS_LABELS[season.status]}
           </span>
         </div>
         <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{season.name}</h3>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,58 +1,43 @@
 import Link from "next/link";
-import { ArrowRight, Trophy } from "lucide-react";
+import { ArrowRight } from "lucide-react";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
 import { APP_BRAND } from "@/lib/branding";
 import { SEASON_STATUS_LABELS } from "@/types/season";
-import type { SeasonStatus } from "@/types/season";
 import { StatusDot } from "@/components/ui/status-dot";
+import type { Season } from "@/db/schema/seasons";
+import type { SeasonStatus } from "@/types/season";
 
-// Mock data — replaced with DB query in Phase 4+
-const seasons: Array<{
-  slug: string;
-  name: string;
-  kind: string;
-  status: SeasonStatus;
-  themeColor: string;
-  description: string;
-  schedule: string;
-}> = [
-  {
-    slug: "2026-nju-rivals",
-    name: "2026 NJU Rivals",
-    kind: "选秀联赛",
-    status: "registration",
-    themeColor: "#f97316",
-    description: "南京大学 CS2 社群选秀联赛，56 选手 · 8 队伍 · 双败淘汰。",
-    schedule: "2026 年春季",
-  },
-];
+export default async function HomePage() {
+  const allSeasons = await db
+    .select()
+    .from(seasons)
+    .orderBy(seasons.createdAt);
 
-export default function HomePage() {
-  const activeSeasons = seasons.filter((s) => s.status !== "finished");
-  const featured = activeSeasons[0];
-  const others = activeSeasons.slice(1);
+  const activeSeasons = allSeasons.filter(
+    (s) => s.status !== "archived" && s.status !== "draft"
+  );
+  const featured = activeSeasons[0] as Season | undefined;
+  const others = activeSeasons.slice(1) as Season[];
 
   return (
     <div className="container mx-auto px-4 py-16 sm:py-24">
       {/* Hero */}
       <div className="max-w-3xl mb-16">
         <div className="inline-flex items-center gap-2 px-3 py-1 mb-6 rounded-full border border-[var(--border)] bg-[var(--bg-elevated)]/50 text-xs text-[var(--text-secondary)]">
-          <Trophy size={12} className="text-amber-400" />
           <span>开源 · 多赛事 · 数据驱动</span>
         </div>
-
         <h1 className="text-4xl sm:text-5xl font-bold text-[var(--text-primary)] mb-4 leading-tight">
           {APP_BRAND.name}
           <span className="block text-[var(--text-secondary)] text-2xl sm:text-3xl font-medium mt-2">
             电竞社群赛事管理平台
           </span>
         </h1>
-
         <p className="text-[var(--text-secondary)] text-base sm:text-lg max-w-xl leading-relaxed">
           {APP_BRAND.description}
         </p>
       </div>
 
-      {/* Active seasons */}
       {featured ? (
         <section>
           <div className="flex items-baseline justify-between mb-6">
@@ -61,15 +46,11 @@ export default function HomePage() {
               共 {activeSeasons.length} 个进行中
             </span>
           </div>
-
-          {/* Featured card (large) */}
           <FeaturedSeasonCard season={featured} />
-
-          {/* Others (small grid) */}
           {others.length > 0 && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
               {others.map((s) => (
-                <CompactSeasonCard key={s.slug} season={s} />
+                <CompactSeasonCard key={s.id} season={s} />
               ))}
             </div>
           )}
@@ -86,38 +67,32 @@ export default function HomePage() {
   );
 }
 
-function FeaturedSeasonCard({ season }: { season: (typeof seasons)[number] }) {
+function FeaturedSeasonCard({ season }: { season: Season }) {
   return (
     <Link
       href={`/${season.slug}` as never}
       className="group block card-elevated rounded-xl border border-[var(--border)] overflow-hidden"
     >
-      {/* Theme color top bar */}
-      <div className="h-1 w-full" style={{ backgroundColor: season.themeColor }} />
-
+      <div className="h-1 w-full" style={{ backgroundColor: season.themeColor ?? "#f97316" }} />
       <div className="p-6 sm:p-8 grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-6 items-center">
         <div>
           <div className="flex items-center gap-2 mb-3 text-xs">
-            <StatusDot status={season.status} />
-            <span className="text-[var(--text-secondary)] uppercase tracking-wider">{SEASON_STATUS_LABELS[season.status]}</span>
+            <StatusDot status={season.status as SeasonStatus} />
+            <span className="text-[var(--text-secondary)] uppercase tracking-wider">
+              {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+            </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-[var(--text-muted)]">{season.kind}</span>
           </div>
-
           <h3 className="text-2xl sm:text-3xl font-bold text-[var(--text-primary)] mb-2">
             {season.name}
           </h3>
-          <p className="text-[var(--text-secondary)] text-sm sm:text-base leading-relaxed mb-3">
-            {season.description}
-          </p>
-          <p className="text-xs text-[var(--text-muted)] tabular">{season.schedule}</p>
         </div>
-
         <div
           className="hidden sm:flex items-center gap-2 px-5 py-3 rounded-lg text-sm font-semibold text-[var(--text-primary)] border transition-colors"
           style={{
-            backgroundColor: `${season.themeColor}1a`,
-            borderColor: `${season.themeColor}40`,
+            backgroundColor: `${season.themeColor ?? "#f97316"}1a`,
+            borderColor: `${season.themeColor ?? "#f97316"}40`,
           }}
         >
           进入赛季
@@ -128,17 +103,19 @@ function FeaturedSeasonCard({ season }: { season: (typeof seasons)[number] }) {
   );
 }
 
-function CompactSeasonCard({ season }: { season: (typeof seasons)[number] }) {
+function CompactSeasonCard({ season }: { season: Season }) {
   return (
     <Link
       href={`/${season.slug}` as never}
       className="block card-elevated rounded-lg border border-[var(--border)] overflow-hidden"
     >
-      <div className="h-0.5 w-full" style={{ backgroundColor: season.themeColor }} />
+      <div className="h-0.5 w-full" style={{ backgroundColor: season.themeColor ?? "#f97316" }} />
       <div className="p-5">
         <div className="flex items-center gap-2 mb-2 text-xs">
-          <StatusDot status={season.status} />
-          <span className="text-[var(--text-secondary)]">{SEASON_STATUS_LABELS[season.status]}</span>
+          <StatusDot status={season.status as SeasonStatus} />
+          <span className="text-[var(--text-secondary)]">
+            {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+          </span>
         </div>
         <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{season.name}</h3>
         <p className="text-sm text-[var(--text-muted)]">{season.kind}</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { db } from "@/db/client";

--- a/src/app/seasons/page.tsx
+++ b/src/app/seasons/page.tsx
@@ -1,58 +1,53 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { desc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
 import { SEASON_STATUS_LABELS } from "@/types/season";
-import type { SeasonStatus } from "@/types/season";
 import { StatusDot } from "@/components/ui/status-dot";
+import type { SeasonStatus } from "@/types/season";
 
-export const metadata: Metadata = { title: "历史赛季" };
+export const metadata: Metadata = { title: "所有赛季" };
 
-// Mock data — replaced with DB query in Phase 4+
-const seasons: Array<{
-  slug: string;
-  name: string;
-  kind: string;
-  status: SeasonStatus;
-  themeColor: string;
-  schedule: string;
-}> = [
-  { slug: "2026-nju-rivals", name: "2026 NJU Rivals", kind: "选秀联赛", status: "registration", themeColor: "#f97316", schedule: "2026 年春季" },
-];
+export default async function SeasonsPage() {
+  const allSeasons = await db
+    .select()
+    .from(seasons)
+    .orderBy(desc(seasons.createdAt));
 
-export default function SeasonsPage() {
   return (
     <div className="container mx-auto px-4 py-12 sm:py-16">
       <div className="mb-10">
         <h1 className="text-3xl sm:text-4xl font-bold text-[var(--text-primary)] mb-2">所有赛季</h1>
         <p className="text-[var(--text-secondary)]">
-          共 <span className="tabular text-[var(--text-primary)]">{seasons.length}</span> 个赛季归档
+          共 <span className="tabular text-[var(--text-primary)]">{allSeasons.length}</span> 个赛季归档
         </p>
       </div>
 
-      {seasons.length === 0 ? (
+      {allSeasons.length === 0 ? (
         <p className="text-[var(--text-muted)] text-center py-16">暂无赛季记录</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {seasons.map((season) => {
-            return (
-              <Link
-                key={season.slug}
-                href={`/${season.slug}` as never}
-                className="card-elevated block rounded-lg border border-[var(--border)] overflow-hidden"
-              >
-                <div className="h-1 w-full" style={{ backgroundColor: season.themeColor }} />
-                <div className="p-5">
-                  <div className="flex items-center gap-2 mb-3 text-xs">
-                    <StatusDot status={season.status} />
-                    <span className="text-[var(--text-secondary)]">{SEASON_STATUS_LABELS[season.status]}</span>
-                    <span className="text-[var(--text-muted)]">·</span>
-                    <span className="text-[var(--text-muted)]">{season.kind}</span>
-                  </div>
-                  <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{season.name}</h3>
-                  <p className="text-xs text-[var(--text-muted)] tabular">{season.schedule}</p>
+          {allSeasons.map((season) => (
+            <Link
+              key={season.id}
+              href={`/${season.slug}` as never}
+              className="card-elevated block rounded-lg border border-[var(--border)] overflow-hidden"
+            >
+              <div className="h-1 w-full" style={{ backgroundColor: season.themeColor ?? "#f97316" }} />
+              <div className="p-5">
+                <div className="flex items-center gap-2 mb-3 text-xs">
+                  <StatusDot status={season.status as SeasonStatus} />
+                  <span className="text-[var(--text-secondary)]">
+                    {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+                  </span>
+                  <span className="text-[var(--text-muted)]">·</span>
+                  <span className="text-[var(--text-muted)]">{season.kind}</span>
                 </div>
-              </Link>
-            );
-          })}
+                <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">{season.name}</h3>
+              </div>
+            </Link>
+          ))}
         </div>
       )}
     </div>

--- a/src/app/seasons/page.tsx
+++ b/src/app/seasons/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import Link from "next/link";
 import type { Metadata } from "next";
 import { desc } from "drizzle-orm";

--- a/src/app/seasons/page.tsx
+++ b/src/app/seasons/page.tsx
@@ -5,7 +5,6 @@ import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { SEASON_STATUS_LABELS } from "@/types/season";
 import { StatusDot } from "@/components/ui/status-dot";
-import type { SeasonStatus } from "@/types/season";
 
 export const metadata: Metadata = { title: "所有赛季" };
 
@@ -37,9 +36,9 @@ export default async function SeasonsPage() {
               <div className="h-1 w-full" style={{ backgroundColor: season.themeColor ?? "#f97316" }} />
               <div className="p-5">
                 <div className="flex items-center gap-2 mb-3 text-xs">
-                  <StatusDot status={season.status as SeasonStatus} />
+                  <StatusDot status={season.status} />
                   <span className="text-[var(--text-secondary)]">
-                    {SEASON_STATUS_LABELS[season.status as SeasonStatus]}
+                    {SEASON_STATUS_LABELS[season.status]}
                   </span>
                   <span className="text-[var(--text-muted)]">·</span>
                   <span className="text-[var(--text-muted)]">{season.kind}</span>


### PR DESCRIPTION
## Summary

- `src/app/page.tsx`: 首页改为 RSC，从 DB 查询赛季，过滤 archived/draft，分为 featured + others 展示
- `src/app/seasons/page.tsx`: 历史赛季页改为 RSC，DB 全量查询按 createdAt DESC 排序
- `src/app/[seasonSlug]/page.tsx`: 赛季首页从 DB 查询，quick links 根据 capability 字段按需显示
- 清理冗余 `as Season | undefined`、`as Season[]`、`as SeasonStatus` 类型断言

## Test plan

- [ ] 访问首页，确认有赛季时显示 featured card + compact cards，无赛季时显示空态提示
- [ ] 访问 `/seasons`，确认所有赛季按时间倒序列出
- [ ] 访问某赛季首页，确认 quick links 仅显示 capability 允许的入口
- [ ] `pnpm tsc --noEmit` 无类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)