### PR TITLE
fix: Bracket Tactical Grid 视觉兼容

### DIFF
--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -25,6 +25,23 @@ interface BracketViewProps {
   seasonSlug?: string;
 }
 
+function bracketThemeStyle(themeColor?: string | null): React.CSSProperties {
+  return {
+    "--primary-background": "var(--color-bg)",
+    "--secondary-background": "var(--color-panel)",
+    "--match-background": "var(--color-panel-hi)",
+    "--font-color": "var(--color-fg)",
+    "--label-color": "var(--color-fg-mid)",
+    "--hint-color": "var(--color-fg-muted)",
+    "--connector-color": "var(--color-border-hi)",
+    "--border-color": "var(--color-border)",
+    "--border-hover-color": "var(--color-accent)",
+    "--border-selected-color": themeColor ?? "var(--color-accent)",
+    "--win-color": "var(--color-success)",
+    "--loss-color": "var(--color-danger)",
+  } as React.CSSProperties;
+}
+
 export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: BracketViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scriptReady, setScriptReady] = useState(false);
@@ -79,10 +96,14 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         onReady={() => setScriptReady(true)}
       />
       <div
-        style={themeColor ? ({ "--primary-color": themeColor } as React.CSSProperties) : undefined}
         className="overflow-x-auto"
       >
-        <div id="bracket-container" className="brackets-viewer" ref={containerRef} />
+        <div
+          id="bracket-container"
+          className="brackets-viewer"
+          ref={containerRef}
+          style={bracketThemeStyle(themeColor)}
+        />
       </div>
     </>
   );

--- a/tests/unit/components/matches/BracketView.test.tsx
+++ b/tests/unit/components/matches/BracketView.test.tsx
@@ -90,4 +90,19 @@ describe("BracketView", () => {
 
     expect(push).toHaveBeenCalledWith("/spring-2026/matches/match-uuid");
   });
+
+  it("overrides brackets-viewer theme variables for Tactical Grid", async () => {
+    const { BracketView } = await import("@/components/matches/BracketView");
+
+    render(<BracketView data={bracketData} themeColor="#ff6b1a" />);
+
+    const container = document.querySelector("#bracket-container") as HTMLElement;
+
+    expect(container.style.getPropertyValue("--primary-background")).toBe("var(--color-bg)");
+    expect(container.style.getPropertyValue("--secondary-background")).toBe("var(--color-panel)");
+    expect(container.style.getPropertyValue("--match-background")).toBe("var(--color-panel-hi)");
+    expect(container.style.getPropertyValue("--font-color")).toBe("var(--color-fg)");
+    expect(container.style.getPropertyValue("--connector-color")).toBe("var(--color-border-hi)");
+    expect(container.style.getPropertyValue("--border-selected-color")).toBe("#ff6b1a");
+  });
 });


### PR DESCRIPTION
## Summary
- Override brackets-viewer CSS variables with Tactical Grid tokens.
- Keep season theme color as selected bracket border/accent fallback.
- Add regression coverage for the bracket theme variables.

## Why
Issue #65 points to #63 P1: brackets-viewer still renders with its default light theme unless its CSS variables are overridden. This PR keeps the library renderer but makes its root consume RivalHub Tactical Grid colors.

## Test Plan
- `pnpm test -- tests/unit/components/matches/BracketView.test.tsx` (267 passed, 6 skipped)
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

Closes #63
Refs #65