### PR TITLE
feat: header user area with login/logout and admin entry

### DIFF
--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { Season } from "@/db/schema/seasons";
 import type { UserSession } from "@/lib/auth/session";
-import type { SeasonStatus } from "@/types/season";
 
 interface HeaderClientProps {
   seasons: Season[];
@@ -45,7 +44,7 @@ export function HeaderClient({ seasons, session }: HeaderClientProps) {
   const navLinks = seasons.map((s) => ({
     href: `/${s.slug}`,
     label: s.name,
-    badge: SEASON_STATUS_LABELS[s.status as SeasonStatus] ?? s.status,
+    badge: SEASON_STATUS_LABELS[s.status] ?? s.status,
     active: pathname.startsWith(`/${s.slug}`),
   }));
 

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import { toast } from "sonner";
+import { APP_BRAND } from "@/lib/branding";
+import { cn } from "@/lib/utils/cn";
+import { SEASON_STATUS_LABELS } from "@/types/season";
+import { logoutUser } from "@/actions/auth";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Season } from "@/db/schema/seasons";
+import type { UserSession } from "@/lib/auth/session";
+import type { SeasonStatus } from "@/types/season";
+
+interface HeaderClientProps {
+  seasons: Season[];
+  session: UserSession | null;
+}
+
+function AvatarButton({ email }: { email: string }) {
+  const initial = email.charAt(0).toUpperCase();
+  return (
+    <span
+      className="inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-semibold text-white"
+      style={{ backgroundColor: "var(--season-primary, #f97316)" }}
+    >
+      {initial}
+    </span>
+  );
+}
+
+export function HeaderClient({ seasons, session }: HeaderClientProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const navLinks = seasons.map((s) => ({
+    href: `/${s.slug}`,
+    label: s.name,
+    badge: SEASON_STATUS_LABELS[s.status as SeasonStatus] ?? s.status,
+    active: pathname.startsWith(`/${s.slug}`),
+  }));
+
+  async function handleLogout() {
+    const result = await logoutUser();
+    if (result.success) {
+      toast.success("已退出登录");
+      router.push("/");
+    } else {
+      toast.error("退出失败，请重试");
+    }
+  }
+
+  const isAdmin = session && session.role !== "user";
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--bg-elevated)]/95 backdrop-blur">
+      <div className="container mx-auto px-4 h-14 flex items-center justify-between">
+        {/* Logo */}
+        <Link
+          href="/"
+          className="font-bold text-lg text-[var(--text-primary)] hover:text-white transition-colors"
+        >
+          {APP_BRAND.name}
+        </Link>
+
+        {/* Desktop nav */}
+        <nav className="hidden sm:flex items-center gap-1">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href as never}
+              className={cn(
+                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors",
+                link.active
+                  ? "bg-[var(--bg-overlay)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+              )}
+            >
+              {link.label}
+              <span className="text-xs px-1.5 py-0.5 rounded-sm bg-[var(--bg-base)] text-[var(--text-muted)]">
+                {link.badge}
+              </span>
+            </Link>
+          ))}
+          <Link
+            href="/seasons"
+            className={cn(
+              "px-3 py-1.5 rounded-md text-sm transition-colors",
+              pathname === "/seasons"
+                ? "bg-[var(--bg-overlay)] text-[var(--text-primary)]"
+                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+            )}
+          >
+            历史赛季
+          </Link>
+        </nav>
+
+        {/* 右侧：用户区域 + mobile hamburger */}
+        <div className="flex items-center gap-2">
+          {/* 用户区域（仅桌面） */}
+          <div className="hidden sm:block">
+            {session ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--season-primary,#f97316)] rounded-full">
+                    <AvatarButton email={session.email} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  {isAdmin && (
+                    <>
+                      <DropdownMenuItem asChild>
+                        <Link href="/admin" className="cursor-pointer">
+                          管理后台
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </>
+                  )}
+                  <DropdownMenuItem asChild>
+                    <Link href="/invite" className="cursor-pointer">
+                      使用邀请码
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-red-500 focus:text-red-500 cursor-pointer"
+                    onSelect={handleLogout}
+                  >
+                    退出登录
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Link
+                href="/login"
+                className="px-3 py-1.5 rounded-md text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)] transition-colors"
+              >
+                登录
+              </Link>
+            )}
+          </div>
+
+          {/* Mobile hamburger */}
+          <button
+            className="sm:hidden p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            onClick={() => setMobileOpen((o) => !o)}
+            aria-label="菜单"
+          >
+            {mobileOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      {mobileOpen && (
+        <div className="sm:hidden border-t border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 flex flex-col gap-1">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href as never}
+              onClick={() => setMobileOpen(false)}
+              className="flex items-center justify-between px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+            >
+              {link.label}
+              <span className="text-xs text-[var(--text-muted)]">{link.badge}</span>
+            </Link>
+          ))}
+          <Link
+            href="/seasons"
+            onClick={() => setMobileOpen(false)}
+            className="px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+          >
+            历史赛季
+          </Link>
+
+          {/* 移动端用户区域 */}
+          <div className="mt-2 pt-2 border-t border-[var(--border)] flex flex-col gap-1">
+            {session ? (
+              <>
+                <div className="flex items-center gap-2 px-3 py-1.5">
+                  <AvatarButton email={session.email} />
+                  <span className="text-sm text-[var(--text-muted)] truncate">{session.email}</span>
+                </div>
+                {isAdmin && (
+                  <Link
+                    href="/admin"
+                    onClick={() => setMobileOpen(false)}
+                    className="px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+                  >
+                    管理后台
+                  </Link>
+                )}
+                <Link
+                  href="/invite"
+                  onClick={() => setMobileOpen(false)}
+                  className="px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+                >
+                  使用邀请码
+                </Link>
+                <button
+                  onClick={() => {
+                    setMobileOpen(false);
+                    void handleLogout();
+                  }}
+                  className="text-left px-3 py-2 rounded-md text-sm text-red-500 hover:bg-[var(--bg-overlay)]"
+                >
+                  退出登录
+                </button>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                onClick={() => setMobileOpen(false)}
+                className="px-3 py-2 rounded-md text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
+              >
+                登录
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,106 +1,17 @@
-"use client";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { getUserSession } from "@/lib/auth/session";
+import { HeaderClient } from "./header-client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useState } from "react";
-import { Menu, X } from "lucide-react";
-import { APP_BRAND } from "@/lib/branding";
-import { cn } from "@/lib/utils/cn";
-import { SEASON_STATUS_LABELS } from "@/types/season";
-import type { SeasonStatus } from "@/types/season";
+export async function Header() {
+  const [allSeasons, session] = await Promise.all([
+    db.select().from(seasons),
+    getUserSession(),
+  ]);
 
-// Mock seasons — replaced with DB query in Phase 4+
-const mockSeasons = [
-  { slug: "2026-nju-rivals", name: "2026 NJU Rivals", status: "registration" as const },
-];
-
-export function Header() {
-  const pathname = usePathname();
-  const [mobileOpen, setMobileOpen] = useState(false);
-
-  const navLinks = mockSeasons.map((s) => ({
-    href: `/${s.slug}`,
-    label: s.name,
-    badge: SEASON_STATUS_LABELS[s.status as SeasonStatus] ?? s.status,
-    active: pathname.startsWith(`/${s.slug}`),
-  }));
-
-  return (
-    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--bg-elevated)]/95 backdrop-blur">
-      <div className="container mx-auto px-4 h-14 flex items-center justify-between">
-        {/* Logo */}
-        <Link
-          href="/"
-          className="font-bold text-lg text-[var(--text-primary)] hover:text-white transition-colors"
-        >
-          {APP_BRAND.name}
-        </Link>
-
-        {/* Desktop nav */}
-        <nav className="hidden sm:flex items-center gap-1">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href as never}
-              className={cn(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors",
-                link.active
-                  ? "bg-[var(--bg-overlay)] text-[var(--text-primary)]"
-                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
-              )}
-            >
-              {link.label}
-              <span className="text-xs px-1.5 py-0.5 rounded-sm bg-[var(--bg-base)] text-[var(--text-muted)]">
-                {link.badge}
-              </span>
-            </Link>
-          ))}
-          <Link
-            href="/seasons"
-            className={cn(
-              "px-3 py-1.5 rounded-md text-sm transition-colors",
-              pathname === "/seasons"
-                ? "bg-[var(--bg-overlay)] text-[var(--text-primary)]"
-                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
-            )}
-          >
-            历史赛季
-          </Link>
-        </nav>
-
-        {/* Mobile hamburger */}
-        <button
-          className="sm:hidden p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-          onClick={() => setMobileOpen((o) => !o)}
-          aria-label="菜单"
-        >
-          {mobileOpen ? <X size={20} /> : <Menu size={20} />}
-        </button>
-      </div>
-
-      {/* Mobile menu */}
-      {mobileOpen && (
-        <div className="sm:hidden border-t border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 flex flex-col gap-1">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href as never}
-              onClick={() => setMobileOpen(false)}
-              className="flex items-center justify-between px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
-            >
-              {link.label}
-              <span className="text-xs text-[var(--text-muted)]">{link.badge}</span>
-            </Link>
-          ))}
-          <Link
-            href="/seasons"
-            onClick={() => setMobileOpen(false)}
-            className="px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-overlay)]"
-          >
-            历史赛季
-          </Link>
-        </div>
-      )}
-    </header>
+  const publicSeasons = allSeasons.filter(
+    (s) => s.status !== "archived" && s.status !== "draft"
   );
+
+  return <HeaderClient seasons={publicSeasons} session={session} />;
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils/cn"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}


### PR DESCRIPTION
## Summary

- 将 `Header` 拆分为 Server Component（`header.tsx`，查 DB + session）和 Client Component（`header-client.tsx`，交互逻辑）
- 新增用户区域：未登录显示登录按钮；已登录显示邮箱头像 + 下拉菜单（邀请码/退出）；管理员额外显示管理后台入口
- 安装 `shadcn/ui` dropdown-menu 组件
- 移除 header 中的 mock 数据，改为从 DB 查询公开赛季（排除 archived/draft）

## Test plan

- [ ] 未登录时 header 右侧显示"登录"按钮，点击跳转 `/login`
- [ ] 普通用户登录后显示邮箱首字母头像，下拉菜单含"使用邀请码"和"退出登录"
- [ ] 管理员登录后下拉菜单顶部额外出现"管理后台"入口
- [ ] 退出登录后跳转首页，toast 提示"已退出登录"
- [ ] 移动端 hamburger 菜单包含用户区域（登录/头像/选项）
- [ ] `pnpm tsc --noEmit` 无类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)