### PR TITLE
[phase-8] 队长选秀与超时自动 pick

### DIFF
--- a/PHASES.md
+++ b/PHASES.md
@@ -103,11 +103,11 @@
 
 ## Phase 8 — 选秀队长端 + 超时 Cron
 
-- [ ] `pickPlayer` Server Action（Postgres 事务 + SELECT FOR UPDATE + 幂等键）
-- [ ] 同位置 ≤ 2 人约束校验
-- [ ] `/[seasonSlug]/draft/captain` 队长选秀面板（仅当前轮队长可操作）
-- [ ] `/api/cron/draft-timeout` Cron route：超时按 peak_rating 降序自动 pick
-- [ ] `autoPick` Server Action
+- [x] `pickPlayer` Server Action（Postgres 事务 + SELECT FOR UPDATE + 幂等键）
+- [x] 同位置 ≤ 2 人约束校验
+- [x] `/[seasonSlug]/draft/captain` 队长选秀面板（仅当前轮队长可操作）
+- [x] `/api/cron/draft-timeout` Cron route：超时按 peak_rating 降序自动 pick
+- [x] `autoPick` Server Action
 
 ---
 

--- a/docs/draft-flow.md
+++ b/docs/draft-flow.md
@@ -36,21 +36,23 @@ SELECT * FROM draft_state
   WHERE season_id = $seasonId
   FOR UPDATE;
 
--- 2. 校验：draft_state.is_active = true
+-- 2. 幂等检查：若 client_request_id 已存在于 draft_picks，
+--    且 season/team/registration 与本次请求一致，直接返回成功
+SELECT id FROM draft_picks WHERE client_request_id = $clientRequestId;
+
+-- 3. 校验：draft_state.is_active = true
 --          current_team_id = $teamId（轮到该队了）
 --          round_deadline > NOW()（未超时）
+--          当前登录用户是该队 captain
 
--- 3. 校验：目标选手未被选（draft_picks 中不存在该 registration_id）
+-- 4. 校验：目标选手未被选（draft_picks 中不存在该 registration_id）
 
--- 4. 校验：同主选位置约束（该队同位置已选 < 2 人）
+-- 5. 校验：同主选位置约束（该队同位置已选 < 2 人，包含队长）
 SELECT COUNT(*) FROM team_members tm
   JOIN season_registrations sr ON sr.id = tm.registration_id
   WHERE tm.team_id = $teamId
     AND sr.primary_position = $targetPosition;
--- 若 COUNT >= 3 → ROLLBACK，返回错误
-
--- 5. 幂等检查：若 client_request_id 已存在于 draft_picks，直接返回成功
-SELECT id FROM draft_picks WHERE client_request_id = $clientRequestId;
+-- 若 COUNT >= 2 → ROLLBACK，返回错误
 
 -- 6. INSERT draft_picks
 INSERT INTO draft_picks (season_id, team_id, registration_id, round,
@@ -78,7 +80,7 @@ COMMIT;
 ```
 
 **违反此规则的常见错误：**
-- 在步骤 5 之前 INSERT（丢失幂等保护）
+- 在步骤 2 之前 INSERT（丢失幂等保护）
 - 遗漏步骤 7（team_members 未写入）
 - 在 COMMIT 前广播 Realtime（导致客户端看到中间态）
 - 将步骤拆分为多个独立事务（破坏原子性）
@@ -106,9 +108,11 @@ Server Action pickPlayer()
 ```typescript
 // 客户端
 const [clientRequestId] = useState(() => crypto.randomUUID());
-// 点击后按钮立即 disabled，同一 ID 的重试请求会被步骤 5 短路
+// 点击后按钮立即 disabled，同一 ID 的重试请求会被步骤 2 短路
 await pickPlayer(teamId, registrationId, clientRequestId);
 ```
+
+重复请求必须允许在 `draft_state` 已经推进到下一队之后返回成功，因此幂等检查要在当前轮次校验之前完成；若同一个 `client_request_id` 被不同 season/team/registration 复用，应返回校验错误。
 
 ---
 

--- a/docs/superpowers/plans/2026-05-11-phase8-pr1-core-pick.md
+++ b/docs/superpowers/plans/2026-05-11-phase8-pr1-core-pick.md
@@ -1,0 +1,53 @@
+# Phase 8 PR1 落地计划：核心 pick 事务
+
+## 目标
+
+把 Phase 8 拆成第一轮可合并 PR：先交付 `pickPlayer` 的后端原子事务、幂等键、队内同位置上限和基础规则测试。队长面板 UI、Cron 超时自动 pick、`autoPick` 独立放到后续 PR。
+
+## 范围
+
+- 修正 `docs/draft-flow.md` 中同位置规则描述：每队同主选位置最多 2 人，检查条件应为 `COUNT >= 2`。
+- 扩展 `src/lib/draft/rules.ts`：
+  - `isStarterRound(round)`：Round 1-4 为首发，Round 5-6 为替补。
+  - `canPickPosition(currentCount)`：当前同主选位置人数小于 2 才允许继续 pick。
+- 扩展 `src/lib/validators/draft.ts`：
+  - 新增 `pickPlayerSchema` 和 `PickPlayerInput`。
+- 实现 `src/actions/draft.ts` 的 `pickPlayer(input)`：
+  - `requireAuth()` 获取当前用户。
+  - 在同一个 `db.transaction()` 内用 `SELECT ... FOR UPDATE` 锁住当前赛季 `draft_state`。
+  - 先检查 `clientRequestId` 幂等记录，重复同请求直接返回成功。
+  - 校验赛季启用 draft、draft active、当前队伍、deadline、队长身份、目标报名状态、目标未被选。
+  - 校验该队同主选位置人数 `< 2`。
+  - 写入 `draft_picks` 与 `team_members`。
+  - 用蛇形顺序推进 `draft_state`；最后一 pick 后关闭 draft，并把赛季推进到 `playing`。
+  - commit 后再 `revalidatePath()` 相关页面。
+- 更新 `PHASES.md` Phase 8 checkbox：PR1 范围完成后勾选 `pickPlayer` 与同位置约束。
+
+## 非目标
+
+- 不做 `/[seasonSlug]/draft/captain` 交互面板。
+- 不做 `/api/cron/draft-timeout` 与 `autoPick`。
+- 不引入新 Realtime 表订阅。
+- 不在本 PR 里改动 Swiss / bracket / match 相关代码。
+
+## 自检
+
+必须通过：
+
+```bash
+pnpm test
+pnpm tsc --noEmit
+```
+
+视改动情况补充：
+
+```bash
+pnpm type-check
+```
+
+## PR 拆分与进度
+
+- PR1：核心 pick 事务与规则测试。已落地。
+- PR2：队长端页面和客户端幂等按钮。已落地。
+- PR3：Cron route + `autoPick` 复用同一事务核心。已落地。
+- PR4：移动端 draft UI 与端到端流程测试。

--- a/src/actions/draft.ts
+++ b/src/actions/draft.ts
@@ -21,11 +21,13 @@ import {
   resumeDraftSchema,
   pickPlayerSchema,
   autoPickSchema,
+  skipDraftTurnSchema,
   type StartDraftInput,
   type PauseDraftInput,
   type ResumeDraftInput,
   type PickPlayerInput,
   type AutoPickInput,
+  type SkipDraftTurnInput,
 } from "@/lib/validators/draft";
 import { DRAFT_ROUND_TIMEOUT_SECONDS, DRAFT_TEAMS, DRAFT_TOTAL_ROUNDS } from "@/types/draft";
 import { canPickPosition, getNextTeamId, getSnakeOrder, isStarterRound } from "@/lib/draft/rules";
@@ -46,6 +48,8 @@ interface DraftPickCoreInput {
   deadlinePolicy: "before-deadline" | "after-deadline";
   captainUserId?: string;
   now?: Date;
+  prefetchedSeason?: typeof seasons.$inferSelect;
+  prefetchedDs?: typeof draftState.$inferSelect;
 }
 
 interface DraftPickCoreResult {
@@ -241,13 +245,116 @@ export async function autoPick(
   }
 }
 
-export async function runDraftTimeoutCron(
-  cronSecret: string,
-): Promise<DraftTimeoutCronSummary> {
-  if (!process.env.CRON_SECRET || cronSecret !== process.env.CRON_SECRET) {
-    throw new AppError(ErrorCode.UNAUTHORIZED, ERROR_MESSAGES.UNAUTHORIZED);
-  }
+// ── 管理员强制跳过当前轮次（用于无可选选手时解除卡死）───────────────────────────────────────
 
+export async function skipDraftTurn(
+  input: SkipDraftTurnInput,
+): Promise<ActionResult<{ skipped: boolean; completed: boolean }>> {
+  const parsed = skipDraftTurnSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("跳过轮次参数无效");
+  }
+  const admin = await requireSeasonAdmin(parsed.data.seasonId);
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, parsed.data.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+      }
+      if (season.status !== "drafting") {
+        throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有 drafting 状态的赛季可以跳过轮次");
+      }
+
+      const [ds] = await tx
+        .select()
+        .from(draftState)
+        .where(eq(draftState.seasonId, parsed.data.seasonId))
+        .for("update");
+
+      if (!ds?.isActive || !ds.currentTeamId) {
+        throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
+      }
+
+      const seasonTeams = await tx
+        .select({ id: teams.id, draftOrder: teams.draftOrder })
+        .from(teams)
+        .where(eq(teams.seasonId, parsed.data.seasonId))
+        .orderBy(asc(teams.draftOrder));
+
+      const skippedTeamId = ds.currentTeamId;
+      const skippedRound = ds.currentRound;
+      const next = getNextTeamId(seasonTeams, ds.currentTeamId, ds.currentRound);
+      const now = new Date();
+
+      if (!next) {
+        await tx
+          .update(draftState)
+          .set({
+            currentRound: DRAFT_TOTAL_ROUNDS + 1,
+            currentTeamId: null,
+            roundDeadline: null,
+            isActive: false,
+            updatedAt: now,
+          })
+          .where(eq(draftState.id, ds.id));
+        await tx
+          .update(seasons)
+          .set({ status: "playing", updatedAt: now })
+          .where(eq(seasons.id, parsed.data.seasonId));
+
+        await tx.insert(auditLogs).values({
+          seasonId: parsed.data.seasonId,
+          action: "draft.skip_turn",
+          actorId: auditActorId(admin),
+          targetId: ds.id,
+          targetType: "draft_state",
+          meta: { skippedTeamId, round: skippedRound, draftCompleted: true, actorEmail: admin.email },
+        });
+
+        return { slug: season.slug, completed: true };
+      }
+
+      const deadline = new Date(now.getTime() + DRAFT_ROUND_TIMEOUT_SECONDS * 1000);
+      await tx
+        .update(draftState)
+        .set({
+          currentRound: next.nextRound,
+          currentTeamId: next.teamId,
+          roundDeadline: deadline,
+          isActive: true,
+          updatedAt: now,
+        })
+        .where(eq(draftState.id, ds.id));
+
+      await tx.insert(auditLogs).values({
+        seasonId: parsed.data.seasonId,
+        action: "draft.skip_turn",
+        actorId: auditActorId(admin),
+        targetId: ds.id,
+        targetType: "draft_state",
+        meta: {
+          skippedTeamId,
+          round: skippedRound,
+          nextTeamId: next.teamId,
+          nextRound: next.nextRound,
+          actorEmail: admin.email,
+        },
+      });
+
+      return { slug: season.slug, completed: false };
+    });
+
+    revalidateDraftPaths(result.slug);
+    return ok({ skipped: true, completed: result.completed });
+  } catch (e) {
+    return actionError("skipDraftTurn", e);
+  }
+}
+
+export async function runDraftTimeoutCron(): Promise<DraftTimeoutCronSummary> {
   const now = new Date();
   const timedOutStates = await db
     .select({ seasonId: draftState.seasonId })
@@ -263,6 +370,11 @@ export async function runDraftTimeoutCron(
       revalidateDraftPaths(result.slug);
     } else {
       skipped += 1;
+      if (result.reason === "no_eligible_player") {
+        console.warn(
+          `[draft-timeout-cron] season ${state.seasonId}: no eligible player, manual skip required (admin → draft.skip_turn)`,
+        );
+      }
     }
   }
 
@@ -423,6 +535,8 @@ async function runAutoPickForSeason(
       autoPicked: true,
       deadlinePolicy: "after-deadline",
       now,
+      prefetchedSeason: season,
+      prefetchedDs: ds,
     });
 
     return {
@@ -440,9 +554,10 @@ async function executeDraftPick(
   input: DraftPickCoreInput,
 ): Promise<DraftPickCoreResult> {
   const now = input.now ?? new Date();
-  const season = await tx.query.seasons.findFirst({
-    where: eq(seasons.id, input.seasonId),
-  });
+
+  const season =
+    input.prefetchedSeason ??
+    (await tx.query.seasons.findFirst({ where: eq(seasons.id, input.seasonId) }));
   if (!season) {
     throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
   }
@@ -459,11 +574,10 @@ async function executeDraftPick(
     );
   }
 
-  const [ds] = await tx
-    .select()
-    .from(draftState)
-    .where(eq(draftState.seasonId, input.seasonId))
-    .for("update");
+  // 如果调用方已持有 FOR UPDATE 锁（同一事务内），直接复用，避免重复 round trip
+  const ds =
+    input.prefetchedDs ??
+    (await tx.select().from(draftState).where(eq(draftState.seasonId, input.seasonId)).for("update"))[0];
   if (!ds) {
     throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
   }
@@ -590,6 +704,21 @@ async function executeDraftPick(
     teamId: input.teamId,
     registrationId: input.registrationId,
     isStarter: isStarterRound(ds.currentRound),
+  });
+
+  await tx.insert(auditLogs).values({
+    seasonId: input.seasonId,
+    action: "draft.pick",
+    actorId: input.captainUserId ?? "system:auto-pick",
+    targetId: pick.id,
+    targetType: "draft_pick",
+    meta: {
+      teamId: input.teamId,
+      registrationId: input.registrationId,
+      round: ds.currentRound,
+      pickNumber,
+      autoPicked: input.autoPicked,
+    },
   });
 
   const seasonTeams = await tx

--- a/src/actions/draft.ts
+++ b/src/actions/draft.ts
@@ -1,22 +1,74 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, asc } from "drizzle-orm";
+import { and, asc, count, eq, lt } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, draftState, auditLogs } from "@/db/schema";
+import {
+  seasons,
+  teams,
+  draftState,
+  draftPicks,
+  teamMembers,
+  seasonRegistrations,
+  auditLogs,
+} from "@/db/schema";
 import { ok, fail, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
-import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
+import { auditActorId, requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
 import {
   startDraftSchema,
   pauseDraftSchema,
   resumeDraftSchema,
+  pickPlayerSchema,
+  autoPickSchema,
   type StartDraftInput,
   type PauseDraftInput,
   type ResumeDraftInput,
+  type PickPlayerInput,
+  type AutoPickInput,
 } from "@/lib/validators/draft";
-import { DRAFT_ROUND_TIMEOUT_SECONDS, DRAFT_TEAMS } from "@/types/draft";
-import { getSnakeOrder } from "@/lib/draft/rules";
+import { DRAFT_ROUND_TIMEOUT_SECONDS, DRAFT_TEAMS, DRAFT_TOTAL_ROUNDS } from "@/types/draft";
+import { canPickPosition, getNextTeamId, getSnakeOrder, isStarterRound } from "@/lib/draft/rules";
+import {
+  createAutoPickRequestId,
+  selectAutoPickCandidate,
+  type AutoPickCandidate,
+} from "@/lib/draft/auto-pick";
+
+type DraftTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+interface DraftPickCoreInput {
+  seasonId: string;
+  teamId: string;
+  registrationId: string;
+  clientRequestId: string;
+  autoPicked: boolean;
+  deadlinePolicy: "before-deadline" | "after-deadline";
+  captainUserId?: string;
+  now?: Date;
+}
+
+interface DraftPickCoreResult {
+  pickId: string;
+  slug: string;
+  idempotent: boolean;
+  completed: boolean;
+}
+
+interface AutoPickRunResult {
+  picked: boolean;
+  seasonId: string;
+  slug: string;
+  pickId?: string;
+  completed?: boolean;
+  reason?: "draft_not_active" | "not_timed_out" | "no_eligible_player";
+}
+
+export interface DraftTimeoutCronSummary {
+  processed: number;
+  picked: number;
+  skipped: number;
+}
 
 // ── 启动选秀 ───────────────────────────────────────────
 
@@ -120,6 +172,101 @@ export async function startDraft(
   } catch (e) {
     return actionError("startDraft", e);
   }
+}
+
+// ── 队长选择选手 ───────────────────────────────────────────
+
+export async function pickPlayer(
+  input: PickPlayerInput,
+): Promise<ActionResult<{ pickId: string; idempotent: boolean; completed: boolean }>> {
+  const parsed = pickPlayerSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("选择选手参数无效");
+  }
+
+  const { seasonId, teamId, registrationId, clientRequestId } = parsed.data;
+
+  try {
+    const user = await requireAuth();
+    const result = await db.transaction(async (tx) => {
+      return executeDraftPick(tx, {
+        seasonId,
+        teamId,
+        registrationId,
+        clientRequestId,
+        autoPicked: false,
+        deadlinePolicy: "before-deadline",
+        captainUserId: user.userId,
+      });
+    });
+
+    revalidatePath(`/${result.slug}/draft`);
+    revalidatePath(`/${result.slug}/draft/captain`);
+    revalidatePath(`/${result.slug}/teams`);
+    revalidatePath(`/admin/${result.slug}/draft`);
+    return ok({
+      pickId: result.pickId,
+      idempotent: result.idempotent,
+      completed: result.completed,
+    });
+  } catch (e) {
+    return actionError("pickPlayer", e);
+  }
+}
+
+// ── 超时自动选择 ───────────────────────────────────────────
+
+export async function autoPick(
+  input: AutoPickInput,
+): Promise<ActionResult<{ picked: boolean; pickId?: string; completed?: boolean; reason?: string }>> {
+  const parsed = autoPickSchema.safeParse(input);
+  if (!parsed.success) {
+    return failValidation("自动选择参数无效");
+  }
+
+  try {
+    await requireSeasonAdmin(parsed.data.seasonId);
+    const result = await runAutoPickForSeason(parsed.data.seasonId);
+    if (result.picked) {
+      revalidateDraftPaths(result.slug);
+    }
+    return ok({
+      picked: result.picked,
+      pickId: result.pickId,
+      completed: result.completed,
+      reason: result.reason,
+    });
+  } catch (e) {
+    return actionError("autoPick", e);
+  }
+}
+
+export async function runDraftTimeoutCron(
+  cronSecret: string,
+): Promise<DraftTimeoutCronSummary> {
+  if (!process.env.CRON_SECRET || cronSecret !== process.env.CRON_SECRET) {
+    throw new AppError(ErrorCode.UNAUTHORIZED, ERROR_MESSAGES.UNAUTHORIZED);
+  }
+
+  const now = new Date();
+  const timedOutStates = await db
+    .select({ seasonId: draftState.seasonId })
+    .from(draftState)
+    .where(and(eq(draftState.isActive, true), lt(draftState.roundDeadline, now)));
+
+  let picked = 0;
+  let skipped = 0;
+  for (const state of timedOutStates) {
+    const result = await runAutoPickForSeason(state.seasonId, now);
+    if (result.picked) {
+      picked += 1;
+      revalidateDraftPaths(result.slug);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return { processed: timedOutStates.length, picked, skipped };
 }
 
 // ── 暂停选秀 ───────────────────────────────────────────
@@ -230,6 +377,348 @@ export async function resumeDraft(
 }
 
 // ── 工具函数 ───────────────────────────────────────────
+
+async function runAutoPickForSeason(
+  seasonId: string,
+  now = new Date(),
+): Promise<AutoPickRunResult> {
+  return db.transaction(async (tx) => {
+    const season = await tx.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+    });
+    if (!season) {
+      throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    }
+
+    const [ds] = await tx
+      .select()
+      .from(draftState)
+      .where(eq(draftState.seasonId, seasonId))
+      .for("update");
+
+    if (!ds?.isActive || !ds.currentTeamId) {
+      return { picked: false, seasonId, slug: season.slug, reason: "draft_not_active" };
+    }
+    if (!ds.roundDeadline || ds.roundDeadline.getTime() > now.getTime()) {
+      return { picked: false, seasonId, slug: season.slug, reason: "not_timed_out" };
+    }
+
+    const positionCounts = await getTeamPositionCounts(tx, ds.currentTeamId);
+    const candidates = await getAutoPickCandidates(tx, seasonId);
+    const selected = selectAutoPickCandidate(candidates, positionCounts);
+    if (!selected) {
+      return { picked: false, seasonId, slug: season.slug, reason: "no_eligible_player" };
+    }
+
+    const pick = await executeDraftPick(tx, {
+      seasonId,
+      teamId: ds.currentTeamId,
+      registrationId: selected.registrationId,
+      clientRequestId: createAutoPickRequestId({
+        seasonId,
+        teamId: ds.currentTeamId,
+        round: ds.currentRound,
+        deadline: ds.roundDeadline,
+      }),
+      autoPicked: true,
+      deadlinePolicy: "after-deadline",
+      now,
+    });
+
+    return {
+      picked: true,
+      seasonId,
+      slug: pick.slug,
+      pickId: pick.pickId,
+      completed: pick.completed,
+    };
+  });
+}
+
+async function executeDraftPick(
+  tx: DraftTransaction,
+  input: DraftPickCoreInput,
+): Promise<DraftPickCoreResult> {
+  const now = input.now ?? new Date();
+  const season = await tx.query.seasons.findFirst({
+    where: eq(seasons.id, input.seasonId),
+  });
+  if (!season) {
+    throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+  }
+  if (!season.hasDraft) {
+    throw new AppError(
+      ErrorCode.SEASON_CAPABILITY_DISABLED,
+      ERROR_MESSAGES.SEASON_CAPABILITY_DISABLED,
+    );
+  }
+  if (season.status !== "drafting") {
+    throw new AppError(
+      ErrorCode.SEASON_INVALID_STATUS,
+      "只有 drafting 状态的赛季可以进行选秀",
+    );
+  }
+
+  const [ds] = await tx
+    .select()
+    .from(draftState)
+    .where(eq(draftState.seasonId, input.seasonId))
+    .for("update");
+  if (!ds) {
+    throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
+  }
+
+  const existingByRequestId = await tx.query.draftPicks.findFirst({
+    where: eq(draftPicks.clientRequestId, input.clientRequestId),
+  });
+  if (existingByRequestId) {
+    if (
+      existingByRequestId.seasonId !== input.seasonId ||
+      existingByRequestId.teamId !== input.teamId ||
+      existingByRequestId.registrationId !== input.registrationId
+    ) {
+      throw new AppError(
+        ErrorCode.VALIDATION_FAILED,
+        "clientRequestId 已被其他 pick 使用",
+      );
+    }
+    return {
+      pickId: existingByRequestId.id,
+      slug: season.slug,
+      idempotent: true,
+      completed: !ds.isActive && !ds.currentTeamId,
+    };
+  }
+
+  if (!ds.isActive) {
+    throw new AppError(ErrorCode.DRAFT_NOT_ACTIVE, ERROR_MESSAGES.DRAFT_NOT_ACTIVE);
+  }
+  if (ds.currentTeamId !== input.teamId) {
+    throw new AppError(ErrorCode.DRAFT_NOT_YOUR_TURN, ERROR_MESSAGES.DRAFT_NOT_YOUR_TURN);
+  }
+  assertDeadline(ds.roundDeadline, input.deadlinePolicy, now);
+
+  const team = await tx.query.teams.findFirst({
+    where: and(eq(teams.id, input.teamId), eq(teams.seasonId, input.seasonId)),
+  });
+  if (!team) {
+    throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
+  }
+
+  const captainRegistration = await tx.query.seasonRegistrations.findFirst({
+    where: and(
+      eq(seasonRegistrations.id, team.captainRegistrationId),
+      eq(seasonRegistrations.seasonId, input.seasonId),
+    ),
+  });
+  if (
+    input.captainUserId &&
+    (!captainRegistration || captainRegistration.userId !== input.captainUserId)
+  ) {
+    throw new AppError(ErrorCode.FORBIDDEN, "只有当前轮次队长可以选择选手");
+  }
+  if (input.registrationId === team.captainRegistrationId) {
+    throw new AppError(ErrorCode.PLAYER_ALREADY_PICKED, "队长已在该队伍中");
+  }
+
+  const targetRegistration = await tx.query.seasonRegistrations.findFirst({
+    where: and(
+      eq(seasonRegistrations.id, input.registrationId),
+      eq(seasonRegistrations.seasonId, input.seasonId),
+    ),
+  });
+  if (!targetRegistration) {
+    throw new AppError(ErrorCode.NOT_FOUND, "目标选手不存在");
+  }
+  if (targetRegistration.status !== "approved") {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "只能选择已通过审核的选手");
+  }
+
+  const existingPick = await tx.query.draftPicks.findFirst({
+    where: and(
+      eq(draftPicks.seasonId, input.seasonId),
+      eq(draftPicks.registrationId, input.registrationId),
+    ),
+  });
+  if (existingPick) {
+    throw new AppError(
+      ErrorCode.PLAYER_ALREADY_PICKED,
+      ERROR_MESSAGES.PLAYER_ALREADY_PICKED,
+    );
+  }
+
+  const [positionCount] = await tx
+    .select({ count: count() })
+    .from(teamMembers)
+    .innerJoin(
+      seasonRegistrations,
+      eq(teamMembers.registrationId, seasonRegistrations.id),
+    )
+    .where(
+      and(
+        eq(teamMembers.teamId, input.teamId),
+        eq(seasonRegistrations.primaryPosition, targetRegistration.primaryPosition),
+      ),
+    );
+  if (!canPickPosition(Number(positionCount?.count ?? 0))) {
+    throw new AppError(
+      ErrorCode.TEAM_POSITION_CAP_EXCEEDED,
+      ERROR_MESSAGES.TEAM_POSITION_CAP_EXCEEDED,
+    );
+  }
+
+  const [pickCount] = await tx
+    .select({ count: count() })
+    .from(draftPicks)
+    .where(eq(draftPicks.seasonId, input.seasonId));
+  const pickNumber = Number(pickCount?.count ?? 0) + 1;
+
+  const [pick] = await tx
+    .insert(draftPicks)
+    .values({
+      seasonId: input.seasonId,
+      teamId: input.teamId,
+      registrationId: input.registrationId,
+      round: ds.currentRound,
+      pickNumber,
+      autoPicked: input.autoPicked,
+      clientRequestId: input.clientRequestId,
+    })
+    .returning({ id: draftPicks.id });
+
+  await tx.insert(teamMembers).values({
+    teamId: input.teamId,
+    registrationId: input.registrationId,
+    isStarter: isStarterRound(ds.currentRound),
+  });
+
+  const seasonTeams = await tx
+    .select({ id: teams.id, draftOrder: teams.draftOrder })
+    .from(teams)
+    .where(eq(teams.seasonId, input.seasonId))
+    .orderBy(asc(teams.draftOrder));
+  const next = getNextTeamId(seasonTeams, input.teamId, ds.currentRound);
+
+  if (!next) {
+    await tx
+      .update(draftState)
+      .set({
+        currentRound: DRAFT_TOTAL_ROUNDS + 1,
+        currentTeamId: null,
+        roundDeadline: null,
+        isActive: false,
+        updatedAt: now,
+      })
+      .where(eq(draftState.id, ds.id));
+    await tx
+      .update(seasons)
+      .set({ status: "playing", updatedAt: now })
+      .where(eq(seasons.id, input.seasonId));
+
+    return { pickId: pick.id, slug: season.slug, idempotent: false, completed: true };
+  }
+
+  const deadline = new Date(now.getTime() + DRAFT_ROUND_TIMEOUT_SECONDS * 1000);
+  await tx
+    .update(draftState)
+    .set({
+      currentRound: next.nextRound,
+      currentTeamId: next.teamId,
+      roundDeadline: deadline,
+      isActive: true,
+      updatedAt: now,
+    })
+    .where(eq(draftState.id, ds.id));
+
+  return { pickId: pick.id, slug: season.slug, idempotent: false, completed: false };
+}
+
+function assertDeadline(
+  deadline: Date | null,
+  policy: DraftPickCoreInput["deadlinePolicy"],
+  now: Date,
+) {
+  if (!deadline) {
+    throw new AppError(ErrorCode.DRAFT_DEADLINE_PASSED, ERROR_MESSAGES.DRAFT_DEADLINE_PASSED);
+  }
+  if (policy === "before-deadline" && deadline.getTime() <= now.getTime()) {
+    throw new AppError(ErrorCode.DRAFT_DEADLINE_PASSED, ERROR_MESSAGES.DRAFT_DEADLINE_PASSED);
+  }
+  if (policy === "after-deadline" && deadline.getTime() > now.getTime()) {
+    throw new AppError(ErrorCode.DRAFT_DEADLINE_PASSED, "当前轮次尚未超时");
+  }
+}
+
+async function getTeamPositionCounts(
+  tx: DraftTransaction,
+  teamId: string,
+): Promise<Record<string, number>> {
+  const rows = await tx
+    .select({
+      primaryPosition: seasonRegistrations.primaryPosition,
+      count: count(),
+    })
+    .from(teamMembers)
+    .innerJoin(
+      seasonRegistrations,
+      eq(teamMembers.registrationId, seasonRegistrations.id),
+    )
+    .where(eq(teamMembers.teamId, teamId))
+    .groupBy(seasonRegistrations.primaryPosition);
+
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    counts[row.primaryPosition] = Number(row.count);
+  }
+  return counts;
+}
+
+async function getAutoPickCandidates(
+  tx: DraftTransaction,
+  seasonId: string,
+): Promise<AutoPickCandidate[]> {
+  const captainRows = await tx
+    .select({ registrationId: teams.captainRegistrationId })
+    .from(teams)
+    .where(eq(teams.seasonId, seasonId));
+  const pickRows = await tx
+    .select({ registrationId: draftPicks.registrationId })
+    .from(draftPicks)
+    .where(eq(draftPicks.seasonId, seasonId));
+  const excluded = new Set([
+    ...captainRows.map((row) => row.registrationId),
+    ...pickRows.map((row) => row.registrationId),
+  ]);
+
+  const candidates = await tx
+    .select({
+      registrationId: seasonRegistrations.id,
+      primaryPosition: seasonRegistrations.primaryPosition,
+      peakRating: seasonRegistrations.peakRating,
+    })
+    .from(seasonRegistrations)
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    );
+
+  return candidates
+    .filter((candidate) => !excluded.has(candidate.registrationId))
+    .map((candidate) => ({
+      registrationId: candidate.registrationId,
+      primaryPosition: candidate.primaryPosition,
+      peakRating: candidate.peakRating,
+    }));
+}
+
+function revalidateDraftPaths(slug: string) {
+  revalidatePath(`/${slug}/draft`);
+  revalidatePath(`/${slug}/draft/captain`);
+  revalidatePath(`/${slug}/teams`);
+  revalidatePath(`/admin/${slug}/draft`);
+}
 
 function failValidation(message: string): ActionResult<never> {
   return fail({ code: ErrorCode.VALIDATION_FAILED, message });

--- a/src/app/[seasonSlug]/draft/captain/page.tsx
+++ b/src/app/[seasonSlug]/draft/captain/page.tsx
@@ -1,14 +1,167 @@
-// TODO: captain pick panel — authenticated captain only, pick action, countdown
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Route } from "next";
+import type { Metadata } from "next";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasonRegistrations, seasons, teams } from "@/db/schema";
+import { CaptainDraftPanel } from "@/components/draft/CaptainDraftPanel";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getUserSession } from "@/lib/auth/session";
+import { getDraftData, type DraftTeamSlot } from "@/lib/draft/data";
+
+export const dynamic = "force-dynamic";
+
 interface DraftCaptainPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
+export async function generateMetadata({ params }: DraftCaptainPageProps): Promise<Metadata> {
+  const { seasonSlug } = await params;
+  return { title: `队长选人 · ${seasonSlug}` };
+}
+
 export default async function DraftCaptainPage({ params }: DraftCaptainPageProps) {
   const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  if (!season.hasDraft) {
+    return <UnavailableCard title={`队长选人 · ${season.name}`} message="该赛季未启用蛇形选秀。" />;
+  }
+
+  if (season.status !== "drafting") {
+    return (
+      <UnavailableCard
+        title={`队长选人 · ${season.name}`}
+        message="当前不在选秀阶段，队长面板暂不可用。"
+        href={`/${seasonSlug}/draft` as Route}
+        action="查看选秀直播间"
+      />
+    );
+  }
+
+  const session = await getUserSession();
+  if (!session) {
+    return (
+      <UnavailableCard
+        title={`队长选人 · ${season.name}`}
+        message="请先登录队长账号后再进入选人面板。"
+        href="/login"
+        action="登录"
+      />
+    );
+  }
+
+  const [captainTeam] = await db
+    .select({
+      teamId: teams.id,
+      teamName: teams.name,
+    })
+    .from(teams)
+    .innerJoin(
+      seasonRegistrations,
+      eq(teams.captainRegistrationId, seasonRegistrations.id),
+    )
+    .where(
+      and(
+        eq(teams.seasonId, season.id),
+        eq(seasonRegistrations.seasonId, season.id),
+        eq(seasonRegistrations.userId, session.userId),
+      ),
+    )
+    .limit(1);
+
+  if (!captainTeam) {
+    return (
+      <UnavailableCard
+        title={`队长选人 · ${season.name}`}
+        message="当前账号不是本赛季队长，无法操作队长选人面板。"
+        href={`/${seasonSlug}/draft` as Route}
+        action="查看选秀直播间"
+      />
+    );
+  }
+
+  const data = await getDraftData(season.id);
+  if (!data.state) {
+    return (
+      <UnavailableCard
+        title={`队长选人 · ${season.name}`}
+        message="选秀尚未启动，等待管理员开启后再操作。"
+      />
+    );
+  }
+
+  const currentTeamName =
+    data.teams.find((team) => team.teamId === data.state?.currentTeamId)?.teamName ?? null;
+  const captainTeamSlot = data.teams.find((team) => team.teamId === captainTeam.teamId);
+  const positionCounts = computePositionCounts(captainTeamSlot);
+
   return (
-    <div className="container mx-auto px-4 py-16 max-w-2xl">
-      <h1 className="text-3xl font-bold mb-8">队长选人 · {seasonSlug.toUpperCase()}</h1>
-      <p className="text-[var(--text-secondary)]">队长面板加载中...</p>
-    </div>
+    <main className="container mx-auto max-w-5xl px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">队长选人 · {season.name}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          当前队长端只在轮到本队时开放选择；重复点击会通过请求 ID 幂等处理。
+        </p>
+      </div>
+
+      <CaptainDraftPanel
+        seasonId={season.id}
+        teamId={captainTeam.teamId}
+        teamName={captainTeam.teamName}
+        currentTeamName={currentTeamName}
+        currentRound={data.state.currentRound}
+        roundDeadline={data.state.roundDeadline}
+        isDraftActive={data.state.isActive}
+        isCurrentCaptainTurn={
+          data.state.isActive && data.state.currentTeamId === captainTeam.teamId
+        }
+        positionCounts={positionCounts}
+        players={data.remainingPlayers}
+        seasonPositions={season.positions}
+      />
+    </main>
   );
+}
+
+function UnavailableCard({
+  title,
+  message,
+  href,
+  action,
+}: {
+  title: string;
+  message: string;
+  href?: Route;
+  action?: string;
+}) {
+  return (
+    <main className="container mx-auto max-w-4xl px-4 py-10">
+      <Card className="p-8">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">{message}</p>
+        {href && action && (
+          <Button asChild className="mt-4" variant="secondary">
+            <Link href={href}>{action}</Link>
+          </Button>
+        )}
+      </Card>
+    </main>
+  );
+}
+
+function computePositionCounts(team: DraftTeamSlot | undefined): Record<string, number> {
+  const counts: Record<string, number> = {};
+  if (!team) return counts;
+
+  counts[team.captain.primaryPosition] = (counts[team.captain.primaryPosition] ?? 0) + 1;
+  for (const member of team.members) {
+    counts[member.primaryPosition] = (counts[member.primaryPosition] ?? 0) + 1;
+  }
+  return counts;
 }

--- a/src/app/api/cron/draft-timeout/route.ts
+++ b/src/app/api/cron/draft-timeout/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const summary = await runDraftTimeoutCron(cronSecret);
+    const summary = await runDraftTimeoutCron();
     return NextResponse.json({ ok: true, ...summary });
   } catch (e) {
     console.error("[draft-timeout-cron]", e);

--- a/src/app/api/cron/draft-timeout/route.ts
+++ b/src/app/api/cron/draft-timeout/route.ts
@@ -1,14 +1,28 @@
 import { NextResponse } from "next/server";
+import { runDraftTimeoutCron } from "@/actions/draft";
 
-// TODO: implement auto-pick logic when captain timer expires
-// 触发：Vercel Cron 每分钟一次（vercel.json 中配置）
-// 安全：通过 Authorization: Bearer ${CRON_SECRET} 验证
-// 逻辑：见 docs/draft-flow.md § Vercel Cron 超时自动 pick
-export async function GET(_request: Request) {
-  // const authHeader = _request.headers.get("authorization");
-  // if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-  //   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  // }
-  // await autoPick(...);
-  return NextResponse.json({ ok: false, error: "not implemented" }, { status: 501 });
+export async function GET(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { ok: false, error: "CRON_SECRET is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await runDraftTimeoutCron(cronSecret);
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (e) {
+    console.error("[draft-timeout-cron]", e);
+    return NextResponse.json(
+      { ok: false, error: "Draft timeout cron failed" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import React from "react";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Clock, Loader2 } from "lucide-react";
+import { pickPlayer } from "@/actions/draft";
+import { Button } from "@/components/ui/button";
+import { DraftCountdown } from "./DraftCountdown";
+import { canPickPosition } from "@/lib/draft/rules";
+import { POSITION_LABELS } from "@/lib/validators/registration";
+
+export interface CaptainDraftPlayer {
+  registrationId: string;
+  steamName: string;
+  primaryPosition: string;
+  secondaryPosition: string;
+  peakRank: string;
+  peakRating: number;
+}
+
+interface CaptainDraftPanelProps {
+  seasonId: string;
+  teamId: string;
+  teamName: string;
+  currentTeamName: string | null;
+  currentRound: number | null;
+  roundDeadline: string | null;
+  isDraftActive: boolean;
+  isCurrentCaptainTurn: boolean;
+  positionCounts: Record<string, number>;
+  players: CaptainDraftPlayer[];
+  seasonPositions: string[];
+}
+
+function positionLabel(position: string): string {
+  return POSITION_LABELS[position as keyof typeof POSITION_LABELS]?.en ?? position;
+}
+
+export function CaptainDraftPanel({
+  seasonId,
+  teamId,
+  teamName,
+  currentTeamName,
+  currentRound,
+  roundDeadline,
+  isDraftActive,
+  isCurrentCaptainTurn,
+  positionCounts,
+  players,
+  seasonPositions,
+}: CaptainDraftPanelProps) {
+  const router = useRouter();
+  const [filter, setFilter] = useState("all");
+  const [pendingRegistrationId, setPendingRegistrationId] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, CaptainDraftPlayer[]>();
+    for (const player of players) {
+      const list = map.get(player.primaryPosition) ?? [];
+      list.push(player);
+      map.set(player.primaryPosition, list);
+    }
+    return map;
+  }, [players]);
+
+  const positionOptions = useMemo(() => {
+    const ordered = [...seasonPositions];
+    for (const position of grouped.keys()) {
+      if (!ordered.includes(position)) ordered.push(position);
+    }
+    return ordered;
+  }, [grouped, seasonPositions]);
+
+  const visiblePlayers =
+    filter === "all"
+      ? players
+      : players.filter((player) => player.primaryPosition === filter);
+
+  const canSubmit = isDraftActive && isCurrentCaptainTurn && pendingRegistrationId === null;
+
+  async function handlePick(player: CaptainDraftPlayer) {
+    if (!canSubmit || !canPickPosition(positionCounts[player.primaryPosition] ?? 0)) return;
+
+    setPendingRegistrationId(player.registrationId);
+    setMessage(null);
+
+    const result = await pickPlayer({
+      seasonId,
+      teamId,
+      registrationId: player.registrationId,
+      clientRequestId: crypto.randomUUID(),
+    });
+
+    setPendingRegistrationId(null);
+    if (!result.success) {
+      setMessage({ type: "error", text: result.error.message });
+      return;
+    }
+
+    setMessage({
+      type: "success",
+      text: result.data.completed ? "选秀已完成" : `${player.steamName} 已加入队伍`,
+    });
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{teamName}</h2>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              {isCurrentCaptainTurn
+                ? `第 ${currentRound ?? "-"} 轮，轮到你选择`
+                : currentTeamName
+                  ? `等待 ${currentTeamName} 选择`
+                  : "等待选秀状态更新"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <Clock className="size-4 text-[var(--text-muted)]" aria-hidden="true" />
+            <DraftCountdown deadline={roundDeadline} isActive={isDraftActive} />
+          </div>
+        </div>
+
+        {message && (
+          <div
+            className={`mt-3 rounded-md border px-3 py-2 text-sm ${
+              message.type === "success"
+                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                : "border-red-500/30 bg-red-500/10 text-red-300"
+            }`}
+            role="status"
+          >
+            {message.text}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant={filter === "all" ? "default" : "secondary"}
+            onClick={() => setFilter("all")}
+          >
+            全部 {players.length}
+          </Button>
+          {positionOptions.map((position) => {
+            const count = grouped.get(position)?.length ?? 0;
+            const teamCount = positionCounts[position] ?? 0;
+            return (
+              <Button
+                key={position}
+                type="button"
+                size="sm"
+                variant={filter === position ? "default" : "secondary"}
+                disabled={count === 0}
+                onClick={() => setFilter(filter === position ? "all" : position)}
+              >
+                {positionLabel(position)} {teamCount}/2 · {count}
+              </Button>
+            );
+          })}
+        </div>
+
+        {visiblePlayers.length === 0 ? (
+          <div className="py-12 text-center text-sm text-[var(--text-muted)]">
+            当前筛选下没有可选选手
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+            {visiblePlayers.map((player) => {
+              const positionCount = positionCounts[player.primaryPosition] ?? 0;
+              const positionOpen = canPickPosition(positionCount);
+              const isPending = pendingRegistrationId === player.registrationId;
+              const disabled = !canSubmit || !positionOpen || isPending;
+              const buttonLabel = positionOpen ? `选择 ${player.steamName}` : `${player.steamName} 已达上限`;
+
+              return (
+                <div
+                  key={player.registrationId}
+                  className="flex min-h-20 items-center justify-between gap-3 rounded-md border border-[var(--border)] bg-[var(--bg-overlay)] px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-[var(--text-primary)]">
+                      {player.steamName}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--text-muted)]">
+                      <span>{positionLabel(player.primaryPosition)}</span>
+                      <span>{player.peakRank} {player.peakRating.toFixed(2)}</span>
+                      <span>副选 {positionLabel(player.secondaryPosition)}</span>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={disabled}
+                    aria-label={buttonLabel}
+                    onClick={() => void handlePick(player)}
+                  >
+                    {isPending ? (
+                      <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                    ) : positionOpen ? (
+                      <Check className="size-4" aria-hidden="true" />
+                    ) : null}
+                    {positionOpen ? "选择" : "已达上限"}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/draft/DraftCountdown.tsx
+++ b/src/components/draft/DraftCountdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { useState, useEffect } from "react";
 
 interface DraftCountdownProps {

--- a/src/lib/draft/auto-pick.ts
+++ b/src/lib/draft/auto-pick.ts
@@ -1,0 +1,36 @@
+import { canPickPosition } from "./rules";
+
+export interface AutoPickCandidate {
+  registrationId: string;
+  primaryPosition: string;
+  peakRating: number;
+}
+
+export function selectAutoPickCandidate(
+  candidates: AutoPickCandidate[],
+  positionCounts: Record<string, number>,
+): AutoPickCandidate | null {
+  return [...candidates]
+    .sort(
+      (a, b) =>
+        b.peakRating - a.peakRating ||
+        a.registrationId.localeCompare(b.registrationId),
+    )
+    .find((candidate) =>
+      canPickPosition(positionCounts[candidate.primaryPosition] ?? 0),
+    ) ?? null;
+}
+
+export function createAutoPickRequestId({
+  seasonId,
+  teamId,
+  round,
+  deadline,
+}: {
+  seasonId: string;
+  teamId: string;
+  round: number;
+  deadline: Date | null;
+}): string {
+  return `auto:${seasonId}:${teamId}:${round}:${deadline?.getTime() ?? "no-deadline"}`;
+}

--- a/src/lib/draft/rules.ts
+++ b/src/lib/draft/rules.ts
@@ -3,6 +3,8 @@ import {
   DRAFT_TEAMS,
 } from "@/types/draft";
 
+export const DRAFT_POSITION_LIMIT_PER_TEAM = 2;
+
 export interface DraftTeamOrder {
   id: string;
   draftOrder: number;
@@ -77,4 +79,22 @@ export function computeTeamPositionCounts(
     teamMap.set(m.primaryPosition, (teamMap.get(m.primaryPosition) ?? 0) + 1);
   }
   return byTeam;
+}
+
+/**
+ * Round 1-4 是首发 pick；Round 5-6 是替补 pick。
+ * 队长在 confirmCaptains 时已作为首发写入 team_members。
+ */
+export function isStarterRound(round: number): boolean {
+  return round >= 1 && round <= 4;
+}
+
+/**
+ * 每队同一主选位置最多 2 人，包含队长本人。
+ */
+export function canPickPosition(
+  currentCount: number,
+  limit = DRAFT_POSITION_LIMIT_PER_TEAM,
+): boolean {
+  return currentCount < limit;
 }

--- a/src/lib/validators/draft.ts
+++ b/src/lib/validators/draft.ts
@@ -23,8 +23,13 @@ export const autoPickSchema = z.object({
   seasonId: z.string().uuid("赛季 ID 格式不正确"),
 });
 
+export const skipDraftTurnSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
+
 export type StartDraftInput = z.infer<typeof startDraftSchema>;
 export type PauseDraftInput = z.infer<typeof pauseDraftSchema>;
 export type ResumeDraftInput = z.infer<typeof resumeDraftSchema>;
 export type PickPlayerInput = z.infer<typeof pickPlayerSchema>;
 export type AutoPickInput = z.infer<typeof autoPickSchema>;
+export type SkipDraftTurnInput = z.infer<typeof skipDraftTurnSchema>;

--- a/src/lib/validators/draft.ts
+++ b/src/lib/validators/draft.ts
@@ -12,6 +12,19 @@ export const resumeDraftSchema = z.object({
   seasonId: z.string().uuid("赛季 ID 格式不正确"),
 });
 
+export const pickPlayerSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  teamId: z.string().uuid("队伍 ID 格式不正确"),
+  registrationId: z.string().uuid("报名 ID 格式不正确"),
+  clientRequestId: z.string().uuid("请求 ID 格式不正确"),
+});
+
+export const autoPickSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+});
+
 export type StartDraftInput = z.infer<typeof startDraftSchema>;
 export type PauseDraftInput = z.infer<typeof pauseDraftSchema>;
 export type ResumeDraftInput = z.infer<typeof resumeDraftSchema>;
+export type PickPlayerInput = z.infer<typeof pickPlayerSchema>;
+export type AutoPickInput = z.infer<typeof autoPickSchema>;

--- a/tests/unit/api/draft-timeout-route.test.ts
+++ b/tests/unit/api/draft-timeout-route.test.ts
@@ -33,6 +33,6 @@ describe("draft timeout cron route", () => {
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ ok: true, processed: 1, picked: 1, skipped: 0 });
-    expect(runDraftTimeoutCronMock).toHaveBeenCalledWith("secret");
+    expect(runDraftTimeoutCronMock).toHaveBeenCalledWith();
   });
 });

--- a/tests/unit/api/draft-timeout-route.test.ts
+++ b/tests/unit/api/draft-timeout-route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runDraftTimeoutCronMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/actions/draft", () => ({
+  runDraftTimeoutCron: runDraftTimeoutCronMock,
+}));
+
+import { GET } from "@/app/api/cron/draft-timeout/route";
+
+describe("draft timeout cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "secret";
+  });
+
+  it("rejects requests without the cron bearer token", async () => {
+    const response = await GET(new Request("http://localhost/api/cron/draft-timeout"));
+
+    expect(response.status).toBe(401);
+    expect(runDraftTimeoutCronMock).not.toHaveBeenCalled();
+  });
+
+  it("runs auto pick when authorized", async () => {
+    runDraftTimeoutCronMock.mockResolvedValue({ processed: 1, picked: 1, skipped: 0 });
+
+    const response = await GET(
+      new Request("http://localhost/api/cron/draft-timeout", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true, processed: 1, picked: 1, skipped: 0 });
+    expect(runDraftTimeoutCronMock).toHaveBeenCalledWith("secret");
+  });
+});

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CaptainDraftPanel } from "@/components/draft/CaptainDraftPanel";
+import { pickPlayer } from "@/actions/draft";
+
+const refreshMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock }),
+}));
+
+vi.mock("@/actions/draft", () => ({
+  pickPlayer: vi.fn(),
+}));
+
+const pickPlayerMock = vi.mocked(pickPlayer);
+
+const baseProps = {
+  seasonId: "11111111-1111-4111-8111-111111111111",
+  teamId: "22222222-2222-4222-8222-222222222222",
+  teamName: "Alpha 队",
+  currentTeamName: "Alpha 队",
+  currentRound: 2,
+  roundDeadline: "2026-05-11T12:03:00.000Z",
+  isDraftActive: true,
+  isCurrentCaptainTurn: true,
+  positionCounts: { igl: 1 },
+  players: [
+    {
+      registrationId: "33333333-3333-4333-8333-333333333333",
+      steamName: "Neo",
+      primaryPosition: "igl",
+      secondaryPosition: "anchor",
+      peakRank: "S",
+      peakRating: 2.01,
+    },
+  ],
+  seasonPositions: ["igl", "anchor"],
+};
+
+describe("CaptainDraftPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pickPlayerMock.mockResolvedValue({
+      success: true,
+      data: { pickId: "pick-1", idempotent: false, completed: false },
+    });
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+      "44444444-4444-4444-8444-444444444444",
+    );
+  });
+
+  it("calls pickPlayer with a generated idempotency key when captain selects a player", async () => {
+    const user = userEvent.setup();
+    render(<CaptainDraftPanel {...baseProps} />);
+
+    await user.click(screen.getByRole("button", { name: /选择 Neo/ }));
+
+    expect(pickPlayerMock).toHaveBeenCalledWith({
+      seasonId: baseProps.seasonId,
+      teamId: baseProps.teamId,
+      registrationId: baseProps.players[0].registrationId,
+      clientRequestId: "44444444-4444-4444-8444-444444444444",
+    });
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it("disables players whose primary position already reached the team cap", () => {
+    render(<CaptainDraftPanel {...baseProps} positionCounts={{ igl: 2 }} />);
+
+    const button = screen.getByRole("button", { name: /Neo 已达上限/ });
+
+    expect(button).toBeDisabled();
+    expect(pickPlayerMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/draft-auto-pick.test.ts
+++ b/tests/unit/lib/draft-auto-pick.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { selectAutoPickCandidate } from "@/lib/draft/auto-pick";
+
+const candidates = [
+  {
+    registrationId: "awp-high",
+    primaryPosition: "awper",
+    peakRating: 2.3,
+  },
+  {
+    registrationId: "igl-best-open-position",
+    primaryPosition: "igl",
+    peakRating: 2.1,
+  },
+  {
+    registrationId: "anchor-low",
+    primaryPosition: "anchor",
+    peakRating: 1.6,
+  },
+];
+
+describe("selectAutoPickCandidate", () => {
+  it("selects the highest rated eligible player while skipping capped positions", () => {
+    const selected = selectAutoPickCandidate(candidates, { awper: 2, igl: 1 });
+
+    expect(selected?.registrationId).toBe("igl-best-open-position");
+  });
+
+  it("returns null when every remaining player is position capped", () => {
+    const selected = selectAutoPickCandidate(candidates, {
+      awper: 2,
+      igl: 2,
+      anchor: 2,
+    });
+
+    expect(selected).toBeNull();
+  });
+});

--- a/tests/unit/lib/draft-rules.test.ts
+++ b/tests/unit/lib/draft-rules.test.ts
@@ -4,6 +4,8 @@ import {
   getNextTeamId,
   isDraftComplete,
   computeTeamPositionCounts,
+  canPickPosition,
+  isStarterRound,
 } from "@/lib/draft/rules";
 
 function team(id: string, draftOrder: number) {
@@ -116,5 +118,29 @@ describe("computeTeamPositionCounts", () => {
   it("returns empty map for no members", () => {
     const result = computeTeamPositionCounts([]);
     expect(result.size).toBe(0);
+  });
+});
+
+describe("isStarterRound", () => {
+  it("marks rounds 1-4 as starters", () => {
+    expect(isStarterRound(1)).toBe(true);
+    expect(isStarterRound(4)).toBe(true);
+  });
+
+  it("marks rounds 5-6 as substitutes", () => {
+    expect(isStarterRound(5)).toBe(false);
+    expect(isStarterRound(6)).toBe(false);
+  });
+});
+
+describe("canPickPosition", () => {
+  it("allows a position while the team has fewer than two players there", () => {
+    expect(canPickPosition(0)).toBe(true);
+    expect(canPickPosition(1)).toBe(true);
+  });
+
+  it("rejects a position once the team already has two players there", () => {
+    expect(canPickPosition(2)).toBe(false);
+    expect(canPickPosition(3)).toBe(false);
   });
 });

--- a/tests/unit/lib/draft-validator.test.ts
+++ b/tests/unit/lib/draft-validator.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { pickPlayerSchema } from "@/lib/validators/draft";
+
+const uuid = "11111111-1111-4111-8111-111111111111";
+
+describe("pickPlayerSchema", () => {
+  it("accepts the required pick identifiers", () => {
+    const parsed = pickPlayerSchema.safeParse({
+      seasonId: uuid,
+      teamId: "22222222-2222-4222-8222-222222222222",
+      registrationId: "33333333-3333-4333-8333-333333333333",
+      clientRequestId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects missing or malformed ids", () => {
+    const parsed = pickPlayerSchema.safeParse({
+      seasonId: "bad",
+      teamId: uuid,
+      registrationId: uuid,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- 实现队长选秀面板 (`CaptainDraftPanel`)：轮次/倒计时展示、选手池、位置筛选
- `executeDraftPick` 事务：SELECT FOR UPDATE 行锁 + `client_request_id` 幂等
- 超时自动 pick：Vercel Cron → `runDraftTimeoutCron` → 按 ratings 最高自动选
- 添加 draft pick audit log，`skipDraftTurn` admin action
- 消除 `runAutoPickForSeason` 中的冗余查询

## Test plan
- [x] `CaptainDraftPanel.test.tsx`：面板渲染 + pick 按钮交互
- [x] `draft-timeout-route.test.ts`：cron route 签名匹配
- [x] `draft-auto-pick.test.ts`：自动选逻辑
- [x] `draft-validator.test.ts`：选秀 Zod schema 校验
- [x] `draft-rules.test.ts`：选秀规则更新
- [x] TypeScript type check + full test suite (201 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)