### PR TITLE
fix: admin/login redirect loop + first-user auto-promote to super_admin

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminNav } from "@/components/admin/AdminNav";
@@ -6,6 +7,13 @@ import { AdminNav } from "@/components/admin/AdminNav";
 export const dynamic = "force-dynamic";
 
 export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const headersList = await headers();
+  const pathname = headersList.get("x-pathname") ?? "";
+
+  if (pathname === "/admin/login") {
+    return <>{children}</>;
+  }
+
   const session = await checkAdminSession();
   if (!session) redirect("/admin/login");
   return (

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users } from "@/db/schema/users";
 import { createUserSession } from "@/lib/auth/session";
@@ -35,10 +36,26 @@ export async function GET(request: NextRequest) {
     })
     .returning();
 
+  // 如果系统里还没有 super_admin，第一个登录的用户自动升级
+  let finalRole = user.role;
+  if (user.role === "user") {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(users)
+      .where(eq(users.role, "super_admin"));
+    if (count === 0) {
+      await db
+        .update(users)
+        .set({ role: "super_admin" })
+        .where(eq(users.id, user.id));
+      finalRole = "super_admin";
+    }
+  }
+
   await createUserSession({
     userId: user.id,
     email: user.email,
-    role: user.role,
+    role: finalRole,
     adminSeasonIds: user.adminSeasonIds,
     authSource: "user",
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set("x-pathname", request.nextUrl.pathname);
+  return response;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary

- 新建 `src/middleware.ts`：为所有请求设置 `x-pathname` header，供 Server Component 读取当前路径
- `admin/layout.tsx` 读取 `x-pathname`，当路径为 `/admin/login` 时直接透传 children，跳过鉴权检查，彻底解决未登录时的无限重定向循环
- `auth/callback/route.ts`：用户 upsert 之后，若系统内 `super_admin` 数量为 0，自动将当前用户升级为 `super_admin`

## 行为说明

- 首次使用：用任意邮箱触发 magic link，登录后自动成为 super_admin，Header 下拉菜单出现"管理后台"入口
- 后续用户：正常注册为普通用户，需邀请码升级权限
- root 紧急登录 `/admin/login` 仍然可用（不再死循环）

## Test plan

- [ ] 清空 DB users 表，用 magic link 登录，确认用户 role = super_admin，Header 显示管理后台入口
- [ ] 第二个用户登录，确认 role = user
- [ ] 未登录访问 `/admin` → 跳转到 `/admin/login`，不出现重定向循环
- [ ] 登录后访问 `/admin/login` → 正常显示登录表单

🤖 Generated with [Claude Code](https://claude.com/claude-code)