### PR TITLE
fix: forward admin pathname in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,9 +2,14 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
-  const response = NextResponse.next();
-  response.headers.set("x-pathname", request.nextUrl.pathname);
-  return response;
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Pass `x-pathname` through middleware request headers instead of response headers.
- Keep `/admin/login` detectable inside `app/admin/layout.tsx` so the auth bypass can work.

## Why
PR #35 intended to prevent an `/admin/login` redirect loop, but `headers()` in Server Components reads request headers. Writing `x-pathname` to the response header means the layout may still see an empty pathname and redirect the login page back to itself.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test`
- [x] `pnpm build`
