### PR TITLE
feat: 容量口径修正 + 报名自动推进 + 后台导航补全

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: Cron — Draft Timeout
+name: Cron
 
 on:
   schedule:
@@ -9,7 +9,13 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Draft timeout
+        run: |
           curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             "https://match.starfie1d.top/api/cron/draft-timeout"
+      - name: Check registration deadline
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://match.starfie1d.top/api/cron/check-registration-deadline"

--- a/docs/superpowers/plans/2026-05-13-admin-ux-auto-advance.md
+++ b/docs/superpowers/plans/2026-05-13-admin-ux-auto-advance.md
@@ -1,0 +1,640 @@
+# 管理后台 UX 补全 + 报名自动推进 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修正报名容量口径（位置=提交数，Total=通过数）、实现审批满/截止自动推进 registration→voting、补全管理后台赛季子页导航
+
+**Architecture:** 三个独立模块，互不阻塞。模块一改 register.ts + page.tsx；模块二新建 transitions.ts + cron route + 嵌入 admin.ts；模块三新建 SeasonSubNav 组件 + 微调 layout 和 sidebar
+
+**Tech Stack:** Next.js 15 App Router, Drizzle ORM, TypeScript strict, Vercel Cron
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 操作 |
+|---|---|---|
+| `src/actions/register.ts` | 加 `getApprovedCount()`；`submitRegistration` maxTotal 检查改为仅统计 approved | 修改 |
+| `src/app/[seasonSlug]/register/page.tsx` | Total 行改用 `getApprovedCount()`，标签改 `Approved` | 修改 |
+| `src/actions/transitions.ts` | `maybeAdvanceFromRegistration(tx, seasonId)` — 唯一推进逻辑 | 新建 |
+| `src/actions/admin.ts` | `reviewRegistration` 审批通过后调用 `maybeAdvanceFromRegistration` | 修改 |
+| `src/app/api/cron/check-registration-deadline/route.ts` | Cron endpoint：每分钟检查过期，调用推进逻辑 | 新建 |
+| `src/components/admin/SeasonSubNav.tsx` | 赛季子页顶部 tab 导航条 | 新建 |
+| `src/app/admin/[seasonSlug]/layout.tsx` | 引入 SeasonSubNav | 修改 |
+| `src/components/admin/AdminSidebar.tsx` | "概览" → "赛季管理" | 修改 |
+
+---
+
+### Task 1: 容量 — 新增 `getApprovedCount()` 并修复提交上限检查
+
+**Files:**
+- Modify: `src/actions/register.ts:203-210, 267-284`
+
+- [ ] **Step 1: 在 `submitRegistration` 中修改 maxTotal 检查为仅统计 approved**
+
+定位 `src/actions/register.ts:203-210`，将：
+
+```typescript
+// 5. 全局总报名人数上限检查
+const [totalCount] = await db
+  .select({ count: count() })
+  .from(seasonRegistrations)
+  .where(eq(seasonRegistrations.seasonId, data.seasonId));
+if (Number(totalCount?.count ?? 0) >= registrationConfig.maxTotal) {
+  throw new AppError(ErrorCode.REGISTRATION_FULL, ERROR_MESSAGES.REGISTRATION_FULL);
+}
+```
+
+改为：
+
+```typescript
+// 5. 全局总报名人数上限检查（仅统计已通过，被拒/候补不占名额）
+const [totalCount] = await db
+  .select({ count: count() })
+  .from(seasonRegistrations)
+  .where(
+    and(
+      eq(seasonRegistrations.seasonId, data.seasonId),
+      eq(seasonRegistrations.status, "approved"),
+    ),
+  );
+if (Number(totalCount?.count ?? 0) >= registrationConfig.maxTotal) {
+  throw new AppError(ErrorCode.REGISTRATION_FULL, ERROR_MESSAGES.REGISTRATION_FULL);
+}
+```
+
+`and` 已从 `drizzle-orm` 导入。
+
+- [ ] **Step 2: 新增 `getApprovedCount()` 函数**
+
+在 `getPositionCounts` 之后（`register.ts` 末尾）添加：
+
+```typescript
+/** 查询某赛季已通过审批的总人数 */
+export async function getApprovedCount(seasonId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: count() })
+    .from(seasonRegistrations)
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    );
+  return Number(row?.count ?? 0);
+}
+```
+
+- [ ] **Step 3: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/actions/register.ts
+git commit -m "fix: maxTotal 检查改为仅统计 approved，新增 getApprovedCount()"
+```
+
+---
+
+### Task 2: 容量 — 报名页 Total 行改为 `Approved: X / 56`
+
+**Files:**
+- Modify: `src/app/[seasonSlug]/register/page.tsx:61-73, 127-134`
+
+- [ ] **Step 1: 导入 `getApprovedCount` 并用其替换 Total 数据**
+
+在 `register/page.tsx:7` 的 import 行中，`getPositionCounts` 后面加 `getApprovedCount`：
+
+```typescript
+import { getPositionCounts, getApprovedCount } from "@/actions/register";
+```
+
+将 `page.tsx:61-63` 中：
+
+```typescript
+const positionCounts = await getPositionCounts(season.id);
+const regConfig = normalizeRegistrationConfig(season.registrationConfig);
+const maxPerPos = regConfig.maxPerPosition;
+```
+
+改为：
+
+```typescript
+const positionCounts = await getPositionCounts(season.id);
+const approvedCount = await getApprovedCount(season.id);
+const regConfig = normalizeRegistrationConfig(season.registrationConfig);
+const maxPerPos = regConfig.maxPerPosition;
+```
+
+删除 `page.tsx:72-73`：
+
+```typescript
+const totalApproved = capacityEntries.reduce((sum, e) => sum + e.cur, 0);
+const maxTotal = regConfig.maxTotal;
+```
+
+- [ ] **Step 2: 修改 Total 行 JSX**
+
+将 `page.tsx:127-134` 中：
+
+```typescript
+<div className="flex justify-between items-center pt-2" style={{ borderTop: "1px solid var(--color-border)" }}>
+  <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-fg-dim)", fontFamily: "var(--font-display)" }}>
+    Total
+  </span>
+  <span className="font-bold" style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-fg)" }}>
+    {totalApproved} / {maxTotal}
+  </span>
+</div>
+```
+
+改为：
+
+```typescript
+<div className="flex justify-between items-center pt-2" style={{ borderTop: "1px solid var(--color-border)" }}>
+  <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-fg-dim)", fontFamily: "var(--font-display)" }}>
+    Approved
+  </span>
+  <span className="font-bold" style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-fg)" }}>
+    {approvedCount} / {regConfig.maxTotal}
+  </span>
+</div>
+```
+
+- [ ] **Step 3: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/[seasonSlug]/register/page.tsx
+git commit -m "feat: 报名页 Total 行改为 Approved 标签，统计口径改为仅审批通过"
+```
+
+---
+
+### Task 3: 自动推进 — 新建 `src/actions/transitions.ts`
+
+**Files:**
+- Create: `src/actions/transitions.ts`
+
+- [ ] **Step 1: 创建 transitions.ts**
+
+```typescript
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, count, and } from "drizzle-orm";
+import { seasons, seasonRegistrations, auditLogs } from "@/db/schema";
+import { normalizeRegistrationConfig } from "@/types/season";
+
+type TxDb = Parameters<Parameters<typeof import("@/db/client").db.transaction>[0]>[0];
+
+async function getApprovedCountInTx(tx: TxDb, seasonId: string): Promise<number> {
+  const [row] = await tx
+    .select({ count: count() })
+    .from(seasonRegistrations)
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    );
+  return Number(row?.count ?? 0);
+}
+
+/**
+ * 如果条件满足（通过数满 / 截止过期），自动推进 registration → 下一状态。
+ * 必须在事务中调用——审批场景用外层的 tx，cron 场景自己包 transaction。
+ */
+export async function maybeAdvanceFromRegistration(
+  tx: TxDb,
+  seasonId: string,
+): Promise<void> {
+  const season = await tx.query.seasons.findFirst({
+    where: eq(seasons.id, seasonId),
+  });
+  if (!season || season.status !== "registration") return;
+
+  const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
+  const approvedCount = await getApprovedCountInTx(tx, seasonId);
+  const full = approvedCount >= registrationConfig.maxTotal;
+
+  const deadlinePassed =
+    season.registrationDeadline != null &&
+    new Date(season.registrationDeadline).getTime() <= Date.now();
+
+  if (!full && !deadlinePassed) return;
+
+  // 无队长投票的赛季直接跳到 playing
+  const nextStatus = season.hasCaptainVoting ? ("voting" as const) : ("playing" as const);
+
+  await tx
+    .update(seasons)
+    .set({ status: nextStatus, updatedAt: new Date() })
+    .where(eq(seasons.id, seasonId));
+
+  await tx.insert(auditLogs).values({
+    seasonId,
+    action: "season.auto_advance",
+    actorId: "system",
+    targetId: seasonId,
+    targetType: "season",
+    meta: {
+      from: "registration",
+      to: nextStatus,
+      reason: full ? "capacity_reached" : "deadline_passed",
+      approvedCount,
+      maxTotal: registrationConfig.maxTotal,
+      deadline: season.registrationDeadline?.toISOString() ?? null,
+    },
+  });
+
+  revalidatePath(`/${season.slug}`);
+  revalidatePath(`/admin/${season.slug}/registrations`);
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/actions/transitions.ts
+git commit -m "feat: 新增 maybeAdvanceFromRegistration 自动推进逻辑"
+```
+
+---
+
+### Task 4: 自动推进 — 审批通过后触发
+
+**Files:**
+- Modify: `src/actions/admin.ts:197-216`
+
+- [ ] **Step 1: 在 reviewRegistration 事务内调用 maybeAdvanceFromRegistration**
+
+在 `admin.ts` 顶部加 import：
+
+```typescript
+import { maybeAdvanceFromRegistration } from "@/actions/transitions";
+```
+
+在 `reviewRegistration` 的事务内，audit_log insert 之后、事务结束之前（`admin.ts:215` 之后）添加：
+
+```typescript
+      // 审批通过后检查是否满足自动推进条件
+      if (targetStatus === "approved") {
+        await maybeAdvanceFromRegistration(tx, reg.seasonId);
+      }
+```
+
+完整上下文——`src/actions/admin.ts:215` 的 `});` 之前插入，即 audit_logs insert 后：
+
+```typescript
+      await tx.insert(auditLogs).values({
+        seasonId: reg.seasonId,
+        action: `registration.${targetStatus}`,
+        // ... 保持不变
+      });
+
+      // 审批通过后检查是否满足自动推进条件
+      if (targetStatus === "approved") {
+        await maybeAdvanceFromRegistration(tx, reg.seasonId);
+      }
+    }); // ← 事务结束
+```
+
+- [ ] **Step 2: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/actions/admin.ts
+git commit -m "feat: 审批通过后自动检查并推进赛季状态"
+```
+
+---
+
+### Task 5: 自动推进 — Cron 定时检查截止时间
+
+**Files:**
+- Create: `src/app/api/cron/check-registration-deadline/route.ts`
+
+- [ ] **Step 1: 创建 cron route**
+
+```typescript
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { maybeAdvanceFromRegistration } from "@/actions/transitions";
+
+// Vercel Cron 每分钟触发
+// 安全：Authorization: Bearer ${CRON_SECRET}
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const activeSeasons = await db
+    .select({ id: seasons.id })
+    .from(seasons)
+    .where(eq(seasons.status, "registration"));
+
+  let advanced = 0;
+  let skipped = 0;
+
+  for (const s of activeSeasons) {
+    await db.transaction(async (tx) => {
+      // maybeAdvanceFromRegistration 内部做二次检查（status + 条件）
+      await maybeAdvanceFromRegistration(tx, s.id);
+    });
+    advanced++;
+  }
+
+  skipped = activeSeasons.length - advanced;
+
+  return NextResponse.json({ ok: true, advanced, skipped });
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/cron/check-registration-deadline/route.ts
+git commit -m "feat: 新增 cron endpoint 检查报名截止自动推进"
+```
+
+部署后需在 Vercel Dashboard → Settings → Cron Jobs 添加：
+- Schedule: `* * * * *`（每分钟）
+- Path: `/api/cron/check-registration-deadline`
+
+---
+
+### Task 6: 后台导航 — 新建 SeasonSubNav 组件
+
+**Files:**
+- Create: `src/components/admin/SeasonSubNav.tsx`
+
+- [ ] **Step 1: 创建 SeasonSubNav 组件**
+
+```typescript
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface Tab {
+  label: string;
+  href: string;
+  show: boolean;
+}
+
+export function SeasonSubNav({
+  seasonSlug,
+  hasCaptainVoting,
+  hasDraft,
+  hasMatches,
+  showSettings,
+}: {
+  seasonSlug: string;
+  hasCaptainVoting: boolean;
+  hasDraft: boolean;
+  hasMatches: boolean;
+  showSettings: boolean;
+}) {
+  const pathname = usePathname();
+
+  const tabs: Tab[] = [
+    { label: "报名审核", href: `/admin/${seasonSlug}/registrations`, show: true },
+    { label: "队长确认", href: `/admin/${seasonSlug}/captains`, show: hasCaptainVoting },
+    { label: "选秀控制", href: `/admin/${seasonSlug}/draft`, show: hasDraft },
+    { label: "赛程管理", href: `/admin/${seasonSlug}/matches`, show: hasMatches },
+    { label: "赛季设置", href: `/admin/${seasonSlug}/settings`, show: showSettings },
+  ].filter((t) => t.show);
+
+  return (
+    <nav
+      className="flex gap-0 mb-6"
+      style={{ borderBottom: "2px solid var(--color-border)" }}
+    >
+      {tabs.map((tab) => {
+        const active = pathname === tab.href || pathname.startsWith(tab.href + "/");
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className="transition-colors"
+            style={{
+              padding: "10px 18px",
+              borderBottom: active ? "2px solid var(--color-accent)" : "2px solid transparent",
+              marginBottom: "-2px",
+              fontWeight: active ? 600 : 500,
+              fontSize: 13,
+              color: active ? "var(--color-fg)" : "var(--color-fg-mid)",
+            }}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/admin/SeasonSubNav.tsx
+git commit -m "feat: 新增 SeasonSubNav 赛季子页导航组件"
+```
+
+---
+
+### Task 7: 后台导航 — 在 season layout 中引入 SeasonSubNav
+
+**Files:**
+- Modify: `src/app/admin/[seasonSlug]/layout.tsx`
+
+- [ ] **Step 1: 扩展 layout 查询以获取 capability 字段**
+
+将 `src/app/admin/[seasonSlug]/layout.tsx:16-19` 的：
+
+```typescript
+const season = await db.query.seasons.findFirst({
+  where: eq(seasons.slug, seasonSlug),
+  columns: { id: true },
+});
+```
+
+改为：
+
+```typescript
+const season = await db.query.seasons.findFirst({
+  where: eq(seasons.slug, seasonSlug),
+  columns: {
+    id: true,
+    hasCaptainVoting: true,
+    hasDraft: true,
+    stagePlan: true,
+    status: true,
+  },
+});
+```
+
+- [ ] **Step 2: 导入 SeasonSubNav 并渲染**
+
+在 `layout.tsx` 顶部加 import：
+
+```typescript
+import { SeasonSubNav } from "@/components/admin/SeasonSubNav";
+```
+
+将 return 部分从：
+
+```typescript
+return <>{children}</>;
+```
+
+改为：
+
+```typescript
+const hasMatches = (season.stagePlan as unknown[])?.length > 0;
+const isSuperAdmin = admin.role === "super_admin";
+
+return (
+  <div className="container mx-auto px-4 py-8 max-w-6xl">
+    <SeasonSubNav
+      seasonSlug={seasonSlug}
+      hasCaptainVoting={season.hasCaptainVoting}
+      hasDraft={season.hasDraft}
+      hasMatches={hasMatches}
+      showSettings={isSuperAdmin}
+    />
+    {children}
+  </div>
+);
+```
+
+注意：`admin` 来自 `requireSeasonAdmin(season.id)` 的返回值，需要确认其类型含 `role` 字段。查看 `admin.ts:22` 可知 `admin` 包含 `{ role: "admin" | "super_admin" }`。
+
+- [ ] **Step 3: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/admin/[seasonSlug]/layout.tsx
+git commit -m "feat: 赛季管理子页引入 SeasonSubNav 导航 tabs"
+```
+
+---
+
+### Task 8: 后台导航 — 侧边栏标签修正
+
+**Files:**
+- Modify: `src/components/admin/AdminSidebar.tsx:10`
+
+- [ ] **Step 1: "概览" → "赛季管理"**
+
+将 `AdminSidebar.tsx:10` 的：
+
+```typescript
+{ href: "/admin", label: "概览" },
+```
+
+改为：
+
+```typescript
+{ href: "/admin", label: "赛季管理" },
+```
+
+路由不变（仍然是 `/admin`）。
+
+- [ ] **Step 2: 类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/admin/AdminSidebar.tsx
+git commit -m "feat: 侧边栏概览→赛季管理，标签更明确"
+```
+
+---
+
+### Task 9: 全量验证
+
+- [ ] **Step 1: 运行类型检查**
+
+```bash
+pnpm tsc --noEmit
+```
+Expected: 0 errors.
+
+- [ ] **Step 2: 运行测试**
+
+```bash
+pnpm test --run
+```
+Expected: All pass.
+
+- [ ] **Step 3: 构建检查**
+
+```bash
+pnpm build
+```
+Expected: Build succeeds.
+
+---
+
+## 自审
+
+- [x] Spec 覆盖：容量口径（Task 1-2）、自动推进（Task 3-5）、后台导航（Task 6-8）全部对应
+- [x] 无占位符：所有 Task 包含完整代码和命令
+- [x] 类型一致性：`TxDb` 类型在 Task 3 定义，Task 4 复用；`SeasonSubNav` props 在 Task 6 定义，Task 7 匹配

--- a/docs/superpowers/specs/2026-05-13-admin-ux-auto-advance-design.md
+++ b/docs/superpowers/specs/2026-05-13-admin-ux-auto-advance-design.md
@@ -36,9 +36,9 @@
 | 行 | 展示 | 数据来源 |
 |---|---|---|
 | 位置 bar | `12 / 15` — 提交/上限 | `getPositionCounts()` (全部提交，不变) |
-| Total | `已通过：32 / 56` | 新增 `getApprovedCount(seasonId)` 查询 |
+| Total | `Approved: 32 / 56` | 新增 `getApprovedCount(seasonId)` 查询 |
 
-底部 Total 行文案从 `Total X / Y` 改为 `已通过：X / Y`。
+底部 Total 行文案从 `Total X / Y` 改为 `Approved: X / Y`。
 
 ### 数据库影响
 

--- a/docs/superpowers/specs/2026-05-13-admin-ux-auto-advance-design.md
+++ b/docs/superpowers/specs/2026-05-13-admin-ux-auto-advance-design.md
@@ -1,0 +1,120 @@
+# 管理后台 UX 补全 + 报名自动推进设计
+
+> 状态：已确认 · 日期：2026-05-13 · 分支：`feat/phase-tracker-v2`
+
+## 范围
+
+三个独立但相关的改进：
+
+1. **容量口径修正** — `maxPerPosition` 限制提交数，`maxTotal` 限制通过数
+2. **报名自动推进** — 审批满或截止时间到，自动 `registration → voting`
+3. **管理后台导航补全** — 赛季子页 tabs + 侧边栏标签明确化
+
+---
+
+## 一、容量口径修正
+
+### 现状问题
+
+`getPositionCounts()` 统计全部报名（含 rejected/waitlisted），变量名叫 `totalApproved` 但实际统计的是全部提交。`maxTotal = 56` 含义被混淆。
+
+### 设计
+
+**`getPositionCounts()` 保持不变** — 统计全部提交（不限 status），用于位置 bar 展示和表单提交时的位置上限检查。
+
+**`src/actions/register.ts:203-210`** — `maxTotal` 提交上限检查改为只检查已通过的：
+
+```typescript
+// 修改前：AND count(*) >= maxTotal（全部报名）
+// 修改后：AND status = 'approved' AND count(*) >= maxTotal
+```
+
+这样只有审批通过的人数达标才关闭报名，被拒的不占名额。
+
+**`src/app/[seasonSlug]/register/page.tsx`** — 容量面板改为双行：
+
+| 行 | 展示 | 数据来源 |
+|---|---|---|
+| 位置 bar | `12 / 15` — 提交/上限 | `getPositionCounts()` (全部提交，不变) |
+| Total | `已通过：32 / 56` | 新增 `getApprovedCount(seasonId)` 查询 |
+
+底部 Total 行文案从 `Total X / Y` 改为 `已通过：X / Y`。
+
+### 数据库影响
+
+无 schema 变更。
+
+---
+
+## 二、自动推进 registration → voting
+
+### 新增文件：`src/actions/transitions.ts`
+
+```
+maybeAdvanceFromRegistration(tx, seasonId)
+  → 查询 approved count
+  → 检查 ≥ maxTotal | registrationDeadline 过期
+  → 任一满足 → set status
+  → 无队长投票的赛季 → 跳到 "playing"
+  → 写 audit_log (action: "season.auto_advance")
+```
+
+### 触发点
+
+1. **`approveRegistration()` / `bulkApprove()`** — 审批通过后调用 `maybeAdvanceFromRegistration()`
+2. **新 Cron API** `src/app/api/cron/check-registration-deadline/route.ts` — 每分钟检查 `status = "registration"` 的赛季，截止时间过期则推进
+
+### 状态迁移
+
+| 赛季能力 | registration 推进到 |
+|---|---|
+| `hasCaptainVoting = true` | `"voting"` |
+| `hasCaptainVoting = false` | `"playing"` |
+
+### 数据库影响
+
+无 schema 变更。依赖现有 `audit_logs` 表。
+
+---
+
+## 三、管理后台导航补全
+
+### 新增组件：`src/components/admin/SeasonSubNav.tsx`
+
+渲染在赛季子页顶部（`[seasonSlug]/layout.tsx` 或各页面自行引入）。
+
+Tabs 及显示规则：
+
+| Tab | 路由 | 显示条件 |
+|---|---|---|
+| 报名审核 | `/admin/[slug]/registrations` | 始终 |
+| 队长确认 | `/admin/[slug]/captains` | `hasCaptainVoting` |
+| 选秀控制 | `/admin/[slug]/draft` | `hasDraft` |
+| 赛程管理 | `/admin/[slug]/matches` | `stagePlan` 非空 |
+| 赛季设置 | `/admin/[slug]/settings` | `super_admin` |
+
+当前页高亮，`status` 不满足的阶段显示为灰色（不可点击）还是始终可点击？始终可点击（页面自行做权限/状态校验）。
+
+### 侧边栏微调
+
+`src/components/admin/AdminSidebar.tsx`：
+- "概览" → "赛季管理"（标签更明确，路由不变）
+
+### 数据库影响
+
+无。
+
+---
+
+## 自我审查
+
+- [x] 无 TBD / TODO 占位符
+- [x] 无内部矛盾
+- [x] 范围聚焦，不涉及无关重构
+- [x] 每条需求明确，无双义
+
+## 未覆盖
+
+- 报名截止后管理员仍可手动改 status（现有功能不受影响）
+- 审批通过后位置容量 bar 不变（只影响底部 Total，语义合理）
+- E2E 测试（实现阶段按需添加）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -215,7 +215,6 @@ export async function reviewRegistration(input: ReviewInput) {
         },
       });
 
-      // 审批通过后检查是否满足自动推进条件
       if (targetStatus === "approved") {
         await maybeAdvanceFromRegistration(tx, reg.seasonId);
       }

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/auth/session";
 import { verifyPassword, hashPassword } from "@/lib/utils/password";
 import { normalizeRegistrationConfig } from "@/types/season";
+import { maybeAdvanceFromRegistration } from "@/actions/transitions";
 import {
   type RegistrationStatus,
   TRANSITION_RULES,
@@ -213,6 +214,11 @@ export async function reviewRegistration(input: ReviewInput) {
           actorEmail: admin.email,
         },
       });
+
+      // 审批通过后检查是否满足自动推进条件
+      if (targetStatus === "approved") {
+        await maybeAdvanceFromRegistration(tx, reg.seasonId);
+      }
     });
 
     // revalidatePath 放在事务外（事务成功后刷新缓存）

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -200,11 +200,16 @@ export async function submitRegistration(input: RegistrationFormData) {
       throw new AppError(ErrorCode.REGISTRATION_DUPLICATE, ERROR_MESSAGES.REGISTRATION_DUPLICATE);
     }
 
-    // 5. 全局总报名人数上限检查
+    // 5. 全局总报名人数上限检查（仅统计已通过，被拒/候补不占名额）
     const [totalCount] = await db
       .select({ count: count() })
       .from(seasonRegistrations)
-      .where(eq(seasonRegistrations.seasonId, data.seasonId));
+      .where(
+        and(
+          eq(seasonRegistrations.seasonId, data.seasonId),
+          eq(seasonRegistrations.status, "approved"),
+        ),
+      );
     if (Number(totalCount?.count ?? 0) >= registrationConfig.maxTotal) {
       throw new AppError(ErrorCode.REGISTRATION_FULL, ERROR_MESSAGES.REGISTRATION_FULL);
     }
@@ -281,4 +286,18 @@ export async function getPositionCounts(
     .groupBy(seasonRegistrations.primaryPosition);
 
   return Object.fromEntries(rows.map((r) => [r.position, Number(r.count)]));
+}
+
+/** 查询某赛季已通过审批的总人数 */
+export async function getApprovedCount(seasonId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: count() })
+    .from(seasonRegistrations)
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    );
+  return Number(row?.count ?? 0);
 }

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -8,6 +8,7 @@ import { auditLogs, seasonRegistrations, seasons } from "@/db/schema";
 import { ok, fail, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { actionError } from "@/lib/action-utils";
+import { parseCSTInput } from "@/lib/utils/date";
 import { auditActorId, requireSuperAdmin } from "@/lib/auth/session";
 import {
   RIVALS_REGISTRATION_CONFIG,
@@ -113,10 +114,7 @@ function withSeasonRefinements<T extends z.ZodTypeAny>(schema: T) {
 }
 
 function toDate(value: string | null): Date | null {
-  if (!value) return null;
-  // datetime-local 输入不含时区信息，管理员在 CST 时区输入
-  const date = new Date(value + "+08:00");
-  return Number.isNaN(date.getTime()) ? null : date;
+  return parseCSTInput(value);
 }
 
 function fieldErrorsFromZod(error: z.ZodError): Record<string, string> {

--- a/src/actions/seasons.ts
+++ b/src/actions/seasons.ts
@@ -114,7 +114,8 @@ function withSeasonRefinements<T extends z.ZodTypeAny>(schema: T) {
 
 function toDate(value: string | null): Date | null {
   if (!value) return null;
-  const date = new Date(value);
+  // datetime-local 输入不含时区信息，管理员在 CST 时区输入
+  const date = new Date(value + "+08:00");
   return Number.isNaN(date.getTime()) ? null : date;
 }
 

--- a/src/actions/transitions.ts
+++ b/src/actions/transitions.ts
@@ -2,10 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 import { eq, count, and } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
 import { seasons, seasonRegistrations, auditLogs } from "@/db/schema";
 import { normalizeRegistrationConfig } from "@/types/season";
-
-type TxDb = Parameters<Parameters<typeof import("@/db/client").db.transaction>[0]>[0];
 
 async function getApprovedCountInTx(tx: TxDb, seasonId: string): Promise<number> {
   const [row] = await tx
@@ -43,8 +42,7 @@ export async function maybeAdvanceFromRegistration(
 
   if (!full && !deadlinePassed) return;
 
-  // 无队长投票的赛季直接跳到 playing
-  const nextStatus = season.hasCaptainVoting ? ("voting" as const) : ("playing" as const);
+  const nextStatus = season.hasCaptainVoting ? "voting" : "playing";
 
   await tx
     .update(seasons)

--- a/src/actions/transitions.ts
+++ b/src/actions/transitions.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, count, and } from "drizzle-orm";
+import { seasons, seasonRegistrations, auditLogs } from "@/db/schema";
+import { normalizeRegistrationConfig } from "@/types/season";
+
+type TxDb = Parameters<Parameters<typeof import("@/db/client").db.transaction>[0]>[0];
+
+async function getApprovedCountInTx(tx: TxDb, seasonId: string): Promise<number> {
+  const [row] = await tx
+    .select({ count: count() })
+    .from(seasonRegistrations)
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        eq(seasonRegistrations.status, "approved"),
+      ),
+    );
+  return Number(row?.count ?? 0);
+}
+
+/**
+ * 如果条件满足（通过数满 / 截止过期），自动推进 registration → 下一状态。
+ * 必须在事务中调用——审批场景用外层的 tx，cron 场景自己包 transaction。
+ */
+export async function maybeAdvanceFromRegistration(
+  tx: TxDb,
+  seasonId: string,
+): Promise<void> {
+  const season = await tx.query.seasons.findFirst({
+    where: eq(seasons.id, seasonId),
+  });
+  if (!season || season.status !== "registration") return;
+
+  const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
+  const approvedCount = await getApprovedCountInTx(tx, seasonId);
+  const full = approvedCount >= registrationConfig.maxTotal;
+
+  const deadlinePassed =
+    season.registrationDeadline != null &&
+    new Date(season.registrationDeadline).getTime() <= Date.now();
+
+  if (!full && !deadlinePassed) return;
+
+  // 无队长投票的赛季直接跳到 playing
+  const nextStatus = season.hasCaptainVoting ? ("voting" as const) : ("playing" as const);
+
+  await tx
+    .update(seasons)
+    .set({ status: nextStatus, updatedAt: new Date() })
+    .where(eq(seasons.id, seasonId));
+
+  await tx.insert(auditLogs).values({
+    seasonId,
+    action: "season.auto_advance",
+    actorId: "system",
+    targetId: seasonId,
+    targetType: "season",
+    meta: {
+      from: "registration",
+      to: nextStatus,
+      reason: full ? "capacity_reached" : "deadline_passed",
+      approvedCount,
+      maxTotal: registrationConfig.maxTotal,
+      deadline: season.registrationDeadline?.toISOString() ?? null,
+    },
+  });
+
+  revalidatePath(`/${season.slug}`);
+  revalidatePath(`/admin/${season.slug}/registrations`);
+}

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -9,7 +9,10 @@ import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
 import { StatusPill, Panel, Marker } from "@/components/rivalhub";
 
-const STATUS_ORDER: SeasonStatus[] = ["draft", "registration", "voting", "drafting", "playing", "finished", "archived"];
+const STATUS_IDX: Record<SeasonStatus, number> = {
+  draft: 0, registration: 1, voting: 2, drafting: 3,
+  playing: 4, finished: 5, archived: 6,
+};
 
 interface SeasonPageProps {
   params: Promise<{ seasonSlug: string }>;
@@ -27,7 +30,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
 
   // 查询已初始化的赛程阶段（有 match 记录的 stage）
   const matchStageRows = await db
-    .select({ stage: matches.stage })
+    .selectDistinct({ stage: matches.stage })
     .from(matches)
     .where(eq(matches.seasonId, season.id));
   const initializedStages = new Set(matchStageRows.map((r) => r.stage));
@@ -39,7 +42,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     done: boolean;
   }
 
-  const currentStatusIdx = STATUS_ORDER.indexOf(season.status);
+  const currentStatusIdx = STATUS_IDX[season.status];
   const phases: Phase[] = [];
 
   // 赛前阶段（capability 驱动）
@@ -56,36 +59,34 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     phases.push({
       key: rule.key,
       label: rule.label,
-      done: currentStatusIdx > STATUS_ORDER.indexOf(rule.doneAfter),
+      done: currentStatusIdx > STATUS_IDX[rule.doneAfter],
     });
   }
 
   // 比赛阶段（从 stagePlan 读取）
   if (stagePlan.length > 0) {
-    // 确定当前 match stage 索引，-1 = 尚未进入 playing
+    const PLAYING_IDX = STATUS_IDX.playing;
     let currentMatchIdx = -1;
-    if (currentStatusIdx >= STATUS_ORDER.indexOf("playing")) {
-      if (currentStatusIdx > STATUS_ORDER.indexOf("playing")) {
-        // finished / archived → 所有阶段完成
-        currentMatchIdx = stagePlan.length;
-      } else {
-        // playing → 找到最后一个已初始化的阶段
-        let lastInit = -1;
-        for (let i = stagePlan.length - 1; i >= 0; i--) {
-          if (initializedStages.has(stagePlan[i].key)) {
-            lastInit = i;
-            break;
-          }
-        }
-        currentMatchIdx = Math.max(0, lastInit);
+
+    if (currentStatusIdx < PLAYING_IDX) {
+      // 尚未进入 playing —— 没有 match stage 开始
+    } else if (currentStatusIdx > PLAYING_IDX) {
+      // finished / archived → 所有阶段完成
+      currentMatchIdx = stagePlan.length;
+    } else {
+      // 恰好 playing → 找到最后一个已初始化的阶段
+      let lastInit = -1;
+      for (let i = stagePlan.length - 1; i >= 0; i--) {
+        if (initializedStages.has(stagePlan[i].key)) { lastInit = i; break; }
       }
+      currentMatchIdx = Math.max(0, lastInit);
     }
 
     for (let i = 0; i < stagePlan.length; i++) {
       const stage = stagePlan[i];
       phases.push({
         key: stage.key,
-        label: stage.key.toUpperCase(),
+        label: stage.name || stage.key.toUpperCase(),
         done: i < currentMatchIdx,
       });
     }
@@ -95,7 +96,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
   phases.push({
     key: "finished",
     label: "FINISHED",
-    done: currentStatusIdx > STATUS_ORDER.indexOf("finished"),
+    done: currentStatusIdx > STATUS_IDX.finished,
   });
 
   // 找当前阶段（第一个未完成的）

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -3,20 +3,13 @@ import { notFound } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { UserPlus, Vote, Users, Swords, Shuffle, BarChart3 } from "lucide-react";
 import { db } from "@/db/client";
-import { seasons } from "@/db/schema";
+import { seasons, matches } from "@/db/schema";
 import { normalizeStagePlan } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
 import { StatusPill, Panel, Marker } from "@/components/rivalhub";
 
-const ALL_PHASES = [
-  { key: "register", label: "REGISTER", after: "registration" as SeasonStatus, required: true },
-  { key: "vote", label: "VOTE", after: "voting" as SeasonStatus, required: "hasCaptainVoting" as const },
-  { key: "draft", label: "DRAFT", after: "drafting" as SeasonStatus, required: "hasDraft" as const },
-  { key: "qualifiers", label: "REGULAR", after: "playing" as SeasonStatus, required: true },
-  { key: "playoffs", label: "PLAYOFFS", after: "finished" as SeasonStatus, required: true },
-  { key: "finals", label: "FINALS", after: "archived" as SeasonStatus, required: true },
-];
+const STATUS_ORDER: SeasonStatus[] = ["draft", "registration", "voting", "drafting", "playing", "finished", "archived"];
 
 interface SeasonPageProps {
   params: Promise<{ seasonSlug: string }>;
@@ -29,14 +22,85 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     where: eq(seasons.slug, seasonSlug),
   });
   if (!season) notFound();
-  const hasMatches = normalizeStagePlan(season.stagePlan).length > 0;
+  const stagePlan = normalizeStagePlan(season.stagePlan);
+  const hasMatches = stagePlan.length > 0;
 
-  const PHASES = ALL_PHASES.filter((phase) => {
-    if (phase.required === true) return true;
-    if (phase.required === "hasCaptainVoting") return season.hasCaptainVoting;
-    if (phase.required === "hasDraft") return season.hasDraft;
-    return false;
+  // 查询已初始化的赛程阶段（有 match 记录的 stage）
+  const matchStageRows = await db
+    .select({ stage: matches.stage })
+    .from(matches)
+    .where(eq(matches.seasonId, season.id));
+  const initializedStages = new Set(matchStageRows.map((r) => r.stage));
+
+  // ── 动态阶段列表 ──────────────────────────────────────────
+  interface Phase {
+    key: string;
+    label: string;
+    done: boolean;
+  }
+
+  const currentStatusIdx = STATUS_ORDER.indexOf(season.status);
+  const phases: Phase[] = [];
+
+  // 赛前阶段（capability 驱动）
+  const preMatchRules: { key: string; label: string; doneAfter: SeasonStatus }[] = [
+    { key: "register", label: "REGISTER", doneAfter: "registration" },
+  ];
+  if (season.hasCaptainVoting) {
+    preMatchRules.push({ key: "vote", label: "VOTE", doneAfter: "voting" });
+  }
+  if (season.hasDraft) {
+    preMatchRules.push({ key: "draft", label: "DRAFT", doneAfter: "drafting" });
+  }
+  for (const rule of preMatchRules) {
+    phases.push({
+      key: rule.key,
+      label: rule.label,
+      done: currentStatusIdx > STATUS_ORDER.indexOf(rule.doneAfter),
+    });
+  }
+
+  // 比赛阶段（从 stagePlan 读取）
+  if (stagePlan.length > 0) {
+    // 确定当前 match stage 索引，-1 = 尚未进入 playing
+    let currentMatchIdx = -1;
+    if (currentStatusIdx >= STATUS_ORDER.indexOf("playing")) {
+      if (currentStatusIdx > STATUS_ORDER.indexOf("playing")) {
+        // finished / archived → 所有阶段完成
+        currentMatchIdx = stagePlan.length;
+      } else {
+        // playing → 找到最后一个已初始化的阶段
+        let lastInit = -1;
+        for (let i = stagePlan.length - 1; i >= 0; i--) {
+          if (initializedStages.has(stagePlan[i].key)) {
+            lastInit = i;
+            break;
+          }
+        }
+        currentMatchIdx = Math.max(0, lastInit);
+      }
+    }
+
+    for (let i = 0; i < stagePlan.length; i++) {
+      const stage = stagePlan[i];
+      phases.push({
+        key: stage.key,
+        label: stage.key.toUpperCase(),
+        done: i < currentMatchIdx,
+      });
+    }
+  }
+
+  // 结束标记
+  phases.push({
+    key: "finished",
+    label: "FINISHED",
+    done: currentStatusIdx > STATUS_ORDER.indexOf("finished"),
   });
+
+  // 找当前阶段（第一个未完成的）
+  let currentPhaseIdx = phases.findIndex((p) => !p.done);
+  if (currentPhaseIdx === -1) currentPhaseIdx = phases.length - 1;
 
   const quickLinks = [
     {
@@ -97,49 +161,43 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
 
       {/* Phase tracker */}
       <Panel pad={0}>
-        <div className="grid" style={{ gridTemplateColumns: `repeat(${PHASES.length}, 1fr)` }}>
-          {(() => {
-            const statusOrder: SeasonStatus[] = ["draft", "registration", "voting", "drafting", "playing", "finished", "archived"];
-            const currentIdx = statusOrder.indexOf(season.status);
-            const thresholdIdx = Object.fromEntries(PHASES.map((p) => [p.key, statusOrder.indexOf(p.after)]));
-            return PHASES.map((phase, i) => {
-              const phaseDone = currentIdx >= thresholdIdx[phase.key];
-              const prevKey = i > 0 ? PHASES[i - 1].key : "";
-              const isCurrent = !phaseDone && (i === 0 || currentIdx >= (thresholdIdx[prevKey] ?? Infinity));
-              return (
-                <div key={phase.key}
-                  className="relative"
-                  style={{
-                    padding: "18px 16px",
-                    borderRight: i < PHASES.length - 1 ? "1px solid var(--color-border)" : "none",
-                    background: isCurrent ? "var(--color-panel-hi)" : "transparent",
-                  }}
-                >
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <div className="grid place-items-center font-bold rounded-sm" style={{
-                      width: 16, height: 16,
-                      border: `1px solid ${phaseDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-border)"}`,
-                      background: phaseDone ? "var(--color-ok)22" : isCurrent ? "var(--color-accent)22" : "transparent",
-                      fontFamily: "var(--font-mono)", fontSize: 10,
-                      color: phaseDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-dim)",
-                    }}>
-                      {phaseDone ? "✓" : i + 1}
-                    </div>
-                    <div className="uppercase" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
-                      STEP {i + 1}
-                    </div>
-                  </div>
-                  <div className="font-semibold" style={{
-                    fontFamily: "var(--font-display)", fontSize: 14,
-                    color: phaseDone ? "var(--color-fg)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-mid)",
-                    letterSpacing: "0.04em",
+        <div className="grid" style={{ gridTemplateColumns: `repeat(${phases.length}, 1fr)` }}>
+          {phases.map((phase, i) => {
+            const isCurrent = i === currentPhaseIdx;
+            const isDone = phase.done;
+            return (
+              <div key={phase.key}
+                className="relative"
+                style={{
+                  padding: "18px 16px",
+                  borderRight: i < phases.length - 1 ? "1px solid var(--color-border)" : "none",
+                  background: isCurrent ? "var(--color-panel-hi)" : "transparent",
+                }}
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <div className="grid place-items-center font-bold rounded-sm" style={{
+                    width: 16, height: 16,
+                    border: `1px solid ${isDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-border)"}`,
+                    background: isDone ? "var(--color-ok)22" : isCurrent ? "var(--color-accent)22" : "transparent",
+                    fontFamily: "var(--font-mono)", fontSize: 10,
+                    color: isDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-dim)",
                   }}>
-                    {phase.label}
+                    {isDone ? "✓" : i + 1}
+                  </div>
+                  <div className="uppercase" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
+                    STEP {i + 1}
                   </div>
                 </div>
-              );
-            });
-          })()}
+                <div className="font-semibold" style={{
+                  fontFamily: "var(--font-display)", fontSize: 14,
+                  color: isDone ? "var(--color-fg)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-mid)",
+                  letterSpacing: "0.04em",
+                }}>
+                  {phase.label}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </Panel>
 

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
-import { getPositionCounts } from "@/actions/register";
+import { getPositionCounts, getApprovedCount } from "@/actions/register";
 import { RegistrationForm } from "@/components/register/RegistrationForm";
 import { normalizeRegistrationConfig } from "@/types/season";
 import { Panel, StatusBanner, PosChip } from "@/components/rivalhub";
@@ -59,6 +59,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   }
 
   const positionCounts = await getPositionCounts(season.id);
+  const approvedCount = await getApprovedCount(season.id);
   const regConfig = normalizeRegistrationConfig(season.registrationConfig);
   const maxPerPos = regConfig.maxPerPosition;
   const registrationWindow = getRegistrationWindowState(season);
@@ -69,8 +70,6 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
     const label = POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.en ?? pos;
     return { pos, label, cur, max: maxPerPos };
   });
-  const totalApproved = capacityEntries.reduce((sum, e) => sum + e.cur, 0);
-  const maxTotal = regConfig.maxTotal;
 
   return (
     <div className="container mx-auto px-4 py-10 max-w-2xl">
@@ -126,10 +125,10 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
             })}
             <div className="flex justify-between items-center pt-2" style={{ borderTop: "1px solid var(--color-border)" }}>
               <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-fg-dim)", fontFamily: "var(--font-display)" }}>
-                Total
+                Approved
               </span>
               <span className="font-bold" style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-fg)" }}>
-                {totalApproved} / {maxTotal}
+                {approvedCount} / {regConfig.maxTotal}
               </span>
             </div>
           </div>

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -66,9 +66,11 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   // 位置容量数据
   const capacityEntries = season.positions.map((pos) => {
     const cur = positionCounts[pos] ?? 0;
-    const label = POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.cn ?? pos;
+    const label = POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.en ?? pos;
     return { pos, label, cur, max: maxPerPos };
   });
+  const totalApproved = capacityEntries.reduce((sum, e) => sum + e.cur, 0);
+  const maxTotal = regConfig.maxTotal;
 
   return (
     <div className="container mx-auto px-4 py-10 max-w-2xl">
@@ -90,7 +92,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
       </div>
 
       <div className="mb-6">
-        <Panel label="位置实时容量">
+        <Panel label="实时容量">
           <div className="grid gap-2.5">
             {capacityEntries.map(({ pos, label, cur, max }) => {
               const pct = Math.min((cur / max) * 100, 100);
@@ -122,6 +124,14 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
                 </div>
               );
             })}
+            <div className="flex justify-between items-center pt-2" style={{ borderTop: "1px solid var(--color-border)" }}>
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-fg-dim)", fontFamily: "var(--font-display)" }}>
+                Total
+              </span>
+              <span className="font-bold" style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-fg)" }}>
+                {totalApproved} / {maxTotal}
+              </span>
+            </div>
           </div>
         </Panel>
       </div>

--- a/src/app/admin/[seasonSlug]/layout.tsx
+++ b/src/app/admin/[seasonSlug]/layout.tsx
@@ -33,7 +33,7 @@ export default async function AdminSeasonLayout({
     redirect("/admin/login");
   }
 
-  const hasMatches = (season.stagePlan as unknown[])?.length > 0;
+  const hasMatches = season.stagePlan.length > 0;
   const isSuperAdmin = admin.role === "super_admin";
 
   return (

--- a/src/app/admin/[seasonSlug]/layout.tsx
+++ b/src/app/admin/[seasonSlug]/layout.tsx
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { requireSeasonAdmin } from "@/lib/auth/session";
+import { SeasonSubNav } from "@/components/admin/SeasonSubNav";
 
 export default async function AdminSeasonLayout({
   children,
@@ -15,7 +16,13 @@ export default async function AdminSeasonLayout({
   const { seasonSlug } = await params;
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),
-    columns: { id: true },
+    columns: {
+      id: true,
+      hasCaptainVoting: true,
+      hasDraft: true,
+      stagePlan: true,
+      status: true,
+    },
   });
   if (!season) notFound();
 
@@ -26,5 +33,19 @@ export default async function AdminSeasonLayout({
     redirect("/admin/login");
   }
 
-  return <>{children}</>;
+  const hasMatches = (season.stagePlan as unknown[])?.length > 0;
+  const isSuperAdmin = admin.role === "super_admin";
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-6xl">
+      <SeasonSubNav
+        seasonSlug={seasonSlug}
+        hasCaptainVoting={season.hasCaptainVoting}
+        hasDraft={season.hasDraft}
+        hasMatches={hasMatches}
+        showSettings={isSuperAdmin}
+      />
+      {children}
+    </div>
+  );
 }

--- a/src/app/admin/[seasonSlug]/settings/page.tsx
+++ b/src/app/admin/[seasonSlug]/settings/page.tsx
@@ -5,16 +5,10 @@ import { seasons } from "@/db/schema";
 import { requireSuperAdmin } from "@/lib/auth/session";
 import { normalizeRegistrationConfig, normalizeStagePlan, normalizeTeamRegistrationConfig } from "@/types/season";
 import { SeasonForm } from "@/components/admin/SeasonForm";
+import { toCSTDateTimeInput } from "@/lib/utils/date";
 
 interface SeasonSettingsPageProps {
   params: Promise<{ seasonSlug: string }>;
-}
-
-function toDateTimeInput(value: Date | null): string | null {
-  if (!value) return null;
-  // 将 UTC 转为 CST (UTC+8) 显示在 datetime-local 输入框中
-  const d = new Date(value.getTime() + 8 * 3600 * 1000);
-  return d.toISOString().slice(0, 16);
 }
 
 export default async function SeasonSettingsPage({ params }: SeasonSettingsPageProps) {
@@ -41,9 +35,9 @@ export default async function SeasonSettingsPage({ params }: SeasonSettingsPageP
           kind: season.kind,
           status: season.status,
           themeColor: season.themeColor,
-          startAt: toDateTimeInput(season.startAt),
-          registrationDeadline: toDateTimeInput(season.registrationDeadline),
-          endAt: toDateTimeInput(season.endAt),
+          startAt: toCSTDateTimeInput(season.startAt),
+          registrationDeadline: toCSTDateTimeInput(season.registrationDeadline),
+          endAt: toCSTDateTimeInput(season.endAt),
           registrationMode: season.registrationMode,
           hasCaptainVoting: season.hasCaptainVoting,
           hasDraft: season.hasDraft,

--- a/src/app/admin/[seasonSlug]/settings/page.tsx
+++ b/src/app/admin/[seasonSlug]/settings/page.tsx
@@ -12,7 +12,9 @@ interface SeasonSettingsPageProps {
 
 function toDateTimeInput(value: Date | null): string | null {
   if (!value) return null;
-  return value.toISOString().slice(0, 16);
+  // 将 UTC 转为 CST (UTC+8) 显示在 datetime-local 输入框中
+  const d = new Date(value.getTime() + 8 * 3600 * 1000);
+  return d.toISOString().slice(0, 16);
 }
 
 export default async function SeasonSettingsPage({ params }: SeasonSettingsPageProps) {

--- a/src/app/api/cron/check-registration-deadline/route.ts
+++ b/src/app/api/cron/check-registration-deadline/route.ts
@@ -3,16 +3,11 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { maybeAdvanceFromRegistration } from "@/actions/transitions";
+import { validateCronAuth } from "@/lib/cron-auth";
 
-// Vercel Cron 每分钟触发
-// 安全：Authorization: Bearer ${CRON_SECRET}
 export async function GET(request: Request) {
-  const authHeader = request.headers.get("authorization");
-  const cronSecret = process.env.CRON_SECRET;
-
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
 
   const activeSeasons = await db
     .select({ id: seasons.id })

--- a/src/app/api/cron/check-registration-deadline/route.ts
+++ b/src/app/api/cron/check-registration-deadline/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { maybeAdvanceFromRegistration } from "@/actions/transitions";
+
+// Vercel Cron 每分钟触发
+// 安全：Authorization: Bearer ${CRON_SECRET}
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const activeSeasons = await db
+    .select({ id: seasons.id })
+    .from(seasons)
+    .where(eq(seasons.status, "registration"));
+
+  let advanced = 0;
+
+  for (const s of activeSeasons) {
+    await db.transaction(async (tx) => {
+      await maybeAdvanceFromRegistration(tx, s.id);
+    });
+    advanced++;
+  }
+
+  const skipped = activeSeasons.length - advanced;
+
+  return NextResponse.json({ ok: true, advanced, skipped });
+}

--- a/src/app/api/cron/draft-timeout/route.ts
+++ b/src/app/api/cron/draft-timeout/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from "next/server";
 import { runDraftTimeoutCron } from "@/actions/draft";
+import { validateCronAuth } from "@/lib/cron-auth";
 
-// Vercel Cron 每分钟触发（见 vercel.json）
-// 安全：Authorization: Bearer ${CRON_SECRET}
-// 逻辑：见 docs/draft-flow.md § Vercel Cron 超时自动 pick
 export async function GET(request: Request) {
-  const authHeader = request.headers.get("authorization");
-  const cronSecret = process.env.CRON_SECRET;
-
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
 
   const result = await runDraftTimeoutCron();
   return NextResponse.json(

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { logoutUser } from "@/actions/auth";
 
 const NAV_ITEMS = [
-  { href: "/admin", label: "概览" },
+  { href: "/admin", label: "赛季管理" },
   { href: "/admin/users", label: "用户管理" },
   { href: "/admin/invites", label: "邀请码" },
   { href: "/admin/settings", label: "系统设置" },

--- a/src/components/admin/SeasonSubNav.tsx
+++ b/src/components/admin/SeasonSubNav.tsx
@@ -3,12 +3,6 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-interface Tab {
-  label: string;
-  href: string;
-  show: boolean;
-}
-
 export function SeasonSubNav({
   seasonSlug,
   hasCaptainVoting,
@@ -24,13 +18,13 @@ export function SeasonSubNav({
 }) {
   const pathname = usePathname();
 
-  const tabs: Tab[] = [
-    { label: "报名审核", href: `/admin/${seasonSlug}/registrations`, show: true },
-    { label: "队长确认", href: `/admin/${seasonSlug}/captains`, show: hasCaptainVoting },
-    { label: "选秀控制", href: `/admin/${seasonSlug}/draft`, show: hasDraft },
-    { label: "赛程管理", href: `/admin/${seasonSlug}/matches`, show: hasMatches },
-    { label: "赛季设置", href: `/admin/${seasonSlug}/settings`, show: showSettings },
-  ].filter((t) => t.show);
+  const tabs: { label: string; href: string }[] = [
+    { label: "报名审核", href: `/admin/${seasonSlug}/registrations` },
+    ...(hasCaptainVoting ? [{ label: "队长确认", href: `/admin/${seasonSlug}/captains` }] : []),
+    ...(hasDraft ? [{ label: "选秀控制", href: `/admin/${seasonSlug}/draft` }] : []),
+    ...(hasMatches ? [{ label: "赛程管理", href: `/admin/${seasonSlug}/matches` }] : []),
+    ...(showSettings ? [{ label: "赛季设置", href: `/admin/${seasonSlug}/settings` }] : []),
+  ];
 
   return (
     <nav

--- a/src/components/admin/SeasonSubNav.tsx
+++ b/src/components/admin/SeasonSubNav.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface Tab {
+  label: string;
+  href: string;
+  show: boolean;
+}
+
+export function SeasonSubNav({
+  seasonSlug,
+  hasCaptainVoting,
+  hasDraft,
+  hasMatches,
+  showSettings,
+}: {
+  seasonSlug: string;
+  hasCaptainVoting: boolean;
+  hasDraft: boolean;
+  hasMatches: boolean;
+  showSettings: boolean;
+}) {
+  const pathname = usePathname();
+
+  const tabs: Tab[] = [
+    { label: "报名审核", href: `/admin/${seasonSlug}/registrations`, show: true },
+    { label: "队长确认", href: `/admin/${seasonSlug}/captains`, show: hasCaptainVoting },
+    { label: "选秀控制", href: `/admin/${seasonSlug}/draft`, show: hasDraft },
+    { label: "赛程管理", href: `/admin/${seasonSlug}/matches`, show: hasMatches },
+    { label: "赛季设置", href: `/admin/${seasonSlug}/settings`, show: showSettings },
+  ].filter((t) => t.show);
+
+  return (
+    <nav
+      className="flex gap-0 mb-6"
+      style={{ borderBottom: "2px solid var(--color-border)" }}
+    >
+      {tabs.map((tab) => {
+        const active = pathname === tab.href || pathname.startsWith(tab.href + "/");
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href as never}
+            className="transition-colors"
+            style={{
+              padding: "10px 18px",
+              borderBottom: active ? "2px solid var(--color-accent)" : "2px solid transparent",
+              marginBottom: "-2px",
+              fontWeight: active ? 600 : 500,
+              fontSize: 13,
+              color: active ? "var(--color-fg)" : "var(--color-fg-mid)",
+            }}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -24,6 +24,7 @@ pool.on("error", (err) => {
 export const db = drizzle(pool, { schema });
 
 export type DB = typeof db;
+export type TxDb = Parameters<Parameters<DB["transaction"]>[0]>[0];
 
 function shouldUseSsl(databaseUrl?: string): boolean {
   if (!databaseUrl) return false;

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+export function validateCronAuth(request: Request): Response | null {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,5 +1,6 @@
 const CST_LOCALE = "zh-CN";
 const CST_TZ = "Asia/Shanghai";
+const CST_OFFSET_MS = 8 * 60 * 60 * 1000;
 
 export function formatCST(date: Date | string): string {
   const d = typeof date === "string" ? new Date(date) : date;
@@ -15,6 +16,20 @@ export function formatCST(date: Date | string): string {
 
 export function parseCST(str: string): Date {
   return new Date(str);
+}
+
+/** datetime-local 输入不含时区信息，管理员在 CST 时区输入 → 解析为 UTC Date */
+export function parseCSTInput(value: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value + "+08:00");
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** 将 UTC Date 转为 CST datetime-local 输入框显示值 */
+export function toCSTDateTimeInput(value: Date | null): string | null {
+  if (!value) return null;
+  const d = new Date(value.getTime() + CST_OFFSET_MS);
+  return d.toISOString().slice(0, 16);
 }
 
 export function getCountdownSeconds(deadline: Date | string): number {


### PR DESCRIPTION
## Summary

### 动态 PhaseTracker & 时区修复（原始 PR 内容）
- PhaseTracker 从 `stagePlan` 读取赛程阶段，查询 DB 获取阶段初始化进度；赛前阶段按 capability 门控
- 修复 `datetime-local` 输入被当作 UTC 的问题 — 提交（`toDate`）和加载（`toDateTimeInput`）方向均按 CST (+08:00) 解析
- 报名页：位置标签切换为英文（IGL/AWPer/...），面板更名为"实时容量"，添加 Total X/Y 计数器

### 容量口径修正
- `maxTotal` 上限检查改为仅统计 `approved`，被拒/候补不占名额
- 新增 `getApprovedCount()` 导出函数
- 报名页容量面板 Total → Approved 标签，统计口径一致

### 报名自动推进
- 新建 `maybeAdvanceFromRegistration(tx, seasonId)` — 满员或截止过期时自动 registration→voting/playing
- 审批通过后事务内触发（`reviewRegistration`）
- 新建 `/api/cron/check-registration-deadline` API route
- GitHub Actions `cron.yml` 已更新，每分钟同时触发两个端点
- **无需手动配置 Vercel Cron Job**，GitHub Actions 自动处理

### 管理后台导航补全
- 新建 `SeasonSubNav` 组件 — 赛季子页顶部 tab 导航（报名审核/队长确认/选秀控制/赛程管理/赛季设置）
- `[seasonSlug]/layout.tsx` 集成 SeasonSubNav，根据 capability 条件渲染
- 侧边栏 "概览" → "赛季管理"

### 简化重构
- 提取 `validateCronAuth` 共享 helper 消除 cron route 重复鉴权
- `TxDb` 类型移至 `db/client.ts` 导出
- 去除冗余类型断言和复述注释

## Test Plan

- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm test --run` — 273 passed, 0 failed
- [x] `pnpm build` — success
- [ ] 生产部署后验证 cron 日志确认 GitHub Actions 正常触发两个端点

🤖 Generated with [Claude Code](https://claude.com/claude-code)