### PR TITLE
[phase-9] 选秀选手入口与队伍改名

### DIFF
--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { db } from "@/db/client";
+import { auditLogs, seasonRegistrations, seasons, teams } from "@/db/schema";
+import { actionError, failValidation } from "@/lib/action-utils";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { auditActorId, requireAuth } from "@/lib/auth/session";
+import { ok, type ActionResult } from "@/types/action";
+
+const MIN_TEAM_NAME_LENGTH = 2;
+const MAX_TEAM_NAME_LENGTH = 32;
+
+export async function updateTeamName(
+  teamId: string,
+  rawName: string,
+): Promise<ActionResult<void>> {
+  const name = rawName.trim();
+  if (name.length < MIN_TEAM_NAME_LENGTH || name.length > MAX_TEAM_NAME_LENGTH) {
+    return failValidation(`队伍名称需为 ${MIN_TEAM_NAME_LENGTH}-${MAX_TEAM_NAME_LENGTH} 个字符`);
+  }
+
+  try {
+    const session = await requireAuth();
+    const result = await db.transaction(async (tx) => {
+      const team = await tx.query.teams.findFirst({
+        where: eq(teams.id, teamId),
+      });
+      if (!team) {
+        throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
+      }
+
+      const registration = await tx.query.seasonRegistrations.findFirst({
+        where: and(
+          eq(seasonRegistrations.seasonId, team.seasonId),
+          eq(seasonRegistrations.userId, session.userId),
+        ),
+      });
+      if (!registration || registration.id !== team.captainRegistrationId) {
+        throw new AppError(ErrorCode.FORBIDDEN, "只有队长可以修改队伍名称");
+      }
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, team.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+      }
+
+      if (team.name !== name) {
+        await tx.update(teams).set({ name }).where(eq(teams.id, team.id));
+        await tx.insert(auditLogs).values({
+          seasonId: team.seasonId,
+          action: "team.rename",
+          actorId: auditActorId(session),
+          targetId: team.id,
+          targetType: "team",
+          meta: { from: team.name, to: name },
+        });
+      }
+
+      return { seasonSlug: season.slug };
+    });
+
+    revalidatePath(`/${result.seasonSlug}/teams`);
+    revalidatePath(`/${result.seasonSlug}/teams/${teamId}`);
+    revalidatePath(`/${result.seasonSlug}/draft`);
+    revalidatePath(`/${result.seasonSlug}/draft/captain`);
+
+    return ok(undefined);
+  } catch (e) {
+    return actionError("updateTeamName", e);
+  }
+}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -5,9 +5,11 @@ import { seasons, teams, teamMembers, seasonRegistrations, users, matches, match
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { Panel, Stat, Marker, PosChip } from "@/components/rivalhub";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
+import { TeamNameForm } from "@/components/teams/TeamNameForm";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { CS2_POSITIONS } from "@/types/season";
+import { getUserSession } from "@/lib/auth/session";
 
 interface TeamDetailPageProps {
   params: Promise<{ seasonSlug: string; teamId: string }>;
@@ -30,6 +32,17 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     where: and(eq(teams.id, teamId), eq(teams.seasonId, season.id)),
   });
   if (!team) notFound();
+
+  const session = await getUserSession();
+  const currentUserRegistration = session
+    ? await db.query.seasonRegistrations.findFirst({
+        where: and(
+          eq(seasonRegistrations.seasonId, season.id),
+          eq(seasonRegistrations.userId, session.userId),
+        ),
+      })
+    : null;
+  const canEditTeamName = currentUserRegistration?.id === team.captainRegistrationId;
 
   // ── 阵容 ──────────────────────────────────────────────────────────────
   const roster = await db
@@ -212,6 +225,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           <span className="text-[var(--color-fg)]">#{team.draftOrder}</span>
         </p>
         <Marker>{team.name}</Marker>
+        {canEditTeamName && (
+          <div className="max-w-md pt-3">
+            <TeamNameForm teamId={team.id} initialName={team.name} />
+          </div>
+        )}
       </div>
 
       {/* 整体战绩 */}

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Check, Clock, Loader2 } from "lucide-react";
 import { pickPlayer } from "@/actions/draft";
@@ -14,6 +15,7 @@ import type { MapPreference } from "@/types/season";
 
 export interface CaptainDraftPlayer {
   registrationId: string;
+  userId: string;
   steamName: string;
   primaryPosition: string;
   secondaryPosition: string;
@@ -190,9 +192,12 @@ export function CaptainDraftPanel({
                   className="flex min-h-20 items-center justify-between gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-panel-hi)] px-3 py-2"
                 >
                   <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-[var(--color-fg)]">
+                    <Link
+                      href={`/players/${player.userId}`}
+                      className="block truncate text-sm font-medium text-[var(--color-fg)] hover:text-[var(--color-accent)]"
+                    >
                       {player.steamName}
-                    </div>
+                    </Link>
                     <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--color-fg-dim)]">
                       <span>{positionLabel(player.primaryPosition)}</span>
                       <span>{player.peakRank} {player.peakRating.toFixed(2)}</span>

--- a/src/components/draft/PlayerPool.tsx
+++ b/src/components/draft/PlayerPool.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import React from "react";
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import type { DraftPlayerRow } from "@/lib/draft/data";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
@@ -89,9 +91,12 @@ export function PlayerPool({ players, seasonPositions }: PlayerPoolProps) {
               className="space-y-1.5 rounded bg-[var(--color-panel)] border border-[var(--color-border)] px-2 py-1.5"
             >
               <div className="flex items-center justify-between text-xs">
-                <span className="text-[var(--color-fg)] truncate">
+                <Link
+                  href={`/players/${p.userId}`}
+                  className="text-[var(--color-fg)] truncate hover:text-[var(--color-accent)]"
+                >
                   {p.steamName}
-                </span>
+                </Link>
                 <span className="text-[var(--color-fg-dim)] tabular ml-1 shrink-0">
                   {p.peakRank} {p.peakRating.toFixed(2)}
                 </span>

--- a/src/components/teams/TeamNameForm.tsx
+++ b/src/components/teams/TeamNameForm.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { updateTeamName } from "@/actions/teams";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface TeamNameFormProps {
+  teamId: string;
+  initialName: string;
+}
+
+export function TeamNameForm({ teamId, initialName }: TeamNameFormProps) {
+  const router = useRouter();
+  const [name, setName] = useState(initialName);
+  const [savedName, setSavedName] = useState(initialName);
+  const [isPending, startTransition] = useTransition();
+  const trimmedName = name.trim();
+  const canSubmit =
+    trimmedName.length >= 2 &&
+    trimmedName.length <= 32 &&
+    trimmedName !== savedName;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    startTransition(async () => {
+      const result = await updateTeamName(teamId, trimmedName);
+      if (result.success) {
+        setSavedName(trimmedName);
+        setName(trimmedName);
+        router.refresh();
+        toast.success("队伍名称已更新");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row">
+      <Input
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        minLength={2}
+        maxLength={32}
+        aria-label="队伍名称"
+      />
+      <Button type="submit" size="sm" disabled={!canSubmit || isPending}>
+        保存
+      </Button>
+    </form>
+  );
+}

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -31,6 +31,7 @@ export interface DraftTeamSlot {
 
 export interface DraftPlayerRow {
   registrationId: string;
+  userId: string;
   steamName: string;
   primaryPosition: string;
   secondaryPosition: string;
@@ -131,6 +132,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
   const remainingRows = await db
     .select({
       registrationId: seasonRegistrations.id,
+      userId: seasonRegistrations.userId,
       steamName: users.steamName,
       primaryPosition: seasonRegistrations.primaryPosition,
       secondaryPosition: seasonRegistrations.secondaryPosition,
@@ -152,6 +154,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
     .filter((r) => !pickedRegIds.has(r.registrationId) && !captainRegIds.has(r.registrationId))
     .map((r) => ({
       registrationId: r.registrationId,
+      userId: r.userId,
       steamName: r.steamName ?? "未知选手",
       primaryPosition: r.primaryPosition,
       secondaryPosition: r.secondaryPosition,

--- a/tests/unit/actions/team-profile.test.ts
+++ b/tests/unit/actions/team-profile.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+const {
+  requireAuthMock,
+  transactionMock,
+  teamFindFirstMock,
+  registrationFindFirstMock,
+  seasonFindFirstMock,
+  updateMock,
+  insertMock,
+  updateSetCalls,
+  insertValuesCalls,
+  revalidatePathMock,
+} = vi.hoisted(() => {
+  const updateSetCalls: unknown[] = [];
+  const insertValuesCalls: unknown[] = [];
+  return {
+    requireAuthMock: vi.fn(),
+    transactionMock: vi.fn(),
+    teamFindFirstMock: vi.fn(),
+    registrationFindFirstMock: vi.fn(),
+    seasonFindFirstMock: vi.fn(),
+    updateMock: vi.fn(),
+    insertMock: vi.fn(),
+    updateSetCalls,
+    insertValuesCalls,
+    revalidatePathMock: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  auditActorId: vi.fn((session) => session.userId),
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("@/db/client", () => {
+  const tx = {
+    query: {
+      teams: { findFirst: teamFindFirstMock },
+      seasonRegistrations: { findFirst: registrationFindFirstMock },
+      seasons: { findFirst: seasonFindFirstMock },
+    },
+    update: updateMock,
+    insert: insertMock,
+  };
+
+  return {
+    db: {
+      transaction: transactionMock.mockImplementation((callback) => callback(tx)),
+    },
+  };
+});
+
+import { updateTeamName } from "@/actions/teams";
+
+describe("updateTeamName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSetCalls.length = 0;
+    insertValuesCalls.length = 0;
+
+    requireAuthMock.mockResolvedValue({
+      userId: "user-1",
+      email: "captain@example.com",
+      role: "user",
+      adminSeasonIds: [],
+      authSource: "user",
+    });
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((values) => {
+        updateSetCalls.push(values);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((values) => {
+        insertValuesCalls.push(values);
+        return Promise.resolve();
+      }),
+    }));
+  });
+
+  it("allows the team captain to rename their team and writes audit log", async () => {
+    teamFindFirstMock.mockResolvedValue({
+      id: "team-1",
+      seasonId: "season-1",
+      name: "Old Name",
+      captainRegistrationId: "reg-1",
+    });
+    registrationFindFirstMock.mockResolvedValue({ id: "reg-1" });
+    seasonFindFirstMock.mockResolvedValue({ slug: "spring" });
+
+    const result = await updateTeamName("team-1", "  New Name  ");
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(updateSetCalls).toContainEqual({
+      name: "New Name",
+    });
+    expect(insertValuesCalls).toContainEqual({
+      seasonId: "season-1",
+      action: "team.rename",
+      actorId: "user-1",
+      targetId: "team-1",
+      targetType: "team",
+      meta: { from: "Old Name", to: "New Name" },
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/spring/teams");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/spring/teams/team-1");
+  });
+
+  it("rejects users who are not the team captain", async () => {
+    teamFindFirstMock.mockResolvedValue({
+      id: "team-1",
+      seasonId: "season-1",
+      name: "Old Name",
+      captainRegistrationId: "reg-1",
+    });
+    registrationFindFirstMock.mockResolvedValue({ id: "reg-other" });
+
+    const result = await updateTeamName("team-1", "New Name");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe(ErrorCode.FORBIDDEN);
+    }
+    expect(updateSetCalls).toEqual([]);
+    expect(insertValuesCalls).toEqual([]);
+  });
+});

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -30,6 +30,7 @@ const baseProps = {
   players: [
     {
       registrationId: "33333333-3333-4333-8333-333333333333",
+      userId: "55555555-5555-4555-8555-555555555555",
       steamName: "Neo",
       primaryPosition: "igl",
       secondaryPosition: "anchor",
@@ -79,5 +80,14 @@ describe("CaptainDraftPanel", () => {
 
     expect(button).toBeDisabled();
     expect(pickPlayerMock).not.toHaveBeenCalled();
+  });
+
+  it("links players to their profile pages", () => {
+    render(<CaptainDraftPanel {...baseProps} />);
+
+    expect(screen.getByRole("link", { name: "Neo" })).toHaveAttribute(
+      "href",
+      `/players/${baseProps.players[0].userId}`,
+    );
   });
 });

--- a/tests/unit/components/draft/PlayerPool.test.tsx
+++ b/tests/unit/components/draft/PlayerPool.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlayerPool } from "@/components/draft/PlayerPool";
+
+describe("PlayerPool", () => {
+  it("links remaining players to their profile pages", () => {
+    render(
+      <PlayerPool
+        seasonPositions={["igl"]}
+        players={[
+          {
+            registrationId: "reg-1",
+            userId: "user-1",
+            steamName: "Neo",
+            primaryPosition: "igl",
+            secondaryPosition: "anchor",
+            peakRank: "S",
+            peakRating: 2.01,
+            mapPreferences: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Neo" })).toHaveAttribute(
+      "href",
+      "/players/user-1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add player profile links in the spectator draft pool and captain draft panel
- add a captain-only team rename Server Action with audit logging and page revalidation
- show a team-name edit form on the team detail page for the current team captain

## Why
Issue #74 asks for draft-time player profile access and team management. This keeps the scope small: profile links plus captain team rename, leaving logo upload for a separate PR.

## Test Plan
- `pnpm test tests/unit/components/draft/PlayerPool.test.tsx tests/unit/components/draft/CaptainDraftPanel.test.tsx tests/unit/actions/team-profile.test.ts`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`

Refs #74