### PR TITLE
fix: PhaseTracker 英文标签 + 报名草稿恢复提示优化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -14,11 +14,6 @@ const STATUS_IDX: Record<SeasonStatus, number> = {
   playing: 4, finished: 5, archived: 6,
 };
 
-const STAGE_DISPLAY: Record<string, string> = {
-  qualifier: "QUALIFIER",
-  playoff: "PLAYOFFS",
-};
-
 interface SeasonPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
@@ -91,7 +86,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       const stage = stagePlan[i];
       phases.push({
         key: stage.key,
-        label: STAGE_DISPLAY[stage.key] || stage.key.toUpperCase(),
+        label: stage.key.toUpperCase(),
         done: i < currentMatchIdx,
       });
     }

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -14,6 +14,11 @@ const STATUS_IDX: Record<SeasonStatus, number> = {
   playing: 4, finished: 5, archived: 6,
 };
 
+const STAGE_DISPLAY: Record<string, string> = {
+  qualifier: "QUALIFIER",
+  playoff: "PLAYOFFS",
+};
+
 interface SeasonPageProps {
   params: Promise<{ seasonSlug: string }>;
 }
@@ -35,12 +40,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     .where(eq(matches.seasonId, season.id));
   const initializedStages = new Set(matchStageRows.map((r) => r.stage));
 
-  const STAGE_DISPLAY: Record<string, string> = {
-  qualifier: "QUALIFIER",
-  playoff: "PLAYOFFS",
-};
-
-// ── 动态阶段列表 ──────────────────────────────────────────
+  // ── 动态阶段列表 ──────────────────────────────────────────
   interface Phase {
     key: string;
     label: string;

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -35,7 +35,12 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
     .where(eq(matches.seasonId, season.id));
   const initializedStages = new Set(matchStageRows.map((r) => r.stage));
 
-  // ── 动态阶段列表 ──────────────────────────────────────────
+  const STAGE_DISPLAY: Record<string, string> = {
+  qualifier: "QUALIFIER",
+  playoff: "PLAYOFFS",
+};
+
+// ── 动态阶段列表 ──────────────────────────────────────────
   interface Phase {
     key: string;
     label: string;
@@ -86,7 +91,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       const stage = stagePlan[i];
       phases.push({
         key: stage.key,
-        label: stage.name || stage.key.toUpperCase(),
+        label: STAGE_DISPLAY[stage.key] || stage.key.toUpperCase(),
         done: i < currentMatchIdx,
       });
     }

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -125,7 +125,6 @@ export function RegistrationForm({
       });
       if (result.success) {
         toast.success("草稿已保存");
-        setLoadedDraftEmail(email);
       } else {
         toast.error(result.error.message);
       }

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -124,7 +124,9 @@ export function RegistrationForm({
         payload: compactUndefined({ ...values, seasonId, email }) as Record<string, unknown>,
       });
       if (result.success) {
-        toast.success("草稿已保存");
+        toast.success("草稿已保存", {
+          description: "下次输入邮箱即可自动恢复",
+        });
       } else {
         toast.error(result.error.message);
       }

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -236,10 +236,17 @@ export function RegistrationForm({
             <Label htmlFor="email" className="text-[var(--color-fg-mid)] mb-1.5 block">
               电子邮件 <Required />
             </Label>
-            <Input id="email" type="email" placeholder="your@email.com" className={inputCls} {...emailField} />
+            <div className="relative">
+              <Input id="email" type="email" placeholder="your@email.com" className={inputCls} {...emailField} />
+              {loadedDraftEmail && (
+                <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded" style={{ background: "var(--color-ok)22", color: "var(--color-ok)" }}>
+                  草稿已恢复
+                </span>
+              )}
+            </div>
             <FieldError name="email" />
             <p className="text-xs text-[var(--color-fg-dim)] mt-1">
-              用于接收登录链接、审核通知和草稿找回
+              输入邮箱后自动恢复已保存的草稿。同时用于接收登录链接和审核通知。
               {loadingDraftEmail && " · 正在查询草稿…"}
             </p>
           </div>

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -246,7 +246,7 @@ export function RegistrationForm({
             </div>
             <FieldError name="email" />
             <p className="text-xs text-[var(--color-fg-dim)] mt-1">
-              输入邮箱后自动恢复已保存的草稿。同时用于接收登录链接和审核通知。
+              输入邮箱后自动恢复已保存的草稿。同时用于接收审核通知。
               {loadingDraftEmail && " · 正在查询草稿…"}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- PhaseTracker: `stage.name`（中文默认）→ `STAGE_DISPLAY[stage.key]` 英文大写映射（QUALIFIER / PLAYOFFS），同时适用于已有赛季（DB 中存的中文名不再影响显示）
- 报名邮箱提示：移除 Magic Link 时代的"登录链接"文案，更直白地说明草稿自动恢复
- 邮箱旁新增"草稿已恢复"标记，加载草稿后有可见反馈

## Test Plan
- [x] `pnpm tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)