### PR TITLE
[phase-4] 报名时间控制与草稿流程

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -38,8 +38,18 @@ erDiagram
     int starter_count
     text[] positions "该赛季可用位置列表"
     json bracket_data "brackets-manager state"
-    timestamp start_at
-    timestamp end_at
+    timestamp start_at "报名提交开放时间"
+    timestamp registration_deadline "报名提交截止时间"
+    timestamp end_at "赛季结束时间"
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  registration_drafts {
+    uuid id PK
+    uuid season_id FK
+    text email
+    json payload "未校验表单快照"
     timestamp created_at
     timestamp updated_at
   }
@@ -347,6 +357,7 @@ erDiagram
 |---|---|
 | `users` | `UNIQUE(email)`, `UNIQUE(auth_id)` |
 | `seasons` | `UNIQUE(slug)` |
+| `registration_drafts` | `UNIQUE(season_id, email)` |
 | `season_registrations` | `UNIQUE(user_id, season_id)` |
 | `captain_votes` | `UNIQUE(voter_registration_id, candidate_registration_id)` |
 | `draft_state` | `UNIQUE(season_id)` |
@@ -360,6 +371,7 @@ erDiagram
 建议索引（`drizzle-kit` 迁移中添加）：
 - `season_registrations(season_id, status)` — 审核列表过滤
 - `season_registrations(season_id, primary_position)` — 位置计数
+- `registration_drafts(season_id, email)` — 草稿找回
 - `captain_votes(candidate_registration_id)` — 票数聚合
 - `draft_picks(season_id, round, pick_number)` — 选秀顺序查询
 - `matches(season_id, status)` — 赛程过滤

--- a/docs/registration-flow.md
+++ b/docs/registration-flow.md
@@ -7,13 +7,20 @@
   ↓
 检查赛季状态是否为 registration（Server Component fetch）
   ├── 否（已截止 / 未开放） → 显示"报名未开放"提示
-  └── 是 → 渲染报名表单
+  └── 是 → 渲染报名表单（赛季发布后可见）
+        ↓
+        根据时间窗口计算操作权限：
+          - now < startAt：可保存草稿，不可正式提交
+          - startAt <= now < registrationDeadline：可保存草稿，可正式提交
+          - now >= registrationDeadline：草稿和提交均关闭
         ↓
         展示各位置已报名人数（页面加载时静态渲染，提交后服务端二次校验）
         ↓
 用户填写表单（含 NJUBox 截图分享链接）
   ↓
-客户端 Zod 校验通过
+保存草稿：只要求 seasonId + email，写入 registration_drafts，不占名额、不进入审核
+  或
+正式提交：客户端 Zod 校验通过
   ↓
 调用 submitRegistration Server Action
   ↓
@@ -27,6 +34,30 @@
               ↓
               返回成功 → 页面跳转"报名成功"
 ```
+
+---
+
+## 时间语义
+
+- `seasons.status = registration`：赛季已发布，赛季页和报名页对外可见。
+- `seasons.startAt`：报名提交开放时间。为空时表示发布后立即可提交。
+- `seasons.registrationDeadline`：报名提交截止时间。为空时表示不设截止。
+- `seasons.endAt`：赛季结束时间，仅用于展示/归档，不控制报名窗口。
+
+报名表单在 `registration` 状态下始终可浏览。正式提交必须满足 `startAt <= now < registrationDeadline`；开始前可以保存草稿，截止后草稿保存和正式提交都关闭。
+
+---
+
+## 草稿与正式报名
+
+草稿独立存储在 `registration_drafts`：
+
+- 唯一键：`(season_id, email)`，重复保存会覆盖旧草稿。
+- `payload` 保存表单快照，不执行完整报名校验。
+- 草稿不写入 `season_registrations`，不占总人数/位置名额，不进入管理员审核。
+- 正式提交成功后删除同 `season_id + email` 的草稿。
+
+正式报名仍写入 `season_registrations(status = pending)`，并执行完整 Zod 校验、重复报名检查、总人数上限和位置上限检查。
 
 ---
 
@@ -146,6 +177,8 @@ GROUP BY primary_position;
 | 场景 | 提示 |
 |---|---|
 | 赛季不在报名阶段 | "报名通道未开放，请关注赛委会公告" |
+| 报名提交尚未开放 | "报名提交尚未开放，可以先保存草稿" |
+| 报名提交已截止 | "报名提交已截止" |
 | 位置已满 | "该位置主选名额已满，可选择其他位置报名" |
 | 已报名过 | "您已提交报名，请等待审核结果通知" |
 | 截图上传失败 | "截图上传失败，请检查网络后重试" |

--- a/drizzle/migrations/0011_registration_drafts_and_deadline.sql
+++ b/drizzle/migrations/0011_registration_drafts_and_deadline.sql
@@ -1,0 +1,11 @@
+ALTER TABLE seasons ADD COLUMN registration_deadline timestamptz;
+
+CREATE TABLE registration_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  season_id uuid NOT NULL REFERENCES seasons(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  payload json NOT NULL DEFAULT '{}'::json,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(season_id, email)
+);

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -11,22 +11,14 @@ import { actionError } from "@/lib/action-utils";
 import { buildRegistrationSchema, registrationSeedSchema, type RegistrationFormData } from "@/lib/validators/registration";
 import { normalizeRegistrationConfig } from "@/types/season";
 import { getRegistrationWindowState } from "@/lib/registration/window";
+import { normalizeEmail } from "@/lib/utils/email";
+import { compactUndefined } from "@/lib/utils/object";
 
 const draftSchema = z.object({
   seasonId: z.string().uuid("赛季 ID 格式不正确"),
   email: z.string().email("请先填写有效邮箱"),
   payload: z.record(z.unknown()).default({}),
 });
-
-function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase();
-}
-
-function sanitizeDraftPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(payload).filter(([, value]) => value !== undefined),
-  );
-}
 
 export async function saveRegistrationDraft(input: unknown) {
   const parsed = draftSchema.safeParse(input);
@@ -55,7 +47,7 @@ export async function saveRegistrationDraft(input: unknown) {
 
     const email = normalizeEmail(parsed.data.email);
     const payload = {
-      ...sanitizeDraftPayload(parsed.data.payload),
+      ...(compactUndefined(parsed.data.payload) as Record<string, unknown>),
       seasonId: parsed.data.seasonId,
       email,
     };
@@ -89,6 +81,18 @@ export async function loadRegistrationDraft(seasonId: string, email: string) {
   }
 
   try {
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, parsed.data.seasonId),
+    });
+    if (!season) {
+      throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    }
+
+    const windowState = getRegistrationWindowState(season);
+    if (!windowState.canSaveDraft && !windowState.canSubmit) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+    }
+
     const draft = await db.query.registrationDrafts.findFirst({
       where: and(
         eq(registrationDrafts.seasonId, parsed.data.seasonId),
@@ -135,9 +139,6 @@ export async function submitRegistration(input: RegistrationFormData) {
     });
     if (!season) {
       throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
-    }
-    if (season.status !== "registration") {
-      throw new AppError(ErrorCode.REGISTRATION_CLOSED, ERROR_MESSAGES.REGISTRATION_CLOSED);
     }
     const windowState = getRegistrationWindowState(season);
     if (!windowState.canSubmit) {

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -2,13 +2,105 @@
 
 import { revalidatePath } from "next/cache";
 import { eq, and, count } from "drizzle-orm";
+import { z } from "zod";
 import { db } from "@/db/client";
-import { users, seasons, seasonRegistrations } from "@/db/schema";
+import { users, seasons, seasonRegistrations, registrationDrafts } from "@/db/schema";
 import { ok, fail } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { actionError } from "@/lib/action-utils";
 import { buildRegistrationSchema, registrationSeedSchema, type RegistrationFormData } from "@/lib/validators/registration";
 import { normalizeRegistrationConfig } from "@/types/season";
+import { getRegistrationWindowState } from "@/lib/registration/window";
+
+const draftSchema = z.object({
+  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  email: z.string().email("请先填写有效邮箱"),
+  payload: z.record(z.unknown()).default({}),
+});
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function sanitizeDraftPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined),
+  );
+}
+
+export async function saveRegistrationDraft(input: unknown) {
+  const parsed = draftSchema.safeParse(input);
+  if (!parsed.success) {
+    return fail({
+      code: ErrorCode.VALIDATION_FAILED,
+      message: "草稿保存失败，请先填写有效邮箱",
+      fieldErrors: Object.fromEntries(
+        parsed.error.issues.map((issue) => [issue.path.join("."), issue.message]),
+      ),
+    });
+  }
+
+  try {
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, parsed.data.seasonId),
+    });
+    if (!season) {
+      throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
+    }
+
+    const windowState = getRegistrationWindowState(season);
+    if (!windowState.canSaveDraft) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+    }
+
+    const email = normalizeEmail(parsed.data.email);
+    const payload = {
+      ...sanitizeDraftPayload(parsed.data.payload),
+      seasonId: parsed.data.seasonId,
+      email,
+    };
+
+    await db
+      .insert(registrationDrafts)
+      .values({
+        seasonId: parsed.data.seasonId,
+        email,
+        payload,
+      })
+      .onConflictDoUpdate({
+        target: [registrationDrafts.seasonId, registrationDrafts.email],
+        set: { payload, updatedAt: new Date() },
+      });
+
+    revalidatePath(`/${season.slug}/register`);
+    return ok({ email });
+  } catch (e) {
+    return actionError("saveRegistrationDraft", e);
+  }
+}
+
+export async function loadRegistrationDraft(seasonId: string, email: string) {
+  const parsed = draftSchema.pick({ seasonId: true, email: true }).safeParse({ seasonId, email });
+  if (!parsed.success) {
+    return fail({
+      code: ErrorCode.VALIDATION_FAILED,
+      message: "请输入有效邮箱后再加载草稿",
+    });
+  }
+
+  try {
+    const draft = await db.query.registrationDrafts.findFirst({
+      where: and(
+        eq(registrationDrafts.seasonId, parsed.data.seasonId),
+        eq(registrationDrafts.email, normalizeEmail(parsed.data.email)),
+      ),
+    });
+
+    return ok({ payload: draft?.payload ?? null });
+  } catch (e) {
+    return actionError("loadRegistrationDraft", e);
+  }
+}
 
 /**
  * 提交报名
@@ -47,6 +139,10 @@ export async function submitRegistration(input: RegistrationFormData) {
     if (season.status !== "registration") {
       throw new AppError(ErrorCode.REGISTRATION_CLOSED, ERROR_MESSAGES.REGISTRATION_CLOSED);
     }
+    const windowState = getRegistrationWindowState(season);
+    if (!windowState.canSubmit) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+    }
 
     const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
     const parsed = buildRegistrationSchema(registrationConfig, season.positions).safeParse(input);
@@ -68,7 +164,7 @@ export async function submitRegistration(input: RegistrationFormData) {
 
     // 3. Upsert 用户（含所有基础信息字段）
     let user = await db.query.users.findFirst({
-      where: eq(users.email, data.email),
+      where: eq(users.email, normalizeEmail(data.email)),
     });
     const userFields = {
       steam64: data.steam64,
@@ -82,7 +178,7 @@ export async function submitRegistration(input: RegistrationFormData) {
     if (!user) {
       const [created] = await db
         .insert(users)
-        .values({ email: data.email, ...userFields })
+        .values({ email: normalizeEmail(data.email), ...userFields })
         .returning();
       user = created;
     } else {
@@ -150,6 +246,15 @@ export async function submitRegistration(input: RegistrationFormData) {
         notes: data.notes,
       })
       .returning();
+
+    await db
+      .delete(registrationDrafts)
+      .where(
+        and(
+          eq(registrationDrafts.seasonId, data.seasonId),
+          eq(registrationDrafts.email, normalizeEmail(data.email)),
+        ),
+      );
 
     revalidatePath(`/${season.slug}/register`);
     return ok({ registrationId: registration.id, email: data.email });

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -86,17 +86,31 @@ const seasonFormBaseSchema = z.object({
   }).optional(),
 });
 
-const seasonFormSchema = seasonFormBaseSchema
-  .refine((data) => data.starterCount <= data.maxTeamSize, {
-    path: ["starterCount"],
-    message: "首发人数不能超过队伍上限",
-  })
-  .refine((data) => data.minTeamSize <= data.maxTeamSize, {
-    path: ["minTeamSize"],
-    message: "最小人数不能超过最大人数",
-  });
+const seasonFormSchema = withSeasonRefinements(seasonFormBaseSchema);
 
 export type SeasonFormInput = z.input<typeof seasonFormSchema>;
+
+function withSeasonRefinements<T extends z.ZodTypeAny>(schema: T) {
+  return schema
+    .refine((data) => data.starterCount <= data.maxTeamSize, {
+      path: ["starterCount"],
+      message: "首发人数不能超过队伍上限",
+    })
+    .refine((data) => data.minTeamSize <= data.maxTeamSize, {
+      path: ["minTeamSize"],
+      message: "最小人数不能超过最大人数",
+    })
+    .refine(
+      (data) => {
+        if (!data.startAt || !data.registrationDeadline) return true;
+        return new Date(data.registrationDeadline) > new Date(data.startAt);
+      },
+      {
+        path: ["registrationDeadline"],
+        message: "报名截止时间必须晚于报名开始时间",
+      },
+    );
+}
 
 function toDate(value: string | null): Date | null {
   if (!value) return null;
@@ -180,15 +194,9 @@ export async function createSeason(input: SeasonFormInput): Promise<ActionResult
 export async function updateSeason(input: SeasonFormInput): Promise<ActionResult<{ slug: string }>> {
   try {
     const admin = await requireSuperAdmin();
-    const updateSchema = seasonFormBaseSchema.extend({ id: z.string().uuid() })
-      .refine(
-        (data) => data.starterCount <= data.maxTeamSize,
-        { path: ["starterCount"], message: "首发人数不能超过队伍上限" },
-      )
-      .refine(
-        (data) => data.minTeamSize <= data.maxTeamSize,
-        { path: ["minTeamSize"], message: "最小人数不能超过最大人数" },
-      );
+    const updateSchema = withSeasonRefinements(
+      seasonFormBaseSchema.extend({ id: z.string().uuid() }),
+    );
     const parsed = updateSchema.safeParse(input);
     if (!parsed.success) {
       return fail({

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -59,6 +59,7 @@ const seasonFormBaseSchema = z.object({
   status: z.enum(["draft", "registration", "voting", "drafting", "playing", "finished", "archived"]).optional(),
   themeColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, "主题色需为 #RRGGBB 格式").nullable(),
   startAt: z.string().nullable(),
+  registrationDeadline: z.string().nullable(),
   endAt: z.string().nullable(),
   registrationMode: z.enum(["solo", "team"]),
   hasCaptainVoting: z.boolean(),
@@ -156,6 +157,7 @@ export async function createSeason(input: SeasonFormInput): Promise<ActionResult
         (data.teamRegistrationConfig ?? {}) as TeamRegistrationConfig,
       ),
       startAt: toDate(data.startAt),
+      registrationDeadline: toDate(data.registrationDeadline),
       endAt: toDate(data.endAt),
     }).returning({ id: seasons.id, slug: seasons.slug });
 
@@ -239,6 +241,7 @@ export async function updateSeason(input: SeasonFormInput): Promise<ActionResult
         (data.teamRegistrationConfig ?? {}) as TeamRegistrationConfig,
       ),
       startAt: toDate(data.startAt),
+      registrationDeadline: toDate(data.registrationDeadline),
       endAt: toDate(data.endAt),
       updatedAt: new Date(),
     }).where(eq(seasons.id, data.id));

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -9,13 +9,13 @@ import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
 import { StatusPill, Panel, Marker } from "@/components/rivalhub";
 
-const PHASES: { key: string; label: string; after: SeasonStatus }[] = [
-  { key: "register", label: "REGISTER", after: "registration" },
-  { key: "vote", label: "VOTE", after: "voting" },
-  { key: "draft", label: "DRAFT", after: "drafting" },
-  { key: "qualifiers", label: "REGULAR", after: "playing" },
-  { key: "playoffs", label: "PLAYOFFS", after: "finished" },
-  { key: "finals", label: "FINALS", after: "archived" },
+const ALL_PHASES = [
+  { key: "register", label: "REGISTER", after: "registration" as SeasonStatus, required: true },
+  { key: "vote", label: "VOTE", after: "voting" as SeasonStatus, required: "hasCaptainVoting" as const },
+  { key: "draft", label: "DRAFT", after: "drafting" as SeasonStatus, required: "hasDraft" as const },
+  { key: "qualifiers", label: "REGULAR", after: "playing" as SeasonStatus, required: true },
+  { key: "playoffs", label: "PLAYOFFS", after: "finished" as SeasonStatus, required: true },
+  { key: "finals", label: "FINALS", after: "archived" as SeasonStatus, required: true },
 ];
 
 interface SeasonPageProps {
@@ -30,6 +30,13 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
   });
   if (!season) notFound();
   const hasMatches = normalizeStagePlan(season.stagePlan).length > 0;
+
+  const PHASES = ALL_PHASES.filter((phase) => {
+    if (phase.required === true) return true;
+    if (phase.required === "hasCaptainVoting") return season.hasCaptainVoting;
+    if (phase.required === "hasDraft") return season.hasDraft;
+    return false;
+  });
 
   const quickLinks = [
     {

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -8,7 +8,7 @@ import { RegistrationForm } from "@/components/register/RegistrationForm";
 import { normalizeRegistrationConfig } from "@/types/season";
 import { Panel, StatusBanner, PosChip } from "@/components/rivalhub";
 import { POSITION_LABELS } from "@/lib/validators/registration";
-import { getRegistrationWindowState } from "@/lib/registration/window";
+import { getRegistrationWindowState, getWindowTone } from "@/lib/registration/window";
 import { formatCST } from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
@@ -80,7 +80,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
       {/* 位置实时容量 */}
       <div className="mb-6">
         <StatusBanner
-          tone={registrationWindow.canSubmit ? "success" : registrationWindow.phase === "closed" ? "warn" : "info"}
+          tone={getWindowTone(registrationWindow.phase, registrationWindow.canSubmit)}
           title={registrationWindow.message}
           sub={[
             season.startAt ? `报名开始：${formatCST(season.startAt)}` : "报名开始：发布后立即开放",
@@ -132,10 +132,8 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           seasonName={season.name}
           positionCounts={positionCounts}
           positions={season.positions}
-          registrationConfig={normalizeRegistrationConfig(season.registrationConfig)}
-          canSaveDraft={registrationWindow.canSaveDraft}
-          canSubmit={registrationWindow.canSubmit}
-          submitDisabledReason={registrationWindow.canSubmit ? null : registrationWindow.message}
+          registrationConfig={regConfig}
+          windowState={registrationWindow}
         />
       </Panel>
 

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -8,6 +8,8 @@ import { RegistrationForm } from "@/components/register/RegistrationForm";
 import { normalizeRegistrationConfig } from "@/types/season";
 import { Panel, StatusBanner, PosChip } from "@/components/rivalhub";
 import { POSITION_LABELS } from "@/lib/validators/registration";
+import { getRegistrationWindowState } from "@/lib/registration/window";
+import { formatCST } from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
 
@@ -59,6 +61,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   const positionCounts = await getPositionCounts(season.id);
   const regConfig = normalizeRegistrationConfig(season.registrationConfig);
   const maxPerPos = regConfig.maxPerPosition;
+  const registrationWindow = getRegistrationWindowState(season);
 
   // 位置容量数据
   const capacityEntries = season.positions.map((pos) => {
@@ -75,6 +78,17 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
       </div>
 
       {/* 位置实时容量 */}
+      <div className="mb-6">
+        <StatusBanner
+          tone={registrationWindow.canSubmit ? "success" : registrationWindow.phase === "closed" ? "warn" : "info"}
+          title={registrationWindow.message}
+          sub={[
+            season.startAt ? `报名开始：${formatCST(season.startAt)}` : "报名开始：发布后立即开放",
+            season.registrationDeadline ? `报名截止：${formatCST(season.registrationDeadline)}` : "报名截止：未设置",
+          ].join(" · ")}
+        />
+      </div>
+
       <div className="mb-6">
         <Panel label="位置实时容量">
           <div className="grid gap-2.5">
@@ -119,6 +133,9 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           positionCounts={positionCounts}
           positions={season.positions}
           registrationConfig={normalizeRegistrationConfig(season.registrationConfig)}
+          canSaveDraft={registrationWindow.canSaveDraft}
+          canSubmit={registrationWindow.canSubmit}
+          submitDisabledReason={registrationWindow.canSubmit ? null : registrationWindow.message}
         />
       </Panel>
 

--- a/src/app/admin/[seasonSlug]/settings/page.tsx
+++ b/src/app/admin/[seasonSlug]/settings/page.tsx
@@ -40,6 +40,7 @@ export default async function SeasonSettingsPage({ params }: SeasonSettingsPageP
           status: season.status,
           themeColor: season.themeColor,
           startAt: toDateTimeInput(season.startAt),
+          registrationDeadline: toDateTimeInput(season.registrationDeadline),
           endAt: toDateTimeInput(season.endAt),
           registrationMode: season.registrationMode,
           hasCaptainVoting: season.hasCaptainVoting,

--- a/src/app/admin/seasons/new/page.tsx
+++ b/src/app/admin/seasons/new/page.tsx
@@ -21,6 +21,7 @@ export default async function NewSeasonPage() {
           status: "draft",
           themeColor: "#f97316",
           startAt: null,
+          registrationDeadline: null,
           endAt: null,
           registrationMode: "team",
           hasCaptainVoting: false,

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -186,7 +186,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
       minTeamSize,
       maxTeamSize,
       starterCount,
-      positions: positionsText.split(",").map((item) => item.trim()).filter(Boolean),
+      positions: positionsText.split(",").map((item: string) => item.trim()).filter(Boolean),
       stagePlan,
       registrationConfig,
       teamRegistrationConfig: teamConfig,

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -67,6 +67,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [kind, setKind] = useState(initial?.kind ?? "Major");
   const [themeColor, setThemeColor] = useState(initial?.themeColor ?? "#f97316");
   const [startAt, setStartAt] = useState(initial?.startAt ?? "");
+  const [registrationDeadline, setRegistrationDeadline] = useState(initial?.registrationDeadline ?? "");
   const [endAt, setEndAt] = useState(initial?.endAt ?? "");
   const [registrationMode, setRegistrationMode] = useState<"solo" | "team">(
     initial?.registrationMode ?? "team",
@@ -177,6 +178,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
       kind,
       themeColor: emptyToNull(themeColor),
       startAt: emptyToNull(startAt),
+      registrationDeadline: emptyToNull(registrationDeadline),
       endAt: emptyToNull(endAt),
       registrationMode,
       hasCaptainVoting: registrationMode === "team" ? false : hasCaptainVoting,
@@ -287,11 +289,26 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
             <ThemeColorPicker value={themeColor} onChange={setThemeColor} />
           </div>
           <div>
-            <Label htmlFor="start-at">开始时间</Label>
+            <Label htmlFor="start-at">报名开始时间</Label>
             <Input id="start-at" type="datetime-local" value={startAt ?? ""} onChange={(e) => setStartAt(e.target.value)} />
+            <p className="text-xs text-muted-foreground mt-1">
+              赛季发布后页面立即可见；到此时间前只能保存草稿。
+            </p>
           </div>
           <div>
-            <Label htmlFor="end-at">结束时间</Label>
+            <Label htmlFor="registration-deadline">报名截止时间</Label>
+            <Input
+              id="registration-deadline"
+              type="datetime-local"
+              value={registrationDeadline ?? ""}
+              onChange={(e) => setRegistrationDeadline(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              截止后关闭草稿保存和正式提交。
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="end-at">赛季结束时间</Label>
             <Input id="end-at" type="datetime-local" value={endAt ?? ""} onChange={(e) => setEndAt(e.target.value)} />
           </div>
         </div>

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -18,6 +18,9 @@ import {
 import { normalizeRegistrationConfig, type RegistrationConfig, type PlayerType } from "@/types/season";
 
 import { loadRegistrationDraft, saveRegistrationDraft, submitRegistration } from "@/actions/register";
+import type { RegistrationWindowState } from "@/lib/registration/window";
+import { normalizeEmail } from "@/lib/utils/email";
+import { compactUndefined } from "@/lib/utils/object";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -36,9 +39,7 @@ interface RegistrationFormProps {
   positionCounts: Record<string, number>;
   positions: string[];
   registrationConfig: RegistrationConfig;
-  canSaveDraft: boolean;
-  canSubmit: boolean;
-  submitDisabledReason: string | null;
+  windowState: RegistrationWindowState;
 }
 
 export function RegistrationForm({
@@ -47,14 +48,14 @@ export function RegistrationForm({
   positionCounts,
   positions,
   registrationConfig: inputRegistrationConfig,
-  canSaveDraft,
-  canSubmit,
-  submitDisabledReason,
+  windowState,
 }: RegistrationFormProps) {
+  const { canSaveDraft, canSubmit, message: windowMessage } = windowState;
   const [submitted, setSubmitted] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState("");
   const [savingDraft, setSavingDraft] = useState(false);
   const [loadingDraftEmail, setLoadingDraftEmail] = useState<string | null>(null);
+  const [lastBlurredEmail, setLastBlurredEmail] = useState<string | null>(null);
   const [loadedDraftEmail, setLoadedDraftEmail] = useState<string | null>(null);
   const registrationConfig = useMemo(
     () => normalizeRegistrationConfig(inputRegistrationConfig),
@@ -86,7 +87,7 @@ export function RegistrationForm({
 
   const onSubmit = async (data: RegistrationFormData) => {
     if (!canSubmit) {
-      toast.error(submitDisabledReason ?? "报名提交暂未开放");
+      toast.error(windowMessage ?? "报名提交暂未开放");
       return;
     }
 
@@ -103,20 +104,6 @@ export function RegistrationForm({
     }
   };
 
-  const compactDraftValue = (value: unknown): unknown => {
-    if (Array.isArray(value)) return value.map(compactDraftValue);
-    if (value && typeof value === "object") {
-      return Object.fromEntries(
-        Object.entries(value as Record<string, unknown>)
-          .filter(([, item]) => item !== undefined)
-          .map(([key, item]) => [key, compactDraftValue(item)]),
-      );
-    }
-    return value;
-  };
-
-  const normalizeEmail = (email: string) => email.trim().toLowerCase();
-
   const handleSaveDraft = async () => {
     const values = getValues();
     const email = typeof values.email === "string" ? normalizeEmail(values.email) : "";
@@ -125,7 +112,7 @@ export function RegistrationForm({
       return;
     }
     if (!canSaveDraft) {
-      toast.error(submitDisabledReason ?? "草稿保存已关闭");
+      toast.error(windowMessage ?? "草稿保存已关闭");
       return;
     }
 
@@ -134,7 +121,7 @@ export function RegistrationForm({
       const result = await saveRegistrationDraft({
         seasonId,
         email,
-        payload: compactDraftValue({ ...values, seasonId, email }) as Record<string, unknown>,
+        payload: compactUndefined({ ...values, seasonId, email }) as Record<string, unknown>,
       });
       if (result.success) {
         toast.success("草稿已保存");
@@ -150,7 +137,8 @@ export function RegistrationForm({
   const emailField = register("email", {
     onBlur: async (event) => {
       const email = normalizeEmail(event.target.value);
-      if (!email || email === loadedDraftEmail) return;
+      if (!email || email === lastBlurredEmail) return;
+      setLastBlurredEmail(email);
       setLoadingDraftEmail(email);
       try {
         const result = await loadRegistrationDraft(seasonId, email);
@@ -748,7 +736,7 @@ export function RegistrationForm({
               提交中…
             </>
           ) : (
-            canSubmit ? "提交报名" : submitDisabledReason ?? "报名提交暂未开放"
+            canSubmit ? "提交报名" : windowMessage ?? "报名提交暂未开放"
           )}
         </Button>
       </div>

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/validators/registration";
 import { normalizeRegistrationConfig, type RegistrationConfig, type PlayerType } from "@/types/season";
 
-import { submitRegistration } from "@/actions/register";
+import { loadRegistrationDraft, saveRegistrationDraft, submitRegistration } from "@/actions/register";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -36,6 +36,9 @@ interface RegistrationFormProps {
   positionCounts: Record<string, number>;
   positions: string[];
   registrationConfig: RegistrationConfig;
+  canSaveDraft: boolean;
+  canSubmit: boolean;
+  submitDisabledReason: string | null;
 }
 
 export function RegistrationForm({
@@ -44,9 +47,15 @@ export function RegistrationForm({
   positionCounts,
   positions,
   registrationConfig: inputRegistrationConfig,
+  canSaveDraft,
+  canSubmit,
+  submitDisabledReason,
 }: RegistrationFormProps) {
   const [submitted, setSubmitted] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState("");
+  const [savingDraft, setSavingDraft] = useState(false);
+  const [loadingDraftEmail, setLoadingDraftEmail] = useState<string | null>(null);
+  const [loadedDraftEmail, setLoadedDraftEmail] = useState<string | null>(null);
   const registrationConfig = useMemo(
     () => normalizeRegistrationConfig(inputRegistrationConfig),
     [inputRegistrationConfig],
@@ -60,6 +69,8 @@ export function RegistrationForm({
   const {
     register,
     handleSubmit,
+    getValues,
+    reset,
     setValue,
     watch,
     formState: { errors, isSubmitting },
@@ -74,6 +85,11 @@ export function RegistrationForm({
   });
 
   const onSubmit = async (data: RegistrationFormData) => {
+    if (!canSubmit) {
+      toast.error(submitDisabledReason ?? "报名提交暂未开放");
+      return;
+    }
+
     const result = await submitRegistration(data);
     if (result.success) {
       setSubmittedEmail(data.email);
@@ -86,6 +102,74 @@ export function RegistrationForm({
       }
     }
   };
+
+  const compactDraftValue = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(compactDraftValue);
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([, item]) => item !== undefined)
+          .map(([key, item]) => [key, compactDraftValue(item)]),
+      );
+    }
+    return value;
+  };
+
+  const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+  const handleSaveDraft = async () => {
+    const values = getValues();
+    const email = typeof values.email === "string" ? normalizeEmail(values.email) : "";
+    if (!email) {
+      toast.error("请先填写邮箱，再保存草稿");
+      return;
+    }
+    if (!canSaveDraft) {
+      toast.error(submitDisabledReason ?? "草稿保存已关闭");
+      return;
+    }
+
+    setSavingDraft(true);
+    try {
+      const result = await saveRegistrationDraft({
+        seasonId,
+        email,
+        payload: compactDraftValue({ ...values, seasonId, email }) as Record<string, unknown>,
+      });
+      if (result.success) {
+        toast.success("草稿已保存");
+        setLoadedDraftEmail(email);
+      } else {
+        toast.error(result.error.message);
+      }
+    } finally {
+      setSavingDraft(false);
+    }
+  };
+
+  const emailField = register("email", {
+    onBlur: async (event) => {
+      const email = normalizeEmail(event.target.value);
+      if (!email || email === loadedDraftEmail) return;
+      setLoadingDraftEmail(email);
+      try {
+        const result = await loadRegistrationDraft(seasonId, email);
+        if (result.success && result.data.payload) {
+          const draftValues = result.data.payload as Partial<RegistrationInput>;
+          reset({
+            ...getValues(),
+            ...draftValues,
+            seasonId,
+            email,
+          } as RegistrationInput);
+          setLoadedDraftEmail(email);
+          toast.success("已加载保存的报名草稿");
+        }
+      } finally {
+        setLoadingDraftEmail(null);
+      }
+    },
+  });
 
   // ── 提交成功页 ──
   if (submitted) {
@@ -164,9 +248,12 @@ export function RegistrationForm({
             <Label htmlFor="email" className="text-[var(--color-fg-mid)] mb-1.5 block">
               电子邮件 <Required />
             </Label>
-            <Input id="email" type="email" placeholder="your@email.com" className={inputCls} {...register("email")} />
+            <Input id="email" type="email" placeholder="your@email.com" className={inputCls} {...emailField} />
             <FieldError name="email" />
-            <p className="text-xs text-[var(--color-fg-dim)] mt-1">用于接收登录链接和审核通知</p>
+            <p className="text-xs text-[var(--color-fg-dim)] mt-1">
+              用于接收登录链接、审核通知和草稿找回
+              {loadingDraftEmail && " · 正在查询草稿…"}
+            </p>
           </div>
 
           {/* 学号 + QQ */}
@@ -631,22 +718,40 @@ export function RegistrationForm({
         <FieldError name="antiCheatPledge" />
       </section>
 
-      {/* ═══════════════════════════════════════ 提交 ═══ */}
-      <Button
-        type="submit"
-        disabled={isSubmitting}
-        className="w-full h-11 text-base font-semibold"
-        style={{ backgroundColor: "var(--color-accent)", color: "#fff" }}
-      >
-        {isSubmitting ? (
-          <>
-            <Loader2 size={16} className="animate-spin mr-2" />
-            提交中…
-          </>
-        ) : (
-          "提交报名"
-        )}
-      </Button>
+      {/* ═══════════════════════════════════════ 草稿 / 提交 ═══ */}
+      <div className="grid grid-cols-1 sm:grid-cols-[180px_1fr] gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={!canSaveDraft || savingDraft}
+          className="h-11 text-base font-semibold"
+          onClick={handleSaveDraft}
+        >
+          {savingDraft ? (
+            <>
+              <Loader2 size={16} className="animate-spin mr-2" />
+              保存中…
+            </>
+          ) : (
+            "保存草稿"
+          )}
+        </Button>
+        <Button
+          type="submit"
+          disabled={!canSubmit || isSubmitting}
+          className="h-11 text-base font-semibold"
+          style={{ backgroundColor: canSubmit ? "var(--color-accent)" : "var(--color-panel-hi)", color: "#fff" }}
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 size={16} className="animate-spin mr-2" />
+              提交中…
+            </>
+          ) : (
+            canSubmit ? "提交报名" : submitDisabledReason ?? "报名提交暂未开放"
+          )}
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./users";
 export * from "./seasons";
 export * from "./registrations";
+export * from "./registration-drafts";
 export * from "./teams";
 export * from "./votes";
 export * from "./draft";

--- a/src/db/schema/registration-drafts.ts
+++ b/src/db/schema/registration-drafts.ts
@@ -1,0 +1,24 @@
+import { pgTable, uuid, text, timestamp, json, unique } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { seasons } from "./seasons";
+
+export const registrationDrafts = pgTable(
+  "registration_drafts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    seasonId: uuid("season_id").notNull().references(() => seasons.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    payload: json("payload")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::json`),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniqueSeasonEmail: unique().on(t.seasonId, t.email),
+  }),
+);
+
+export type RegistrationDraft = typeof registrationDrafts.$inferSelect;
+export type NewRegistrationDraft = typeof registrationDrafts.$inferInsert;

--- a/src/db/schema/seasons.ts
+++ b/src/db/schema/seasons.ts
@@ -58,6 +58,7 @@ export const seasons = pgTable("seasons", {
   bracketData: json("bracket_data").$type<Database>(),
 
   startAt: timestamp("start_at", { withTimezone: true }),
+  registrationDeadline: timestamp("registration_deadline", { withTimezone: true }),
   endAt: timestamp("end_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/lib/registration/window.ts
+++ b/src/lib/registration/window.ts
@@ -27,6 +27,12 @@ function toTime(value: Date | string | null): number | null {
   return Number.isNaN(time) ? null : time;
 }
 
+export function getWindowTone(phase: RegistrationWindowPhase, canSubmit: boolean): "success" | "warn" | "info" {
+  if (canSubmit) return "success";
+  if (phase === "closed") return "warn";
+  return "info";
+}
+
 export function getRegistrationWindowState(
   season: RegistrationWindowSeason,
   now: Date = new Date(),

--- a/src/lib/registration/window.ts
+++ b/src/lib/registration/window.ts
@@ -1,0 +1,75 @@
+import type { SeasonStatus } from "@/types/season";
+
+type RegistrationWindowSeason = {
+  status: SeasonStatus;
+  startAt: Date | string | null;
+  registrationDeadline: Date | string | null;
+};
+
+export type RegistrationWindowPhase =
+  | "hidden"
+  | "upcoming"
+  | "open"
+  | "closed";
+
+export interface RegistrationWindowState {
+  phase: RegistrationWindowPhase;
+  canViewForm: boolean;
+  canSaveDraft: boolean;
+  canSubmit: boolean;
+  message: string;
+}
+
+function toTime(value: Date | string | null): number | null {
+  if (!value) return null;
+  const date = typeof value === "string" ? new Date(value) : value;
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+export function getRegistrationWindowState(
+  season: RegistrationWindowSeason,
+  now: Date = new Date(),
+): RegistrationWindowState {
+  if (season.status !== "registration") {
+    return {
+      phase: "hidden",
+      canViewForm: false,
+      canSaveDraft: false,
+      canSubmit: false,
+      message: "报名通道当前不可用。",
+    };
+  }
+
+  const nowTime = now.getTime();
+  const startTime = toTime(season.startAt);
+  const deadlineTime = toTime(season.registrationDeadline);
+
+  if (deadlineTime !== null && nowTime >= deadlineTime) {
+    return {
+      phase: "closed",
+      canViewForm: true,
+      canSaveDraft: false,
+      canSubmit: false,
+      message: "报名提交已截止。",
+    };
+  }
+
+  if (startTime !== null && nowTime < startTime) {
+    return {
+      phase: "upcoming",
+      canViewForm: true,
+      canSaveDraft: true,
+      canSubmit: false,
+      message: "报名提交尚未开放，可以先保存草稿。",
+    };
+  }
+
+  return {
+    phase: "open",
+    canViewForm: true,
+    canSaveDraft: true,
+    canSubmit: true,
+    message: "报名提交已开放。",
+  };
+}

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -1,0 +1,3 @@
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}

--- a/src/lib/utils/object.ts
+++ b/src/lib/utils/object.ts
@@ -1,0 +1,11 @@
+export function compactUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(compactUndefined);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, compactUndefined(v)]),
+    );
+  }
+  return value;
+}

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -130,7 +130,11 @@ export interface Season extends SeasonCapabilities {
   kind: SeasonKind;
   status: SeasonStatus;
   themeColor: string | null;
+  /** 报名提交开放时间；赛季发布后页面可见，但 now < startAt 时只能保存草稿。 */
   startAt: Date | null;
+  /** 报名提交截止时间；超过后草稿和提交都关闭。 */
+  registrationDeadline: Date | null;
+  /** 赛季结束时间，仅用于展示/归档，不控制报名窗口。 */
   endAt: Date | null;
   createdAt: Date;
   updatedAt: Date;

--- a/tests/unit/lib/registration-window.test.ts
+++ b/tests/unit/lib/registration-window.test.ts
@@ -50,4 +50,38 @@ describe("getRegistrationWindowState", () => {
     expect(state.phase).toBe("hidden");
     expect(state.canViewForm).toBe(false);
   });
+
+  it("opens immediately when startAt is null", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: null,
+      registrationDeadline: "2026-05-14T12:00:00.000Z",
+    }, now);
+
+    expect(state.phase).toBe("open");
+    expect(state.canSubmit).toBe(true);
+  });
+
+  it("never closes when registrationDeadline is null", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: "2026-05-11T12:00:00.000Z",
+      registrationDeadline: null,
+    }, now);
+
+    expect(state.phase).toBe("open");
+    expect(state.canSubmit).toBe(true);
+  });
+
+  it("opens immediately and never closes when both null", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: null,
+      registrationDeadline: null,
+    }, now);
+
+    expect(state.phase).toBe("open");
+    expect(state.canSaveDraft).toBe(true);
+    expect(state.canSubmit).toBe(true);
+  });
 });

--- a/tests/unit/lib/registration-window.test.ts
+++ b/tests/unit/lib/registration-window.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getRegistrationWindowState } from "@/lib/registration/window";
+
+const now = new Date("2026-05-12T12:00:00.000Z");
+
+describe("getRegistrationWindowState", () => {
+  it("allows draft but blocks submit before startAt", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: "2026-05-13T12:00:00.000Z",
+      registrationDeadline: "2026-05-14T12:00:00.000Z",
+    }, now);
+
+    expect(state.phase).toBe("upcoming");
+    expect(state.canViewForm).toBe(true);
+    expect(state.canSaveDraft).toBe(true);
+    expect(state.canSubmit).toBe(false);
+  });
+
+  it("allows submit after startAt and before deadline", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: "2026-05-11T12:00:00.000Z",
+      registrationDeadline: "2026-05-14T12:00:00.000Z",
+    }, now);
+
+    expect(state.phase).toBe("open");
+    expect(state.canSubmit).toBe(true);
+  });
+
+  it("closes draft and submit at registrationDeadline", () => {
+    const state = getRegistrationWindowState({
+      status: "registration",
+      startAt: "2026-05-11T12:00:00.000Z",
+      registrationDeadline: "2026-05-12T12:00:00.000Z",
+    }, now);
+
+    expect(state.phase).toBe("closed");
+    expect(state.canSaveDraft).toBe(false);
+    expect(state.canSubmit).toBe(false);
+  });
+
+  it("hides form outside registration status", () => {
+    const state = getRegistrationWindowState({
+      status: "draft",
+      startAt: null,
+      registrationDeadline: null,
+    }, now);
+
+    expect(state.phase).toBe("hidden");
+    expect(state.canViewForm).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Define registration window semantics: `startAt` controls submit opening, new `registrationDeadline` controls close, `endAt` stays season-level.
- Add server-side `registration_drafts` storage keyed by season + email, with save/load actions that do not occupy registration capacity.
- Add register-page status banner, draft/save dual actions, and submit-time server enforcement.
- Update registration/data-model docs and add window-state unit coverage.

## Why
Closes #60. Published seasons should be visible before registration opens, while formal submission remains time-gated. Drafts need to be separate from `season_registrations` so they do not enter review or lock capacity.

## Test Plan
- `pnpm test`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`