### PR TITLE
[phase-12] 比赛时间自动裁定 Cron

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,3 +19,8 @@ jobs:
           curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             "https://match.starfie1d.top/api/cron/check-registration-deadline"
+      - name: Match time auto award
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://match.starfie1d.top/api/cron/match-time-auto-award"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ password: RivalHub_password
 
 - `https://match.starfie1d.top/api/cron/draft-timeout` — 选秀超时自动递补
 - `https://match.starfie1d.top/api/cron/check-registration-deadline` — 报名截止/满员自动推进赛季
+- `https://match.starfie1d.top/api/cron/match-time-auto-award` — 比赛时间协商截止后自动采用最早提议
 
 更多细节见 [docs/deployment.md](./docs/deployment.md)。
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,12 +63,14 @@ const pgConfig = {
 
 ## Cron
 
-`/api/cron/draft-timeout` 负责选秀超时自动 pick，并通过 `Authorization: Bearer $CRON_SECRET` 鉴权。
+Cron endpoint 均通过 `Authorization: Bearer $CRON_SECRET` 鉴权。
 
 当前生产调用由 `.github/workflows/cron.yml` 每分钟触发：
 
 ```text
 https://match.starfie1d.top/api/cron/draft-timeout
+https://match.starfie1d.top/api/cron/check-registration-deadline
+https://match.starfie1d.top/api/cron/match-time-auto-award
 ```
 
 因此需要同时配置：

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,4 +1,4 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
 export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline } from "./results";
-export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals } from "./scheduling";
+export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster } from "./roster";

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNotNull, isNull, lte } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matchTimeProposals, matches, auditLogs } from "@/db/schema";
+import { matchTimeProposals, matches, auditLogs, seasons } from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
@@ -11,6 +11,12 @@ import { revalidateMatchPaths } from "@/lib/revalidation";
 import { getTeamIdForCaptain } from "./_shared";
 
 const TIME_CONFIRMATION_BUFFER_HOURS = 24;
+
+export interface MatchTimeAutoAwardCronSummary {
+  processed: number;
+  awarded: number;
+  skipped: number;
+}
 
 /**
  * 队长提议比赛时间。
@@ -195,12 +201,119 @@ export async function forceSetMatchTime(
 }
 
 /**
+ * 协商截止后自动采用最早创建的 pending 时间提议。
+ */
+export async function runMatchTimeAutoAwardCron(
+  now = new Date(),
+): Promise<MatchTimeAutoAwardCronSummary> {
+  const cutoffThreshold = new Date(
+    now.getTime() + TIME_CONFIRMATION_BUFFER_HOURS * 60 * 60 * 1000,
+  );
+
+  const candidateMatches = await db.query.matches.findMany({
+    where: and(
+      eq(matches.status, "scheduled"),
+      isNull(matches.scheduledAt),
+      isNotNull(matches.completionDeadline),
+      lte(matches.completionDeadline, cutoffThreshold),
+    ),
+  });
+
+  let awarded = 0;
+  let skipped = 0;
+
+  for (const match of candidateMatches) {
+    const result = await autoAwardMatchTime(match.id, now);
+    if (result.awarded) {
+      awarded += 1;
+      revalidateMatchPaths(result.seasonSlug, match.id);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return { processed: candidateMatches.length, awarded, skipped };
+}
+
+/**
  * 查询某场比赛的所有时间提议（按创建时间倒序）。
  */
 export async function getTimeProposals(matchId: string) {
   return db.query.matchTimeProposals.findMany({
     where: eq(matchTimeProposals.matchId, matchId),
     orderBy: (tps, { desc }) => [desc(tps.createdAt)],
+  });
+}
+
+async function autoAwardMatchTime(
+  matchId: string,
+  now: Date,
+): Promise<{ awarded: true; seasonSlug: string } | { awarded: false }> {
+  return db.transaction(async (tx) => {
+    const match = await tx.query.matches.findFirst({
+      where: eq(matches.id, matchId),
+    });
+    if (!match || match.status !== "scheduled" || match.scheduledAt || !match.completionDeadline) {
+      return { awarded: false };
+    }
+
+    const cutoff = getTimeConfirmationCutoff(match.completionDeadline);
+    if (!cutoff || now.getTime() < cutoff.getTime()) {
+      return { awarded: false };
+    }
+
+    const proposal = await tx.query.matchTimeProposals.findFirst({
+      where: and(
+        eq(matchTimeProposals.matchId, match.id),
+        eq(matchTimeProposals.status, "pending"),
+      ),
+      orderBy: (tps, { asc }) => [asc(tps.createdAt)],
+    });
+    if (!proposal) {
+      return { awarded: false };
+    }
+
+    const season = await tx.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+    });
+    if (!season) {
+      return { awarded: false };
+    }
+
+    await tx
+      .update(matches)
+      .set({ scheduledAt: proposal.proposedTime, updatedAt: now })
+      .where(eq(matches.id, match.id));
+
+    await tx
+      .update(matchTimeProposals)
+      .set({ status: "expired", updatedAt: now })
+      .where(
+        and(
+          eq(matchTimeProposals.matchId, match.id),
+          eq(matchTimeProposals.status, "pending"),
+        ),
+      );
+
+    await tx
+      .update(matchTimeProposals)
+      .set({ status: "accepted", responseAt: now, updatedAt: now })
+      .where(eq(matchTimeProposals.id, proposal.id));
+
+    await tx.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.auto_award_time",
+      actorId: "system",
+      targetId: match.id,
+      targetType: "match",
+      meta: {
+        proposalId: proposal.id,
+        proposedBy: proposal.proposedBy,
+        scheduledAt: proposal.proposedTime.toISOString(),
+      },
+    });
+
+    return { awarded: true, seasonSlug: season.slug };
   });
 }
 

--- a/src/app/api/cron/match-time-auto-award/route.ts
+++ b/src/app/api/cron/match-time-auto-award/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { runMatchTimeAutoAwardCron } from "@/actions/matches";
+import { validateCronAuth } from "@/lib/cron-auth";
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const result = await runMatchTimeAutoAwardCron();
+
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/tests/unit/actions/match-time-auto-award.test.ts
+++ b/tests/unit/actions/match-time-auto-award.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  matchFindManyMock,
+  txMatchFindFirstMock,
+  txProposalFindFirstMock,
+  txSeasonFindFirstMock,
+  transactionMock,
+  updateMock,
+  insertMock,
+  updateSetCalls,
+  insertValuesCalls,
+  revalidateMatchPathsMock,
+} = vi.hoisted(() => {
+  const updateSetCalls: unknown[] = [];
+  const insertValuesCalls: unknown[] = [];
+  return {
+    matchFindManyMock: vi.fn(),
+    txMatchFindFirstMock: vi.fn(),
+    txProposalFindFirstMock: vi.fn(),
+    txSeasonFindFirstMock: vi.fn(),
+    transactionMock: vi.fn(),
+    updateMock: vi.fn(),
+    insertMock: vi.fn(),
+    updateSetCalls,
+    insertValuesCalls,
+    revalidateMatchPathsMock: vi.fn(),
+  };
+});
+
+vi.mock("@/db/client", () => {
+  const tx = {
+    query: {
+      matches: { findFirst: txMatchFindFirstMock },
+      matchTimeProposals: { findFirst: txProposalFindFirstMock },
+      seasons: { findFirst: txSeasonFindFirstMock },
+    },
+    update: updateMock,
+    insert: insertMock,
+  };
+
+  return {
+    db: {
+      query: {
+        matches: { findMany: matchFindManyMock },
+      },
+      transaction: transactionMock.mockImplementation((callback) => callback(tx)),
+    },
+  };
+});
+
+vi.mock("@/db/schema", () => ({
+  matches: {
+    id: "matches.id",
+    status: "matches.status",
+    scheduledAt: "matches.scheduledAt",
+    completionDeadline: "matches.completionDeadline",
+  },
+  matchTimeProposals: {
+    id: "match_time_proposals.id",
+    matchId: "match_time_proposals.matchId",
+    status: "match_time_proposals.status",
+    createdAt: "match_time_proposals.createdAt",
+  },
+  auditLogs: {},
+  seasons: { id: "seasons.id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args: unknown[]) => ({ op: "and", args })),
+  asc: vi.fn((column: unknown) => ({ op: "asc", column })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: "eq", left, right })),
+  isNotNull: vi.fn((column: unknown) => ({ op: "isNotNull", column })),
+  isNull: vi.fn((column: unknown) => ({ op: "isNull", column })),
+  lte: vi.fn((left: unknown, right: unknown) => ({ op: "lte", left, right })),
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateMatchPaths: revalidateMatchPathsMock,
+}));
+
+import { runMatchTimeAutoAwardCron } from "@/actions/matches/scheduling";
+
+describe("runMatchTimeAutoAwardCron", () => {
+  const now = new Date("2026-05-14T12:00:00.000Z");
+  const proposedTime = new Date("2026-05-15T08:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSetCalls.length = 0;
+    insertValuesCalls.length = 0;
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((values) => {
+        updateSetCalls.push(values);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((values) => {
+        insertValuesCalls.push(values);
+        return Promise.resolve();
+      }),
+    }));
+  });
+
+  it("awards the earliest pending proposal after the negotiation cutoff", async () => {
+    matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
+    txMatchFindFirstMock.mockResolvedValue({
+      id: "match-1",
+      seasonId: "season-1",
+      status: "scheduled",
+      scheduledAt: null,
+      completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
+    });
+    txProposalFindFirstMock.mockResolvedValue({
+      id: "proposal-1",
+      proposedBy: "user-1",
+      proposedTime,
+    });
+    txSeasonFindFirstMock.mockResolvedValue({ slug: "spring" });
+
+    const result = await runMatchTimeAutoAwardCron(now);
+
+    expect(result).toEqual({ processed: 1, awarded: 1, skipped: 0 });
+    expect(updateSetCalls).toContainEqual({ scheduledAt: proposedTime, updatedAt: now });
+    expect(updateSetCalls).toContainEqual({ status: "expired", updatedAt: now });
+    expect(updateSetCalls).toContainEqual({
+      status: "accepted",
+      responseAt: now,
+      updatedAt: now,
+    });
+    expect(insertValuesCalls).toContainEqual({
+      seasonId: "season-1",
+      action: "match.auto_award_time",
+      actorId: "system",
+      targetId: "match-1",
+      targetType: "match",
+      meta: {
+        proposalId: "proposal-1",
+        proposedBy: "user-1",
+        scheduledAt: proposedTime.toISOString(),
+      },
+    });
+    expect(revalidateMatchPathsMock).toHaveBeenCalledWith("spring", "match-1");
+  });
+
+  it("skips matches without pending proposals", async () => {
+    matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
+    txMatchFindFirstMock.mockResolvedValue({
+      id: "match-1",
+      seasonId: "season-1",
+      status: "scheduled",
+      scheduledAt: null,
+      completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
+    });
+    txProposalFindFirstMock.mockResolvedValue(null);
+
+    const result = await runMatchTimeAutoAwardCron(now);
+
+    expect(result).toEqual({ processed: 1, awarded: 0, skipped: 1 });
+    expect(updateSetCalls).toEqual([]);
+    expect(insertValuesCalls).toEqual([]);
+    expect(revalidateMatchPathsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/match-time-auto-award-route.test.ts
+++ b/tests/unit/api/match-time-auto-award-route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runMatchTimeAutoAwardCronMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/actions/matches", () => ({
+  runMatchTimeAutoAwardCron: runMatchTimeAutoAwardCronMock,
+}));
+
+import { GET } from "@/app/api/cron/match-time-auto-award/route";
+
+describe("match time auto-award cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "secret";
+  });
+
+  it("rejects requests without the cron bearer token", async () => {
+    const response = await GET(new Request("http://localhost/api/cron/match-time-auto-award"));
+
+    expect(response.status).toBe(401);
+    expect(runMatchTimeAutoAwardCronMock).not.toHaveBeenCalled();
+  });
+
+  it("runs match time auto-award when authorized", async () => {
+    runMatchTimeAutoAwardCronMock.mockResolvedValue({ processed: 1, awarded: 1, skipped: 0 });
+
+    const response = await GET(
+      new Request("http://localhost/api/cron/match-time-auto-award", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true, processed: 1, awarded: 1, skipped: 0 });
+    expect(runMatchTimeAutoAwardCronMock).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
## Summary
- add `runMatchTimeAutoAwardCron` to select the earliest pending match-time proposal after the negotiation cutoff
- add `/api/cron/match-time-auto-award` with `CRON_SECRET` auth and wire it into the GitHub Actions cron workflow
- document the new cron endpoint and cover the action/route with unit tests

## Why
Issue #74 tracks that match-time negotiation currently stops at “contact admin” after the cutoff. This makes scheduled matches automatically adopt the first proposed time once negotiation closes.

## Test Plan
- `pnpm type-check`
- `pnpm test`
- `pnpm build`

Refs #74