### PR TITLE
chore: MIT → AGPLv3 许可证更换 + README 更新至 1.1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,23 @@
-MIT License
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
 
-Copyright (c) 2026 Xinyu Du
+Copyright (C) 2026 Xinyu Du
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+RivalHub — an open-source esports tournament management platform.
+https://github.com/Starfie1d1272/RivalHub
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,22 @@
 
 RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，覆盖报名、审核、队长投票、蛇形选秀、队伍展示、赛程管理、Bracket、比分录入、数据统计与上线部署。
 
-当前 `1.0.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
+当前 `1.1.1` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
 
 ## 功能状态
 
-| 模块 | 1.0.0 能力 |
-|---|---|
-| 赛季管理 | capability 驱动的多赛事模型，所有公开页面使用 `/[seasonSlug]` 路由 |
-| 报名 | 邮箱密码账号、报名草稿、Zod 校验、位置/人数上限、NJUBox 截图链接 |
-| 审核 | 管理员审核、等待名单、邀请码提权、操作审计 |
+| 模块 | 1.1.1 能力 |
+|---|----|
+| 赛季管理 | capability 驱动的多赛事模型，`/[seasonSlug]` 路由，动态 PhaseTracker 阶段追踪 |
+| 报名 | 邮箱密码账号、自动草稿恢复、Zod 校验、位置/人数上限（仅统计 approved）、NJUBox 截图链接 |
+| 审核 | 管理员审核、等待名单、邀请码提权、审批通过自动推进赛季状态、操作审计 |
 | 队长投票 | 每人最多 3 票，Realtime 刷新票数 |
 | 选秀 | 队长面板、围观直播间、倒计时、事务行锁、幂等 pick、超时自动递补 |
 | 队伍 | 阵容展示、首发/替补、队长标识 |
-| 比赛 | 赛程、Bracket、地图结果、比分录入、比赛状态流转 |
-| 协商 | 管理员设置最晚完成时间，队长协商截止自动为前 24 小时 |
-| 名单 | 每场比赛提交 5 名首发 + 最多 2 名替补 |
+| 比赛 | 赛程、Bracket（Tactical Grid 暗色主题）、地图结果、比分录入 |
+| 协商 | 比赛时间提议/接受/拒绝、管理员强制设定、协商截止自动为截止前 24h、阵容提交 |
 | 数据 | 完美平台截图 OCR、比赛数据表、MVP 投票、选手/队伍统计 |
-| 部署 | Vercel + Supabase + GitHub Actions Cron |
+| 部署 | Vercel + Supabase + GitHub Actions Cron（选秀超时 + 报名截止自动推进） |
 
 ## 技术栈
 
@@ -82,11 +81,10 @@ password: RivalHub_password
 5. 在 GitHub Actions Secrets 配置 `CRON_SECRET`。
 6. 合并到 `main` 后由 Vercel 部署生产站点。
 
-当前选秀超时自动递补由 `.github/workflows/cron.yml` 每分钟请求：
+当前 GitHub Actions Cron 每分钟触发两个端点（见 `.github/workflows/cron.yml`）：
 
-```text
-https://match.starfie1d.top/api/cron/draft-timeout
-```
+- `https://match.starfie1d.top/api/cron/draft-timeout` — 选秀超时自动递补
+- `https://match.starfie1d.top/api/cron/check-registration-deadline` — 报名截止/满员自动推进赛季
 
 更多细节见 [docs/deployment.md](./docs/deployment.md)。
 
@@ -154,4 +152,9 @@ pnpm build
 
 ## License
 
-[MIT](./LICENSE)
+[GNU AGPLv3](./LICENSE)
+
+RivalHub is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rivalhub",
   "version": "1.1.1",
   "private": true,
+  "license": "AGPL-3.0",
   "scripts": {
     "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- LICENSE: MIT → GNU AGPLv3（防止竞品闭源白嫖，保留 dual-license 商业化可能）
- package.json: 新增 `license: "AGPL-3.0"`
- README: 版本号 1.0.0 → 1.1.1，功能列表更新，cron 说明补全

## Test Plan
- [x] 仅文档/许可证变更，无代码影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)