### PR TITLE
[codex] Fix bracket viewer integration for PR 39

### DIFF
--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -68,11 +68,25 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
     allTeams
   );
 
-  // 过滤掉没有 match 的 stage（如排位赛 round_robin，matches 存在 DB 里但不在 bracket 中）
-  const stageIdsWithMatches = new Set(fullBracketData.match.map((m) => m.stageId));
+  // 正赛 stage 的 bracket 数据；brackets-viewer 需要 stage 和 match 同步过滤。
+  const playoffBracketStageIds = new Set(
+    fullBracketData.stage
+      .filter((s) => s.name === playoffStage?.name)
+      .map((s) => s.id),
+  );
+  const playoffBracketMatchIds = new Set(
+    fullBracketData.match
+      .filter((m) => playoffBracketStageIds.has(m.stage_id))
+      .map((m) => m.id),
+  );
   const bracketData = {
     ...fullBracketData,
-    stage: fullBracketData.stage.filter((s) => stageIdsWithMatches.has(s.id)),
+    stage: fullBracketData.stage.filter((s) => playoffBracketStageIds.has(s.id)),
+    match: fullBracketData.match.filter((m) => playoffBracketStageIds.has(m.stage_id)),
+    match_game: fullBracketData.match_game.filter((game) => {
+      const parentId = game.parent_id;
+      return typeof parentId === "number" && playoffBracketMatchIds.has(parentId);
+    }),
   };
 
   // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -40,14 +40,14 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
           stages: data.stage,
           matches: data.match,
           participants: data.participant,
-          matchGames: [],
+          matchGames: data.match_game,
         },
         { selector: "#bracket-container", clear: true }
       )
       .then(() => {
         if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
-        containerRef.current.querySelectorAll<HTMLElement>("[data-id]").forEach((el) => {
-          const bracketId = el.getAttribute("data-id");
+        containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
+          const bracketId = el.getAttribute("data-match-id");
           if (!bracketId) return;
           const matchId = matchNodeMap.get(bracketId);
           if (!matchId) return;
@@ -82,7 +82,7 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         style={themeColor ? ({ "--primary-color": themeColor } as React.CSSProperties) : undefined}
         className="overflow-x-auto"
       >
-        <div id="bracket-container" ref={containerRef} />
+        <div id="bracket-container" className="brackets-viewer" ref={containerRef} />
       </div>
     </>
   );

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -19,21 +19,38 @@ type PlayoffFormat = "double_elim" | "single_elim";
 
 export interface BracketStage {
   id: number;
+  tournament_id?: number;
   name: string;
+  number?: number;
   type: "double_elimination" | "single_elimination" | "round_robin";
+  settings?: Record<string, unknown>;
 }
 
 export interface BracketMatch {
   id: number;
-  stageId: number;
-  roundNumber: number;
+  stage_id: number;
+  group_id: number;
+  round_id: number;
+  number: number;
+  status: number;
   opponent1: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
   opponent2: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+}
+
+export interface BracketMatchGame {
+  id: number;
+  parent_id: number;
+  stage_id?: number;
+  number?: number;
+  status?: number;
+  opponent1?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+  opponent2?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
 }
 
 export interface BracketData {
   stage: BracketStage[];
   match: BracketMatch[];
+  match_game: BracketMatchGame[];
   participant: { id: number; name: string }[];
 }
 
@@ -158,7 +175,7 @@ export function serializeBracket(
   teams: Team[]
 ): BracketData {
   if (!data) {
-    return { stage: [], match: [], participant: [] };
+    return { stage: [], match: [], match_game: [], participant: [] };
   }
 
   // participant 表只有 name；id 顺序对应 teams 按 draft_order 排列
@@ -167,32 +184,42 @@ export function serializeBracket(
     name: p.name,
   }));
 
-  // round 表：按 stageId+number 查找 roundNumber
-  const roundMap = new Map<number, number>();
-  for (const r of data.round as Array<{ id: number; stage_id: number; number: number }>) {
-    roundMap.set(r.id, r.number);
-  }
-
   const stage: BracketStage[] = (
-    data.stage as Array<{ id: number; name: string; type: string }>
+    data.stage as Array<{
+      id: number;
+      tournament_id?: number;
+      name: string;
+      number?: number;
+      type: string;
+      settings?: Record<string, unknown>;
+    }>
   ).map((s) => ({
     id: s.id,
+    tournament_id: s.tournament_id,
     name: s.name,
+    number: s.number,
     type: s.type as BracketStage["type"],
+    settings: s.settings ?? {},
   }));
 
   const match: BracketMatch[] = (
     data.match as Array<{
       id: number;
       stage_id: number;
+      group_id: number;
       round_id: number;
+      number: number;
+      status: number;
       opponent1: { id: number | null; score: number | null; result?: string } | null;
       opponent2: { id: number | null; score: number | null; result?: string } | null;
     }>
   ).map((m) => ({
     id: m.id,
-    stageId: m.stage_id,
-    roundNumber: roundMap.get(m.round_id) ?? 0,
+    stage_id: m.stage_id,
+    group_id: m.group_id,
+    round_id: m.round_id,
+    number: m.number,
+    status: m.status,
     opponent1: m.opponent1
       ? {
           id: m.opponent1.id,
@@ -209,7 +236,12 @@ export function serializeBracket(
       : null,
   }));
 
-  return { stage, match, participant };
+  return {
+    stage,
+    match,
+    match_game: (data.match_game as unknown as BracketMatchGame[] | undefined) ?? [],
+    participant,
+  };
 }
 
 /**

--- a/tests/unit/components/matches/BracketView.test.tsx
+++ b/tests/unit/components/matches/BracketView.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BracketData } from "@/lib/bracket";
+
+const push = vi.fn();
+const renderBracket = vi.fn(async () => {
+  const root = document.querySelector("#bracket-container");
+  const match = document.createElement("div");
+  match.setAttribute("data-match-id", "7");
+  match.textContent = "Match 7";
+  root?.append(match);
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("next/script", () => ({
+  default: ({ onReady, src }: { onReady?: () => void; src: string }) => {
+    useEffect(() => {
+      onReady?.();
+    }, [onReady]);
+    return <script src={src} />;
+  },
+}));
+
+const bracketData: BracketData = {
+  stage: [{ id: 1, name: "Playoff", type: "single_elimination", settings: {} }],
+  match: [
+    {
+      id: 7,
+      stage_id: 1,
+      group_id: 0,
+      round_id: 3,
+      number: 1,
+      status: 2,
+      opponent1: { id: 0, score: null },
+      opponent2: { id: 1, score: null },
+    },
+  ],
+  participant: [
+    { id: 0, name: "Team 1" },
+    { id: 1, name: "Team 2" },
+  ],
+  match_game: [],
+};
+
+describe("BracketView", () => {
+  beforeEach(() => {
+    push.mockClear();
+    renderBracket.mockClear();
+    window.React = React;
+    window.bracketsViewer = { render: renderBracket };
+  });
+
+  it("renders the root required by brackets-viewer and passes raw bracket data", async () => {
+    const { BracketView } = await import("@/components/matches/BracketView");
+
+    render(<BracketView data={bracketData} />);
+
+    expect(document.querySelector("#bracket-container")).toHaveClass("brackets-viewer");
+
+    await waitFor(() => expect(renderBracket).toHaveBeenCalledTimes(1));
+    expect(renderBracket).toHaveBeenCalledWith(
+      {
+        stages: bracketData.stage,
+        matches: bracketData.match,
+        participants: bracketData.participant,
+        matchGames: bracketData.match_game,
+      },
+      { selector: "#bracket-container", clear: true },
+    );
+  });
+
+  it("binds bracket match clicks using brackets-viewer data-match-id nodes", async () => {
+    const { BracketView } = await import("@/components/matches/BracketView");
+
+    render(
+      <BracketView
+        data={bracketData}
+        matchNodeMap={new Map([["7", "match-uuid"]])}
+        seasonSlug="spring-2026"
+      />,
+    );
+
+    const matchNode = await screen.findByText("Match 7");
+    fireEvent.click(matchNode);
+
+    expect(push).toHaveBeenCalledWith("/spring-2026/matches/match-uuid");
+  });
+});

--- a/tests/unit/lib/bracket.test.ts
+++ b/tests/unit/lib/bracket.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { generateBracket, serializeBracket } from "@/lib/bracket";
+
+function makeTeams(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `team-${index}`,
+    name: `Team ${index + 1}`,
+    draftOrder: index + 1,
+  })) as never;
+}
+
+describe("serializeBracket()", () => {
+  it("preserves brackets-viewer match fields from brackets-manager data", async () => {
+    const { data } = await generateBracket(makeTeams(4), {
+      qualifierFormat: null,
+      playoffFormat: "single_elim",
+      playoffName: "Playoff",
+    });
+
+    const serialized = serializeBracket(data, makeTeams(4));
+
+    expect(serialized.stage).toHaveLength(1);
+    expect(serialized.match.length).toBeGreaterThan(0);
+    expect(serialized.match[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(Number),
+        stage_id: serialized.stage[0].id,
+        round_id: expect.any(Number),
+        group_id: expect.any(Number),
+        number: expect.any(Number),
+        status: expect.any(Number),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve brackets-manager field names when preparing bracket data for brackets-viewer
- Add the required `.brackets-viewer` root class and bind match clicks via `data-match-id`
- Filter playoff bracket stage, matches, and match games together for multi-stage bracket data
- Add regression tests for BracketView integration and serialized bracket viewer data shape

## Why
PR #39 introduced Swiss bracket work and updated bracket rendering for multi-stage data. The existing viewer integration still passed camelCase match fields (`stageId`, `roundNumber`) to `brackets-viewer`, but the library expects the original brackets-manager shape (`stage_id`, `round_id`, `group_id`, etc.). The root element also missed the required `.brackets-viewer` class, and click binding looked for `data-id` while the library renders `data-match-id`.

## Test Plan
- `pnpm test`
- `pnpm type-check`
