### PR TITLE
fix: strip CJK from slug auto-generation

### DIFF
--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -47,7 +47,7 @@ function emptyToNull(value: string): string | null {
 function slugFromName(name: string): string {
   if (!name) return "";
   return name
-    .replace(/[^\w\s一-鿿-]/g, "")
+    .replace(/[^\w\s-]/g, "")
     .replace(/\s+/g, "-")
     .toLowerCase()
     .replace(/-+/g, "-")


### PR DESCRIPTION
SlugFromName was keeping CJK characters in the output, producing invalid slugs like `2026-nju-rivals-春季赛`.