### PR TITLE
[phase-11] Add configurable season stages

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -30,11 +30,12 @@ erDiagram
     registration_mode registration_mode "solo | team"
     bool has_captain_voting
     bool has_draft
-    qualifier_format qualifier_format "round_robin | swiss | null"
-    playoff_format playoff_format "double_elim | single_elim | null"
+    json stage_plan "StageConfig[]"
+    json registration_config "RegistrationConfig"
     int team_size
     int starter_count
     text[] positions "该赛季可用位置列表"
+    json bracket_data "brackets-manager state"
     timestamp start_at
     timestamp end_at
     timestamp created_at
@@ -45,6 +46,7 @@ erDiagram
     uuid id PK
     uuid user_id FK
     uuid season_id FK
+    text player_type "enrolled | graduated | external"
     text primary_position
     text secondary_position
     text peak_rank
@@ -116,7 +118,8 @@ erDiagram
     uuid season_id FK
     uuid team_a_id FK
     uuid team_b_id FK
-    match_stage stage "qualifier | playoff"
+    text stage "StagePlan[n].key"
+    int round "Swiss round; null for round_robin / elim"
     match_format format "bo1 | bo3 | bo5"
     int score_a "系列赛比分（如 BO3 中 2:1）"
     int score_b
@@ -290,7 +293,9 @@ erDiagram
 | `finished` | 已结束 |
 | `cancelled` | 已取消 |
 
-### `match_stage`
+### `matches.stage`
+`matches.stage` 是文本字段，存 `StagePlan[n].key`，不存展示名。Rivals 默认继续使用：
+
 | 值 | 说明 |
 |---|---|
 | `qualifier` | 排位赛 |
@@ -303,21 +308,19 @@ erDiagram
 | `bo3` | 三局两胜，正赛大部分轮次 |
 | `bo5` | 五局三胜，仅总决赛 |
 
-### `qualifier_format`
-| 值 | 说明 |
-|---|---|
-| `round_robin` | 循环赛 |
-| `swiss` | 瑞士轮（保留扩展） |
-| `null` | 无排位赛阶段 |
+### `stagePlan`
+`seasons.stage_plan` 是 `StageConfig[]` JSON，按顺序描述赛事阶段：
 
-### `playoff_format`
-| 值 | 说明 |
+| 字段 | 说明 |
 |---|---|
-| `double_elim` | 双败淘汰 |
-| `single_elim` | 单败淘汰 |
-| `null` | 无正赛阶段 |
+| `key` | 稳定业务标识，写入 `matches.stage` |
+| `name` | 展示名，可改名 / i18n |
+| `type` | `round_robin` / `double_elim` / `single_elim` / `swiss` |
+| `teamCount` | 当前阶段队伍数 |
+| `advance` | 晋级队伍数 |
+| `seeds` | Swiss 预留种子配置 |
 
-> 排位赛与正赛各自的赛制独立配置；任一为 `null` 时跳过该阶段。业务代码读 `qualifierFormat` / `playoffFormat`，不读 `season.kind`。
+> 业务代码读 capability 字段和 `stagePlan`，不读 `season.kind` 做功能分支。
 
 ### `side`
 | 值 | 说明 |

--- a/docs/registration-flow.md
+++ b/docs/registration-flow.md
@@ -96,7 +96,7 @@ GROUP BY primary_position;
 | `peakRating` | 历史最高完美平台 Rating | 0.01–3.00，两位小数（均值约 1.0） |
 | `currentSeasonPeakRank` | 当前赛季最高段位 | 合法段位值；**报名门槛见下** |
 | `currentRating` | 当前赛季 Rating | 0.01–3.00，两位小数 |
-| `screenshotUrl` | 天梯截图 NJUBox 分享链接 | HTTPS URL |
+| `screenshotUrls` | 天梯截图 NJUBox 分享链接数组 | 数量由 `registrationConfig.screenshotCount` 控制 |
 | `gameplayStyle` | 游戏风格自述 | ≤100 字 |
 | `antiCheatPledge` | 反作弊承诺勾选 | 必须为 true |
 

--- a/docs/season-abstraction.md
+++ b/docs/season-abstraction.md
@@ -15,13 +15,13 @@
 | `registrationMode` | `solo \| team` | `solo` | `team` | 个人报名 vs 队伍报名 |
 | `hasCaptainVoting` | `boolean` | `true` | `false` | 是否有队长投票环节 |
 | `hasDraft` | `boolean` | `true` | `false` | 是否有蛇形选秀 |
-| `qualifierFormat` | `round_robin \| swiss \| null` | `round_robin` | `round_robin` | 排位赛赛制 |
-| `playoffFormat` | `double_elim \| single_elim \| null` | `double_elim` | `double_elim` | 正赛赛制 |
+| `stagePlan` | `StagePlan` | `round_robin -> double_elim` | `round_robin -> double_elim` | 多阶段赛制计划，`matches.stage` 存阶段 `key` |
+| `registrationConfig` | `RegistrationConfig` | Rivals 默认报名规则 | Rivals 默认报名规则 | 身份类型、段位门槛、位置上限、截图数量 |
 | `teamSize` | `integer` | `7` | `5` | 每队人数 |
 | `starterCount` | `integer` | `5` | `5` | 首发人数 |
 | `positions` | `text[]` | `["igl","awper","opener","closer","anchor"]` | `["igl","awper","opener","closer","anchor"]` | 该赛季可用位置列表 |
 
-**为什么 qualifier 与 playoff 拆开**：有些赛事可能仅有排位赛或仅有正赛，必须能独立配置。
+**为什么使用 stagePlan**：有些赛事可能仅有排位赛、仅有正赛，或有多个 Swiss / Playoff 阶段。用 `stagePlan` 的阶段数组统一描述，业务代码读取稳定的 `stage.key`，展示使用可变的 `stage.name`。
 
 **这意味着**：新增娱乐赛、All-Star 赛、1v1 赛等，只需在数据库里配置一行不同的 capability，不需要修改任何业务代码。
 
@@ -78,8 +78,8 @@ if (season.hasDraft) { showDraftPage() }
 | 报名表单类型 | `registrationMode` | `solo`（个人） | `team`（队伍） |
 | 队长投票入口 | `hasCaptainVoting` | `true` | `false` |
 | 蛇形选秀入口 | `hasDraft` | `true` | `false` |
-| 排位赛展示 | `qualifierFormat !== null` | `round_robin` | `round_robin` |
-| Bracket 视图 | `playoffFormat !== null` | `double_elim` | `double_elim` |
+| 排位赛展示 | `showQualifier(season)` | `round_robin` | `round_robin` |
+| Bracket 视图 | `showPlayoffBracket(season)` | `double_elim` | `double_elim` |
 
 **代码中 capability 检查的位置**（统一用 `lib/utils/season.ts` 的工具函数）：
 - `[seasonSlug]/draft/page.tsx`：`if (!showDraft(season)) return <ComingSoon />`

--- a/drizzle/migrations/0005_supreme_magus.sql
+++ b/drizzle/migrations/0005_supreme_magus.sql
@@ -1,0 +1,55 @@
+ALTER TABLE "matches" ALTER COLUMN "stage" SET DATA TYPE text USING "stage"::text;--> statement-breakpoint
+ALTER TABLE "seasons" ADD COLUMN "stage_plan" json DEFAULT '[]'::json NOT NULL;--> statement-breakpoint
+ALTER TABLE "seasons" ADD COLUMN "registration_config" json DEFAULT '{}'::json NOT NULL;--> statement-breakpoint
+UPDATE "seasons"
+SET "stage_plan" = CASE
+  WHEN "qualifier_format" IS NULL AND "playoff_format" IS NULL THEN '[]'::json
+  WHEN "qualifier_format" IS NULL THEN json_build_array(
+    json_build_object(
+      'key', 'playoff',
+      'name', '正赛',
+      'type', "playoff_format"::text,
+      'teamCount', 8,
+      'advance', 1
+    )
+  )
+  WHEN "playoff_format" IS NULL THEN json_build_array(
+    json_build_object(
+      'key', 'qualifier',
+      'name', '排位赛',
+      'type', "qualifier_format"::text,
+      'teamCount', 8,
+      'advance', 8
+    )
+  )
+  ELSE json_build_array(
+    json_build_object(
+      'key', 'qualifier',
+      'name', '排位赛',
+      'type', "qualifier_format"::text,
+      'teamCount', 8,
+      'advance', 8
+    ),
+    json_build_object(
+      'key', 'playoff',
+      'name', '正赛',
+      'type', "playoff_format"::text,
+      'teamCount', 8,
+      'advance', 1
+    )
+  )
+END;--> statement-breakpoint
+UPDATE "seasons"
+SET "registration_config" = json_build_object(
+  'allowedPlayerTypes', json_build_array('enrolled'),
+  'rankThreshold', json_build_object('currentMin', 'A', 'peakMin', 'A+'),
+  'maxPerPosition', 15,
+  'screenshotCount', 1
+);--> statement-breakpoint
+ALTER TABLE "season_registrations" ADD COLUMN "player_type" text DEFAULT 'enrolled' NOT NULL;--> statement-breakpoint
+ALTER TABLE "matches" ADD COLUMN "round" integer;--> statement-breakpoint
+ALTER TABLE "seasons" DROP COLUMN "qualifier_format";--> statement-breakpoint
+ALTER TABLE "seasons" DROP COLUMN "playoff_format";--> statement-breakpoint
+DROP TYPE "public"."playoff_format";--> statement-breakpoint
+DROP TYPE "public"."qualifier_format";--> statement-breakpoint
+DROP TYPE "public"."match_stage";

--- a/drizzle/migrations/meta/0005_snapshot.json
+++ b/drizzle/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1729 @@
+{
+  "id": "142055f6-811f-4675-a62a-f5485a58fdd2",
+  "prevId": "d4e6cb93-72c7-4c45-81d6-dabe0d97b474",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_size": {
+          "name": "team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1746806400000,
       "tag": "0004_player_stats",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778341013690,
+      "tag": "0005_supreme_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -46,8 +46,16 @@ async function main() {
       registrationMode: "solo",
       hasCaptainVoting: true,
       hasDraft: true,
-      qualifierFormat: "round_robin",
-      playoffFormat: "double_elim",
+      stagePlan: JSON.stringify([
+        { key: "qualifier", name: "排位赛", type: "round_robin", teamCount: 8, advance: 8 },
+        { key: "playoff", name: "正赛", type: "double_elim", teamCount: 8, advance: 1 },
+      ]),
+      registrationConfig: JSON.stringify({
+        allowedPlayerTypes: ["enrolled"],
+        rankThreshold: { currentMin: "A", peakMin: "A+" },
+        maxPerPosition: 15,
+        screenshotCount: 1,
+      }),
       teamSize: 7,
       starterCount: 5,
       positions: "{igl,awper,opener,closer,anchor}",
@@ -61,8 +69,16 @@ async function main() {
       registrationMode: "solo",
       hasCaptainVoting: true,
       hasDraft: true,
-      qualifierFormat: "round_robin",
-      playoffFormat: "double_elim",
+      stagePlan: JSON.stringify([
+        { key: "qualifier", name: "排位赛", type: "round_robin", teamCount: 8, advance: 8 },
+        { key: "playoff", name: "正赛", type: "double_elim", teamCount: 8, advance: 1 },
+      ]),
+      registrationConfig: JSON.stringify({
+        allowedPlayerTypes: ["enrolled"],
+        rankThreshold: { currentMin: "A", peakMin: "A+" },
+        maxPerPosition: 15,
+        screenshotCount: 1,
+      }),
       teamSize: 7,
       starterCount: 5,
       positions: "{igl,awper,opener,closer,anchor}",
@@ -76,8 +92,16 @@ async function main() {
       registrationMode: "team",
       hasCaptainVoting: false,
       hasDraft: false,
-      qualifierFormat: "round_robin",
-      playoffFormat: "double_elim",
+      stagePlan: JSON.stringify([
+        { key: "qualifier", name: "排位赛", type: "round_robin", teamCount: 8, advance: 8 },
+        { key: "playoff", name: "正赛", type: "double_elim", teamCount: 8, advance: 1 },
+      ]),
+      registrationConfig: JSON.stringify({
+        allowedPlayerTypes: ["enrolled"],
+        rankThreshold: { currentMin: "A", peakMin: "A+" },
+        maxPerPosition: 15,
+        screenshotCount: 1,
+      }),
       teamSize: 5,
       starterCount: 5,
       positions: "{igl,awper,opener,closer,anchor}",
@@ -86,13 +110,13 @@ async function main() {
     await pool.query(
       `INSERT INTO seasons (slug, name, kind, status, theme_color,
         registration_mode, has_captain_voting, has_draft,
-        qualifier_format, playoff_format, team_size, starter_count, positions)
+        stage_plan, registration_config, team_size, starter_count, positions)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
        ON CONFLICT (slug) DO NOTHING`,
       [
         season.slug, season.name, season.kind, season.status,
         season.themeColor, season.registrationMode, season.hasCaptainVoting,
-        season.hasDraft, season.qualifierFormat, season.playoffFormat,
+        season.hasDraft, season.stagePlan, season.registrationConfig,
         season.teamSize, season.starterCount, season.positions,
       ],
     );

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -15,7 +15,7 @@ import {
   getAdminSession,
 } from "@/lib/auth/session";
 import { verifyPassword, hashPassword } from "@/lib/utils/password";
-import { MAX_PER_POSITION } from "@/lib/validators/registration";
+import { normalizeRegistrationConfig } from "@/types/season";
 
 // ── 共享工具 ────────────────────────────────────────────
 
@@ -227,7 +227,8 @@ export async function reviewRegistration(input: ReviewInput) {
               eq(seasonRegistrations.status, "approved"),
             ),
           );
-        if (Number(posCount?.count ?? 0) >= MAX_PER_POSITION) {
+        const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
+        if (Number(posCount?.count ?? 0) >= registrationConfig.maxPerPosition) {
           throw new AppError(ErrorCode.POSITION_FULL, ERROR_MESSAGES.POSITION_FULL);
         }
       }

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -8,15 +8,12 @@ import { ok, fail } from "@/types/action";
 import type { ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { requireSeasonAdmin } from "@/lib/auth/session";
-import { generateBracket, advanceMatch as bracketAdvance, seedPlayoff } from "@/lib/bracket";
-import { calculateStandings } from "@/lib/standings";
+import { advanceMatch as bracketAdvance } from "@/lib/bracket";
 import { getExecutor } from "@/lib/formats";
 import {
   getFirstStage,
-  getFirstStageOfType,
   getPreviousStage,
   normalizeStagePlan,
-  type StageConfig,
 } from "@/types/season";
 import type { Database } from "brackets-manager";
 
@@ -57,19 +54,6 @@ async function getMatchOrThrow(matchId: string) {
   });
   if (!match) throw new AppError(ErrorCode.MATCH_NOT_FOUND, ERROR_MESSAGES.MATCH_NOT_FOUND);
   return match;
-}
-
-function isEliminationStage(stage: StageConfig): boolean {
-  return stage.type === "double_elim" || stage.type === "single_elim";
-}
-
-function matchFormatForStage(stage: StageConfig): "bo1" | "bo3" {
-  return stage.type === "round_robin" || stage.type === "swiss" ? "bo1" : "bo3";
-}
-
-function getBracketStageId(data: Database, stageName: string): number | null {
-  const dbStages = data.stage as Array<{ id: number; name: string }>;
-  return dbStages.find((s) => s.name === stageName)?.id ?? null;
 }
 
 // ── 一键生成赛程 ──────────────────────────────────────────────────────────
@@ -117,48 +101,11 @@ export async function generateSchedule(
       throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "Swiss 执行器将在 v2 接入");
     }
 
-    const playoffStage = firstStage.type === "round_robin"
-      ? getFirstStageOfType(stagePlan, ["double_elim", "single_elim"])
-      : isEliminationStage(firstStage)
-        ? firstStage
-        : null;
-
-    const { data, resolvedMatches } = await generateBracket(seasonTeams, {
-      qualifierFormat: firstStage.type === "round_robin" ? "round_robin" : null,
-      playoffFormat: playoffStage
-        ? (playoffStage.type === "double_elim" ? "double_elim" : "single_elim")
-        : null,
-      qualifierName: firstStage.type === "round_robin" ? firstStage.name : undefined,
-      playoffName: playoffStage?.name,
-    });
-
-    const firstStageId = getBracketStageId(data as Database, firstStage.name);
-
-    // 批量创建 match 记录
-    let matchCount = 0;
-    for (const bm of resolvedMatches) {
-      if (firstStageId !== null && bm.stageId !== firstStageId) continue;
-      const teamA = seasonTeams[bm.teamAParticipantId];
-      const teamB = seasonTeams[bm.teamBParticipantId];
-      if (!teamA || !teamB) continue;
-
-      await db.insert(matches).values({
-        seasonId,
-        teamAId: teamA.id,
-        teamBId: teamB.id,
-        stage: firstStage.key,
-        format: matchFormatForStage(firstStage),
-        status: "scheduled",
-        bracketNodeId: bm.bracketMatchId.toString(),
-      });
-      matchCount++;
-    }
-
-    // 持久化 bracket JSON
-    await db
-      .update(seasons)
-      .set({ bracketData: data as Database, updatedAt: new Date() })
-      .where(eq(seasons.id, seasonId));
+    const { matchCount } = await getExecutor(firstStage.type).initialize(
+      seasonId,
+      firstStage,
+      seasonTeams,
+    );
 
     // Audit
     await db.insert(auditLogs).values({
@@ -611,22 +558,11 @@ export async function initializeStage(
     if (season.status !== "playing") {
       throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有在赛季进行中才能初始化阶段");
     }
-    if (!season.bracketData) {
-      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "请先一键生成赛程");
-    }
-
     const stagePlan = normalizeStagePlan(season.stagePlan);
     const stage = stagePlan.find((s) => s.key === stageKey);
     if (!stage) {
       throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季没有这个赛程阶段");
     }
-    if (!isEliminationStage(stage)) {
-      throw new AppError(
-        ErrorCode.SEASON_CAPABILITY_DISABLED,
-        "v1 仅支持从上一阶段结果初始化淘汰赛阶段",
-      );
-    }
-
     const previousStage = getPreviousStage(stagePlan, stage.key);
     if (!previousStage) {
       throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "首个阶段请使用一键生成赛程");
@@ -649,58 +585,12 @@ export async function initializeStage(
       throw new AppError(ErrorCode.SEASON_INVALID_STATUS, `${stage.name} 已生成，不可重复生成`);
     }
 
-    // 计算积分榜 → 得到种子顺序
     const seasonTeams = await db.query.teams.findMany({
       where: eq(teams.seasonId, seasonId),
       orderBy: [asc(teams.draftOrder)],
     });
 
-    const standings = await calculateStandings(seasonId, seasonTeams, previousStage.key);
-    // standings 已按种子排序（seed 1 在 index 0）
-    const seededNames = standings.slice(0, stage.teamCount).map((s) => s.teamName);
-
-    // 更新目标 bracket stage 种子
-    const { updatedData, resolvedMatches } = await seedPlayoff(
-      seededNames,
-      season.bracketData as Database,
-      stage.name,
-    );
-
-    // 持久化更新后的 bracket JSON
-    await db
-      .update(seasons)
-      .set({ bracketData: updatedData as Database, updatedAt: new Date() })
-      .where(eq(seasons.id, seasonId));
-
-    // 创建第一轮正赛 match 记录
-    // 注意：seedPlayoff 返回的 participantId 对应更新后 participant 表的 ID（按种子顺序）
-    // 需要从 participant 名称反查 teamId
-    const nameToTeam = new Map(seasonTeams.map((t) => [t.name, t]));
-    const participants = updatedData.participant as Array<{ id: number; name: string }>;
-    const participantIdToTeam = new Map(
-      participants.map((p) => [p.id, nameToTeam.get(p.name)])
-    );
-
-    let matchCount = 0;
-    const targetStageId = getBracketStageId(updatedData as Database, stage.name);
-
-    for (const bm of resolvedMatches) {
-      if (targetStageId === null || bm.stageId !== targetStageId) continue;
-      const teamA = participantIdToTeam.get(bm.teamAParticipantId);
-      const teamB = participantIdToTeam.get(bm.teamBParticipantId);
-      if (!teamA || !teamB) continue;
-
-      await db.insert(matches).values({
-        seasonId,
-        teamAId: teamA.id,
-        teamBId: teamB.id,
-        stage: stage.key,
-        format: matchFormatForStage(stage),
-        status: "scheduled",
-        bracketNodeId: bm.bracketMatchId.toString(),
-      });
-      matchCount++;
-    }
+    const { matchCount } = await getExecutor(stage.type).initialize(seasonId, stage, seasonTeams);
 
     await db.insert(auditLogs).values({
       seasonId,
@@ -708,7 +598,7 @@ export async function initializeStage(
       actorId: session.email,
       targetId: seasonId,
       targetType: "season",
-      meta: { matchCount, stageKey: stage.key, seeds: seededNames },
+      meta: { matchCount, stageKey: stage.key },
     });
 
     revalidatePath(`/admin/${season.slug}/matches`);

--- a/src/actions/matches.ts
+++ b/src/actions/matches.ts
@@ -10,6 +10,14 @@ import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { requireSeasonAdmin } from "@/lib/auth/session";
 import { generateBracket, advanceMatch as bracketAdvance, seedPlayoff } from "@/lib/bracket";
 import { calculateStandings } from "@/lib/standings";
+import { getExecutor } from "@/lib/formats";
+import {
+  getFirstStage,
+  getFirstStageOfType,
+  getPreviousStage,
+  normalizeStagePlan,
+  type StageConfig,
+} from "@/types/season";
 import type { Database } from "brackets-manager";
 
 // ── 状态机 ────────────────────────────────────────────────────────────────
@@ -51,6 +59,19 @@ async function getMatchOrThrow(matchId: string) {
   return match;
 }
 
+function isEliminationStage(stage: StageConfig): boolean {
+  return stage.type === "double_elim" || stage.type === "single_elim";
+}
+
+function matchFormatForStage(stage: StageConfig): "bo1" | "bo3" {
+  return stage.type === "round_robin" || stage.type === "swiss" ? "bo1" : "bo3";
+}
+
+function getBracketStageId(data: Database, stageName: string): number | null {
+  const dbStages = data.stage as Array<{ id: number; name: string }>;
+  return dbStages.find((s) => s.name === stageName)?.id ?? null;
+}
+
 // ── 一键生成赛程 ──────────────────────────────────────────────────────────
 
 /**
@@ -87,36 +108,46 @@ export async function generateSchedule(
       throw new AppError(ErrorCode.VALIDATION_FAILED, "队伍数量不足，无法生成赛程");
     }
 
+    const stagePlan = normalizeStagePlan(season.stagePlan);
+    const firstStage = getFirstStage(stagePlan);
+    if (!firstStage) {
+      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季没有可生成的赛程阶段");
+    }
+    if (firstStage.type === "swiss") {
+      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "Swiss 执行器将在 v2 接入");
+    }
+
+    const playoffStage = firstStage.type === "round_robin"
+      ? getFirstStageOfType(stagePlan, ["double_elim", "single_elim"])
+      : isEliminationStage(firstStage)
+        ? firstStage
+        : null;
+
     const { data, resolvedMatches } = await generateBracket(seasonTeams, {
-      qualifierFormat: season.qualifierFormat ?? null,
-      playoffFormat: season.playoffFormat ?? null,
+      qualifierFormat: firstStage.type === "round_robin" ? "round_robin" : null,
+      playoffFormat: playoffStage
+        ? (playoffStage.type === "double_elim" ? "double_elim" : "single_elim")
+        : null,
+      qualifierName: firstStage.type === "round_robin" ? firstStage.name : undefined,
+      playoffName: playoffStage?.name,
     });
 
-    // 确定 qualifier stage id（若存在）
-    const dbStages = data.stage as Array<{ id: number; name: string }>;
-    const qualifierStageId = season.qualifierFormat
-      ? (dbStages.find((s) => s.name === "排位赛")?.id ?? null)
-      : null;
+    const firstStageId = getBracketStageId(data as Database, firstStage.name);
 
     // 批量创建 match 记录
     let matchCount = 0;
     for (const bm of resolvedMatches) {
+      if (firstStageId !== null && bm.stageId !== firstStageId) continue;
       const teamA = seasonTeams[bm.teamAParticipantId];
       const teamB = seasonTeams[bm.teamBParticipantId];
       if (!teamA || !teamB) continue;
-
-      const stage = qualifierStageId !== null && bm.stageId === qualifierStageId
-        ? "qualifier"
-        : "playoff";
-      // 排位赛默认 BO1，正赛第一轮 BO3
-      const format = stage === "qualifier" ? "bo1" : "bo3";
 
       await db.insert(matches).values({
         seasonId,
         teamAId: teamA.id,
         teamBId: teamB.id,
-        stage,
-        format,
+        stage: firstStage.key,
+        format: matchFormatForStage(firstStage),
         status: "scheduled",
         bracketNodeId: bm.bracketMatchId.toString(),
       });
@@ -136,7 +167,7 @@ export async function generateSchedule(
       actorId: session.email,
       targetId: seasonId,
       targetType: "season",
-      meta: { matchCount },
+      meta: { matchCount, stageKey: firstStage.key },
     });
 
     revalidatePath(`/admin/${season.slug}/matches`);
@@ -159,7 +190,7 @@ export async function createMatch(
   seasonId: string,
   teamAId: string,
   teamBId: string,
-  stage: "qualifier" | "playoff",
+  stage: string,
   format: "bo1" | "bo3" | "bo5"
 ): Promise<ActionResult<{ matchId: string }>> {
   try {
@@ -168,11 +199,14 @@ export async function createMatch(
     if (teamAId === teamBId) {
       throw new AppError(ErrorCode.VALIDATION_FAILED, "双方队伍不能相同");
     }
-    if (stage === "qualifier" && format !== "bo1") {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "排位赛只能是 BO1");
-    }
-
     const season = await getSeasonOrThrow(seasonId);
+    const stageConfig = normalizeStagePlan(season.stagePlan).find((s) => s.key === stage);
+    if (!stageConfig) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "未知赛程阶段");
+    }
+    if ((stageConfig.type === "round_robin" || stageConfig.type === "swiss") && format !== "bo1") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, `${stageConfig.name} 只能是 BO1`);
+    }
 
     // 校验两支队伍属于本赛季
     const teamRows = await db.query.teams.findMany({
@@ -327,12 +361,10 @@ export async function recordMatchResult(
         const teamB = seasonTeams[bm.teamBParticipantId];
         if (!teamA || !teamB) continue;
 
-        // 正赛阶段的 stage 列表名为"正赛"
         const dbStages = updatedData.stage as Array<{ id: number; name: string }>;
-        const playoffStageId = dbStages.find((s) => s.name === "正赛")?.id;
-        const stage = playoffStageId !== undefined && bm.stageId === playoffStageId
-          ? "playoff"
-          : "qualifier";
+        const bmStageName = dbStages.find((s) => s.id === bm.stageId)?.name;
+        const stage = normalizeStagePlan(season.stagePlan).find((s) => s.name === bmStageName)?.key
+          ?? match.stage;
 
         await db.insert(matches).values({
           seasonId: match.seasonId,
@@ -431,7 +463,12 @@ export async function recordMapResult(
 
     // 如果系列赛结束且有 bracket，提前计算 bracket 推进结果（纯计算，不写 DB）
     let updatedBracketData: Database | null = null;
-    let resolvedMatches: Array<{ teamAParticipantId: number; teamBParticipantId: number; bracketMatchId: number }> = [];
+    let resolvedMatches: Array<{
+      teamAParticipantId: number;
+      teamBParticipantId: number;
+      bracketMatchId: number;
+      stageId: number;
+    }> = [];
     let seasonTeams: Awaited<ReturnType<typeof db.query.teams.findMany>> = [];
 
     if (seriesFinished && season.bracketData && match.bracketNodeId) {
@@ -477,11 +514,15 @@ export async function recordMapResult(
             const teamA = seasonTeams[bm.teamAParticipantId];
             const teamB = seasonTeams[bm.teamBParticipantId];
             if (!teamA || !teamB) continue;
+            const dbStages = updatedBracketData.stage as Array<{ id: number; name: string }>;
+            const bmStageName = dbStages.find((s) => s.id === bm.stageId)?.name;
+            const stage = normalizeStagePlan(season.stagePlan).find((s) => s.name === bmStageName)?.key
+              ?? match.stage;
             await tx.insert(matches).values({
               seasonId: match.seasonId,
               teamAId: teamA.id,
               teamBId: teamB.id,
-              stage: "playoff",
+              stage,
               format: "bo3",
               status: "scheduled",
               bracketNodeId: bm.bracketMatchId.toString(),
@@ -557,91 +598,55 @@ export async function updateMatchScheduledAt(
   }
 }
 
-// ── 生成正赛（基于积分榜种子） ────────────────────────────────────────────
+// ── 初始化后续 Stage（基于上一阶段结果种子）───────────────────────────────
 
-/**
- * 在所有排位赛结束后，根据积分榜种子更新正赛 bracket，并创建第一轮对阵。
- * 前置：season.qualifierFormat 非 null，所有 qualifier 场次均为 finished。
- */
-export async function generatePlayoff(
-  seasonId: string
+export async function initializeStage(
+  seasonId: string,
+  stageKey: string,
 ): Promise<ActionResult<{ matchCount: number }>> {
   try {
     const session = await requireSeasonAdmin(seasonId);
     const season = await getSeasonOrThrow(seasonId);
 
     if (season.status !== "playing") {
-      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有在赛季进行中才能生成正赛");
-    }
-    if (!season.qualifierFormat) {
-      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季无排位赛阶段，无需单独生成正赛");
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有在赛季进行中才能初始化阶段");
     }
     if (!season.bracketData) {
       throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "请先一键生成赛程");
     }
 
-    // 确认所有排位赛已结束
-    const [{ value: unfinished }] = await db
-      .select({ value: count() })
-      .from(matches)
-      .where(
-        and(
-          eq(matches.seasonId, seasonId),
-          eq(matches.stage, "qualifier"),
-        )
-      )
-      // 未结束的场次
-      .then(async () =>
-        db.select({ value: count() }).from(matches).where(
-          and(
-            eq(matches.seasonId, seasonId),
-            eq(matches.stage, "qualifier"),
-            // status NOT 'finished'：用 sql 表达
-          )
-        )
-      );
-
-    // 重新查询：unfinished qualifier 场次数
-    const unfinishedCount = await db
-      .select({ value: count() })
-      .from(matches)
-      .where(
-        and(
-          eq(matches.seasonId, seasonId),
-          eq(matches.stage, "qualifier"),
-        )
-      )
-      .then(async (rows) => {
-        // 查所有 qualifier 总数
-        const total = rows[0]?.value ?? 0;
-        const finished = await db
-          .select({ value: count() })
-          .from(matches)
-          .where(
-            and(
-              eq(matches.seasonId, seasonId),
-              eq(matches.stage, "qualifier"),
-              eq(matches.status, "finished"),
-            )
-          );
-        return total - (finished[0]?.value ?? 0);
-      });
-
-    if (unfinishedCount > 0) {
+    const stagePlan = normalizeStagePlan(season.stagePlan);
+    const stage = stagePlan.find((s) => s.key === stageKey);
+    if (!stage) {
+      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季没有这个赛程阶段");
+    }
+    if (!isEliminationStage(stage)) {
       throw new AppError(
-        ErrorCode.SEASON_INVALID_STATUS,
-        `还有 ${unfinishedCount} 场排位赛未结束，无法生成正赛`
+        ErrorCode.SEASON_CAPABILITY_DISABLED,
+        "v1 仅支持从上一阶段结果初始化淘汰赛阶段",
       );
     }
 
-    // 检查正赛是否已生成（幂等）
-    const [{ value: existingPlayoff }] = await db
+    const previousStage = getPreviousStage(stagePlan, stage.key);
+    if (!previousStage) {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "首个阶段请使用一键生成赛程");
+    }
+
+    const previousComplete = await getExecutor(previousStage.type).isComplete(seasonId, previousStage.key);
+    if (!previousComplete) {
+      throw new AppError(
+        ErrorCode.SEASON_INVALID_STATUS,
+        `${previousStage.name} 尚未全部结束，无法初始化 ${stage.name}`,
+      );
+    }
+
+    const [{ value: existingStageMatches }] = await db
       .select({ value: count() })
       .from(matches)
-      .where(and(eq(matches.seasonId, seasonId), eq(matches.stage, "playoff")));
+      .where(and(eq(matches.seasonId, seasonId), eq(matches.stage, stage.key)));
 
-    if (existingPlayoff > 0) {
-      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "正赛已生成，不可重复生成");
+    if (existingStageMatches > 0) {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, `${stage.name} 已生成，不可重复生成`);
     }
 
     // 计算积分榜 → 得到种子顺序
@@ -650,14 +655,15 @@ export async function generatePlayoff(
       orderBy: [asc(teams.draftOrder)],
     });
 
-    const standings = await calculateStandings(seasonId, seasonTeams);
+    const standings = await calculateStandings(seasonId, seasonTeams, previousStage.key);
     // standings 已按种子排序（seed 1 在 index 0）
-    const seededNames = standings.map((s) => s.teamName);
+    const seededNames = standings.slice(0, stage.teamCount).map((s) => s.teamName);
 
-    // 更新正赛 bracket 种子
+    // 更新目标 bracket stage 种子
     const { updatedData, resolvedMatches } = await seedPlayoff(
       seededNames,
-      season.bracketData as Database
+      season.bracketData as Database,
+      stage.name,
     );
 
     // 持久化更新后的 bracket JSON
@@ -676,11 +682,10 @@ export async function generatePlayoff(
     );
 
     let matchCount = 0;
-    const dbStages = updatedData.stage as Array<{ id: number; name: string }>;
-    const playoffStageId = dbStages.find((s) => s.name === "正赛")?.id;
+    const targetStageId = getBracketStageId(updatedData as Database, stage.name);
 
     for (const bm of resolvedMatches) {
-      if (playoffStageId === undefined || bm.stageId !== playoffStageId) continue;
+      if (targetStageId === null || bm.stageId !== targetStageId) continue;
       const teamA = participantIdToTeam.get(bm.teamAParticipantId);
       const teamB = participantIdToTeam.get(bm.teamBParticipantId);
       if (!teamA || !teamB) continue;
@@ -689,8 +694,8 @@ export async function generatePlayoff(
         seasonId,
         teamAId: teamA.id,
         teamBId: teamB.id,
-        stage: "playoff",
-        format: "bo3",
+        stage: stage.key,
+        format: matchFormatForStage(stage),
         status: "scheduled",
         bracketNodeId: bm.bracketMatchId.toString(),
       });
@@ -699,11 +704,11 @@ export async function generatePlayoff(
 
     await db.insert(auditLogs).values({
       seasonId,
-      action: "match.generate_playoff",
+      action: "match.initialize_stage",
       actorId: session.email,
       targetId: seasonId,
       targetType: "season",
-      meta: { matchCount, seeds: seededNames },
+      meta: { matchCount, stageKey: stage.key, seeds: seededNames },
     });
 
     revalidatePath(`/admin/${season.slug}/matches`);
@@ -712,7 +717,16 @@ export async function generatePlayoff(
     return ok({ matchCount });
   } catch (e) {
     if (e instanceof AppError) return fail({ code: e.code, message: e.message });
-    console.error("[generatePlayoff]", e);
+    console.error("[initializeStage]", e);
     return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
   }
+}
+
+/**
+ * 向后兼容现有 UI：Rivals 的正赛 stage key 默认为 playoff。
+ */
+export async function generatePlayoff(
+  seasonId: string
+): Promise<ActionResult<{ matchCount: number }>> {
+  return initializeStage(seasonId, "playoff");
 }

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -7,11 +7,12 @@ import { users, seasons, seasonRegistrations } from "@/db/schema";
 import { ok, fail } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import {
-  registrationSchema,
-  MAX_PER_POSITION,
+  buildRegistrationSchema,
+  registrationSeedSchema,
   type RegistrationFormData,
 } from "@/lib/validators/registration";
 import { createServiceClient } from "@/lib/auth/supabase";
+import { normalizeRegistrationConfig } from "@/types/season";
 
 /**
  * 提交报名
@@ -24,12 +25,11 @@ import { createServiceClient } from "@/lib/auth/supabase";
  * 7. 发送 Magic Link 邮件（非关键，失败不影响报名）
  */
 export async function submitRegistration(input: RegistrationFormData) {
-  // 1. 校验
-  const parsed = registrationSchema.safeParse(input);
-  if (!parsed.success) {
+  const seedParsed = registrationSeedSchema.safeParse(input);
+  if (!seedParsed.success) {
     const fieldErrors: Record<string, string> = {};
     for (const [field, errors] of Object.entries(
-      parsed.error.flatten().fieldErrors
+      seedParsed.error.flatten().fieldErrors
     )) {
       if (errors?.[0]) fieldErrors[field] = errors[0];
     }
@@ -40,12 +40,10 @@ export async function submitRegistration(input: RegistrationFormData) {
     });
   }
 
-  const data = parsed.data;
-
   try {
     // 2. 查赛季
     const season = await db.query.seasons.findFirst({
-      where: eq(seasons.id, data.seasonId),
+      where: eq(seasons.id, seedParsed.data.seasonId),
     });
     if (!season) {
       throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
@@ -53,6 +51,24 @@ export async function submitRegistration(input: RegistrationFormData) {
     if (season.status !== "registration") {
       throw new AppError(ErrorCode.REGISTRATION_CLOSED, ERROR_MESSAGES.REGISTRATION_CLOSED);
     }
+
+    const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
+    const parsed = buildRegistrationSchema(registrationConfig, season.positions).safeParse(input);
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const [field, errors] of Object.entries(
+        parsed.error.flatten().fieldErrors
+      )) {
+        if (errors?.[0]) fieldErrors[field] = errors[0];
+      }
+      return fail({
+        code: ErrorCode.VALIDATION_FAILED,
+        message: "输入校验失败，请检查各字段",
+        fieldErrors,
+      });
+    }
+
+    const data = parsed.data;
 
     // 3. Upsert 用户（含所有基础信息字段）
     let user = await db.query.users.findFirst({
@@ -101,18 +117,17 @@ export async function submitRegistration(input: RegistrationFormData) {
           eq(seasonRegistrations.primaryPosition, data.primaryPosition)
         )
       );
-    if (Number(posCount?.count ?? 0) >= MAX_PER_POSITION) {
+    if (Number(posCount?.count ?? 0) >= registrationConfig.maxPerPosition) {
       throw new AppError(ErrorCode.POSITION_FULL, ERROR_MESSAGES.POSITION_FULL);
     }
 
     // 6. 插入报名记录
-    const screenshotUrls = [data.screenshotUrl];
-
     const [registration] = await db
       .insert(seasonRegistrations)
       .values({
         userId: user.id,
         seasonId: data.seasonId,
+        playerType: data.playerType,
         primaryPosition: data.primaryPosition,
         secondaryPosition: data.secondaryPosition,
         peakRank: data.peakRank,
@@ -122,7 +137,7 @@ export async function submitRegistration(input: RegistrationFormData) {
         currentSeasonPeakRank: data.currentSeasonPeakRank,
         currentRating: data.currentRating,
         currentWe: data.currentWe,
-        screenshotUrls,
+        screenshotUrls: data.screenshotUrls,
         gameplayStyle: data.gameplayStyle,
         competitionHistory: data.competitionHistory,
         highlightVideoUrl: data.highlightVideoUrl,

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -13,7 +13,6 @@ import {
   RIVALS_STAGE_PLAN,
   normalizeRegistrationConfig,
   type RegistrationConfig,
-  type SeasonStatus,
   type StagePlan,
 } from "@/types/season";
 
@@ -34,8 +33,8 @@ const registrationConfigSchema = z.object({
     currentMin: z.string().min(1).nullable(),
     peakMin: z.string().min(1).nullable(),
   }),
-  maxPerPosition: z.number().int().min(1).max(200),
-  screenshotCount: z.number().int().min(1).max(10),
+  maxPerPosition: z.number().int().min(1).max(50),
+  screenshotCount: z.number().int().min(1).max(5),
 });
 
 const seasonFormBaseSchema = z.object({
@@ -43,7 +42,7 @@ const seasonFormBaseSchema = z.object({
   name: z.string().min(1, "请填写赛季名称"),
   slug: z.string().min(1, "请填写 slug").regex(/^[a-z0-9][a-z0-9-]*$/, "slug 只能使用小写字母、数字和连字符"),
   kind: z.string().min(1, "请填写赛事类型"),
-  status: z.enum(["draft", "registration", "voting", "drafting", "playing", "finished", "archived"]),
+  status: z.enum(["draft", "registration", "voting", "drafting", "playing", "finished", "archived"]).optional(),
   themeColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, "主题色需为 #RRGGBB 格式").nullable(),
   startAt: z.string().nullable(),
   endAt: z.string().nullable(),
@@ -108,7 +107,7 @@ export async function createSeason(input: SeasonFormInput): Promise<ActionResult
       slug: data.slug,
       name: data.name,
       kind: data.kind,
-      status: data.status,
+      status: "draft",
       themeColor: data.themeColor,
       registrationMode: data.registrationMode,
       hasCaptainVoting: data.hasCaptainVoting,
@@ -163,10 +162,12 @@ export async function updateSeason(input: SeasonFormInput): Promise<ActionResult
       where: eq(seasons.id, data.id),
     });
     if (!existing) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    if (existing.slug !== data.slug) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "编辑赛季时不能修改 slug");
+    }
 
     if (existing.status !== "draft") {
       const coreChanged =
-        existing.slug !== data.slug ||
         existing.registrationMode !== data.registrationMode ||
         existing.hasCaptainVoting !== data.hasCaptainVoting ||
         existing.hasDraft !== data.hasDraft ||
@@ -180,10 +181,8 @@ export async function updateSeason(input: SeasonFormInput): Promise<ActionResult
     }
 
     await db.update(seasons).set({
-      slug: data.slug,
       name: data.name,
       kind: data.kind,
-      status: data.status as SeasonStatus,
       themeColor: data.themeColor,
       registrationMode: data.registrationMode,
       hasCaptainVoting: data.hasCaptainVoting,
@@ -204,16 +203,52 @@ export async function updateSeason(input: SeasonFormInput): Promise<ActionResult
       actorId: auditActorId(admin),
       targetId: data.id,
       targetType: "season",
-      meta: { slug: data.slug },
+      meta: { slug: existing.slug },
     });
 
     revalidatePath("/admin");
     revalidatePath(`/admin/${existing.slug}/settings`);
-    revalidatePath(`/admin/${data.slug}/settings`);
-    return ok({ slug: data.slug });
+    return ok({ slug: existing.slug });
   } catch (e) {
     if (e instanceof AppError) return fail({ code: e.code, message: e.message });
     console.error("[updateSeason]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
+export async function publishSeason(seasonId: string): Promise<ActionResult<{ slug: string }>> {
+  try {
+    const admin = await requireSuperAdmin();
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    if (season.status !== "draft") {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有 draft 状态可发布");
+    }
+
+    await db.update(seasons).set({
+      status: "registration",
+      updatedAt: new Date(),
+    }).where(eq(seasons.id, seasonId));
+
+    await db.insert(auditLogs).values({
+      seasonId,
+      action: "season.publish",
+      actorId: auditActorId(admin),
+      targetId: seasonId,
+      targetType: "season",
+      meta: { slug: season.slug, from: "draft", to: "registration" },
+    });
+
+    revalidatePath("/admin");
+    revalidatePath(`/admin/${season.slug}/settings`);
+    revalidatePath(`/${season.slug}`);
+    revalidatePath("/seasons");
+    return ok({ slug: season.slug });
+  } catch (e) {
+    if (e instanceof AppError) return fail({ code: e.code, message: e.message });
+    console.error("[publishSeason]", e);
     return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
   }
 }
@@ -239,7 +274,7 @@ export async function deleteSeason(seasonId: string): Promise<ActionResult<void>
 
     await db.insert(auditLogs).values({
       seasonId: null,
-      action: "season.delete",
+      action: "season.deleted",
       actorId: auditActorId(admin),
       targetId: seasonId,
       targetType: "season",

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -1,0 +1,262 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, count } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { auditLogs, seasonRegistrations, seasons } from "@/db/schema";
+import { ok, fail, type ActionResult } from "@/types/action";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { auditActorId, requireSuperAdmin } from "@/lib/auth/session";
+import {
+  RIVALS_REGISTRATION_CONFIG,
+  RIVALS_STAGE_PLAN,
+  normalizeRegistrationConfig,
+  type RegistrationConfig,
+  type SeasonStatus,
+  type StagePlan,
+} from "@/types/season";
+
+const stageConfigSchema = z.object({
+  key: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/),
+  name: z.string().min(1),
+  type: z.enum(["round_robin", "double_elim", "single_elim", "swiss"]),
+  teamCount: z.number().int().min(2).max(128),
+  advance: z.number().int().min(0).max(128),
+  seeds: z.array(z.number().int().positive()).optional(),
+});
+
+const stagePlanSchema = z.array(stageConfigSchema);
+
+const registrationConfigSchema = z.object({
+  allowedPlayerTypes: z.array(z.enum(["enrolled", "graduated", "external"])).min(1),
+  rankThreshold: z.object({
+    currentMin: z.string().min(1).nullable(),
+    peakMin: z.string().min(1).nullable(),
+  }),
+  maxPerPosition: z.number().int().min(1).max(200),
+  screenshotCount: z.number().int().min(1).max(10),
+});
+
+const seasonFormBaseSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1, "请填写赛季名称"),
+  slug: z.string().min(1, "请填写 slug").regex(/^[a-z0-9][a-z0-9-]*$/, "slug 只能使用小写字母、数字和连字符"),
+  kind: z.string().min(1, "请填写赛事类型"),
+  status: z.enum(["draft", "registration", "voting", "drafting", "playing", "finished", "archived"]),
+  themeColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, "主题色需为 #RRGGBB 格式").nullable(),
+  startAt: z.string().nullable(),
+  endAt: z.string().nullable(),
+  registrationMode: z.enum(["solo", "team"]),
+  hasCaptainVoting: z.boolean(),
+  hasDraft: z.boolean(),
+  teamSize: z.number().int().min(1).max(20),
+  starterCount: z.number().int().min(1).max(20),
+  positions: z.array(z.string().min(1)).min(1),
+  stagePlan: stagePlanSchema,
+  registrationConfig: registrationConfigSchema,
+});
+
+const seasonFormSchema = seasonFormBaseSchema.refine((data) => data.starterCount <= data.teamSize, {
+  path: ["starterCount"],
+  message: "首发人数不能超过队伍人数",
+});
+
+export type SeasonFormInput = z.input<typeof seasonFormSchema>;
+
+function toDate(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function fieldErrorsFromZod(error: z.ZodError): Record<string, string> {
+  const fieldErrors: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const path = issue.path.join(".");
+    if (path && !fieldErrors[path]) fieldErrors[path] = issue.message;
+  }
+  return fieldErrors;
+}
+
+function assertUniqueStageKeys(stagePlan: StagePlan): void {
+  const keys = new Set<string>();
+  for (const stage of stagePlan) {
+    if (keys.has(stage.key)) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, `stage key 重复: ${stage.key}`);
+    }
+    keys.add(stage.key);
+  }
+}
+
+export async function createSeason(input: SeasonFormInput): Promise<ActionResult<{ seasonId: string; slug: string }>> {
+  try {
+    const admin = await requireSuperAdmin();
+    const parsed = seasonFormSchema.safeParse(input);
+    if (!parsed.success) {
+      return fail({
+        code: ErrorCode.VALIDATION_FAILED,
+        message: "赛季配置校验失败",
+        fieldErrors: fieldErrorsFromZod(parsed.error),
+      });
+    }
+
+    const data = parsed.data;
+    assertUniqueStageKeys(data.stagePlan as StagePlan);
+
+    const [season] = await db.insert(seasons).values({
+      slug: data.slug,
+      name: data.name,
+      kind: data.kind,
+      status: data.status,
+      themeColor: data.themeColor,
+      registrationMode: data.registrationMode,
+      hasCaptainVoting: data.hasCaptainVoting,
+      hasDraft: data.hasDraft,
+      teamSize: data.teamSize,
+      starterCount: data.starterCount,
+      positions: data.positions,
+      stagePlan: data.stagePlan as StagePlan,
+      registrationConfig: normalizeRegistrationConfig(data.registrationConfig as RegistrationConfig),
+      startAt: toDate(data.startAt),
+      endAt: toDate(data.endAt),
+    }).returning({ id: seasons.id, slug: seasons.slug });
+
+    await db.insert(auditLogs).values({
+      seasonId: season.id,
+      action: "season.create",
+      actorId: auditActorId(admin),
+      targetId: season.id,
+      targetType: "season",
+      meta: { slug: season.slug },
+    });
+
+    revalidatePath("/admin");
+    return ok({ seasonId: season.id, slug: season.slug });
+  } catch (e) {
+    if (e instanceof AppError) return fail({ code: e.code, message: e.message });
+    console.error("[createSeason]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
+export async function updateSeason(input: SeasonFormInput): Promise<ActionResult<{ slug: string }>> {
+  try {
+    const admin = await requireSuperAdmin();
+    const updateSchema = seasonFormBaseSchema.extend({ id: z.string().uuid() }).refine(
+      (data) => data.starterCount <= data.teamSize,
+      { path: ["starterCount"], message: "首发人数不能超过队伍人数" },
+    );
+    const parsed = updateSchema.safeParse(input);
+    if (!parsed.success) {
+      return fail({
+        code: ErrorCode.VALIDATION_FAILED,
+        message: "赛季配置校验失败",
+        fieldErrors: fieldErrorsFromZod(parsed.error),
+      });
+    }
+
+    const data = parsed.data;
+    assertUniqueStageKeys(data.stagePlan as StagePlan);
+
+    const existing = await db.query.seasons.findFirst({
+      where: eq(seasons.id, data.id),
+    });
+    if (!existing) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+
+    if (existing.status !== "draft") {
+      const coreChanged =
+        existing.slug !== data.slug ||
+        existing.registrationMode !== data.registrationMode ||
+        existing.hasCaptainVoting !== data.hasCaptainVoting ||
+        existing.hasDraft !== data.hasDraft ||
+        existing.teamSize !== data.teamSize ||
+        existing.starterCount !== data.starterCount ||
+        JSON.stringify(existing.positions) !== JSON.stringify(data.positions) ||
+        JSON.stringify(existing.stagePlan) !== JSON.stringify(data.stagePlan);
+      if (coreChanged) {
+        throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有 draft 状态可修改核心赛季配置");
+      }
+    }
+
+    await db.update(seasons).set({
+      slug: data.slug,
+      name: data.name,
+      kind: data.kind,
+      status: data.status as SeasonStatus,
+      themeColor: data.themeColor,
+      registrationMode: data.registrationMode,
+      hasCaptainVoting: data.hasCaptainVoting,
+      hasDraft: data.hasDraft,
+      teamSize: data.teamSize,
+      starterCount: data.starterCount,
+      positions: data.positions,
+      stagePlan: data.stagePlan as StagePlan,
+      registrationConfig: normalizeRegistrationConfig(data.registrationConfig as RegistrationConfig),
+      startAt: toDate(data.startAt),
+      endAt: toDate(data.endAt),
+      updatedAt: new Date(),
+    }).where(eq(seasons.id, data.id));
+
+    await db.insert(auditLogs).values({
+      seasonId: data.id,
+      action: "season.update",
+      actorId: auditActorId(admin),
+      targetId: data.id,
+      targetType: "season",
+      meta: { slug: data.slug },
+    });
+
+    revalidatePath("/admin");
+    revalidatePath(`/admin/${existing.slug}/settings`);
+    revalidatePath(`/admin/${data.slug}/settings`);
+    return ok({ slug: data.slug });
+  } catch (e) {
+    if (e instanceof AppError) return fail({ code: e.code, message: e.message });
+    console.error("[updateSeason]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
+export async function deleteSeason(seasonId: string): Promise<ActionResult<void>> {
+  try {
+    const admin = await requireSuperAdmin();
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    if (season.status !== "draft") {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有 draft 状态可删除");
+    }
+
+    const [{ value: registrationCount }] = await db
+      .select({ value: count() })
+      .from(seasonRegistrations)
+      .where(eq(seasonRegistrations.seasonId, seasonId));
+    if (registrationCount > 0) {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "已有报名记录，不能删除赛季");
+    }
+
+    await db.insert(auditLogs).values({
+      seasonId: null,
+      action: "season.delete",
+      actorId: auditActorId(admin),
+      targetId: seasonId,
+      targetType: "season",
+      meta: { slug: season.slug },
+    });
+    await db.delete(seasons).where(eq(seasons.id, seasonId));
+
+    revalidatePath("/admin");
+    return ok(undefined);
+  } catch (e) {
+    if (e instanceof AppError) return fail({ code: e.code, message: e.message });
+    console.error("[deleteSeason]", e);
+    return fail({ code: ErrorCode.INTERNAL_ERROR, message: ERROR_MESSAGES.INTERNAL_ERROR });
+  }
+}
+
+export const DEFAULT_SEASON_FORM_VALUES = {
+  stagePlan: RIVALS_STAGE_PLAN,
+  registrationConfig: RIVALS_REGISTRATION_CONFIG,
+};

--- a/src/app/[seasonSlug]/layout.tsx
+++ b/src/app/[seasonSlug]/layout.tsx
@@ -6,6 +6,7 @@ import { seasons } from "@/db/schema";
 import { Breadcrumb } from "@/components/layout/breadcrumb";
 import { SeasonNav } from "@/components/layout/season-nav";
 import { hexToRgbString } from "@/lib/utils/color";
+import { normalizeStagePlan } from "@/types/season";
 
 interface SeasonLayoutProps {
   children: React.ReactNode;
@@ -53,8 +54,7 @@ export default async function SeasonLayout({ children, params }: SeasonLayoutPro
         slug={season.slug}
         hasCaptainVoting={season.hasCaptainVoting}
         hasDraft={season.hasDraft}
-        qualifierFormat={season.qualifierFormat}
-        playoffFormat={season.playoffFormat}
+        hasMatches={normalizeStagePlan(season.stagePlan).length > 0}
       />
       {children}
     </div>

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BracketView } from "@/components/matches/BracketView";
 import { MatchCard } from "@/components/matches/MatchCard";
 import { StandingsTable } from "@/components/matches/StandingsTable";
+import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import type { Database } from "brackets-manager";
 
 export const dynamic = "force-dynamic";
@@ -36,13 +37,18 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
   ]);
 
   const teamMap = new Map(allTeams.map((t) => [t.id, t.name]));
+  const stagePlan = normalizeStagePlan(season.stagePlan);
+  const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
+  const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
+  const qualifierKey = qualifierStage?.key ?? "qualifier";
+  const playoffKey = playoffStage?.key ?? "playoff";
 
-  const qualifierMatches = allMatches.filter((m) => m.stage === "qualifier");
-  const playoffMatches = allMatches.filter((m) => m.stage === "playoff");
+  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
+  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey);
 
   // 积分榜（仅当有排位赛时计算）
-  const standings = season.qualifierFormat
-    ? await calculateStandings(season.id, allTeams)
+  const standings = qualifierStage
+    ? await calculateStandings(season.id, allTeams, qualifierKey)
     : [];
 
   const allQualifierFinished =
@@ -58,9 +64,9 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
   // 正赛 stage 的 bracket 数据（筛出正赛 stage）
   const playoffBracketData = {
     ...bracketData,
-    stage: bracketData.stage.filter((s) => s.name === "正赛"),
+    stage: bracketData.stage.filter((s) => s.name === playoffStage?.name),
     match: bracketData.match.filter((m) =>
-      bracketData.stage.some((s) => s.name === "正赛" && s.id === m.stageId)
+      bracketData.stage.some((s) => s.name === playoffStage?.name && s.id === m.stageId)
     ),
   };
 
@@ -71,8 +77,8 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
       .map((m) => [m.bracketNodeId!, m.id])
   );
 
-  const hasQualifier = !!season.qualifierFormat;
-  const hasPlayoff = !!season.playoffFormat;
+  const hasQualifier = !!qualifierStage;
+  const hasPlayoff = !!playoffStage;
 
   if (allMatches.length === 0 && allTeams.length === 0) {
     return (
@@ -86,15 +92,15 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
     <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
       <h1 className="text-3xl font-bold text-[var(--text-primary)]">赛程总览</h1>
 
-      <Tabs defaultValue={hasQualifier ? "qualifier" : "playoff"} className="w-full">
+      <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey} className="w-full">
         <TabsList className="mb-6">
-          {hasQualifier && <TabsTrigger value="qualifier">排位赛</TabsTrigger>}
-          {hasPlayoff && <TabsTrigger value="playoff">正赛</TabsTrigger>}
+          {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
+          {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}
         </TabsList>
 
         {/* ── 排位赛面板 ─────────────────────────────────────────── */}
         {hasQualifier && (
-          <TabsContent value="qualifier" className="space-y-8">
+          <TabsContent value={qualifierKey} className="space-y-8">
             {/* 积分榜 */}
             {standings.length > 0 && (
               <section className="space-y-3">
@@ -126,7 +132,7 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
                       teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
                       scoreA={m.scoreA}
                       scoreB={m.scoreB}
-                      stage="qualifier"
+                      stage={qualifierKey}
                       format={m.format as "bo1" | "bo3" | "bo5"}
                       status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                     />
@@ -145,7 +151,7 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
 
         {/* ── 正赛面板 ───────────────────────────────────────────── */}
         {hasPlayoff && (
-          <TabsContent value="playoff" className="space-y-8">
+          <TabsContent value={playoffKey} className="space-y-8">
             {/* Bracket 图 */}
             {playoffBracketData.stage.length > 0 && (
               <section id="bracket" className="space-y-3">
@@ -173,7 +179,7 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
                       teamBName={teamMap.get(m.teamBId) ?? "TBD"}
                       scoreA={m.scoreA}
                       scoreB={m.scoreB}
-                      stage="playoff"
+                      stage={playoffKey}
                       format={m.format as "bo1" | "bo3" | "bo5"}
                       status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                     />

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { UserPlus, Vote, Users, Swords, Shuffle } from "lucide-react";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
-import { SEASON_STATUS_LABELS } from "@/types/season";
+import { normalizeStagePlan, SEASON_STATUS_LABELS } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 
 interface SeasonPageProps {
@@ -18,6 +18,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     where: eq(seasons.slug, seasonSlug),
   });
   if (!season) notFound();
+  const hasMatches = normalizeStagePlan(season.stagePlan).length > 0;
 
   const quickLinks = [
     {
@@ -53,7 +54,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       label: "赛程对决",
       description: "Bracket + 战报",
       icon: Swords,
-      show: season.qualifierFormat !== null || season.playoffFormat !== null,
+      show: hasMatches,
     },
   ].filter((l) => l.show);
 

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -5,6 +5,7 @@ import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { getPositionCounts } from "@/actions/register";
 import { RegistrationForm } from "@/components/register/RegistrationForm";
+import { normalizeRegistrationConfig } from "@/types/season";
 
 export const dynamic = "force-dynamic";
 
@@ -66,6 +67,8 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           seasonId={season.id}
           seasonName={season.name}
           positionCounts={positionCounts}
+          positions={season.positions}
+          registrationConfig={normalizeRegistrationConfig(season.registrationConfig)}
         />
       </div>
 

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -151,8 +151,13 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
       )}
 
       {/* 生成正赛（排位赛全部结束后） */}
-      {canGeneratePlayoff && standings.length > 0 && (
-        <GeneratePlayoffCard seasonId={season.id} standings={standings} />
+      {canGeneratePlayoff && standings.length > 0 && playoffStage && (
+        <GeneratePlayoffCard
+          seasonId={season.id}
+          stageKey={playoffStage.key}
+          stageName={playoffStage.name}
+          standings={standings}
+        />
       )}
 
       {/* Tab 面板 */}

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -64,8 +65,13 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
   }
 
   const teamMap = new Map(allTeams.map((t) => [t.id, t.name]));
-  const qualifierMatches = allMatches.filter((m) => m.stage === "qualifier");
-  const playoffMatches = allMatches.filter((m) => m.stage === "playoff");
+  const stagePlan = normalizeStagePlan(season.stagePlan);
+  const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
+  const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
+  const qualifierKey = qualifierStage?.key ?? "qualifier";
+  const playoffKey = playoffStage?.key ?? "playoff";
+  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
+  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey);
 
   // 已完成比赛的地图列表（用于 OCR 录入面板）
   const finishedMatchIds = allMatches
@@ -98,19 +104,19 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
 
   // 是否可以生成正赛
   const canGeneratePlayoff =
-    !!season.qualifierFormat &&
-    !!season.playoffFormat &&
+    !!qualifierStage &&
+    !!playoffStage &&
     allQualifierFinished &&
     playoffCount === 0;
 
   // 积分榜（有排位赛时计算）
   const standings =
-    season.qualifierFormat && qualifierCount > 0
-      ? await calculateStandings(season.id, allTeams)
+    qualifierStage && qualifierCount > 0
+      ? await calculateStandings(season.id, allTeams, qualifierKey)
       : [];
 
-  const hasQualifier = !!season.qualifierFormat;
-  const hasPlayoff = !!season.playoffFormat;
+  const hasQualifier = !!qualifierStage;
+  const hasPlayoff = !!playoffStage;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
@@ -139,8 +145,7 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
       {canGenerate && (
         <GenerateScheduleCard
           seasonId={season.id}
-          qualifierFormat={season.qualifierFormat ?? null}
-          playoffFormat={season.playoffFormat ?? null}
+          stagePlan={stagePlan}
           teamCount={allTeams.length}
         />
       )}
@@ -152,15 +157,15 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
 
       {/* Tab 面板 */}
       {matchCount > 0 && (
-        <Tabs defaultValue={hasQualifier ? "qualifier" : "playoff"}>
+        <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey}>
           <TabsList>
-            {hasQualifier && <TabsTrigger value="qualifier">排位赛</TabsTrigger>}
-            {hasPlayoff && <TabsTrigger value="playoff">正赛</TabsTrigger>}
+            {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
+            {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}
           </TabsList>
 
           {/* 排位赛面板 */}
           {hasQualifier && (
-            <TabsContent value="qualifier" className="space-y-6 mt-4">
+            <TabsContent value={qualifierKey} className="space-y-6 mt-4">
               {/* 积分榜 */}
               {standings.length > 0 && (
                 <section className="space-y-2">
@@ -235,7 +240,7 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
 
           {/* 正赛面板 */}
           {hasPlayoff && (
-            <TabsContent value="playoff" className="space-y-3 mt-4">
+            <TabsContent value={playoffKey} className="space-y-3 mt-4">
               <h2 className="text-base font-semibold text-[var(--text-primary)]">赛程</h2>
               {playoffMatches.length === 0 ? (
                 <Card className="p-8 text-center text-[var(--text-secondary)]">

--- a/src/app/admin/[seasonSlug]/settings/page.tsx
+++ b/src/app/admin/[seasonSlug]/settings/page.tsx
@@ -1,0 +1,56 @@
+import { notFound, redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { requireSuperAdmin } from "@/lib/auth/session";
+import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
+import { SeasonForm } from "@/components/admin/SeasonForm";
+
+interface SeasonSettingsPageProps {
+  params: Promise<{ seasonSlug: string }>;
+}
+
+function toDateTimeInput(value: Date | null): string | null {
+  if (!value) return null;
+  return value.toISOString().slice(0, 16);
+}
+
+export default async function SeasonSettingsPage({ params }: SeasonSettingsPageProps) {
+  try {
+    await requireSuperAdmin();
+  } catch {
+    redirect("/admin/login");
+  }
+
+  const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <SeasonForm
+        mode="edit"
+        initial={{
+          id: season.id,
+          name: season.name,
+          slug: season.slug,
+          kind: season.kind,
+          status: season.status,
+          themeColor: season.themeColor,
+          startAt: toDateTimeInput(season.startAt),
+          endAt: toDateTimeInput(season.endAt),
+          registrationMode: season.registrationMode,
+          hasCaptainVoting: season.hasCaptainVoting,
+          hasDraft: season.hasDraft,
+          teamSize: season.teamSize,
+          starterCount: season.starterCount,
+          positions: season.positions,
+          stagePlan: normalizeStagePlan(season.stagePlan),
+          registrationConfig: normalizeRegistrationConfig(season.registrationConfig),
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -26,11 +26,18 @@ export default async function AdminDashboardPage() {
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold">赛季列表</h1>
           {admin.role === "super_admin" && (
-            <Link href="/admin/invites">
-              <Button variant="outline" size="sm">
-                管理邀请码
-              </Button>
-            </Link>
+            <div className="flex items-center gap-2">
+              <Link href={"/admin/seasons/new" as never}>
+                <Button size="sm">
+                  新建赛季
+                </Button>
+              </Link>
+              <Link href="/admin/invites">
+                <Button variant="outline" size="sm">
+                  管理邀请码
+                </Button>
+              </Link>
+            </div>
           )}
         </div>
 
@@ -39,17 +46,27 @@ export default async function AdminDashboardPage() {
         ) : (
           <div className="space-y-3">
             {allSeasons.map((s) => (
-              <Link key={s.id} href={`/admin/${s.slug}/registrations`}>
-                <Card className="p-4 hover:bg-[var(--bg-elevated)] transition-colors cursor-pointer flex items-center justify-between">
+              <Card key={s.id} className="p-4 flex items-center justify-between gap-4">
+                <Link
+                  href={`/admin/${s.slug}/registrations`}
+                  className="min-w-0 flex-1 hover:text-[var(--text-primary)] transition-colors"
+                >
                   <div>
                     <span className="font-medium">{s.name}</span>
                     <span className="text-sm text-[var(--text-secondary)] ml-2">
                       {s.slug}
                     </span>
                   </div>
+                </Link>
+                <div className="flex items-center gap-2">
                   <Badge variant="outline">{s.status}</Badge>
-                </Card>
-              </Link>
+                  {admin.role === "super_admin" && (
+                    <Link href={`/admin/${s.slug}/settings` as never}>
+                      <Button variant="outline" size="sm">设置</Button>
+                    </Link>
+                  )}
+                </div>
+              </Card>
             ))}
           </div>
         )}

--- a/src/app/admin/seasons/new/page.tsx
+++ b/src/app/admin/seasons/new/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from "next/navigation";
+import { requireSuperAdmin } from "@/lib/auth/session";
+import { RIVALS_REGISTRATION_CONFIG, RIVALS_STAGE_PLAN } from "@/types/season";
+import { SeasonForm } from "@/components/admin/SeasonForm";
+
+export default async function NewSeasonPage() {
+  try {
+    await requireSuperAdmin();
+  } catch {
+    redirect("/admin/login");
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      <SeasonForm
+        mode="create"
+        initial={{
+          name: "",
+          slug: "",
+          kind: "选秀联赛",
+          status: "draft",
+          themeColor: "#f97316",
+          startAt: null,
+          endAt: null,
+          registrationMode: "solo",
+          hasCaptainVoting: true,
+          hasDraft: true,
+          teamSize: 7,
+          starterCount: 5,
+          positions: ["igl", "awper", "opener", "closer", "anchor"],
+          stagePlan: RIVALS_STAGE_PLAN,
+          registrationConfig: RIVALS_REGISTRATION_CONFIG,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -3,17 +3,16 @@
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { createSeason, deleteSeason, updateSeason, type SeasonFormInput } from "@/actions/seasons";
+import { createSeason, deleteSeason, publishSeason, updateSeason, type SeasonFormInput } from "@/actions/seasons";
 import {
   PLAYER_TYPE_LABELS,
   RIVALS_REGISTRATION_CONFIG,
   RIVALS_STAGE_PLAN,
-  SEASON_STATUS_LABELS,
   type PlayerType,
   type RegistrationConfig,
-  type SeasonStatus,
   type StagePlan,
 } from "@/types/season";
+import { rankValues, RANK_LABELS } from "@/lib/validators/registration";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -28,15 +27,8 @@ import {
 } from "@/components/ui/select";
 
 const PLAYER_TYPES: PlayerType[] = ["enrolled", "graduated", "external"];
-const STATUSES: SeasonStatus[] = [
-  "draft",
-  "registration",
-  "voting",
-  "drafting",
-  "playing",
-  "finished",
-  "archived",
-];
+const NO_RANK = "__none__";
+type StagePlanMode = "rivals" | "custom";
 
 interface SeasonFormProps {
   mode: "create" | "edit";
@@ -61,7 +53,6 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [name, setName] = useState(initial?.name ?? "");
   const [slug, setSlug] = useState(initial?.slug ?? "");
   const [kind, setKind] = useState(initial?.kind ?? "选秀联赛");
-  const [status, setStatus] = useState<SeasonStatus>(initial?.status ?? "draft");
   const [themeColor, setThemeColor] = useState(initial?.themeColor ?? "#f97316");
   const [startAt, setStartAt] = useState(initial?.startAt ?? "");
   const [endAt, setEndAt] = useState(initial?.endAt ?? "");
@@ -73,12 +64,16 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [teamSize, setTeamSize] = useState(initial?.teamSize ?? 7);
   const [starterCount, setStarterCount] = useState(initial?.starterCount ?? 5);
   const [positionsText, setPositionsText] = useState((initial?.positions ?? ["igl", "awper", "opener", "closer", "anchor"]).join(","));
-  const [stagePlanText, setStagePlanText] = useState(JSON.stringify(initial?.stagePlan ?? RIVALS_STAGE_PLAN, null, 2));
+  const initialStagePlan = initial?.stagePlan ?? RIVALS_STAGE_PLAN;
+  const initialStagePlanMode =
+    JSON.stringify(initialStagePlan) === JSON.stringify(RIVALS_STAGE_PLAN) ? "rivals" : "custom";
+  const [stagePlanMode, setStagePlanMode] = useState<StagePlanMode>(initialStagePlanMode);
+  const [stagePlanText, setStagePlanText] = useState(JSON.stringify(initialStagePlan, null, 2));
   const [allowedPlayerTypes, setAllowedPlayerTypes] = useState<PlayerType[]>(
     defaultConfig.allowedPlayerTypes,
   );
-  const [currentMin, setCurrentMin] = useState(defaultConfig.rankThreshold.currentMin ?? "");
-  const [peakMin, setPeakMin] = useState(defaultConfig.rankThreshold.peakMin ?? "");
+  const [currentMin, setCurrentMin] = useState(defaultConfig.rankThreshold.currentMin ?? NO_RANK);
+  const [peakMin, setPeakMin] = useState(defaultConfig.rankThreshold.peakMin ?? NO_RANK);
   const [maxPerPosition, setMaxPerPosition] = useState(defaultConfig.maxPerPosition);
   const [screenshotCount, setScreenshotCount] = useState(defaultConfig.screenshotCount);
 
@@ -99,13 +94,22 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
     });
   }
 
+  function handleStagePlanModeChange(value: string) {
+    const nextMode = value as StagePlanMode;
+    setStagePlanMode(nextMode);
+    if (nextMode === "rivals") {
+      setStagePlanText(JSON.stringify(RIVALS_STAGE_PLAN, null, 2));
+    }
+  }
+
   function buildPayload(): SeasonFormInput {
-    const stagePlan = parseJson<StagePlan>(stagePlanText, RIVALS_STAGE_PLAN);
+    const stagePlan =
+      stagePlanMode === "rivals" ? RIVALS_STAGE_PLAN : parseJson<StagePlan>(stagePlanText, RIVALS_STAGE_PLAN);
     const registrationConfig: RegistrationConfig = {
       allowedPlayerTypes,
       rankThreshold: {
-        currentMin: emptyToNull(currentMin),
-        peakMin: emptyToNull(peakMin),
+        currentMin: currentMin === NO_RANK ? null : currentMin,
+        peakMin: peakMin === NO_RANK ? null : peakMin,
       },
       maxPerPosition,
       screenshotCount,
@@ -116,7 +120,6 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
       name,
       slug,
       kind,
-      status,
       themeColor: emptyToNull(themeColor),
       startAt: emptyToNull(startAt),
       endAt: emptyToNull(endAt),
@@ -146,6 +149,20 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
         : await updateSeason(payload);
       if (result.success) {
         toast.success(mode === "create" ? "赛季已创建" : "赛季已更新");
+        router.push(`/admin/${result.data.slug}/settings` as never);
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handlePublish() {
+    if (!initial?.id) return;
+    startTransition(async () => {
+      const result = await publishSeason(initial.id!);
+      if (result.success) {
+        toast.success("赛季已发布");
         router.push(`/admin/${result.data.slug}/settings` as never);
         router.refresh();
       } else {
@@ -185,22 +202,11 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
           </div>
           <div>
             <Label htmlFor="season-slug">Slug</Label>
-            <Input id="season-slug" value={slug} disabled={coreLocked} onChange={(e) => setSlug(e.target.value)} />
+            <Input id="season-slug" value={slug} disabled={mode === "edit"} onChange={(e) => setSlug(e.target.value)} />
           </div>
           <div>
             <Label htmlFor="season-kind">类型</Label>
             <Input id="season-kind" value={kind} onChange={(e) => setKind(e.target.value)} />
-          </div>
-          <div>
-            <Label>状态</Label>
-            <Select value={status} onValueChange={(value) => setStatus(value as SeasonStatus)}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {STATUSES.map((item) => (
-                  <SelectItem key={item} value={item}>{SEASON_STATUS_LABELS[item]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
           </div>
           <div>
             <Label htmlFor="theme-color">主题色</Label>
@@ -271,29 +277,54 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <Label htmlFor="current-min">当前段位门槛</Label>
-            <Input id="current-min" value={currentMin} onChange={(e) => setCurrentMin(e.target.value)} placeholder="A，留空表示无门槛" />
+            <Label>当前段位门槛</Label>
+            <Select value={currentMin} onValueChange={setCurrentMin}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_RANK}>无门槛</SelectItem>
+                {rankValues.map((rank) => (
+                  <SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
-            <Label htmlFor="peak-min">历史段位门槛</Label>
-            <Input id="peak-min" value={peakMin} onChange={(e) => setPeakMin(e.target.value)} placeholder="A+，留空表示无门槛" />
+            <Label>历史段位门槛</Label>
+            <Select value={peakMin} onValueChange={setPeakMin}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_RANK}>无门槛</SelectItem>
+                {rankValues.map((rank) => (
+                  <SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
             <Label htmlFor="max-position">每位置上限</Label>
-            <Input id="max-position" type="number" min={1} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} />
+            <Input id="max-position" type="number" min={1} max={50} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} />
           </div>
           <div>
             <Label htmlFor="screenshot-count">截图链接数量</Label>
-            <Input id="screenshot-count" type="number" min={1} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} />
+            <Input id="screenshot-count" type="number" min={1} max={5} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} />
           </div>
         </div>
       </section>
 
       <section className="space-y-4">
-        <h2 className="font-semibold">Stage Plan JSON</h2>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="font-semibold">赛制配置</h2>
+          <Select value={stagePlanMode} disabled={coreLocked} onValueChange={handleStagePlanModeChange}>
+            <SelectTrigger className="w-full sm:w-56"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="rivals">Rivals 8队预设</SelectItem>
+              <SelectItem value="custom">自定义 JSON</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <Textarea
           value={stagePlanText}
-          disabled={coreLocked}
+          disabled={coreLocked || stagePlanMode === "rivals"}
           onChange={(e) => setStagePlanText(e.target.value)}
           rows={12}
           className="font-mono text-xs"
@@ -308,9 +339,16 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
             </Button>
           )}
         </div>
-        <Button type="button" disabled={isPending} onClick={handleSubmit}>
-          {isPending ? "保存中…" : mode === "create" ? "创建赛季" : "保存设置"}
-        </Button>
+        <div className="flex items-center gap-2">
+          {mode === "edit" && initial?.status === "draft" && (
+            <Button type="button" variant="outline" disabled={isPending} onClick={handlePublish}>
+              发布
+            </Button>
+          )}
+          <Button type="button" disabled={isPending} onClick={handleSubmit}>
+            {isPending ? "保存中…" : mode === "create" ? "创建赛季" : "保存设置"}
+          </Button>
+        </div>
       </div>
     </Card>
   );

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { createSeason, deleteSeason, updateSeason, type SeasonFormInput } from "@/actions/seasons";
+import {
+  PLAYER_TYPE_LABELS,
+  RIVALS_REGISTRATION_CONFIG,
+  RIVALS_STAGE_PLAN,
+  SEASON_STATUS_LABELS,
+  type PlayerType,
+  type RegistrationConfig,
+  type SeasonStatus,
+  type StagePlan,
+} from "@/types/season";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const PLAYER_TYPES: PlayerType[] = ["enrolled", "graduated", "external"];
+const STATUSES: SeasonStatus[] = [
+  "draft",
+  "registration",
+  "voting",
+  "drafting",
+  "playing",
+  "finished",
+  "archived",
+];
+
+interface SeasonFormProps {
+  mode: "create" | "edit";
+  initial?: SeasonFormInput;
+}
+
+function emptyToNull(value: string): string | null {
+  return value.trim() === "" ? null : value;
+}
+
+function parseJson<T>(value: string, fallback: T): T {
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  return JSON.parse(trimmed) as T;
+}
+
+export function SeasonForm({ mode, initial }: SeasonFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const defaultConfig = initial?.registrationConfig ?? RIVALS_REGISTRATION_CONFIG;
+  const [name, setName] = useState(initial?.name ?? "");
+  const [slug, setSlug] = useState(initial?.slug ?? "");
+  const [kind, setKind] = useState(initial?.kind ?? "选秀联赛");
+  const [status, setStatus] = useState<SeasonStatus>(initial?.status ?? "draft");
+  const [themeColor, setThemeColor] = useState(initial?.themeColor ?? "#f97316");
+  const [startAt, setStartAt] = useState(initial?.startAt ?? "");
+  const [endAt, setEndAt] = useState(initial?.endAt ?? "");
+  const [registrationMode, setRegistrationMode] = useState<"solo" | "team">(
+    initial?.registrationMode ?? "solo",
+  );
+  const [hasCaptainVoting, setHasCaptainVoting] = useState(initial?.hasCaptainVoting ?? true);
+  const [hasDraft, setHasDraft] = useState(initial?.hasDraft ?? true);
+  const [teamSize, setTeamSize] = useState(initial?.teamSize ?? 7);
+  const [starterCount, setStarterCount] = useState(initial?.starterCount ?? 5);
+  const [positionsText, setPositionsText] = useState((initial?.positions ?? ["igl", "awper", "opener", "closer", "anchor"]).join(","));
+  const [stagePlanText, setStagePlanText] = useState(JSON.stringify(initial?.stagePlan ?? RIVALS_STAGE_PLAN, null, 2));
+  const [allowedPlayerTypes, setAllowedPlayerTypes] = useState<PlayerType[]>(
+    defaultConfig.allowedPlayerTypes,
+  );
+  const [currentMin, setCurrentMin] = useState(defaultConfig.rankThreshold.currentMin ?? "");
+  const [peakMin, setPeakMin] = useState(defaultConfig.rankThreshold.peakMin ?? "");
+  const [maxPerPosition, setMaxPerPosition] = useState(defaultConfig.maxPerPosition);
+  const [screenshotCount, setScreenshotCount] = useState(defaultConfig.screenshotCount);
+
+  const coreLocked = mode === "edit" && initial?.status !== "draft";
+  const title = mode === "create" ? "新建赛季" : "赛季设置";
+
+  const fieldHelp = useMemo(() => {
+    if (!coreLocked) return null;
+    return "当前赛季不在 draft 状态，slug、赛制、队伍规模等核心配置不可修改。";
+  }, [coreLocked]);
+
+  function togglePlayerType(type: PlayerType) {
+    setAllowedPlayerTypes((current) => {
+      if (current.includes(type)) {
+        return current.length === 1 ? current : current.filter((item) => item !== type);
+      }
+      return [...current, type];
+    });
+  }
+
+  function buildPayload(): SeasonFormInput {
+    const stagePlan = parseJson<StagePlan>(stagePlanText, RIVALS_STAGE_PLAN);
+    const registrationConfig: RegistrationConfig = {
+      allowedPlayerTypes,
+      rankThreshold: {
+        currentMin: emptyToNull(currentMin),
+        peakMin: emptyToNull(peakMin),
+      },
+      maxPerPosition,
+      screenshotCount,
+    };
+
+    return {
+      id: initial?.id,
+      name,
+      slug,
+      kind,
+      status,
+      themeColor: emptyToNull(themeColor),
+      startAt: emptyToNull(startAt),
+      endAt: emptyToNull(endAt),
+      registrationMode,
+      hasCaptainVoting,
+      hasDraft,
+      teamSize,
+      starterCount,
+      positions: positionsText.split(",").map((item) => item.trim()).filter(Boolean),
+      stagePlan,
+      registrationConfig,
+    };
+  }
+
+  function handleSubmit() {
+    let payload: SeasonFormInput;
+    try {
+      payload = buildPayload();
+    } catch {
+      toast.error("stagePlan JSON 格式不正确");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = mode === "create"
+        ? await createSeason(payload)
+        : await updateSeason(payload);
+      if (result.success) {
+        toast.success(mode === "create" ? "赛季已创建" : "赛季已更新");
+        router.push(`/admin/${result.data.slug}/settings` as never);
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handleDelete() {
+    if (!initial?.id) return;
+    if (!confirm("确认删除这个 draft 赛季？")) return;
+    startTransition(async () => {
+      const result = await deleteSeason(initial.id!);
+      if (result.success) {
+        toast.success("赛季已删除");
+        router.push("/admin");
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <Card className="p-6 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {fieldHelp && <p className="text-sm text-yellow-600 mt-2">{fieldHelp}</p>}
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="font-semibold">基础信息</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="season-name">名称</Label>
+            <Input id="season-name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="season-slug">Slug</Label>
+            <Input id="season-slug" value={slug} disabled={coreLocked} onChange={(e) => setSlug(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="season-kind">类型</Label>
+            <Input id="season-kind" value={kind} onChange={(e) => setKind(e.target.value)} />
+          </div>
+          <div>
+            <Label>状态</Label>
+            <Select value={status} onValueChange={(value) => setStatus(value as SeasonStatus)}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {STATUSES.map((item) => (
+                  <SelectItem key={item} value={item}>{SEASON_STATUS_LABELS[item]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="theme-color">主题色</Label>
+            <Input id="theme-color" value={themeColor} onChange={(e) => setThemeColor(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="start-at">开始时间</Label>
+            <Input id="start-at" type="datetime-local" value={startAt ?? ""} onChange={(e) => setStartAt(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="end-at">结束时间</Label>
+            <Input id="end-at" type="datetime-local" value={endAt ?? ""} onChange={(e) => setEndAt(e.target.value)} />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-semibold">Capability</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <Label>报名模式</Label>
+            <Select value={registrationMode} disabled={coreLocked} onValueChange={(value) => setRegistrationMode(value as "solo" | "team")}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="solo">个人报名</SelectItem>
+                <SelectItem value="team">队伍报名</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="positions">位置列表</Label>
+            <Input id="positions" value={positionsText} disabled={coreLocked} onChange={(e) => setPositionsText(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="team-size">每队人数</Label>
+            <Input id="team-size" type="number" min={1} value={teamSize} disabled={coreLocked} onChange={(e) => setTeamSize(Number(e.target.value))} />
+          </div>
+          <div>
+            <Label htmlFor="starter-count">首发人数</Label>
+            <Input id="starter-count" type="number" min={1} value={starterCount} disabled={coreLocked} onChange={(e) => setStarterCount(Number(e.target.value))} />
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-4 text-sm">
+          <label className="flex items-center gap-2">
+            <input type="checkbox" checked={hasCaptainVoting} disabled={coreLocked} onChange={(e) => setHasCaptainVoting(e.target.checked)} />
+            队长投票
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="checkbox" checked={hasDraft} disabled={coreLocked} onChange={(e) => setHasDraft(e.target.checked)} />
+            蛇形选秀
+          </label>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-semibold">报名配置</h2>
+        <div className="flex flex-wrap gap-4 text-sm">
+          {PLAYER_TYPES.map((type) => (
+            <label key={type} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={allowedPlayerTypes.includes(type)}
+                onChange={() => togglePlayerType(type)}
+              />
+              {PLAYER_TYPE_LABELS[type]}
+            </label>
+          ))}
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="current-min">当前段位门槛</Label>
+            <Input id="current-min" value={currentMin} onChange={(e) => setCurrentMin(e.target.value)} placeholder="A，留空表示无门槛" />
+          </div>
+          <div>
+            <Label htmlFor="peak-min">历史段位门槛</Label>
+            <Input id="peak-min" value={peakMin} onChange={(e) => setPeakMin(e.target.value)} placeholder="A+，留空表示无门槛" />
+          </div>
+          <div>
+            <Label htmlFor="max-position">每位置上限</Label>
+            <Input id="max-position" type="number" min={1} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} />
+          </div>
+          <div>
+            <Label htmlFor="screenshot-count">截图链接数量</Label>
+            <Input id="screenshot-count" type="number" min={1} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-semibold">Stage Plan JSON</h2>
+        <Textarea
+          value={stagePlanText}
+          disabled={coreLocked}
+          onChange={(e) => setStagePlanText(e.target.value)}
+          rows={12}
+          className="font-mono text-xs"
+        />
+      </section>
+
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          {mode === "edit" && initial?.status === "draft" && (
+            <Button type="button" variant="destructive" disabled={isPending} onClick={handleDelete}>
+              删除赛季
+            </Button>
+          )}
+        </div>
+        <Button type="button" disabled={isPending} onClick={handleSubmit}>
+          {isPending ? "保存中…" : mode === "create" ? "创建赛季" : "保存设置"}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/layout/season-nav.tsx
+++ b/src/components/layout/season-nav.tsx
@@ -8,8 +8,7 @@ interface SeasonNavProps {
   slug: string;
   hasCaptainVoting: boolean;
   hasDraft: boolean;
-  qualifierFormat: string | null;
-  playoffFormat: string | null;
+  hasMatches: boolean;
 }
 
 interface NavItem {
@@ -21,8 +20,7 @@ export function SeasonNav({
   slug,
   hasCaptainVoting,
   hasDraft,
-  qualifierFormat,
-  playoffFormat,
+  hasMatches,
 }: SeasonNavProps) {
   const pathname = usePathname();
 
@@ -32,7 +30,7 @@ export function SeasonNav({
     ...(hasCaptainVoting ? [{ label: "队长投票", href: `/${slug}/captains` }] : []),
     ...(hasDraft ? [{ label: "选秀", href: `/${slug}/draft` }] : []),
     { label: "队伍", href: `/${slug}/teams` },
-    ...((qualifierFormat || playoffFormat) ? [{ label: "赛程", href: `/${slug}/matches` }] : []),
+    ...(hasMatches ? [{ label: "赛程", href: `/${slug}/matches` }] : []),
   ];
 
   return (

--- a/src/components/matches/GeneratePlayoffCard.tsx
+++ b/src/components/matches/GeneratePlayoffCard.tsx
@@ -13,23 +13,25 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { generatePlayoff } from "@/actions/matches";
+import { initializeStage } from "@/actions/matches";
 import type { TeamStanding } from "@/lib/standings";
 
 interface GeneratePlayoffCardProps {
   seasonId: string;
+  stageKey: string;
+  stageName: string;
   standings: TeamStanding[];
 }
 
-export function GeneratePlayoffCard({ seasonId, standings }: GeneratePlayoffCardProps) {
+export function GeneratePlayoffCard({ seasonId, stageKey, stageName, standings }: GeneratePlayoffCardProps) {
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   function handleGenerate() {
     startTransition(async () => {
-      const result = await generatePlayoff(seasonId);
+      const result = await initializeStage(seasonId, stageKey);
       if (result.success) {
-        toast.success(`正赛已生成，共 ${result.data.matchCount} 场第一轮对阵`);
+        toast.success(`${stageName}已生成，共 ${result.data.matchCount} 场第一轮对阵`);
         setOpen(false);
       } else {
         toast.error(result.error.message);
@@ -44,18 +46,18 @@ export function GeneratePlayoffCard({ seasonId, standings }: GeneratePlayoffCard
         <div className="space-y-1">
           <h2 className="text-lg font-bold text-[var(--text-primary)]">排位赛已全部结束</h2>
           <p className="text-sm text-[var(--text-secondary)]">
-            可根据积分榜生成正赛第一轮对阵
+            可根据积分榜生成{stageName}第一轮对阵
           </p>
         </div>
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
-            <Button className="font-bold">生成正赛</Button>
+            <Button className="font-bold">生成{stageName}</Button>
           </DialogTrigger>
           <DialogContent className="max-w-md">
             <DialogHeader>
-              <DialogTitle>确认生成正赛？</DialogTitle>
+              <DialogTitle>确认生成{stageName}？</DialogTitle>
               <DialogDescription className="space-y-3 pt-2">
-                <span className="block">系统将按以下种子顺序生成正赛对阵：</span>
+                <span className="block">系统将按以下种子顺序生成{stageName}对阵：</span>
                 <div className="space-y-1">
                   {standings.map((s) => (
                     <div key={s.teamId} className="flex items-center justify-between text-sm">

--- a/src/components/matches/GenerateScheduleCard.tsx
+++ b/src/components/matches/GenerateScheduleCard.tsx
@@ -14,27 +14,17 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { generateSchedule } from "@/actions/matches";
+import { STAGE_TYPE_LABELS, type StagePlan } from "@/types/season";
 
 interface GenerateScheduleCardProps {
   seasonId: string;
-  qualifierFormat: string | null;
-  playoffFormat: string | null;
+  stagePlan: StagePlan;
   teamCount: number;
 }
 
-const QUALIFIER_LABELS: Record<string, string> = {
-  round_robin: "单循环（Round Robin）",
-  swiss: "瑞士轮",
-};
-const PLAYOFF_LABELS: Record<string, string> = {
-  double_elim: "双败淘汰",
-  single_elim: "单败淘汰",
-};
-
 export function GenerateScheduleCard({
   seasonId,
-  qualifierFormat,
-  playoffFormat,
+  stagePlan,
   teamCount,
 }: GenerateScheduleCardProps) {
   const [open, setOpen] = useState(false);
@@ -53,14 +43,19 @@ export function GenerateScheduleCard({
     });
   }
 
+  const firstStage = stagePlan[0];
+
   return (
     <Card className="p-6 border-dashed border-2 text-center space-y-4">
       <div className="space-y-2">
         <h2 className="text-xl font-bold text-[var(--text-primary)]">赛程尚未生成</h2>
         <p className="text-[var(--text-secondary)] text-sm">
           共 {teamCount} 支队伍参赛
-          {qualifierFormat && ` · 排位赛：${QUALIFIER_LABELS[qualifierFormat] ?? qualifierFormat}`}
-          {playoffFormat && ` · 正赛：${PLAYOFF_LABELS[playoffFormat] ?? playoffFormat}`}
+          {stagePlan.map((stage) => (
+            <span key={stage.key}>
+              {" · "}{stage.name}：{STAGE_TYPE_LABELS[stage.type] ?? stage.type}
+            </span>
+          ))}
         </p>
       </div>
 
@@ -75,9 +70,9 @@ export function GenerateScheduleCard({
             <DialogTitle>确认生成赛程？</DialogTitle>
             <DialogDescription className="space-y-2 pt-2">
               <span className="block">
-                系统将根据赛季配置自动创建所有排位赛对阵。
+                系统将根据赛季配置初始化第一个阶段。
               </span>
-              {qualifierFormat === "round_robin" && (
+              {firstStage?.type === "round_robin" && (
                 <span className="block">
                   单循环 {teamCount} 队 → 共 {(teamCount * (teamCount - 1)) / 2} 场 BO1。
                 </span>

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -10,12 +10,12 @@ interface MatchCardProps {
   teamBName: string;
   scoreA: number | null;
   scoreB: number | null;
-  stage: "qualifier" | "playoff";
+  stage: string;
   format: "bo1" | "bo3" | "bo5";
   status: "scheduled" | "in_progress" | "finished" | "cancelled";
 }
 
-const STAGE_LABELS = { qualifier: "排位赛", playoff: "正赛" };
+const STAGE_LABELS: Record<string, string> = { qualifier: "排位赛", playoff: "正赛" };
 const FORMAT_LABELS = { bo1: "BO1", bo3: "BO3", bo5: "BO5" };
 
 export function MatchCard({
@@ -44,7 +44,7 @@ export function MatchCard({
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <Badge variant="outline" className="text-xs text-[var(--text-secondary)]">
-              {STAGE_LABELS[stage]}
+              {STAGE_LABELS[stage] ?? stage}
             </Badge>
             <Badge variant="outline" className="text-xs text-[var(--text-secondary)]">
               {FORMAT_LABELS[format]}

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { CheckCircle2, Loader2 } from "lucide-react";
 import {
-  registrationSchema,
+  buildRegistrationSchema,
   positionValues,
   POSITION_LABELS,
   rankValues,
   RANK_LABELS,
-  MAX_PER_POSITION,
+  PLAYER_TYPE_LABELS,
   type RegistrationFormData,
   type RegistrationInput,
 } from "@/lib/validators/registration";
+import { normalizeRegistrationConfig, type RegistrationConfig, type PlayerType } from "@/types/season";
 
 import { submitRegistration } from "@/actions/register";
 import { Button } from "@/components/ui/button";
@@ -33,15 +34,28 @@ interface RegistrationFormProps {
   seasonId: string;
   seasonName: string;
   positionCounts: Record<string, number>;
+  positions: string[];
+  registrationConfig: RegistrationConfig;
 }
 
 export function RegistrationForm({
   seasonId,
   seasonName,
   positionCounts,
+  positions,
+  registrationConfig: inputRegistrationConfig,
 }: RegistrationFormProps) {
   const [submitted, setSubmitted] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState("");
+  const registrationConfig = useMemo(
+    () => normalizeRegistrationConfig(inputRegistrationConfig),
+    [inputRegistrationConfig],
+  );
+  const schema = useMemo(
+    () => buildRegistrationSchema(registrationConfig, positions),
+    [registrationConfig, positions],
+  );
+  const activePositions = positions.length > 0 ? positions : [...positionValues];
 
   const {
     register,
@@ -50,10 +64,12 @@ export function RegistrationForm({
     watch,
     formState: { errors, isSubmitting },
   } = useForm<RegistrationInput, unknown, RegistrationFormData>({
-    resolver: zodResolver(registrationSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       seasonId,
       willingToBeCaptain: false,
+      playerType: registrationConfig.allowedPlayerTypes[0],
+      screenshotUrls: Array.from({ length: registrationConfig.screenshotCount }, () => ""),
     },
   });
 
@@ -93,20 +109,28 @@ export function RegistrationForm({
 
   // ── 工具函数 ──
   const FieldError = ({ name }: { name: string }) => {
-    const err = (errors as Record<string, { message?: string }>)[name];
-    return err?.message ? (
-      <p className="text-xs text-red-400 mt-1">{err.message}</p>
+    const err = name.split(".").reduce<unknown>((acc, key) => {
+      if (acc && typeof acc === "object") return (acc as Record<string, unknown>)[key];
+      return undefined;
+    }, errors);
+    const message =
+      err && typeof err === "object" && "message" in err
+        ? String((err as { message?: unknown }).message)
+        : "";
+    return message ? (
+      <p className="text-xs text-red-400 mt-1">{message}</p>
     ) : null;
   };
 
   const positionFull = (pos: string) =>
-    (positionCounts[pos] ?? 0) >= MAX_PER_POSITION;
+    (positionCounts[pos] ?? 0) >= registrationConfig.maxPerPosition;
 
   const positionLabel = (pos: string) => {
     const p = POSITION_LABELS[pos as keyof typeof POSITION_LABELS];
     const cnt = positionCounts[pos] ?? 0;
-    const full = cnt >= MAX_PER_POSITION;
-    return `${p.full}  ${full ? "已满" : `${cnt}/${MAX_PER_POSITION}`}`;
+    const label = p?.full ?? pos;
+    const full = cnt >= registrationConfig.maxPerPosition;
+    return `${label}  ${full ? "已满" : `${cnt}/${registrationConfig.maxPerPosition}`}`;
   };
 
   const SectionTitle = ({ children }: { children: React.ReactNode }) => (
@@ -154,6 +178,34 @@ export function RegistrationForm({
               <Input id="studentId" placeholder="毕业生填「毕业年份+学院」" className={inputCls} {...register("studentId")} />
               <FieldError name="studentId" />
             </div>
+            <div>
+              <Label className="text-[var(--text-secondary)] mb-1.5 block">
+                身份类型 <Required />
+              </Label>
+              <Select
+                defaultValue={registrationConfig.allowedPlayerTypes[0]}
+                onValueChange={(v) =>
+                  setValue("playerType", v as PlayerType, {
+                    shouldValidate: true,
+                  })
+                }
+              >
+                <SelectTrigger className={inputCls}>
+                  <SelectValue placeholder="选择身份类型" />
+                </SelectTrigger>
+                <SelectContent>
+                  {registrationConfig.allowedPlayerTypes.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {PLAYER_TYPE_LABELS[type]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError name="playerType" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <Label htmlFor="qq" className="text-[var(--text-secondary)] mb-1.5 block">
                 QQ 号 <Required />
@@ -232,7 +284,7 @@ export function RegistrationForm({
                 <SelectValue placeholder="选择主选位置" />
               </SelectTrigger>
               <SelectContent>
-                {positionValues.map((pos) => (
+                {activePositions.map((pos) => (
                   <SelectItem key={pos} value={pos} disabled={positionFull(pos)}>
                     {positionLabel(pos)}
                   </SelectItem>
@@ -241,7 +293,7 @@ export function RegistrationForm({
             </Select>
             <FieldError name="primaryPosition" />
             <p className="text-xs text-[var(--text-muted)] mt-1">
-              每个位置最多 {MAX_PER_POSITION} 人，满员后自动关闭
+              每个位置最多 {registrationConfig.maxPerPosition} 人，满员后自动关闭
             </p>
           </div>
 
@@ -260,9 +312,9 @@ export function RegistrationForm({
                 <SelectValue placeholder="选择次选位置" />
               </SelectTrigger>
               <SelectContent>
-                {positionValues.map((pos) => (
+                {activePositions.map((pos) => (
                   <SelectItem key={pos} value={pos}>
-                    {POSITION_LABELS[pos].full}
+                    {POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.full ?? pos}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -423,7 +475,7 @@ export function RegistrationForm({
       <section>
         <SectionTitle>近两周天梯截图</SectionTitle>
         <p className="text-sm text-[var(--text-secondary)] mb-4">
-          请将近两周 5 场天梯对局截图上传至
+          请将近两周天梯对局截图上传至
           <a
             href="https://box.nju.edu.cn"
             target="_blank"
@@ -434,18 +486,23 @@ export function RegistrationForm({
           </a>
           并获取分享链接，粘贴到下方。
         </p>
-        <div>
-          <Label htmlFor="screenshotUrl" className="text-[var(--text-secondary)] mb-1.5 block">
-            NJUBox 分享链接 <Required />
-          </Label>
-          <Input
-            id="screenshotUrl"
-            type="url"
-            placeholder="https://box.nju.edu.cn/d/..."
-            className={inputCls}
-            {...register("screenshotUrl")}
-          />
-          <FieldError name="screenshotUrl" />
+        <div className="space-y-3">
+          {Array.from({ length: registrationConfig.screenshotCount }, (_, index) => (
+            <div key={index}>
+              <Label htmlFor={`screenshotUrls.${index}`} className="text-[var(--text-secondary)] mb-1.5 block">
+                NJUBox 分享链接 {registrationConfig.screenshotCount > 1 ? index + 1 : ""} <Required />
+              </Label>
+              <Input
+                id={`screenshotUrls.${index}`}
+                type="url"
+                placeholder="https://box.nju.edu.cn/d/..."
+                className={inputCls}
+                {...register(`screenshotUrls.${index}`)}
+              />
+              <FieldError name={`screenshotUrls.${index}`} />
+            </div>
+          ))}
+          <FieldError name="screenshotUrls" />
         </div>
       </section>
 

--- a/src/db/schema/matches.ts
+++ b/src/db/schema/matches.ts
@@ -10,9 +10,6 @@ export const matchStatusEnum = pgEnum("match_status", [
   "cancelled",
 ]);
 
-// 比赛阶段：排位赛 / 正赛
-export const matchStageEnum = pgEnum("match_stage", ["qualifier", "playoff"]);
-
 // 比赛格式：BO1 / BO3 / BO5（决定 BP 流程与图数）
 export const matchFormatEnum = pgEnum("match_format", ["bo1", "bo3", "bo5"]);
 
@@ -23,7 +20,8 @@ export const matches = pgTable("matches", {
   teamBId: uuid("team_b_id").notNull().references(() => teams.id),
 
   // ── 比赛元数据 ────────────────────────────────────────────────────────
-  stage: matchStageEnum("stage").notNull(),                              // qualifier | playoff
+  stage: text("stage").notNull(),                                        // StageConfig.key
+  round: integer("round"),                                               // swiss round; null for round_robin / elim
   format: matchFormatEnum("format").notNull().default("bo1"),            // bo1 | bo3 | bo5
   // ──────────────────────────────────────────────────────────────────────
 

--- a/src/db/schema/registrations.ts
+++ b/src/db/schema/registrations.ts
@@ -17,6 +17,9 @@ export const seasonRegistrations = pgTable(
     userId: uuid("user_id").notNull().references(() => users.id),
     seasonId: uuid("season_id").notNull().references(() => seasons.id),
 
+    // ── 身份类型 ─────────────────────────────────────
+    playerType: text("player_type").notNull().default("enrolled"),
+
     // ── 位置 ─────────────────────────────────────────
     primaryPosition: text("primary_position").notNull(),
     secondaryPosition: text("secondary_position").notNull(), // 不能与主选相同

--- a/src/db/schema/seasons.ts
+++ b/src/db/schema/seasons.ts
@@ -1,6 +1,7 @@
 import { pgTable, uuid, text, integer, boolean, timestamp, pgEnum, json } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import type { Database } from "brackets-manager";
+import type { RegistrationConfig, StagePlan } from "@/types/season";
 
 export const seasonStatusEnum = pgEnum("season_status", [
   "draft",        // 未发布
@@ -14,16 +15,6 @@ export const seasonStatusEnum = pgEnum("season_status", [
 
 // 报名模式：solo = 个人报名，team = 队伍整体报名
 export const registrationModeEnum = pgEnum("registration_mode", ["solo", "team"]);
-
-// 排位赛 / 正赛各自的赛制（拆开是因为一个赛季可能两阶段不同制）
-export const qualifierFormatEnum = pgEnum("qualifier_format", [
-  "round_robin",  // 单循环
-  "swiss",        // 瑞士轮（备选）
-]);
-export const playoffFormatEnum = pgEnum("playoff_format", [
-  "double_elim",  // 双败淘汰
-  "single_elim",  // 单败淘汰
-]);
 
 export const seasons = pgTable("seasons", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -41,10 +32,13 @@ export const seasons = pgTable("seasons", {
   hasCaptainVoting: boolean("has_captain_voting").notNull().default(true),
   // 是否有蛇形选秀环节
   hasDraft: boolean("has_draft").notNull().default(true),
-  // 排位赛赛制（null = 无排位赛阶段）
-  qualifierFormat: qualifierFormatEnum("qualifier_format").default("round_robin"),
-  // 正赛赛制（null = 无正赛阶段，纯排位赛）
-  playoffFormat: playoffFormatEnum("playoff_format").default("double_elim"),
+  // 赛制阶段计划；matches.stage 存这里的 StageConfig.key
+  stagePlan: json("stage_plan").$type<StagePlan>().notNull().default(sql`'[]'::json`),
+  // 报名配置；缺失字段由应用层 fallback 到默认配置
+  registrationConfig: json("registration_config")
+    .$type<RegistrationConfig>()
+    .notNull()
+    .default(sql`'{}'::json`),
   // 每支队伍总人数（含队长）
   teamSize: integer("team_size").notNull().default(7),
   // 首发人数

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -12,8 +12,10 @@ import { InMemoryDatabase } from "brackets-memory-db";
 import { Status } from "brackets-model";
 import type { Database } from "brackets-manager";
 import type { Match } from "@/types/match";
-import type { QualifierFormat, PlayoffFormat } from "@/types/season";
 import type { Team } from "@/db/schema/teams";
+
+type QualifierFormat = "round_robin" | "swiss";
+type PlayoffFormat = "double_elim" | "single_elim";
 
 export interface BracketStage {
   id: number;
@@ -63,6 +65,8 @@ export async function generateBracket(
   config: {
     qualifierFormat: QualifierFormat | null;
     playoffFormat: PlayoffFormat | null;
+    qualifierName?: string;
+    playoffName?: string;
   }
 ): Promise<{ data: Database; resolvedMatches: ResolvedBracketMatch[] }> {
   const db = new InMemoryDatabase();
@@ -74,7 +78,7 @@ export async function generateBracket(
     // 排位赛 stage（round_robin 或 swiss；swiss 暂不支持，统一用 round_robin）
     await manager.create.stage({
       tournamentId: 0,
-      name: "排位赛",
+      name: config.qualifierName ?? "排位赛",
       type: "round_robin",
       seeding,
       settings: {
@@ -89,7 +93,7 @@ export async function generateBracket(
       config.playoffFormat === "double_elim" ? "double_elimination" : "single_elimination";
     await manager.create.stage({
       tournamentId: 0,
-      name: "正赛",
+      name: config.playoffName ?? "正赛",
       type,
       seeding: config.qualifierFormat !== null
         // 排位赛结束后才确定晋级顺序；先全部 TBD
@@ -217,13 +221,14 @@ export function serializeBracket(
  */
 export async function seedPlayoff(
   seededTeamNames: string[],
-  currentData: Database
+  currentData: Database,
+  stageName = "正赛",
 ): Promise<{ updatedData: Database; resolvedMatches: ResolvedBracketMatch[] }> {
   const { manager } = buildManager(currentData);
 
   const stages = currentData.stage as Array<{ id: number; name: string }>;
-  const playoffStage = stages.find((s) => s.name === "正赛");
-  if (!playoffStage) throw new Error("正赛 stage 未找到，请先生成赛程");
+  const playoffStage = stages.find((s) => s.name === stageName);
+  if (!playoffStage) throw new Error(`${stageName} stage 未找到，请先生成赛程`);
 
   // 用实际队伍名替换 TBD seed
   await manager.update.seeding(playoffStage.id, seededTeamNames);

--- a/src/lib/formats/double-elim.ts
+++ b/src/lib/formats/double-elim.ts
@@ -1,12 +1,108 @@
 import { and, count, eq } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matches } from "@/db/schema";
+import { matches, seasons } from "@/db/schema";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { generateBracket, seedPlayoff } from "@/lib/bracket";
+import { calculateStandings } from "@/lib/standings";
+import { getPreviousStage, normalizeStagePlan } from "@/types/season";
 import type { StageExecutor } from "./types";
+import type { Database } from "brackets-manager";
 
 export const doubleElimExecutor: StageExecutor = {
-  async initialize() {
-    throw new Error("double_elim initialize is orchestrated by initializeStage");
+  async initialize(seasonId, config, teams) {
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) {
+      throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    }
+
+    const stagePlan = normalizeStagePlan(season.stagePlan);
+    const previousStage = getPreviousStage(stagePlan, config.key);
+    const playoffFormat = config.type === "double_elim" ? "double_elim" : "single_elim";
+
+    if (!previousStage) {
+      const { data, resolvedMatches } = await generateBracket(teams, {
+        qualifierFormat: null,
+        playoffFormat,
+        playoffName: config.name,
+      });
+      const bracketStages = data.stage as Array<{ id: number; name: string }>;
+      const stageId = bracketStages.find((stage) => stage.name === config.name)?.id ?? null;
+      let matchCount = 0;
+
+      for (const bm of resolvedMatches) {
+        if (stageId !== null && bm.stageId !== stageId) continue;
+        const teamA = teams[bm.teamAParticipantId];
+        const teamB = teams[bm.teamBParticipantId];
+        if (!teamA || !teamB) continue;
+
+        await db.insert(matches).values({
+          seasonId,
+          teamAId: teamA.id,
+          teamBId: teamB.id,
+          stage: config.key,
+          format: "bo3",
+          status: "scheduled",
+          bracketNodeId: bm.bracketMatchId.toString(),
+        });
+        matchCount++;
+      }
+
+      await db
+        .update(seasons)
+        .set({ bracketData: data as Database, updatedAt: new Date() })
+        .where(eq(seasons.id, seasonId));
+
+      return { matchCount };
+    }
+
+    if (!season.bracketData) {
+      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "请先一键生成赛程");
+    }
+
+    const standings = await calculateStandings(seasonId, teams, previousStage.key);
+    const seededNames = standings.slice(0, config.teamCount).map((standing) => standing.teamName);
+    const { updatedData, resolvedMatches } = await seedPlayoff(
+      seededNames,
+      season.bracketData as Database,
+      config.name,
+    );
+
+    await db
+      .update(seasons)
+      .set({ bracketData: updatedData as Database, updatedAt: new Date() })
+      .where(eq(seasons.id, seasonId));
+
+    const nameToTeam = new Map(teams.map((team) => [team.name, team]));
+    const participants = updatedData.participant as Array<{ id: number; name: string }>;
+    const participantIdToTeam = new Map(
+      participants.map((participant) => [participant.id, nameToTeam.get(participant.name)]),
+    );
+    const bracketStages = updatedData.stage as Array<{ id: number; name: string }>;
+    const stageId = bracketStages.find((stage) => stage.name === config.name)?.id ?? null;
+    let matchCount = 0;
+
+    for (const bm of resolvedMatches) {
+      if (stageId === null || bm.stageId !== stageId) continue;
+      const teamA = participantIdToTeam.get(bm.teamAParticipantId);
+      const teamB = participantIdToTeam.get(bm.teamBParticipantId);
+      if (!teamA || !teamB) continue;
+
+      await db.insert(matches).values({
+        seasonId,
+        teamAId: teamA.id,
+        teamBId: teamB.id,
+        stage: config.key,
+        format: "bo3",
+        status: "scheduled",
+        bracketNodeId: bm.bracketMatchId.toString(),
+      });
+      matchCount++;
+    }
+
+    return { matchCount };
   },
 
   async isComplete(seasonId, stageKey) {

--- a/src/lib/formats/double-elim.ts
+++ b/src/lib/formats/double-elim.ts
@@ -1,0 +1,31 @@
+import { and, count, eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matches } from "@/db/schema";
+import type { StageExecutor } from "./types";
+
+export const doubleElimExecutor: StageExecutor = {
+  async initialize() {
+    throw new Error("double_elim initialize is orchestrated by initializeStage");
+  },
+
+  async isComplete(seasonId, stageKey) {
+    const [{ value: total }] = await db
+      .select({ value: count() })
+      .from(matches)
+      .where(and(eq(matches.seasonId, seasonId), eq(matches.stage, stageKey)));
+    if (total === 0) return false;
+
+    const [{ value: active }] = await db
+      .select({ value: count() })
+      .from(matches)
+      .where(
+        and(
+          eq(matches.seasonId, seasonId),
+          eq(matches.stage, stageKey),
+          sql`${matches.status} in ('scheduled', 'in_progress')`,
+        ),
+      );
+    return active === 0;
+  },
+};

--- a/src/lib/formats/index.ts
+++ b/src/lib/formats/index.ts
@@ -14,6 +14,9 @@ const EXECUTORS: Partial<Record<StageType, StageExecutor>> = {
 export function getExecutor(type: StageType): StageExecutor {
   const executor = EXECUTORS[type];
   if (!executor) {
+    if (type === "swiss") {
+      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "Swiss 执行器将在 v2 接入");
+    }
     throw new AppError(ErrorCode.INTERNAL_ERROR, `未知赛制: ${type}`);
   }
   return executor;

--- a/src/lib/formats/index.ts
+++ b/src/lib/formats/index.ts
@@ -1,0 +1,20 @@
+import { AppError, ErrorCode } from "@/lib/errors";
+import type { StageType } from "@/types/season";
+import type { StageExecutor } from "./types";
+import { roundRobinExecutor } from "./round-robin";
+import { doubleElimExecutor } from "./double-elim";
+import { singleElimExecutor } from "./single-elim";
+
+const EXECUTORS: Partial<Record<StageType, StageExecutor>> = {
+  round_robin: roundRobinExecutor,
+  double_elim: doubleElimExecutor,
+  single_elim: singleElimExecutor,
+};
+
+export function getExecutor(type: StageType): StageExecutor {
+  const executor = EXECUTORS[type];
+  if (!executor) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, `未知赛制: ${type}`);
+  }
+  return executor;
+}

--- a/src/lib/formats/round-robin.ts
+++ b/src/lib/formats/round-robin.ts
@@ -1,12 +1,63 @@
 import { and, count, eq } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matches } from "@/db/schema";
+import { matches, seasons } from "@/db/schema";
+import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { generateBracket } from "@/lib/bracket";
+import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import type { StageExecutor } from "./types";
+import type { Database } from "brackets-manager";
 
 export const roundRobinExecutor: StageExecutor = {
-  async initialize() {
-    throw new Error("round_robin initialize is orchestrated by generateSchedule");
+  async initialize(seasonId, config, teams) {
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) {
+      throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    }
+
+    const playoffStage = getFirstStageOfType(
+      normalizeStagePlan(season.stagePlan),
+      ["double_elim", "single_elim"],
+    );
+    const { data, resolvedMatches } = await generateBracket(teams, {
+      qualifierFormat: "round_robin",
+      playoffFormat: playoffStage
+        ? (playoffStage.type === "double_elim" ? "double_elim" : "single_elim")
+        : null,
+      qualifierName: config.name,
+      playoffName: playoffStage?.name,
+    });
+
+    const bracketStages = data.stage as Array<{ id: number; name: string }>;
+    const stageId = bracketStages.find((stage) => stage.name === config.name)?.id ?? null;
+    let matchCount = 0;
+
+    for (const bm of resolvedMatches) {
+      if (stageId !== null && bm.stageId !== stageId) continue;
+      const teamA = teams[bm.teamAParticipantId];
+      const teamB = teams[bm.teamBParticipantId];
+      if (!teamA || !teamB) continue;
+
+      await db.insert(matches).values({
+        seasonId,
+        teamAId: teamA.id,
+        teamBId: teamB.id,
+        stage: config.key,
+        format: "bo1",
+        status: "scheduled",
+        bracketNodeId: bm.bracketMatchId.toString(),
+      });
+      matchCount++;
+    }
+
+    await db
+      .update(seasons)
+      .set({ bracketData: data as Database, updatedAt: new Date() })
+      .where(eq(seasons.id, seasonId));
+
+    return { matchCount };
   },
 
   async isComplete(seasonId, stageKey) {

--- a/src/lib/formats/round-robin.ts
+++ b/src/lib/formats/round-robin.ts
@@ -1,0 +1,31 @@
+import { and, count, eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matches } from "@/db/schema";
+import type { StageExecutor } from "./types";
+
+export const roundRobinExecutor: StageExecutor = {
+  async initialize() {
+    throw new Error("round_robin initialize is orchestrated by generateSchedule");
+  },
+
+  async isComplete(seasonId, stageKey) {
+    const [{ value: total }] = await db
+      .select({ value: count() })
+      .from(matches)
+      .where(and(eq(matches.seasonId, seasonId), eq(matches.stage, stageKey)));
+    if (total === 0) return false;
+
+    const [{ value: active }] = await db
+      .select({ value: count() })
+      .from(matches)
+      .where(
+        and(
+          eq(matches.seasonId, seasonId),
+          eq(matches.stage, stageKey),
+          sql`${matches.status} in ('scheduled', 'in_progress')`,
+        ),
+      );
+    return active === 0;
+  },
+};

--- a/src/lib/formats/single-elim.ts
+++ b/src/lib/formats/single-elim.ts
@@ -1,0 +1,7 @@
+import { doubleElimExecutor } from "./double-elim";
+import type { StageExecutor } from "./types";
+
+export const singleElimExecutor: StageExecutor = {
+  initialize: doubleElimExecutor.initialize,
+  isComplete: doubleElimExecutor.isComplete,
+};

--- a/src/lib/formats/types.ts
+++ b/src/lib/formats/types.ts
@@ -1,0 +1,12 @@
+import type { Team } from "@/db/schema/teams";
+import type { StageConfig } from "@/types/season";
+
+export interface StageExecutor {
+  initialize(
+    seasonId: string,
+    config: StageConfig,
+    teams: Team[],
+  ): Promise<{ matchCount: number }>;
+  advanceRound?(seasonId: string, stageKey: string): Promise<{ matchCount: number }>;
+  isComplete(seasonId: string, stageKey: string): Promise<boolean>;
+}

--- a/src/lib/standings.ts
+++ b/src/lib/standings.ts
@@ -37,12 +37,13 @@ export interface TeamStanding {
  */
 export async function calculateStandings(
   seasonId: string,
-  teams: Team[]
+  teams: Team[],
+  stageKey = "qualifier",
 ): Promise<TeamStanding[]> {
   const finishedMatches = await db.query.matches.findMany({
     where: and(
       eq(matches.seasonId, seasonId),
-      eq(matches.stage, "qualifier"),
+      eq(matches.stage, stageKey),
       eq(matches.status, "finished")
     ),
   });

--- a/src/lib/utils/season.ts
+++ b/src/lib/utils/season.ts
@@ -2,7 +2,7 @@
 // 所有判断均基于 season capability 字段，禁止读取 season.kind
 // TODO: 实现各函数体
 
-import type { Season, SeasonStatus } from "@/types/season";
+import { getFirstStageOfType, normalizeStagePlan, type Season, type SeasonStatus } from "@/types/season";
 
 // ── 阶段判断（基于 status）────────────────────────────────────────────────
 
@@ -36,12 +36,16 @@ export function showDraft(season: Season): boolean {
 
 /** 是否展示排位赛视图 */
 export function showQualifier(season: Season): boolean {
-  return season.qualifierFormat !== null;
+  return !!getFirstStageOfType(season.stagePlan, ["round_robin", "swiss"]);
 }
 
 /** 是否展示正赛 Bracket 视图 */
 export function showPlayoffBracket(season: Season): boolean {
-  return season.playoffFormat !== null;
+  return !!getFirstStageOfType(season.stagePlan, ["double_elim", "single_elim"]);
+}
+
+export function showMatches(season: Season): boolean {
+  return normalizeStagePlan(season.stagePlan).length > 0;
 }
 
 /** 是否为个人报名模式 */

--- a/src/lib/validators/registration.ts
+++ b/src/lib/validators/registration.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import { REGISTRATION_DEFAULTS } from "@/lib/config/registration-defaults";
+import {
+  PLAYER_TYPE_LABELS,
+  normalizeRegistrationConfig,
+  type PlayerType,
+  type RegistrationConfig,
+} from "@/types/season";
 import type { PositionValue, RankValue } from "@/lib/config/registration-defaults";
 
 // ── 从配置派生位置常量 ──────────────────────────────
@@ -13,174 +19,229 @@ export const rankValues = REGISTRATION_DEFAULTS.ranks.values;
 export type Rank = RankValue;
 
 export const RANK_LABELS = REGISTRATION_DEFAULTS.ranks.labels;
+export { PLAYER_TYPE_LABELS };
 
-// ── 每位置报名上限 ──────────────────────────────────
-export const MAX_PER_POSITION = REGISTRATION_DEFAULTS.maxPerPosition;
+// ── 默认报名配置 ────────────────────────────────────
+export const DEFAULT_REGISTRATION_CONFIG: RegistrationConfig = {
+  allowedPlayerTypes: ["enrolled"],
+  rankThreshold: { currentMin: "A", peakMin: "A+" },
+  maxPerPosition: REGISTRATION_DEFAULTS.maxPerPosition,
+  screenshotCount: REGISTRATION_DEFAULTS.screenshotCount,
+};
 
-// ── 报名段位门槛（满足其一即可）──────────────────────
-// 当前赛季最高段位 ≥ A，或历史最高段位 ≥ A+
+export const MAX_PER_POSITION = DEFAULT_REGISTRATION_CONFIG.maxPerPosition;
 export const RANK_ORDER = REGISTRATION_DEFAULTS.ranks.values;
-const RANK_IDX_A   = RANK_ORDER.indexOf("A");    // 7
-const RANK_IDX_A_PLUS = RANK_ORDER.indexOf("A+"); // 8
 
-// ── 验证 schema ──────────────────────────────────────
-export const registrationSchema = z
-  .object({
-    seasonId: z.string().uuid("赛季 ID 格式不正确"),
+export const registrationSeedSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
 
-    // ── 基础信息 ──
-    email: z
-      .string()
-      .min(1, "请填写电子邮件")
-      .email("请输入有效的电子邮件地址"),
+function isAllowedRank(value: string): value is RankValue {
+  return (RANK_ORDER as readonly string[]).includes(value);
+}
 
-    studentId: z
-      .string()
-      .min(1, "请填写学号（毕业生填「毕业年份+学院」）"),
+function rankMeetsThreshold(rank: string, min: string | null): boolean {
+  if (min === null) return true;
+  const rankIndex = RANK_ORDER.indexOf(rank as RankValue);
+  const minIndex = RANK_ORDER.indexOf(min as RankValue);
+  return rankIndex >= 0 && minIndex >= 0 && rankIndex >= minIndex;
+}
 
-    qq: z
-      .string()
-      .min(1, "请填写 QQ 号")
-      .regex(/^\d{5,12}$/, "请输入有效的 QQ 号（5-12 位数字）"),
+function rankThresholdMessage(config: RegistrationConfig): string {
+  const current = config.rankThreshold.currentMin;
+  const peak = config.rankThreshold.peakMin;
+  if (current && peak) {
+    return `报名资格：当前赛季最高段位需达到 ${current}，或历史最高段位需达到 ${peak}`;
+  }
+  if (current) return `报名资格：当前赛季最高段位需达到 ${current}`;
+  if (peak) return `报名资格：历史最高段位需达到 ${peak}`;
+  return "段位未达到报名资格";
+}
 
-    perfectName: z
-      .string()
-      .min(1, "请填写完美平台昵称"),
+function nonEmptyAllowed<T extends string>(values: readonly T[], fallback: readonly T[]): readonly T[] {
+  return values.length > 0 ? values : fallback;
+}
 
-    steamName: z
-      .string()
-      .min(1, "请填写 Steam 昵称"),
-
-    steam64: z
-      .string()
-      .min(1, "请填写 Steam 64 位 ID")
-      .regex(/^\d{17}$/, "Steam64 ID 应为 17 位纯数字"),
-
-    steamProfileUrl: z
-      .string()
-      .min(1, "请填写 Steam 个人资料链接")
-      .url("请输入有效的链接")
-      .refine(
-        (v) => v.includes("steamcommunity.com"),
-        "链接必须为 steamcommunity.com 域名",
-      ),
-
-    // ── 位置 ──
-    primaryPosition: z.enum(positionValues, {
-      errorMap: () => ({ message: "请选择主选位置" }),
-    }),
-
-    secondaryPosition: z.enum(positionValues, {
-      errorMap: () => ({ message: "请选择次选位置" }),
-    }),
-
-    // ── 段位 · 历史最高 ──
-    peakRank: z.enum(rankValues, {
-      errorMap: () => ({ message: "请选择历史最高段位" }),
-    }),
-
-    peakRankSeason: z
-      .string()
-      .min(1, "请填写取得最高段位的赛季（如 S1 2026）"),
-
-    // Rating：完美平台 Rating，0.01–3.00，两位小数
-    peakRating: z
-      .number({ invalid_type_error: "请输入数字" })
-      .min(0.01, "Rating 最小 0.01")
-      .max(3.00, "Rating 最大 3.00")
-      .refine(
-        (v) => Math.round(v * 100) / 100 === v,
-        "Rating 最多保留两位小数",
-      ),
-
-    // WE：Win Effect，0.0–16.0，一位小数
-    peakWe: z
-      .number({ invalid_type_error: "请输入数字" })
-      .min(0, "WE 不能为负")
-      .max(16.0, "WE 最大 16.0")
-      .refine(
-        (v) => Math.round(v * 10) / 10 === v,
-        "WE 最多保留一位小数",
-      )
-      .optional(),
-
-    // ── 段位 · 当前赛季最高 ──
-    currentSeasonPeakRank: z.enum(rankValues, {
-      errorMap: () => ({ message: "请选择当前赛季最高段位" }),
-    }),
-
-    currentRating: z
-      .number({ invalid_type_error: "请输入数字" })
-      .min(0.01, "Rating 最小 0.01")
-      .max(3.00, "Rating 最大 3.00")
-      .refine(
-        (v) => Math.round(v * 100) / 100 === v,
-        "Rating 最多保留两位小数",
-      ),
-
-    currentWe: z
-      .number({ invalid_type_error: "请输入数字" })
-      .min(0, "WE 不能为负")
-      .max(16.0, "WE 最大 16.0")
-      .refine(
-        (v) => Math.round(v * 10) / 10 === v,
-        "WE 最多保留一位小数",
-      )
-      .optional(),
-
-    // ── 天梯截图（NJUBox 分享链接）──
-    screenshotUrl: z
-      .string()
-      .min(1, "请填写 NJUBox 分享链接")
-      .refine((v) => /^https?:\/\/.+/.test(v), {
-        message: "请输入有效的链接（以 http:// 或 https:// 开头）",
-      }),
-
-    // ── 风格与经历 ──
-    gameplayStyle: z
-      .string()
-      .min(1, "请填写游戏风格自述")
-      .max(100, "游戏风格自述不超过 100 字"),
-
-    competitionHistory: z
-      .string()
-      .max(500, "历史比赛经历不超过 500 字")
-      .optional(),
-
-    highlightVideoUrl: z
-      .string()
-      .optional()
-      .refine((v) => !v || /^https?:\/\/.+/.test(v), {
-        message: "请输入有效的链接（以 http:// 或 https:// 开头）",
-      }),
-
-    // ── 其他 ──
-    willingToBeCaptain: z.boolean().default(false),
-
-    notes: z.string().max(500, "备注不超过 500 字").optional(),
-
-    antiCheatPledge: z.literal(true, {
-      errorMap: () => ({ message: "请勾选反作弊承诺方可提交" }),
-    }),
-  })
-  .refine((data) => data.secondaryPosition !== data.primaryPosition, {
-    message: "次选位置不能与主选位置相同",
-    path: ["secondaryPosition"],
-  })
-  .refine(
-    (data) => {
-      const currentIdx = RANK_ORDER.indexOf(data.currentSeasonPeakRank as typeof RANK_ORDER[number]);
-      const peakIdx    = RANK_ORDER.indexOf(data.peakRank as typeof RANK_ORDER[number]);
-      return currentIdx >= RANK_IDX_A || peakIdx >= RANK_IDX_A_PLUS;
-    },
-    {
-      message: "报名资格：当前赛季最高段位需达到 A，或历史最高段位需达到 A+",
-      path: ["currentSeasonPeakRank"],
-    },
+// ── 验证 schema factory ─────────────────────────────
+export function buildRegistrationSchema(
+  inputConfig: Partial<RegistrationConfig> | null | undefined,
+  inputPositions: readonly string[],
+) {
+  const config = normalizeRegistrationConfig(inputConfig);
+  const positions = nonEmptyAllowed(inputPositions, positionValues);
+  const allowedPlayerTypes = nonEmptyAllowed<PlayerType>(
+    config.allowedPlayerTypes,
+    DEFAULT_REGISTRATION_CONFIG.allowedPlayerTypes,
   );
+
+  return z
+    .object({
+      seasonId: z.string().uuid("赛季 ID 格式不正确"),
+
+      // ── 基础信息 ──
+      email: z
+        .string()
+        .min(1, "请填写电子邮件")
+        .email("请输入有效的电子邮件地址"),
+
+      studentId: z
+        .string()
+        .min(1, "请填写学号（毕业生填「毕业年份+学院」）"),
+
+      playerType: z
+        .string()
+        .refine((v): v is PlayerType => (allowedPlayerTypes as readonly string[]).includes(v), {
+          message: "请选择允许的身份类型",
+        }),
+
+      qq: z
+        .string()
+        .min(1, "请填写 QQ 号")
+        .regex(/^\d{5,12}$/, "请输入有效的 QQ 号（5-12 位数字）"),
+
+      perfectName: z
+        .string()
+        .min(1, "请填写完美平台昵称"),
+
+      steamName: z
+        .string()
+        .min(1, "请填写 Steam 昵称"),
+
+      steam64: z
+        .string()
+        .min(1, "请填写 Steam 64 位 ID")
+        .regex(/^\d{17}$/, "Steam64 ID 应为 17 位纯数字"),
+
+      steamProfileUrl: z
+        .string()
+        .min(1, "请填写 Steam 个人资料链接")
+        .url("请输入有效的链接")
+        .refine(
+          (v) => v.includes("steamcommunity.com"),
+          "链接必须为 steamcommunity.com 域名",
+        ),
+
+      // ── 位置 ──
+      primaryPosition: z.string().refine((v) => positions.includes(v), {
+        message: "请选择主选位置",
+      }),
+
+      secondaryPosition: z.string().refine((v) => positions.includes(v), {
+        message: "请选择次选位置",
+      }),
+
+      // ── 段位 · 历史最高 ──
+      peakRank: z.string().refine(isAllowedRank, {
+        message: "请选择历史最高段位",
+      }),
+
+      peakRankSeason: z
+        .string()
+        .min(1, "请填写取得最高段位的赛季（如 S1 2026）"),
+
+      // Rating：完美平台 Rating，0.01–3.00，两位小数
+      peakRating: z
+        .number({ invalid_type_error: "请输入数字" })
+        .min(0.01, "Rating 最小 0.01")
+        .max(3.00, "Rating 最大 3.00")
+        .refine(
+          (v) => Math.round(v * 100) / 100 === v,
+          "Rating 最多保留两位小数",
+        ),
+
+      // WE：Win Effect，0.0–16.0，一位小数
+      peakWe: z
+        .number({ invalid_type_error: "请输入数字" })
+        .min(0, "WE 不能为负")
+        .max(16.0, "WE 最大 16.0")
+        .refine(
+          (v) => Math.round(v * 10) / 10 === v,
+          "WE 最多保留一位小数",
+        )
+        .optional(),
+
+      // ── 段位 · 当前赛季最高 ──
+      currentSeasonPeakRank: z.string().refine(isAllowedRank, {
+        message: "请选择当前赛季最高段位",
+      }),
+
+      currentRating: z
+        .number({ invalid_type_error: "请输入数字" })
+        .min(0.01, "Rating 最小 0.01")
+        .max(3.00, "Rating 最大 3.00")
+        .refine(
+          (v) => Math.round(v * 100) / 100 === v,
+          "Rating 最多保留两位小数",
+        ),
+
+      currentWe: z
+        .number({ invalid_type_error: "请输入数字" })
+        .min(0, "WE 不能为负")
+        .max(16.0, "WE 最大 16.0")
+        .refine(
+          (v) => Math.round(v * 10) / 10 === v,
+          "WE 最多保留一位小数",
+        )
+        .optional(),
+
+      // ── 天梯截图（NJUBox 分享链接）──
+      screenshotUrls: z
+        .array(
+          z.string().min(1, "请填写 NJUBox 分享链接").refine((v) => /^https?:\/\/.+/.test(v), {
+            message: "请输入有效的链接（以 http:// 或 https:// 开头）",
+          }),
+        )
+        .length(config.screenshotCount, `请填写 ${config.screenshotCount} 个截图链接`),
+
+      // ── 风格与经历 ──
+      gameplayStyle: z
+        .string()
+        .min(1, "请填写游戏风格自述")
+        .max(100, "游戏风格自述不超过 100 字"),
+
+      competitionHistory: z
+        .string()
+        .max(500, "历史比赛经历不超过 500 字")
+        .optional(),
+
+      highlightVideoUrl: z
+        .string()
+        .optional()
+        .refine((v) => !v || /^https?:\/\/.+/.test(v), {
+          message: "请输入有效的链接（以 http:// 或 https:// 开头）",
+        }),
+
+      // ── 其他 ──
+      willingToBeCaptain: z.boolean().default(false),
+
+      notes: z.string().max(500, "备注不超过 500 字").optional(),
+
+      antiCheatPledge: z.literal(true, {
+        errorMap: () => ({ message: "请勾选反作弊承诺方可提交" }),
+      }),
+    })
+    .refine((data) => data.secondaryPosition !== data.primaryPosition, {
+      message: "次选位置不能与主选位置相同",
+      path: ["secondaryPosition"],
+    })
+    .refine(
+      (data) => {
+        const hasCurrent = rankMeetsThreshold(data.currentSeasonPeakRank, config.rankThreshold.currentMin);
+        const hasPeak = rankMeetsThreshold(data.peakRank, config.rankThreshold.peakMin);
+        return hasCurrent || hasPeak;
+      },
+      {
+        message: rankThresholdMessage(config),
+        path: ["currentSeasonPeakRank"],
+      },
+    );
+}
+
+export const registrationSchema = buildRegistrationSchema(
+  DEFAULT_REGISTRATION_CONFIG,
+  positionValues,
+);
 
 // ── 导出类型 ─────────────────────────────────────────
 export type RegistrationFormData = z.infer<typeof registrationSchema>;
-// React Hook Form 的输入类型（与 RegistrationFormData 大部分一致，
-// 但 willingToBeCaptain 初始可能是 undefined）
 export type RegistrationInput = z.input<typeof registrationSchema>;

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -1,7 +1,7 @@
 // 共享比赛类型
 
 export type MatchStatus = "scheduled" | "in_progress" | "finished" | "cancelled";
-export type MatchStage = "qualifier" | "playoff";
+export type MatchStage = string;
 export type MatchFormat = "bo1" | "bo3" | "bo5";
 export type Side = "t" | "ct";
 
@@ -11,6 +11,7 @@ export interface Match {
   teamAId: string;
   teamBId: string;
   stage: MatchStage;
+  round: number | null;
   format: MatchFormat;
   /** 系列赛比分（如 BO3 中 2:1）；单图比分见 MatchMap */
   scoreA: number | null;
@@ -49,7 +50,7 @@ export const MATCH_STATUS_LABELS: Record<MatchStatus, string> = {
   cancelled: "已取消",
 };
 
-export const MATCH_STAGE_LABELS: Record<MatchStage, string> = {
+export const MATCH_STAGE_LABELS: Record<string, string> = {
   qualifier: "排位赛",
   playoff: "正赛",
 };

--- a/src/types/registration.ts
+++ b/src/types/registration.ts
@@ -11,7 +11,8 @@ export interface Registration {
   primaryPosition: Position;
   secondaryPosition: Position | null;
   peakRating: number | null;
-  screenshotUrl: string | null;
+  playerType: "enrolled" | "graduated" | "external";
+  screenshotUrls: string[];
   status: RegistrationStatus;
   willingToBeCaptain: boolean;
   notes: string | null;

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -160,15 +160,28 @@ export const STAGE_TYPE_LABELS: Record<StageType, string> = {
   swiss: "瑞士轮",
 };
 
+type PartialRegistrationConfig = Partial<Omit<RegistrationConfig, "rankThreshold">> & {
+  rankThreshold?: Partial<RegistrationConfig["rankThreshold"]>;
+};
+
 export function normalizeRegistrationConfig(
-  config: Partial<RegistrationConfig> | null | undefined,
+  config: PartialRegistrationConfig | null | undefined,
 ): RegistrationConfig {
+  const currentMin =
+    config?.rankThreshold?.currentMin === undefined
+      ? RIVALS_REGISTRATION_CONFIG.rankThreshold.currentMin
+      : config.rankThreshold.currentMin;
+  const peakMin =
+    config?.rankThreshold?.peakMin === undefined
+      ? RIVALS_REGISTRATION_CONFIG.rankThreshold.peakMin
+      : config.rankThreshold.peakMin;
+
   return {
     allowedPlayerTypes:
       config?.allowedPlayerTypes?.length ? config.allowedPlayerTypes : RIVALS_REGISTRATION_CONFIG.allowedPlayerTypes,
     rankThreshold: {
-      currentMin: config?.rankThreshold?.currentMin ?? RIVALS_REGISTRATION_CONFIG.rankThreshold.currentMin,
-      peakMin: config?.rankThreshold?.peakMin ?? RIVALS_REGISTRATION_CONFIG.rankThreshold.peakMin,
+      currentMin,
+      peakMin,
     },
     maxPerPosition: config?.maxPerPosition ?? RIVALS_REGISTRATION_CONFIG.maxPerPosition,
     screenshotCount: config?.screenshotCount ?? RIVALS_REGISTRATION_CONFIG.screenshotCount,

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -12,8 +12,29 @@ export type SeasonStatus =
   | "archived";
 
 export type RegistrationMode = "solo" | "team";
-export type QualifierFormat = "round_robin" | "swiss";
-export type PlayoffFormat = "double_elim" | "single_elim";
+export type StageType = "round_robin" | "double_elim" | "single_elim" | "swiss";
+export type PlayerType = "enrolled" | "graduated" | "external";
+
+export interface StageConfig {
+  key: string;
+  name: string;
+  type: StageType;
+  teamCount: number;
+  advance: number;
+  seeds?: number[];
+}
+
+export type StagePlan = StageConfig[];
+
+export interface RegistrationConfig {
+  allowedPlayerTypes: PlayerType[];
+  rankThreshold: {
+    currentMin: string | null;
+    peakMin: string | null;
+  };
+  maxPerPosition: number;
+  screenshotCount: number;
+}
 
 /**
  * Capability 字段——业务逻辑的唯一判断依据。
@@ -30,10 +51,10 @@ export interface SeasonCapabilities {
   registrationMode: RegistrationMode;
   hasCaptainVoting: boolean;
   hasDraft: boolean;
-  /** 排位赛赛制；null = 无排位赛阶段 */
-  qualifierFormat: QualifierFormat | null;
-  /** 正赛赛制；null = 无正赛阶段（如纯排位赛娱乐赛）*/
-  playoffFormat: PlayoffFormat | null;
+  /** 赛事阶段计划；空数组 = 无赛程阶段 */
+  stagePlan: StagePlan;
+  /** 报名规则配置 */
+  registrationConfig: RegistrationConfig;
   teamSize: number;
   starterCount: number;
   /** 该赛季可用的位置标识符列表 */
@@ -58,13 +79,25 @@ export interface Season extends SeasonCapabilities {
 
 export const CS2_POSITIONS = ["igl", "awper", "opener", "closer", "anchor"];
 
+export const RIVALS_STAGE_PLAN: StagePlan = [
+  { key: "qualifier", name: "排位赛", type: "round_robin", teamCount: 8, advance: 8 },
+  { key: "playoff", name: "正赛", type: "double_elim", teamCount: 8, advance: 1 },
+];
+
+export const RIVALS_REGISTRATION_CONFIG: RegistrationConfig = {
+  allowedPlayerTypes: ["enrolled"],
+  rankThreshold: { currentMin: "A", peakMin: "A+" },
+  maxPerPosition: 15,
+  screenshotCount: 1,
+};
+
 /** 选秀联赛预设：个人报名 → 队长投票 → 蛇形选秀 → 循环赛 + 双败淘汰 */
 export const DRAFT_LEAGUE_PRESET: SeasonCapabilities = {
   registrationMode: "solo",
   hasCaptainVoting: true,
   hasDraft: true,
-  qualifierFormat: "round_robin",
-  playoffFormat: "double_elim",
+  stagePlan: RIVALS_STAGE_PLAN,
+  registrationConfig: RIVALS_REGISTRATION_CONFIG,
   teamSize: 7,
   starterCount: 5,
   positions: CS2_POSITIONS,
@@ -75,8 +108,8 @@ export const OPEN_TOURNAMENT_PRESET: SeasonCapabilities = {
   registrationMode: "team",
   hasCaptainVoting: false,
   hasDraft: false,
-  qualifierFormat: "round_robin",
-  playoffFormat: "double_elim",
+  stagePlan: RIVALS_STAGE_PLAN,
+  registrationConfig: RIVALS_REGISTRATION_CONFIG,
   teamSize: 5,
   starterCount: 5,
   positions: CS2_POSITIONS,
@@ -113,3 +146,62 @@ export const SEASON_STATUS_TONE: Record<SeasonStatus, "live" | "soon" | "done"> 
   finished:     "done",
   archived:     "done",
 };
+
+export const PLAYER_TYPE_LABELS: Record<PlayerType, string> = {
+  enrolled: "在校",
+  graduated: "毕业",
+  external: "外校",
+};
+
+export const STAGE_TYPE_LABELS: Record<StageType, string> = {
+  round_robin: "单循环",
+  double_elim: "双败淘汰",
+  single_elim: "单败淘汰",
+  swiss: "瑞士轮",
+};
+
+export function normalizeRegistrationConfig(
+  config: Partial<RegistrationConfig> | null | undefined,
+): RegistrationConfig {
+  return {
+    allowedPlayerTypes:
+      config?.allowedPlayerTypes?.length ? config.allowedPlayerTypes : RIVALS_REGISTRATION_CONFIG.allowedPlayerTypes,
+    rankThreshold: {
+      currentMin: config?.rankThreshold?.currentMin ?? RIVALS_REGISTRATION_CONFIG.rankThreshold.currentMin,
+      peakMin: config?.rankThreshold?.peakMin ?? RIVALS_REGISTRATION_CONFIG.rankThreshold.peakMin,
+    },
+    maxPerPosition: config?.maxPerPosition ?? RIVALS_REGISTRATION_CONFIG.maxPerPosition,
+    screenshotCount: config?.screenshotCount ?? RIVALS_REGISTRATION_CONFIG.screenshotCount,
+  };
+}
+
+export function normalizeStagePlan(stagePlan: StagePlan | null | undefined): StagePlan {
+  return stagePlan ?? RIVALS_STAGE_PLAN;
+}
+
+export function getStageByKey(stagePlan: StagePlan | null | undefined, key: string): StageConfig | null {
+  return normalizeStagePlan(stagePlan).find((stage) => stage.key === key) ?? null;
+}
+
+export function getFirstStage(stagePlan: StagePlan | null | undefined): StageConfig | null {
+  return normalizeStagePlan(stagePlan)[0] ?? null;
+}
+
+export function getNextStage(stagePlan: StagePlan | null | undefined, key: string): StageConfig | null {
+  const stages = normalizeStagePlan(stagePlan);
+  const index = stages.findIndex((stage) => stage.key === key);
+  return index >= 0 ? stages[index + 1] ?? null : null;
+}
+
+export function getPreviousStage(stagePlan: StagePlan | null | undefined, key: string): StageConfig | null {
+  const stages = normalizeStagePlan(stagePlan);
+  const index = stages.findIndex((stage) => stage.key === key);
+  return index > 0 ? stages[index - 1] ?? null : null;
+}
+
+export function getFirstStageOfType(
+  stagePlan: StagePlan | null | undefined,
+  types: readonly StageType[],
+): StageConfig | null {
+  return normalizeStagePlan(stagePlan).find((stage) => types.includes(stage.type)) ?? null;
+}

--- a/tests/unit/lib/season.test.ts
+++ b/tests/unit/lib/season.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRegistrationConfig } from "@/types/season";
+
+describe("normalizeRegistrationConfig()", () => {
+  it("preserves null rank thresholds as no-threshold settings", () => {
+    const config = normalizeRegistrationConfig({
+      rankThreshold: {
+        currentMin: null,
+        peakMin: null,
+      },
+    });
+
+    expect(config.rankThreshold).toEqual({
+      currentMin: null,
+      peakMin: null,
+    });
+  });
+
+  it("fills only missing rank threshold fields from Rivals defaults", () => {
+    const config = normalizeRegistrationConfig({
+      rankThreshold: {
+        currentMin: null,
+      },
+    });
+
+    expect(config.rankThreshold).toEqual({
+      currentMin: null,
+      peakMin: "A+",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace fixed qualifier/playoff season columns with stagePlan and registrationConfig JSON fields, plus migration/backfill for existing data.
- Add configurable registration validation and playerType/screenshotUrls handling across client, submit, and admin review flows.
- Add v1 StageExecutor scaffolding, initializeStage flow, and super admin season create/settings UI.

## Why
#37 moved platform configurability from a design note into the v1 foundation: Rivals should keep working on stage keys while Major/Swiss can plug in later without rewriting registration and match flows.

## Test Plan
- pnpm tsc --noEmit
- pnpm test
- pnpm type-check
- pnpm build
- pnpm db:generate
- git diff --check