### PR TITLE
feat(swiss): implement Swiss tournament executor and HLTV-style brack…

### DIFF
--- a/drizzle/migrations/0006_lame_silver_centurion.sql
+++ b/drizzle/migrations/0006_lame_silver_centurion.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "swiss_standings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"stage" text NOT NULL,
+	"team_id" uuid NOT NULL,
+	"seed" integer NOT NULL,
+	"wins" integer DEFAULT 0 NOT NULL,
+	"losses" integer DEFAULT 0 NOT NULL,
+	"bu_score" integer DEFAULT 0 NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	CONSTRAINT "swiss_standings_season_id_stage_team_id_unique" UNIQUE("season_id","stage","team_id")
+);
+--> statement-breakpoint
+ALTER TABLE "swiss_standings" ADD CONSTRAINT "swiss_standings_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "swiss_standings" ADD CONSTRAINT "swiss_standings_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/migrations/meta/0006_snapshot.json
+++ b/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1838 @@
+{
+  "id": "ff2fdf06-01f3-4e4a-ac81-a1001ad34b68",
+  "prevId": "142055f6-811f-4675-a62a-f5485a58fdd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_size": {
+          "name": "team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778341013690,
       "tag": "0005_supreme_magus",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778408316538,
+      "tag": "0006_lame_silver_centurion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -68,11 +68,25 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
     allTeams
   );
 
-  // 过滤掉没有 match 的 stage（如排位赛 round_robin，matches 存在 DB 里但不在 bracket 中）
-  const stageIdsWithMatches = new Set(fullBracketData.match.map((m) => m.stageId));
+  // 正赛 stage 的 bracket 数据；brackets-viewer 需要 stage 和 match 同步过滤。
+  const playoffBracketStageIds = new Set(
+    fullBracketData.stage
+      .filter((s) => s.name === playoffStage?.name)
+      .map((s) => s.id),
+  );
+  const playoffBracketMatchIds = new Set(
+    fullBracketData.match
+      .filter((m) => playoffBracketStageIds.has(m.stage_id))
+      .map((m) => m.id),
+  );
   const bracketData = {
     ...fullBracketData,
-    stage: fullBracketData.stage.filter((s) => stageIdsWithMatches.has(s.id)),
+    stage: fullBracketData.stage.filter((s) => playoffBracketStageIds.has(s.id)),
+    match: fullBracketData.match.filter((m) => playoffBracketStageIds.has(m.stage_id)),
+    match_game: fullBracketData.match_game.filter((game) => {
+      const parentId = game.parent_id;
+      return typeof parentId === "number" && playoffBracketMatchIds.has(parentId);
+    }),
   };
 
   // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -8,6 +8,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BracketView } from "@/components/matches/BracketView";
 import { MatchCard } from "@/components/matches/MatchCard";
 import { StandingsTable } from "@/components/matches/StandingsTable";
+import { SwissBracket } from "@/components/matches/SwissBracket";
+import { getSwissViewData } from "@/lib/swiss/data";
 import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import type { Database } from "brackets-manager";
 
@@ -46,28 +48,31 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
   const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
   const playoffMatches = allMatches.filter((m) => m.stage === playoffKey);
 
-  // 积分榜（仅当有排位赛时计算）
-  const standings = qualifierStage
+  // 积分榜（仅当有 round_robin 排位赛时计算）
+  const standings = qualifierStage && qualifierStage.type !== "swiss"
     ? await calculateStandings(season.id, allTeams, qualifierKey)
     : [];
+
+  // 瑞士轮视图数据（仅当有 swiss 排位赛时查询）
+  const swissData = qualifierStage?.type === "swiss"
+    ? await getSwissViewData(season.id, qualifierKey, qualifierStage.name)
+    : null;
 
   const allQualifierFinished =
     qualifierMatches.length > 0 &&
     qualifierMatches.every((m) => m.status === "finished" || m.status === "cancelled");
 
   // Bracket 数据（用于正赛 bracket 视图）
-  const bracketData = serializeBracket(
+  const fullBracketData = serializeBracket(
     (season.bracketData as Database | null) ?? null,
     allTeams
   );
 
-  // 正赛 stage 的 bracket 数据（筛出正赛 stage）
-  const playoffBracketData = {
-    ...bracketData,
-    stage: bracketData.stage.filter((s) => s.name === playoffStage?.name),
-    match: bracketData.match.filter((m) =>
-      bracketData.stage.some((s) => s.name === playoffStage?.name && s.id === m.stageId)
-    ),
+  // 过滤掉没有 match 的 stage（如排位赛 round_robin，matches 存在 DB 里但不在 bracket 中）
+  const stageIdsWithMatches = new Set(fullBracketData.match.map((m) => m.stageId));
+  const bracketData = {
+    ...fullBracketData,
+    stage: fullBracketData.stage.filter((s) => stageIdsWithMatches.has(s.id)),
   };
 
   // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转
@@ -101,50 +106,62 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
         {/* ── 排位赛面板 ─────────────────────────────────────────── */}
         {hasQualifier && (
           <TabsContent value={qualifierKey} className="space-y-8">
-            {/* 积分榜 */}
-            {standings.length > 0 && (
+            {/* Swiss 视图 */}
+            {swissData ? (
               <section className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-lg font-semibold text-[var(--text-primary)]">积分榜</h2>
-                  {allQualifierFinished && (
-                    <span className="text-xs text-green-600 font-medium">最终排名</span>
-                  )}
-                </div>
-                <StandingsTable
-                  standings={standings}
-                  seasonSlug={seasonSlug}
-                  isFinal={allQualifierFinished}
-                />
+                <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+                  {qualifierStage?.name ?? "瑞士轮"}
+                </h2>
+                <SwissBracket data={swissData} seasonSlug={seasonSlug} />
               </section>
-            )}
-
-            {/* 赛程列表 */}
-            {qualifierMatches.length > 0 && (
-              <section className="space-y-3">
-                <h2 className="text-lg font-semibold text-[var(--text-primary)]">赛程</h2>
-                <div className="space-y-2">
-                  {qualifierMatches.map((m) => (
-                    <MatchCard
-                      key={m.id}
-                      matchId={m.id}
+            ) : (
+              <>
+                {/* 积分榜 */}
+                {standings.length > 0 && (
+                  <section className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <h2 className="text-lg font-semibold text-[var(--text-primary)]">积分榜</h2>
+                      {allQualifierFinished && (
+                        <span className="text-xs text-green-600 font-medium">最终排名</span>
+                      )}
+                    </div>
+                    <StandingsTable
+                      standings={standings}
                       seasonSlug={seasonSlug}
-                      teamAName={teamMap.get(m.teamAId) ?? "未知队伍"}
-                      teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
-                      scoreA={m.scoreA}
-                      scoreB={m.scoreB}
-                      stage={qualifierKey}
-                      format={m.format as "bo1" | "bo3" | "bo5"}
-                      status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                      isFinal={allQualifierFinished}
                     />
-                  ))}
-                </div>
-              </section>
-            )}
+                  </section>
+                )}
 
-            {qualifierMatches.length === 0 && (
-              <div className="text-center py-16 text-[var(--text-secondary)]">
-                排位赛赛程尚未生成
-              </div>
+                {/* 赛程列表 */}
+                {qualifierMatches.length > 0 && (
+                  <section className="space-y-3">
+                    <h2 className="text-lg font-semibold text-[var(--text-primary)]">赛程</h2>
+                    <div className="space-y-2">
+                      {qualifierMatches.map((m) => (
+                        <MatchCard
+                          key={m.id}
+                          matchId={m.id}
+                          seasonSlug={seasonSlug}
+                          teamAName={teamMap.get(m.teamAId) ?? "未知队伍"}
+                          teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
+                          scoreA={m.scoreA}
+                          scoreB={m.scoreB}
+                          stage={qualifierKey}
+                          format={m.format as "bo1" | "bo3" | "bo5"}
+                          status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {qualifierMatches.length === 0 && (
+                  <div className="text-center py-16 text-[var(--text-secondary)]">
+                    排位赛赛程尚未生成
+                  </div>
+                )}
+              </>
             )}
           </TabsContent>
         )}
@@ -153,11 +170,11 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
         {hasPlayoff && (
           <TabsContent value={playoffKey} className="space-y-8">
             {/* Bracket 图 */}
-            {playoffBracketData.stage.length > 0 && (
+            {bracketData.stage.length > 0 && (
               <section id="bracket" className="space-y-3">
                 <h2 className="text-lg font-semibold text-[var(--text-primary)]">对阵图</h2>
                 <BracketView
-                  data={playoffBracketData}
+                  data={bracketData}
                   themeColor={season.themeColor}
                   matchNodeMap={matchNodeMap}
                   seasonSlug={seasonSlug}

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -40,14 +40,14 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
           stages: data.stage,
           matches: data.match,
           participants: data.participant,
-          matchGames: [],
+          matchGames: data.match_game,
         },
         { selector: "#bracket-container", clear: true }
       )
       .then(() => {
         if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
-        containerRef.current.querySelectorAll<HTMLElement>("[data-id]").forEach((el) => {
-          const bracketId = el.getAttribute("data-id");
+        containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
+          const bracketId = el.getAttribute("data-match-id");
           if (!bracketId) return;
           const matchId = matchNodeMap.get(bracketId);
           if (!matchId) return;
@@ -82,7 +82,7 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         style={themeColor ? ({ "--primary-color": themeColor } as React.CSSProperties) : undefined}
         className="overflow-x-auto"
       >
-        <div id="bracket-container" ref={containerRef} />
+        <div id="bracket-container" className="brackets-viewer" ref={containerRef} />
       </div>
     </>
   );

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import Script from "next/script";
 import type { BracketData } from "@/lib/bracket";
 
-// brackets-viewer 通过 UMD bundle 暴露在 window.bracketsViewer
 declare global {
   interface Window {
     bracketsViewer?: {
@@ -22,7 +21,6 @@ declare global {
 interface BracketViewProps {
   data: BracketData;
   themeColor?: string | null;
-  /** bracketNodeId（数字字符串）→ matchId（UUID），用于点击 bracket 节点跳转详情 */
   matchNodeMap?: Map<string, string>;
   seasonSlug?: string;
 }
@@ -34,32 +32,34 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
 
   useEffect(() => {
     if (!scriptReady || !window.bracketsViewer || data.stage.length === 0) return;
+    if (data.match.length === 0) return;
 
-    window.bracketsViewer.render(
-      {
-        stages: data.stage,
-        matches: data.match,
-        participants: data.participant,
-        matchGames: [],
-      },
-      { selector: "#bracket-container", clear: true }
-    ).then(() => {
-      // brackets-viewer renders match elements with data-id attribute
-      if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
-      const matchEls = containerRef.current.querySelectorAll<HTMLElement>("[data-id]");
-      matchEls.forEach((el) => {
-        const bracketId = el.getAttribute("data-id");
-        if (!bracketId) return;
-        const matchId = matchNodeMap.get(bracketId);
-        if (!matchId) return;
-        el.style.cursor = "pointer";
-        el.title = "点击查看比赛详情";
-        el.addEventListener("click", (e) => {
-          e.stopPropagation();
-          router.push(`/${seasonSlug}/matches/${matchId}`);
+    window.bracketsViewer
+      .render(
+        {
+          stages: data.stage,
+          matches: data.match,
+          participants: data.participant,
+          matchGames: [],
+        },
+        { selector: "#bracket-container", clear: true }
+      )
+      .then(() => {
+        if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
+        containerRef.current.querySelectorAll<HTMLElement>("[data-id]").forEach((el) => {
+          const bracketId = el.getAttribute("data-id");
+          if (!bracketId) return;
+          const matchId = matchNodeMap.get(bracketId);
+          if (!matchId) return;
+          el.style.cursor = "pointer";
+          el.title = "点击查看比赛详情";
+          el.addEventListener("click", (e) => {
+            e.stopPropagation();
+            router.push(`/${seasonSlug}/matches/${matchId}`);
+          });
         });
-      });
-    });
+      })
+      .catch(console.error);
   }, [scriptReady, data, matchNodeMap, seasonSlug, router]);
 
   if (data.stage.length === 0) {

--- a/src/components/matches/SwissBracket.tsx
+++ b/src/components/matches/SwissBracket.tsx
@@ -1,0 +1,295 @@
+import Link from "next/link";
+import type {
+  SwissViewData,
+  SwissRoundColumn,
+  SwissRecordGroup,
+  SwissMatchRow,
+  SwissTeamSlot,
+} from "@/lib/swiss/data";
+
+interface SwissBracketProps {
+  data: SwissViewData;
+  seasonSlug: string;
+}
+
+export function SwissBracket({ data, seasonSlug }: SwissBracketProps) {
+  if (data.rounds.length === 0) {
+    return (
+      <div className="py-16 text-center text-[var(--text-secondary)] text-sm">
+        瑞士轮赛程尚未生成
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto -mx-4 px-4">
+      <div className="flex gap-4 min-w-[800px] pb-4">
+        {data.rounds.map((round) => (
+          <SwissColumn
+            key={round.round}
+            round={round}
+            seasonSlug={seasonSlug}
+          />
+        ))}
+        {/* 晋级/淘汰汇总列 */}
+        {data.rounds.length > 0 && (
+          <AdvancementColumn
+            teams={data.teams}
+            advanceCount={data.advanceCount}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SwissColumn({
+  round,
+  seasonSlug,
+}: {
+  round: SwissRoundColumn;
+  seasonSlug: string;
+}) {
+  const statusColor = {
+    finished: "opacity-70",
+    active: "",
+    upcoming: "opacity-40",
+  };
+
+  return (
+    <div className={`flex-1 min-w-[160px] max-w-[200px] ${statusColor[round.status]}`}>
+      {/* 轮次标题 */}
+      <div className="text-center mb-2">
+        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">
+          {round.status === "upcoming" && round.groups.length === 0
+            ? `R${round.round}`
+            : `第 ${round.round} 轮`}
+        </span>
+        {round.status === "active" && (
+          <span className="ml-1.5 inline-block w-1.5 h-1.5 rounded-full bg-emerald-400" />
+        )}
+      </div>
+
+      {/* 战绩分组 */}
+      <div className="space-y-3">
+        {round.groups.map((group) => (
+          <SwissMatchupGroup
+            key={group.record}
+            group={group}
+            round={round}
+            seasonSlug={seasonSlug}
+          />
+        ))}
+        {round.status === "upcoming" && round.groups.length === 0 && (
+          <div className="py-8 text-center text-[var(--text-muted)] text-xs">
+            —
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SwissMatchupGroup({
+  group,
+  round,
+  seasonSlug,
+}: {
+  group: SwissRecordGroup;
+  round: SwissRoundColumn;
+  seasonSlug: string;
+}) {
+  return (
+    <div>
+      {/* 战绩标签 */}
+      <div
+        className={`text-xs font-medium mb-1.5 px-1.5 py-0.5 rounded text-center ${
+          isEliminatedRecord(group.record)
+            ? "bg-red-500/10 text-red-400"
+            : isAdvancedRecord(group.record)
+              ? "bg-emerald-500/10 text-emerald-400"
+              : "bg-[var(--bg-overlay)] text-[var(--text-secondary)]"
+        }`}
+      >
+        {group.record}
+      </div>
+
+      {/* 对阵列表 */}
+      <div className="space-y-1.5">
+        {group.matchups.map((match) => (
+          <SwissMatchupRow
+            key={match.matchId}
+            match={match}
+            seasonSlug={seasonSlug}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SwissMatchupRow({
+  match,
+  seasonSlug,
+}: {
+  match: SwissMatchRow;
+  seasonSlug: string;
+}) {
+  const winA = (match.scoreA ?? 0) > (match.scoreB ?? 0);
+  const winB = (match.scoreB ?? 0) > (match.scoreA ?? 0);
+  const isFinished = match.status === "finished";
+
+  return (
+    <Link
+      href={`/${seasonSlug}/matches/${match.matchId}`}
+      className="block rounded border border-[var(--border)] bg-[var(--bg-elevated)] hover:border-[var(--border-strong)] transition-colors p-2"
+    >
+      {/* Team A */}
+      <div className="flex items-center justify-between gap-1 text-xs">
+        <span
+          className={`truncate flex-1 ${
+            isFinished
+              ? winA
+                ? "text-[var(--text-primary)] font-medium"
+                : "text-[var(--text-muted)]"
+              : "text-[var(--text-primary)]"
+          }`}
+        >
+          {match.teamAName}
+        </span>
+        {isFinished && (
+          <span
+            className={`tabular shrink-0 ${
+              winA
+                ? "text-emerald-400 font-semibold"
+                : "text-[var(--text-muted)]"
+            }`}
+          >
+            {match.scoreA}
+          </span>
+        )}
+      </div>
+
+      {/* Team B */}
+      <div className="flex items-center justify-between gap-1 text-xs mt-0.5">
+        <span
+          className={`truncate flex-1 ${
+            isFinished
+              ? winB
+                ? "text-[var(--text-primary)] font-medium"
+                : "text-[var(--text-muted)]"
+              : "text-[var(--text-primary)]"
+          }`}
+        >
+          {match.teamBName}
+        </span>
+        {isFinished && (
+          <span
+            className={`tabular shrink-0 ${
+              winB
+                ? "text-emerald-400 font-semibold"
+                : "text-[var(--text-muted)]"
+            }`}
+          >
+            {match.scoreB}
+          </span>
+        )}
+      </div>
+
+      {/* 状态标签 */}
+      {!isFinished && (
+        <div className="mt-1 text-[10px] text-[var(--text-muted)]">
+          {match.status === "in_progress" ? (
+            <span className="text-amber-400">进行中</span>
+          ) : match.status === "cancelled" ? (
+            <span className="text-red-400">已取消</span>
+          ) : (
+            <span className="text-[var(--text-muted)]">{match.format.toUpperCase()}</span>
+          )}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function AdvancementColumn({
+  teams,
+  advanceCount,
+}: {
+  teams: SwissTeamSlot[];
+  advanceCount: number;
+}) {
+  const advanced = teams
+    .filter((t) => t.status === "advanced")
+    .sort((a, b) => a.seed - b.seed);
+  const eliminated = teams
+    .filter((t) => t.status === "eliminated")
+    .sort((a, b) => a.seed - b.seed);
+
+  return (
+    <div className="flex-1 min-w-[140px] max-w-[180px] space-y-4">
+      {/* 晋级 */}
+      {advanced.length > 0 && (
+        <div>
+          <div className="text-xs font-medium mb-1.5 px-1.5 py-0.5 rounded text-center bg-emerald-500/10 text-emerald-400">
+            晋级 ({advanced.length}/{advanceCount})
+          </div>
+          <div className="space-y-1">
+            {advanced.map((t) => (
+              <div
+                key={t.teamId}
+                className="flex items-center justify-between text-xs px-2 py-1 rounded bg-[var(--bg-elevated)] border border-[var(--border)]"
+              >
+                <span className="text-[var(--text-primary)] truncate">
+                  {t.teamName}
+                </span>
+                <span className="text-[var(--text-muted)] ml-1 tabular">
+                  {t.wins}:{t.losses}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 淘汰 */}
+      {eliminated.length > 0 && (
+        <div>
+          <div className="text-xs font-medium mb-1.5 px-1.5 py-0.5 rounded text-center bg-red-500/10 text-red-400">
+            淘汰 ({eliminated.length})
+          </div>
+          <div className="space-y-1">
+            {eliminated.map((t) => (
+              <div
+                key={t.teamId}
+                className="flex items-center justify-between text-xs px-2 py-1 rounded bg-[var(--bg-elevated)] border border-[var(--border)] opacity-60"
+              >
+                <span className="text-[var(--text-muted)] truncate">
+                  {t.teamName}
+                </span>
+                <span className="text-[var(--text-muted)] ml-1 tabular">
+                  {t.wins}:{t.losses}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 未定 */}
+      {advanced.length === 0 && eliminated.length === 0 && (
+        <div className="py-8 text-center text-[var(--text-muted)] text-xs">
+          —
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isAdvancedRecord(record: string): boolean {
+  return record === "3:0" || record === "3:1" || record === "3:2";
+}
+
+function isEliminatedRecord(record: string): boolean {
+  return record === "0:3" || record === "1:3" || record === "2:3";
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -10,3 +10,4 @@ export * from "./audit";
 export * from "./admin-users";
 export * from "./admin-invites";
 export * from "./player-stats";
+export * from "./swiss-standings";

--- a/src/db/schema/swiss-standings.ts
+++ b/src/db/schema/swiss-standings.ts
@@ -1,0 +1,32 @@
+import { pgTable, uuid, integer, text, unique } from "drizzle-orm/pg-core";
+import { seasons } from "./seasons";
+import { teams } from "./teams";
+
+/**
+ * 瑞士轮实时计分表
+ * 每个 (season, stage, team) 一行，逐轮更新
+ */
+export const swissStandings = pgTable(
+  "swiss_standings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    seasonId: uuid("season_id")
+      .notNull()
+      .references(() => seasons.id),
+    stage: text("stage").notNull(),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id),
+    seed: integer("seed").notNull(),
+    wins: integer("wins").notNull().default(0),
+    losses: integer("losses").notNull().default(0),
+    buScore: integer("bu_score").notNull().default(0),
+    status: text("status").notNull().default("active"),
+  },
+  (t) => ({
+    uniqueStanding: unique().on(t.seasonId, t.stage, t.teamId),
+  }),
+);
+
+export type SwissStanding = typeof swissStandings.$inferSelect;
+export type NewSwissStanding = typeof swissStandings.$inferInsert;

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -19,21 +19,38 @@ type PlayoffFormat = "double_elim" | "single_elim";
 
 export interface BracketStage {
   id: number;
+  tournament_id?: number;
   name: string;
+  number?: number;
   type: "double_elimination" | "single_elimination" | "round_robin";
+  settings?: Record<string, unknown>;
 }
 
 export interface BracketMatch {
   id: number;
-  stageId: number;
-  roundNumber: number;
+  stage_id: number;
+  group_id: number;
+  round_id: number;
+  number: number;
+  status: number;
   opponent1: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
   opponent2: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+}
+
+export interface BracketMatchGame {
+  id: number;
+  parent_id: number;
+  stage_id?: number;
+  number?: number;
+  status?: number;
+  opponent1?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+  opponent2?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
 }
 
 export interface BracketData {
   stage: BracketStage[];
   match: BracketMatch[];
+  match_game: BracketMatchGame[];
   participant: { id: number; name: string }[];
 }
 
@@ -158,7 +175,7 @@ export function serializeBracket(
   teams: Team[]
 ): BracketData {
   if (!data) {
-    return { stage: [], match: [], participant: [] };
+    return { stage: [], match: [], match_game: [], participant: [] };
   }
 
   // participant 表只有 name；id 顺序对应 teams 按 draft_order 排列
@@ -167,32 +184,42 @@ export function serializeBracket(
     name: p.name,
   }));
 
-  // round 表：按 stageId+number 查找 roundNumber
-  const roundMap = new Map<number, number>();
-  for (const r of data.round as Array<{ id: number; stage_id: number; number: number }>) {
-    roundMap.set(r.id, r.number);
-  }
-
   const stage: BracketStage[] = (
-    data.stage as Array<{ id: number; name: string; type: string }>
+    data.stage as Array<{
+      id: number;
+      tournament_id?: number;
+      name: string;
+      number?: number;
+      type: string;
+      settings?: Record<string, unknown>;
+    }>
   ).map((s) => ({
     id: s.id,
+    tournament_id: s.tournament_id,
     name: s.name,
+    number: s.number,
     type: s.type as BracketStage["type"],
+    settings: s.settings ?? {},
   }));
 
   const match: BracketMatch[] = (
     data.match as Array<{
       id: number;
       stage_id: number;
+      group_id: number;
       round_id: number;
+      number: number;
+      status: number;
       opponent1: { id: number | null; score: number | null; result?: string } | null;
       opponent2: { id: number | null; score: number | null; result?: string } | null;
     }>
   ).map((m) => ({
     id: m.id,
-    stageId: m.stage_id,
-    roundNumber: roundMap.get(m.round_id) ?? 0,
+    stage_id: m.stage_id,
+    group_id: m.group_id,
+    round_id: m.round_id,
+    number: m.number,
+    status: m.status,
     opponent1: m.opponent1
       ? {
           id: m.opponent1.id,
@@ -209,7 +236,12 @@ export function serializeBracket(
       : null,
   }));
 
-  return { stage, match, participant };
+  return {
+    stage,
+    match,
+    match_game: (data.match_game as unknown as BracketMatchGame[] | undefined) ?? [],
+    participant,
+  };
 }
 
 /**

--- a/src/lib/formats/index.ts
+++ b/src/lib/formats/index.ts
@@ -4,19 +4,18 @@ import type { StageExecutor } from "./types";
 import { roundRobinExecutor } from "./round-robin";
 import { doubleElimExecutor } from "./double-elim";
 import { singleElimExecutor } from "./single-elim";
+import { swissExecutor } from "./swiss";
 
 const EXECUTORS: Partial<Record<StageType, StageExecutor>> = {
   round_robin: roundRobinExecutor,
   double_elim: doubleElimExecutor,
   single_elim: singleElimExecutor,
+  swiss: swissExecutor,
 };
 
 export function getExecutor(type: StageType): StageExecutor {
   const executor = EXECUTORS[type];
   if (!executor) {
-    if (type === "swiss") {
-      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "Swiss 执行器将在 v2 接入");
-    }
     throw new AppError(ErrorCode.INTERNAL_ERROR, `未知赛制: ${type}`);
   }
   return executor;

--- a/src/lib/formats/swiss.ts
+++ b/src/lib/formats/swiss.ts
@@ -1,0 +1,419 @@
+import { and, eq, asc, sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matches, swissStandings, teams as teamsTable } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import type { StageExecutor } from "./types";
+import type { StageConfig } from "@/types/season";
+import type { Team } from "@/db/schema/teams";
+
+// ── 常量 ───────────────────────────────────────────────
+
+const WIN_THRESHOLD = 3;
+const LOSS_THRESHOLD = 3;
+
+interface SwissRow {
+  id: string;
+  seasonId: string;
+  stage: string;
+  teamId: string;
+  seed: number;
+  wins: number;
+  losses: number;
+  buScore: number;
+  status: string;
+}
+
+interface MatchPair {
+  teamAId: string;
+  teamBId: string;
+  format: "bo1" | "bo3";
+}
+
+// ── Executor ───────────────────────────────────────────
+
+export const swissExecutor: StageExecutor = {
+  async initialize(seasonId, config, teams) {
+    if (!config.seeds || config.seeds.length !== teams.length) {
+      throw new AppError(
+        ErrorCode.VALIDATION_FAILED,
+        `瑞士轮需要 ${teams.length} 个种子，当前种子数为 ${config.seeds?.length ?? 0}`,
+      );
+    }
+
+    // 按种子排序队伍
+    const teamWithSeed = teams
+      .map((t, i) => ({ team: t, seed: config.seeds![i] }))
+      .sort((a, b) => a.seed - b.seed);
+    const sorted = teamWithSeed.map((ts) => ts.team);
+
+    // 写入 standings
+    await db.insert(swissStandings).values(
+      teamWithSeed.map((ts) => ({
+        seasonId,
+        stage: config.key,
+        teamId: ts.team.id,
+        seed: ts.seed,
+        wins: 0,
+        losses: 0,
+        buScore: 0,
+        status: "active",
+      })),
+    );
+
+    // R1: 上半区 vs 下半区
+    const half = sorted.length / 2;
+    const pairs: MatchPair[] = [];
+    for (let i = 0; i < half; i++) {
+      pairs.push({ teamAId: sorted[i].id, teamBId: sorted[i + half].id, format: "bo1" });
+    }
+
+    for (const p of pairs) {
+      await db.insert(matches).values({
+        seasonId,
+        teamAId: p.teamAId,
+        teamBId: p.teamBId,
+        stage: config.key,
+        round: 1,
+        format: p.format,
+        status: "scheduled",
+      });
+    }
+
+    return { matchCount: pairs.length };
+  },
+
+  async advanceRound(seasonId, stageKey) {
+    return db.transaction(async (tx) => {
+      // 1. 查当前轮次
+      const matchRows = await tx
+        .select({ round: matches.round })
+        .from(matches)
+        .where(and(eq(matches.seasonId, seasonId), eq(matches.stage, stageKey)));
+      if (matchRows.length === 0) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, "瑞士轮尚未初始化");
+      }
+      const currentRound = Math.max(...matchRows.map((r) => r.round ?? 0));
+
+      // 2. 检查当前轮是否全部结束
+      const roundMatches = await tx.query.matches.findMany({
+        where: and(
+          eq(matches.seasonId, seasonId),
+          eq(matches.stage, stageKey),
+          eq(matches.round, currentRound),
+        ),
+      });
+      const unfinished = roundMatches.filter(
+        (m) => m.status !== "finished" && m.status !== "cancelled",
+      );
+      if (unfinished.length > 0) {
+        throw new AppError(
+          ErrorCode.SEASON_INVALID_STATUS,
+          `第 ${currentRound} 轮还有 ${unfinished.length} 场比赛未结束`,
+        );
+      }
+
+      // 3. 读 standings
+      const standings = await tx.query.swissStandings.findMany({
+        where: and(
+          eq(swissStandings.seasonId, seasonId),
+          eq(swissStandings.stage, stageKey),
+        ),
+        orderBy: [asc(swissStandings.seed)],
+      });
+      const standingMap = new Map(standings.map((s) => [s.teamId, s]));
+
+      // 4. 更新 wins/losses
+      for (const m of roundMatches) {
+        if (m.status === "cancelled") continue;
+        const winA = (m.scoreA ?? 0) > (m.scoreB ?? 0);
+        if (winA) {
+          await tx
+            .update(swissStandings)
+            .set({ wins: sql`wins + 1` })
+            .where(
+              and(
+                eq(swissStandings.seasonId, seasonId),
+                eq(swissStandings.stage, stageKey),
+                eq(swissStandings.teamId, m.teamAId),
+              ),
+            );
+          await tx
+            .update(swissStandings)
+            .set({ losses: sql`losses + 1` })
+            .where(
+              and(
+                eq(swissStandings.seasonId, seasonId),
+                eq(swissStandings.stage, stageKey),
+                eq(swissStandings.teamId, m.teamBId),
+              ),
+            );
+        } else {
+          await tx
+            .update(swissStandings)
+            .set({ wins: sql`wins + 1` })
+            .where(
+              and(
+                eq(swissStandings.seasonId, seasonId),
+                eq(swissStandings.stage, stageKey),
+                eq(swissStandings.teamId, m.teamBId),
+              ),
+            );
+          await tx
+            .update(swissStandings)
+            .set({ losses: sql`losses + 1` })
+            .where(
+              and(
+                eq(swissStandings.seasonId, seasonId),
+                eq(swissStandings.stage, stageKey),
+                eq(swissStandings.teamId, m.teamAId),
+              ),
+            );
+        }
+      }
+
+      // 5. 重读 standings
+      const updated = await tx.query.swissStandings.findMany({
+        where: and(
+          eq(swissStandings.seasonId, seasonId),
+          eq(swissStandings.stage, stageKey),
+        ),
+      }) as SwissRow[];
+
+      // 6. 标记 advanced / eliminated
+      for (const s of updated) {
+        if (s.status !== "active") continue;
+        if (s.wins >= WIN_THRESHOLD) {
+          await tx
+            .update(swissStandings)
+            .set({ status: "advanced" })
+            .where(eq(swissStandings.id, s.id));
+        } else if (s.losses >= LOSS_THRESHOLD) {
+          await tx
+            .update(swissStandings)
+            .set({ status: "eliminated" })
+            .where(eq(swissStandings.id, s.id));
+        }
+      }
+
+      // 7. BU 计算：对每个 active 队伍，汇总所有对手的 (wins - losses)
+      const finalStandings = await tx.query.swissStandings.findMany({
+        where: and(
+          eq(swissStandings.seasonId, seasonId),
+          eq(swissStandings.stage, stageKey),
+        ),
+      }) as SwissRow[];
+      const teamDiff = new Map<string, number>(
+        finalStandings.map((s) => [s.teamId, s.wins - s.losses]),
+      );
+
+      const allMatches = await tx.query.matches.findMany({
+        where: and(
+          eq(matches.seasonId, seasonId),
+          eq(matches.stage, stageKey),
+          eq(matches.status, "finished"),
+        ),
+      });
+
+      for (const s of finalStandings) {
+        if (s.status !== "active") continue;
+        let bu = 0;
+        for (const m of allMatches) {
+          if (m.teamAId === s.teamId) {
+            bu += teamDiff.get(m.teamBId) ?? 0;
+          } else if (m.teamBId === s.teamId) {
+            bu += teamDiff.get(m.teamAId) ?? 0;
+          }
+        }
+        await tx
+          .update(swissStandings)
+          .set({ buScore: bu })
+          .where(eq(swissStandings.id, s.id));
+      }
+
+      // 8. 配对
+      const activeRows = (await tx.query.swissStandings.findMany({
+        where: and(
+          eq(swissStandings.seasonId, seasonId),
+          eq(swissStandings.stage, stageKey),
+          eq(swissStandings.status, "active"),
+        ),
+        orderBy: [asc(swissStandings.seed)],
+      })) as SwissRow[];
+      if (activeRows.length === 0) return { matchCount: 0 };
+
+      // 构建已交手记录
+      const opponents = buildOpponents(allMatches);
+
+      const nextRound = currentRound + 1;
+      const pairs = pairSwissRound(activeRows, nextRound, opponents);
+
+      // 9. 插入新 matches
+      for (const p of pairs) {
+        const isDecisive =
+          isWinAndIn(p, activeRows) || isLossAndOut(p, activeRows);
+        const format = isDecisive ? "bo3" : "bo1";
+
+        await tx.insert(matches).values({
+          seasonId,
+          teamAId: p.teamAId,
+          teamBId: p.teamBId,
+          stage: stageKey,
+          round: nextRound,
+          format,
+          status: "scheduled",
+        });
+      }
+
+      return { matchCount: pairs.length };
+    });
+  },
+
+  async isComplete(seasonId, stageKey) {
+    const standings = await db.query.swissStandings.findMany({
+      where: and(
+        eq(swissStandings.seasonId, seasonId),
+        eq(swissStandings.stage, stageKey),
+      ),
+    });
+    if (standings.length === 0) return false;
+    return standings.every((s) => s.status !== "active");
+  },
+};
+
+// ── 配对算法 ───────────────────────────────────────────
+
+function buildOpponents(
+  allMatches: { teamAId: string; teamBId: string; status: string }[],
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  const finished = allMatches.filter((m) => m.status === "finished");
+  for (const m of finished) {
+    addOpponent(map, m.teamAId, m.teamBId);
+    addOpponent(map, m.teamBId, m.teamAId);
+  }
+  return map;
+}
+
+function addOpponent(map: Map<string, Set<string>>, teamId: string, opponentId: string) {
+  let set = map.get(teamId);
+  if (!set) {
+    set = new Set<string>();
+    map.set(teamId, set);
+  }
+  set.add(opponentId);
+}
+
+function pairSwissRound(
+  active: SwissRow[],
+  round: number,
+  opponents: Map<string, Set<string>>,
+): MatchPair[] {
+  // 按 wins 分组
+  const groups = new Map<number, SwissRow[]>();
+  for (const t of active) {
+    const list = groups.get(t.wins) ?? [];
+    list.push(t);
+    groups.set(t.wins, list);
+  }
+
+  // 每组内排序
+  for (const [, group] of groups) {
+    group.sort((a, b) => {
+      if (round === 2) {
+        return a.seed - b.seed; // R2: seed 升序
+      }
+      // R3+: BU 降序，tiebreak seed 升序
+      if (b.buScore !== a.buScore) return b.buScore - a.buScore;
+      return a.seed - b.seed;
+    });
+  }
+
+  const sortedWins = Array.from(groups.keys()).sort((a, b) => b - a);
+  const paired = new Set<string>();
+  const result: MatchPair[] = [];
+
+  for (const wins of sortedWins) {
+    const group = groups.get(wins)!;
+    const available = group.filter((t) => !paired.has(t.teamId));
+    const groupPairs = slidePair(available, opponents);
+    for (const p of groupPairs) {
+      paired.add(p.teamAId);
+      paired.add(p.teamBId);
+      result.push(p);
+    }
+  }
+
+  // 处理未配对的：向下配对
+  const unpaired = active.filter((t) => !paired.has(t.teamId));
+  for (const u of unpaired) {
+    for (const lowerWins of sortedWins) {
+      if (lowerWins >= (u.wins ?? 0)) continue;
+      const lowerGroup = groups.get(lowerWins)!;
+      const candidate = lowerGroup.find(
+        (t) =>
+          !paired.has(t.teamId) &&
+          !(opponents.get(u.teamId)?.has(t.teamId) ?? false),
+      );
+      if (candidate) {
+        paired.add(u.teamId);
+        paired.add(candidate.teamId);
+        result.push({ teamAId: u.teamId, teamBId: candidate.teamId, format: "bo1" });
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+function slidePair(
+  available: SwissRow[],
+  opponents: Map<string, Set<string>>,
+): MatchPair[] {
+  const result: MatchPair[] = [];
+  const used = new Set<string>();
+
+  while (available.filter((t) => !used.has(t.teamId)).length >= 2) {
+    const remaining = available.filter((t) => !used.has(t.teamId));
+    const top = remaining[0];
+    const bottom = remaining[remaining.length - 1];
+
+    if (!(opponents.get(top.teamId)?.has(bottom.teamId) ?? false)) {
+      used.add(top.teamId);
+      used.add(bottom.teamId);
+      result.push({ teamAId: top.teamId, teamBId: bottom.teamId, format: "bo1" });
+    } else {
+      // 尝试与倒数第二个配对
+      let found = false;
+      for (let i = remaining.length - 2; i >= 1; i--) {
+        if (!(opponents.get(top.teamId)?.has(remaining[i].teamId) ?? false)) {
+          used.add(top.teamId);
+          used.add(remaining[i].teamId);
+          result.push({ teamAId: top.teamId, teamBId: remaining[i].teamId, format: "bo1" });
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // 退而求其次：与第二个配对
+        used.add(top.teamId);
+        used.add(remaining[1].teamId);
+        result.push({ teamAId: top.teamId, teamBId: remaining[1].teamId, format: "bo1" });
+      }
+    }
+  }
+
+  return result;
+}
+
+function isWinAndIn(p: MatchPair, standings: SwissRow[]): boolean {
+  const tA = standings.find((s) => s.teamId === p.teamAId);
+  const tB = standings.find((s) => s.teamId === p.teamBId);
+  return (tA?.wins === WIN_THRESHOLD - 1) || (tB?.wins === WIN_THRESHOLD - 1);
+}
+
+function isLossAndOut(p: MatchPair, standings: SwissRow[]): boolean {
+  const tA = standings.find((s) => s.teamId === p.teamAId);
+  const tB = standings.find((s) => s.teamId === p.teamBId);
+  return (tA?.losses === LOSS_THRESHOLD - 1) || (tB?.losses === LOSS_THRESHOLD - 1);
+}

--- a/src/lib/swiss/data.ts
+++ b/src/lib/swiss/data.ts
@@ -1,0 +1,218 @@
+import { eq, and, asc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matches, swissStandings, teams } from "@/db/schema";
+
+export interface SwissTeamSlot {
+  teamId: string;
+  teamName: string;
+  seed: number;
+  wins: number;
+  losses: number;
+  status: string; // active | advanced | eliminated
+  buScore: number;
+}
+
+export interface SwissMatchRow {
+  matchId: string;
+  teamAId: string;
+  teamBId: string;
+  teamAName: string;
+  teamBName: string;
+  scoreA: number | null;
+  scoreB: number | null;
+  status: string; // scheduled | in_progress | finished | cancelled
+  format: string;
+  round: number;
+}
+
+export interface SwissRecordGroup {
+  record: string; // "0:0", "1:0", "0:1", etc.
+  matchups: SwissMatchRow[];
+}
+
+export interface SwissRoundColumn {
+  round: number;
+  status: "finished" | "active" | "upcoming";
+  groups: SwissRecordGroup[];
+}
+
+export interface SwissViewData {
+  stageName: string;
+  teamCount: number;
+  advanceCount: number;
+  rounds: SwissRoundColumn[];
+  teams: SwissTeamSlot[];
+}
+
+export async function getSwissViewData(
+  seasonId: string,
+  stageKey: string,
+  stageName: string,
+): Promise<SwissViewData> {
+  // 1. 所有 standings
+  const standings = await db.query.swissStandings.findMany({
+    where: and(
+      eq(swissStandings.seasonId, seasonId),
+      eq(swissStandings.stage, stageKey),
+    ),
+    orderBy: [asc(swissStandings.seed)],
+  });
+
+  // 2. 所有 matches
+  const allMatches = await db.query.matches.findMany({
+    where: and(
+      eq(matches.seasonId, seasonId),
+      eq(matches.stage, stageKey),
+    ),
+    orderBy: [asc(matches.round), asc(matches.createdAt)],
+  });
+
+  // 3. 队伍名称
+  const teamRows = await db.query.teams.findMany({
+    where: eq(teams.seasonId, seasonId),
+  });
+  const teamNameMap = new Map(teamRows.map((t) => [t.id, t.name]));
+
+  // 4. 构建团队列表
+  const teamSlots: SwissTeamSlot[] = standings.map((s) => ({
+    teamId: s.teamId,
+    teamName: teamNameMap.get(s.teamId) ?? "未知队伍",
+    seed: s.seed,
+    wins: s.wins,
+    losses: s.losses,
+    status: s.status,
+    buScore: s.buScore,
+  }));
+
+  const advanceCount = standings.filter((s) => s.status === "advanced").length;
+
+  // 5. 当前最大轮次
+  const maxRound = allMatches.length > 0
+    ? Math.max(...allMatches.map((m) => m.round ?? 0))
+    : 0;
+
+  const currentRound = maxRound > 0
+    ? (allMatches.some(
+        (m) =>
+          m.round === maxRound &&
+          m.status !== "finished" &&
+          m.status !== "cancelled",
+      )
+        ? maxRound // still has active matches
+        : maxRound + 1) // all matches in max round finished → next round upcoming
+    : 1;
+
+  // 6. 按轮次分组
+  const matchesByRound = new Map<number, SwissMatchRow[]>();
+  for (const m of allMatches) {
+    const r = m.round ?? 1;
+    const list = matchesByRound.get(r) ?? [];
+    list.push({
+      matchId: m.id,
+      teamAId: m.teamAId,
+      teamBId: m.teamBId,
+      teamAName: teamNameMap.get(m.teamAId) ?? "TBD",
+      teamBName: teamNameMap.get(m.teamBId) ?? "TBD",
+      scoreA: m.scoreA,
+      scoreB: m.scoreB,
+      status: m.status,
+      format: m.format,
+      round: r,
+    });
+    matchesByRound.set(r, list);
+  }
+
+  // 7. 建列
+  const maxPossibleRounds = Math.min(5, Math.ceil(Math.log2(standings.length)) + 3);
+  const totalRounds = Math.max(maxRound + 1, maxPossibleRounds);
+
+  const rounds: SwissRoundColumn[] = [];
+  for (let r = 1; r <= totalRounds; r++) {
+    const roundMatches = matchesByRound.get(r) ?? [];
+    const status: SwissRoundColumn["status"] =
+      r < currentRound
+        ? "finished"
+        : r === currentRound && roundMatches.length > 0
+          ? "active"
+          : "upcoming";
+
+    // 按 record 分组
+    const groups = groupMatchesByRecord(roundMatches, standings, r === 1);
+    rounds.push({ round: r, status, groups });
+  }
+
+  return {
+    stageName,
+    teamCount: standings.length,
+    advanceCount,
+    rounds,
+    teams: teamSlots,
+  };
+}
+
+function groupMatchesByRecord(
+  matchRows: SwissMatchRow[],
+  standings: SwissStanding[],
+  _isFirstRound: boolean,
+): SwissRecordGroup[] {
+  const teamRecord = new Map<string, string>();
+  for (const s of standings) {
+    teamRecord.set(s.teamId, `${s.wins}:${s.losses}`);
+  }
+
+  // 按 record 分组
+  const groupMap = new Map<string, SwissMatchRow[]>();
+  for (const m of matchRows) {
+    // 用 teamA 的 record 作为组标识
+    const recordA = teamRecord.get(m.teamAId) ?? "0:0";
+    const recordB = teamRecord.get(m.teamBId) ?? "0:0";
+    // 组的 key 用两个队伍共同的 record（同一组配对）
+    const key = recordA === recordB ? recordA : `${recordA} | ${recordB}`;
+    const list = groupMap.get(key) ?? [];
+    list.push(m);
+    groupMap.set(key, list);
+  }
+
+  // 去重（同一个 match 可能被重复分组）
+  const seen = new Set<string>();
+  const grouped = new Map<string, SwissMatchRow[]>();
+  for (const [key, rows] of groupMap) {
+    const deduped = rows.filter((r) => {
+      if (seen.has(r.matchId)) return false;
+      seen.add(r.matchId);
+      return true;
+    });
+    if (deduped.length > 0) grouped.set(key, deduped);
+  }
+
+  // 排序：按 record 优先级
+  const recordOrder = [
+    "0:0", "1:0", "0:1", "2:0", "1:1", "0:2",
+    "3:0", "2:1", "1:2", "0:3", "2:2", "3:1", "1:3", "3:2", "2:3",
+  ];
+
+  return Array.from(grouped.entries())
+    .sort(([a], [b]) => {
+      const ai = recordOrder.indexOf(a);
+      const bi = recordOrder.indexOf(b);
+      if (ai === -1 && bi === -1) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    })
+    .map(([record, matchups]) => ({
+      record,
+      matchups,
+    }));
+}
+
+type SwissStanding = {
+  seasonId: string;
+  stage: string;
+  teamId: string;
+  seed: number;
+  wins: number;
+  losses: number;
+  buScore: number;
+  status: string;
+};

--- a/tests/unit/components/matches/BracketView.test.tsx
+++ b/tests/unit/components/matches/BracketView.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BracketData } from "@/lib/bracket";
+
+const push = vi.fn();
+const renderBracket = vi.fn(async () => {
+  const root = document.querySelector("#bracket-container");
+  const match = document.createElement("div");
+  match.setAttribute("data-match-id", "7");
+  match.textContent = "Match 7";
+  root?.append(match);
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("next/script", () => ({
+  default: ({ onReady, src }: { onReady?: () => void; src: string }) => {
+    useEffect(() => {
+      onReady?.();
+    }, [onReady]);
+    return <script src={src} />;
+  },
+}));
+
+const bracketData: BracketData = {
+  stage: [{ id: 1, name: "Playoff", type: "single_elimination", settings: {} }],
+  match: [
+    {
+      id: 7,
+      stage_id: 1,
+      group_id: 0,
+      round_id: 3,
+      number: 1,
+      status: 2,
+      opponent1: { id: 0, score: null },
+      opponent2: { id: 1, score: null },
+    },
+  ],
+  participant: [
+    { id: 0, name: "Team 1" },
+    { id: 1, name: "Team 2" },
+  ],
+  match_game: [],
+};
+
+describe("BracketView", () => {
+  beforeEach(() => {
+    push.mockClear();
+    renderBracket.mockClear();
+    window.React = React;
+    window.bracketsViewer = { render: renderBracket };
+  });
+
+  it("renders the root required by brackets-viewer and passes raw bracket data", async () => {
+    const { BracketView } = await import("@/components/matches/BracketView");
+
+    render(<BracketView data={bracketData} />);
+
+    expect(document.querySelector("#bracket-container")).toHaveClass("brackets-viewer");
+
+    await waitFor(() => expect(renderBracket).toHaveBeenCalledTimes(1));
+    expect(renderBracket).toHaveBeenCalledWith(
+      {
+        stages: bracketData.stage,
+        matches: bracketData.match,
+        participants: bracketData.participant,
+        matchGames: bracketData.match_game,
+      },
+      { selector: "#bracket-container", clear: true },
+    );
+  });
+
+  it("binds bracket match clicks using brackets-viewer data-match-id nodes", async () => {
+    const { BracketView } = await import("@/components/matches/BracketView");
+
+    render(
+      <BracketView
+        data={bracketData}
+        matchNodeMap={new Map([["7", "match-uuid"]])}
+        seasonSlug="spring-2026"
+      />,
+    );
+
+    const matchNode = await screen.findByText("Match 7");
+    fireEvent.click(matchNode);
+
+    expect(push).toHaveBeenCalledWith("/spring-2026/matches/match-uuid");
+  });
+});

--- a/tests/unit/lib/bracket.test.ts
+++ b/tests/unit/lib/bracket.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { generateBracket, serializeBracket } from "@/lib/bracket";
+
+function makeTeams(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `team-${index}`,
+    name: `Team ${index + 1}`,
+    draftOrder: index + 1,
+  })) as never;
+}
+
+describe("serializeBracket()", () => {
+  it("preserves brackets-viewer match fields from brackets-manager data", async () => {
+    const { data } = await generateBracket(makeTeams(4), {
+      qualifierFormat: null,
+      playoffFormat: "single_elim",
+      playoffName: "Playoff",
+    });
+
+    const serialized = serializeBracket(data, makeTeams(4));
+
+    expect(serialized.stage).toHaveLength(1);
+    expect(serialized.match.length).toBeGreaterThan(0);
+    expect(serialized.match[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        stage_id: serialized.stage[0].id,
+        round_id: expect.any(Number),
+        group_id: expect.any(Number),
+        number: expect.any(Number),
+        status: expect.any(Number),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
…et view

- Add Swiss standings table (wins/losses/BU_score/status per team per stage)
- Implement Swiss executor with initialize (R1 pairing), advanceRound (standings update, BU recalculation, slide pairing with rematch avoidance)
- Add SwissBracket component with HLTV-style column layout grouped by record
- Add Swiss data query (getSwissViewData) for full stage snapshot
- Register Swiss executor in format registry (remove v2-only placeholder)
- Fix BracketView error handling for multi-stage bracket_data
- Update matches page to render SwissBracket for Swiss qualifier stages