### PR TITLE
simplify: PR #80/#81 合并后代码审查优化

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,3 +19,8 @@ jobs:
           curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             "https://match.starfie1d.top/api/cron/check-registration-deadline"
+      - name: Match time auto award
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "https://match.starfie1d.top/api/cron/match-time-auto-award"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ password: RivalHub_password
 
 - `https://match.starfie1d.top/api/cron/draft-timeout` — 选秀超时自动递补
 - `https://match.starfie1d.top/api/cron/check-registration-deadline` — 报名截止/满员自动推进赛季
+- `https://match.starfie1d.top/api/cron/match-time-auto-award` — 比赛时间协商截止后自动采用最早提议
 
 更多细节见 [docs/deployment.md](./docs/deployment.md)。
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,12 +63,14 @@ const pgConfig = {
 
 ## Cron
 
-`/api/cron/draft-timeout` 负责选秀超时自动 pick，并通过 `Authorization: Bearer $CRON_SECRET` 鉴权。
+Cron endpoint 均通过 `Authorization: Bearer $CRON_SECRET` 鉴权。
 
 当前生产调用由 `.github/workflows/cron.yml` 每分钟触发：
 
 ```text
 https://match.starfie1d.top/api/cron/draft-timeout
+https://match.starfie1d.top/api/cron/check-registration-deadline
+https://match.starfie1d.top/api/cron/match-time-auto-award
 ```
 
 因此需要同时配置：

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,4 +1,4 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
 export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline } from "./results";
-export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals } from "./scheduling";
+export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster } from "./roster";

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -16,6 +16,7 @@ export interface MatchTimeAutoAwardCronSummary {
   processed: number;
   awarded: number;
   skipped: number;
+  failed: number;
 }
 
 /**
@@ -219,7 +220,7 @@ export async function runMatchTimeAutoAwardCron(
     ),
   });
 
-  const results = await Promise.all(
+  const settled = await Promise.allSettled(
     candidateMatches.map(async (match) => {
       const result = await autoAwardMatchTime(match.id, now);
       return { matchId: match.id, result };
@@ -228,7 +229,13 @@ export async function runMatchTimeAutoAwardCron(
 
   let awarded = 0;
   let skipped = 0;
-  for (const { matchId, result } of results) {
+  let failed = 0;
+  for (const item of settled) {
+    if (item.status === "rejected") {
+      failed += 1;
+      continue;
+    }
+    const { matchId, result } = item.value;
     if (result.awarded) {
       awarded += 1;
       revalidateMatchPaths(result.seasonSlug, matchId);
@@ -237,7 +244,7 @@ export async function runMatchTimeAutoAwardCron(
     }
   }
 
-  return { processed: candidateMatches.length, awarded, skipped };
+  return { processed: candidateMatches.length, awarded, skipped, failed };
 }
 
 /**
@@ -255,9 +262,7 @@ async function autoAwardMatchTime(
   now: Date,
 ): Promise<{ awarded: true; seasonSlug: string } | { awarded: false }> {
   return db.transaction(async (tx) => {
-    const match = await tx.query.matches.findFirst({
-      where: eq(matches.id, matchId),
-    });
+    const [match] = await tx.select().from(matches).where(eq(matches.id, matchId)).for("update");
     if (!match || match.status !== "scheduled" || match.scheduledAt || !match.completionDeadline) {
       return { awarded: false };
     }

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, and } from "drizzle-orm";
+import { eq, and, isNotNull, isNull, lte } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matchTimeProposals, matches, auditLogs } from "@/db/schema";
+import { matchTimeProposals, matches, auditLogs, seasons } from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
@@ -11,6 +11,12 @@ import { revalidateMatchPaths } from "@/lib/revalidation";
 import { getTeamIdForCaptain } from "./_shared";
 
 const TIME_CONFIRMATION_BUFFER_HOURS = 24;
+
+export interface MatchTimeAutoAwardCronSummary {
+  processed: number;
+  awarded: number;
+  skipped: number;
+}
 
 /**
  * 队长提议比赛时间。
@@ -195,12 +201,119 @@ export async function forceSetMatchTime(
 }
 
 /**
+ * 协商截止后自动采用最早创建的 pending 时间提议。
+ */
+export async function runMatchTimeAutoAwardCron(
+  now = new Date(),
+): Promise<MatchTimeAutoAwardCronSummary> {
+  const cutoffThreshold = new Date(
+    now.getTime() + TIME_CONFIRMATION_BUFFER_HOURS * 60 * 60 * 1000,
+  );
+
+  const candidateMatches = await db.query.matches.findMany({
+    where: and(
+      eq(matches.status, "scheduled"),
+      isNull(matches.scheduledAt),
+      isNotNull(matches.completionDeadline),
+      lte(matches.completionDeadline, cutoffThreshold),
+    ),
+  });
+
+  let awarded = 0;
+  let skipped = 0;
+
+  for (const match of candidateMatches) {
+    const result = await autoAwardMatchTime(match.id, now);
+    if (result.awarded) {
+      awarded += 1;
+      revalidateMatchPaths(result.seasonSlug, match.id);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return { processed: candidateMatches.length, awarded, skipped };
+}
+
+/**
  * 查询某场比赛的所有时间提议（按创建时间倒序）。
  */
 export async function getTimeProposals(matchId: string) {
   return db.query.matchTimeProposals.findMany({
     where: eq(matchTimeProposals.matchId, matchId),
     orderBy: (tps, { desc }) => [desc(tps.createdAt)],
+  });
+}
+
+async function autoAwardMatchTime(
+  matchId: string,
+  now: Date,
+): Promise<{ awarded: true; seasonSlug: string } | { awarded: false }> {
+  return db.transaction(async (tx) => {
+    const match = await tx.query.matches.findFirst({
+      where: eq(matches.id, matchId),
+    });
+    if (!match || match.status !== "scheduled" || match.scheduledAt || !match.completionDeadline) {
+      return { awarded: false };
+    }
+
+    const cutoff = getTimeConfirmationCutoff(match.completionDeadline);
+    if (!cutoff || now.getTime() < cutoff.getTime()) {
+      return { awarded: false };
+    }
+
+    const proposal = await tx.query.matchTimeProposals.findFirst({
+      where: and(
+        eq(matchTimeProposals.matchId, match.id),
+        eq(matchTimeProposals.status, "pending"),
+      ),
+      orderBy: (tps, { asc }) => [asc(tps.createdAt)],
+    });
+    if (!proposal) {
+      return { awarded: false };
+    }
+
+    const season = await tx.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+    });
+    if (!season) {
+      return { awarded: false };
+    }
+
+    await tx
+      .update(matches)
+      .set({ scheduledAt: proposal.proposedTime, updatedAt: now })
+      .where(eq(matches.id, match.id));
+
+    await tx
+      .update(matchTimeProposals)
+      .set({ status: "expired", updatedAt: now })
+      .where(
+        and(
+          eq(matchTimeProposals.matchId, match.id),
+          eq(matchTimeProposals.status, "pending"),
+        ),
+      );
+
+    await tx
+      .update(matchTimeProposals)
+      .set({ status: "accepted", responseAt: now, updatedAt: now })
+      .where(eq(matchTimeProposals.id, proposal.id));
+
+    await tx.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.auto_award_time",
+      actorId: "system",
+      targetId: match.id,
+      targetType: "match",
+      meta: {
+        proposalId: proposal.id,
+        proposedBy: proposal.proposedBy,
+        scheduledAt: proposal.proposedTime.toISOString(),
+      },
+    });
+
+    return { awarded: true, seasonSlug: season.slug };
   });
 }
 

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -219,14 +219,19 @@ export async function runMatchTimeAutoAwardCron(
     ),
   });
 
+  const results = await Promise.all(
+    candidateMatches.map(async (match) => {
+      const result = await autoAwardMatchTime(match.id, now);
+      return { matchId: match.id, result };
+    }),
+  );
+
   let awarded = 0;
   let skipped = 0;
-
-  for (const match of candidateMatches) {
-    const result = await autoAwardMatchTime(match.id, now);
+  for (const { matchId, result } of results) {
     if (result.awarded) {
       awarded += 1;
-      revalidateMatchPaths(result.seasonSlug, match.id);
+      revalidateMatchPaths(result.seasonSlug, matchId);
     } else {
       skipped += 1;
     }

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -9,9 +9,7 @@ import { AppError, ErrorCode } from "@/lib/errors";
 import { auditActorId, requireAuth } from "@/lib/auth/session";
 import { revalidateSeasonPaths } from "@/lib/revalidation";
 import { ok, type ActionResult } from "@/types/action";
-
-export const MIN_TEAM_NAME_LENGTH = 2;
-export const MAX_TEAM_NAME_LENGTH = 32;
+import { MIN_TEAM_NAME_LENGTH, MAX_TEAM_NAME_LENGTH } from "@/lib/config/team-config";
 
 export async function updateTeamName(
   teamId: string,

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { db } from "@/db/client";
+import { auditLogs, seasonRegistrations, seasons, teams } from "@/db/schema";
+import { actionError, failValidation } from "@/lib/action-utils";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { auditActorId, requireAuth } from "@/lib/auth/session";
+import { ok, type ActionResult } from "@/types/action";
+
+const MIN_TEAM_NAME_LENGTH = 2;
+const MAX_TEAM_NAME_LENGTH = 32;
+
+export async function updateTeamName(
+  teamId: string,
+  rawName: string,
+): Promise<ActionResult<void>> {
+  const name = rawName.trim();
+  if (name.length < MIN_TEAM_NAME_LENGTH || name.length > MAX_TEAM_NAME_LENGTH) {
+    return failValidation(`队伍名称需为 ${MIN_TEAM_NAME_LENGTH}-${MAX_TEAM_NAME_LENGTH} 个字符`);
+  }
+
+  try {
+    const session = await requireAuth();
+    const result = await db.transaction(async (tx) => {
+      const team = await tx.query.teams.findFirst({
+        where: eq(teams.id, teamId),
+      });
+      if (!team) {
+        throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
+      }
+
+      const registration = await tx.query.seasonRegistrations.findFirst({
+        where: and(
+          eq(seasonRegistrations.seasonId, team.seasonId),
+          eq(seasonRegistrations.userId, session.userId),
+        ),
+      });
+      if (!registration || registration.id !== team.captainRegistrationId) {
+        throw new AppError(ErrorCode.FORBIDDEN, "只有队长可以修改队伍名称");
+      }
+
+      const season = await tx.query.seasons.findFirst({
+        where: eq(seasons.id, team.seasonId),
+      });
+      if (!season) {
+        throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+      }
+
+      if (team.name !== name) {
+        await tx.update(teams).set({ name }).where(eq(teams.id, team.id));
+        await tx.insert(auditLogs).values({
+          seasonId: team.seasonId,
+          action: "team.rename",
+          actorId: auditActorId(session),
+          targetId: team.id,
+          targetType: "team",
+          meta: { from: team.name, to: name },
+        });
+      }
+
+      return { seasonSlug: season.slug };
+    });
+
+    revalidatePath(`/${result.seasonSlug}/teams`);
+    revalidatePath(`/${result.seasonSlug}/teams/${teamId}`);
+    revalidatePath(`/${result.seasonSlug}/draft`);
+    revalidatePath(`/${result.seasonSlug}/draft/captain`);
+
+    return ok(undefined);
+  } catch (e) {
+    return actionError("updateTeamName", e);
+  }
+}

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -7,10 +7,11 @@ import { auditLogs, seasonRegistrations, seasons, teams } from "@/db/schema";
 import { actionError, failValidation } from "@/lib/action-utils";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { auditActorId, requireAuth } from "@/lib/auth/session";
+import { revalidateSeasonPaths } from "@/lib/revalidation";
 import { ok, type ActionResult } from "@/types/action";
 
-const MIN_TEAM_NAME_LENGTH = 2;
-const MAX_TEAM_NAME_LENGTH = 32;
+export const MIN_TEAM_NAME_LENGTH = 2;
+export const MAX_TEAM_NAME_LENGTH = 32;
 
 export async function updateTeamName(
   teamId: string,
@@ -63,10 +64,8 @@ export async function updateTeamName(
       return { seasonSlug: season.slug };
     });
 
-    revalidatePath(`/${result.seasonSlug}/teams`);
+    revalidateSeasonPaths(result.seasonSlug, ["teams", "draft", "draftCaptain"]);
     revalidatePath(`/${result.seasonSlug}/teams/${teamId}`);
-    revalidatePath(`/${result.seasonSlug}/draft`);
-    revalidatePath(`/${result.seasonSlug}/draft/captain`);
 
     return ok(undefined);
   } catch (e) {

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -5,9 +5,11 @@ import { seasons, teams, teamMembers, seasonRegistrations, users, matches, match
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { Panel, Stat, Marker, PosChip } from "@/components/rivalhub";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
+import { TeamNameForm } from "@/components/teams/TeamNameForm";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { CS2_POSITIONS } from "@/types/season";
+import { getUserSession } from "@/lib/auth/session";
 
 interface TeamDetailPageProps {
   params: Promise<{ seasonSlug: string; teamId: string }>;
@@ -30,6 +32,17 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     where: and(eq(teams.id, teamId), eq(teams.seasonId, season.id)),
   });
   if (!team) notFound();
+
+  const session = await getUserSession();
+  const currentUserRegistration = session
+    ? await db.query.seasonRegistrations.findFirst({
+        where: and(
+          eq(seasonRegistrations.seasonId, season.id),
+          eq(seasonRegistrations.userId, session.userId),
+        ),
+      })
+    : null;
+  const canEditTeamName = currentUserRegistration?.id === team.captainRegistrationId;
 
   // ── 阵容 ──────────────────────────────────────────────────────────────
   const roster = await db
@@ -212,6 +225,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           <span className="text-[var(--color-fg)]">#{team.draftOrder}</span>
         </p>
         <Marker>{team.name}</Marker>
+        {canEditTeamName && (
+          <div className="max-w-md pt-3">
+            <TeamNameForm teamId={team.id} initialName={team.name} />
+          </div>
+        )}
       </div>
 
       {/* 整体战绩 */}

--- a/src/app/api/cron/match-time-auto-award/route.ts
+++ b/src/app/api/cron/match-time-auto-award/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { runMatchTimeAutoAwardCron } from "@/actions/matches";
+import { validateCronAuth } from "@/lib/cron-auth";
+
+export async function GET(request: Request) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const result = await runMatchTimeAutoAwardCron();
+
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Check, Clock, Loader2 } from "lucide-react";
 import { pickPlayer } from "@/actions/draft";
@@ -14,6 +15,7 @@ import type { MapPreference } from "@/types/season";
 
 export interface CaptainDraftPlayer {
   registrationId: string;
+  userId: string;
   steamName: string;
   primaryPosition: string;
   secondaryPosition: string;
@@ -190,9 +192,12 @@ export function CaptainDraftPanel({
                   className="flex min-h-20 items-center justify-between gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-panel-hi)] px-3 py-2"
                 >
                   <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-[var(--color-fg)]">
+                    <Link
+                      href={`/players/${player.userId}`}
+                      className="block truncate text-sm font-medium text-[var(--color-fg)] hover:text-[var(--color-accent)]"
+                    >
                       {player.steamName}
-                    </div>
+                    </Link>
                     <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--color-fg-dim)]">
                       <span>{positionLabel(player.primaryPosition)}</span>
                       <span>{player.peakRank} {player.peakRating.toFixed(2)}</span>

--- a/src/components/draft/PlayerPool.tsx
+++ b/src/components/draft/PlayerPool.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import React from "react";
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import type { DraftPlayerRow } from "@/lib/draft/data";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
@@ -89,9 +91,12 @@ export function PlayerPool({ players, seasonPositions }: PlayerPoolProps) {
               className="space-y-1.5 rounded bg-[var(--color-panel)] border border-[var(--color-border)] px-2 py-1.5"
             >
               <div className="flex items-center justify-between text-xs">
-                <span className="text-[var(--color-fg)] truncate">
+                <Link
+                  href={`/players/${p.userId}`}
+                  className="text-[var(--color-fg)] truncate hover:text-[var(--color-accent)]"
+                >
                   {p.steamName}
-                </span>
+                </Link>
                 <span className="text-[var(--color-fg-dim)] tabular ml-1 shrink-0">
                   {p.peakRank} {p.peakRating.toFixed(2)}
                 </span>

--- a/src/components/teams/TeamNameForm.tsx
+++ b/src/components/teams/TeamNameForm.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { updateTeamName } from "@/actions/teams";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface TeamNameFormProps {
+  teamId: string;
+  initialName: string;
+}
+
+export function TeamNameForm({ teamId, initialName }: TeamNameFormProps) {
+  const router = useRouter();
+  const [name, setName] = useState(initialName);
+  const [savedName, setSavedName] = useState(initialName);
+  const [isPending, startTransition] = useTransition();
+  const trimmedName = name.trim();
+  const canSubmit =
+    trimmedName.length >= 2 &&
+    trimmedName.length <= 32 &&
+    trimmedName !== savedName;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    startTransition(async () => {
+      const result = await updateTeamName(teamId, trimmedName);
+      if (result.success) {
+        setSavedName(trimmedName);
+        setName(trimmedName);
+        router.refresh();
+        toast.success("队伍名称已更新");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row">
+      <Input
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        minLength={2}
+        maxLength={32}
+        aria-label="队伍名称"
+      />
+      <Button type="submit" size="sm" disabled={!canSubmit || isPending}>
+        保存
+      </Button>
+    </form>
+  );
+}

--- a/src/components/teams/TeamNameForm.tsx
+++ b/src/components/teams/TeamNameForm.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useTransition, type FormEvent } from "react";
 import { toast } from "sonner";
-import { updateTeamName, MIN_TEAM_NAME_LENGTH, MAX_TEAM_NAME_LENGTH } from "@/actions/teams";
+import { updateTeamName } from "@/actions/teams";
+import { MIN_TEAM_NAME_LENGTH, MAX_TEAM_NAME_LENGTH } from "@/lib/config/team-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -40,8 +41,8 @@ export function TeamNameForm({ teamId, initialName }: TeamNameFormProps) {
       <Input
         value={name}
         onChange={(event) => setName(event.target.value)}
-        minLength={2}
-        maxLength={32}
+        minLength={MIN_TEAM_NAME_LENGTH}
+        maxLength={MAX_TEAM_NAME_LENGTH}
         aria-label="队伍名称"
       />
       <Button type="submit" size="sm" disabled={!canSubmit || isPending}>

--- a/src/components/teams/TeamNameForm.tsx
+++ b/src/components/teams/TeamNameForm.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useTransition, type FormEvent } from "react";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { updateTeamName } from "@/actions/teams";
+import { updateTeamName, MIN_TEAM_NAME_LENGTH, MAX_TEAM_NAME_LENGTH } from "@/actions/teams";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -13,15 +12,13 @@ interface TeamNameFormProps {
 }
 
 export function TeamNameForm({ teamId, initialName }: TeamNameFormProps) {
-  const router = useRouter();
   const [name, setName] = useState(initialName);
-  const [savedName, setSavedName] = useState(initialName);
   const [isPending, startTransition] = useTransition();
   const trimmedName = name.trim();
   const canSubmit =
-    trimmedName.length >= 2 &&
-    trimmedName.length <= 32 &&
-    trimmedName !== savedName;
+    trimmedName.length >= MIN_TEAM_NAME_LENGTH &&
+    trimmedName.length <= MAX_TEAM_NAME_LENGTH &&
+    trimmedName !== initialName;
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -30,9 +27,7 @@ export function TeamNameForm({ teamId, initialName }: TeamNameFormProps) {
     startTransition(async () => {
       const result = await updateTeamName(teamId, trimmedName);
       if (result.success) {
-        setSavedName(trimmedName);
         setName(trimmedName);
-        router.refresh();
         toast.success("队伍名称已更新");
       } else {
         toast.error(result.error.message);

--- a/src/lib/config/team-config.ts
+++ b/src/lib/config/team-config.ts
@@ -1,0 +1,2 @@
+export const MIN_TEAM_NAME_LENGTH = 2;
+export const MAX_TEAM_NAME_LENGTH = 32;

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -31,6 +31,7 @@ export interface DraftTeamSlot {
 
 export interface DraftPlayerRow {
   registrationId: string;
+  userId: string;
   steamName: string;
   primaryPosition: string;
   secondaryPosition: string;
@@ -131,6 +132,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
   const remainingRows = await db
     .select({
       registrationId: seasonRegistrations.id,
+      userId: seasonRegistrations.userId,
       steamName: users.steamName,
       primaryPosition: seasonRegistrations.primaryPosition,
       secondaryPosition: seasonRegistrations.secondaryPosition,
@@ -152,6 +154,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
     .filter((r) => !pickedRegIds.has(r.registrationId) && !captainRegIds.has(r.registrationId))
     .map((r) => ({
       registrationId: r.registrationId,
+      userId: r.userId,
       steamName: r.steamName ?? "未知选手",
       primaryPosition: r.primaryPosition,
       secondaryPosition: r.secondaryPosition,

--- a/tests/unit/actions/match-time-auto-award.test.ts
+++ b/tests/unit/actions/match-time-auto-award.test.ts
@@ -31,10 +31,14 @@ const {
 vi.mock("@/db/client", () => {
   const tx = {
     query: {
-      matches: { findFirst: txMatchFindFirstMock },
       matchTimeProposals: { findFirst: txProposalFindFirstMock },
       seasons: { findFirst: txSeasonFindFirstMock },
     },
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      for: txMatchFindFirstMock,
+    }),
     update: updateMock,
     insert: insertMock,
   };
@@ -105,13 +109,13 @@ describe("runMatchTimeAutoAwardCron", () => {
 
   it("awards the earliest pending proposal after the negotiation cutoff", async () => {
     matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
-    txMatchFindFirstMock.mockResolvedValue({
+    txMatchFindFirstMock.mockResolvedValue([{
       id: "match-1",
       seasonId: "season-1",
       status: "scheduled",
       scheduledAt: null,
       completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
-    });
+    }]);
     txProposalFindFirstMock.mockResolvedValue({
       id: "proposal-1",
       proposedBy: "user-1",
@@ -121,7 +125,7 @@ describe("runMatchTimeAutoAwardCron", () => {
 
     const result = await runMatchTimeAutoAwardCron(now);
 
-    expect(result).toEqual({ processed: 1, awarded: 1, skipped: 0 });
+    expect(result).toEqual({ processed: 1, awarded: 1, skipped: 0, failed: 0 });
     expect(updateSetCalls).toContainEqual({ scheduledAt: proposedTime, updatedAt: now });
     expect(updateSetCalls).toContainEqual({ status: "expired", updatedAt: now });
     expect(updateSetCalls).toContainEqual({
@@ -146,18 +150,18 @@ describe("runMatchTimeAutoAwardCron", () => {
 
   it("skips matches without pending proposals", async () => {
     matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
-    txMatchFindFirstMock.mockResolvedValue({
+    txMatchFindFirstMock.mockResolvedValue([{
       id: "match-1",
       seasonId: "season-1",
       status: "scheduled",
       scheduledAt: null,
       completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
-    });
+    }]);
     txProposalFindFirstMock.mockResolvedValue(null);
 
     const result = await runMatchTimeAutoAwardCron(now);
 
-    expect(result).toEqual({ processed: 1, awarded: 0, skipped: 1 });
+    expect(result).toEqual({ processed: 1, awarded: 0, skipped: 1, failed: 0 });
     expect(updateSetCalls).toEqual([]);
     expect(insertValuesCalls).toEqual([]);
     expect(revalidateMatchPathsMock).not.toHaveBeenCalled();

--- a/tests/unit/actions/match-time-auto-award.test.ts
+++ b/tests/unit/actions/match-time-auto-award.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  matchFindManyMock,
+  txMatchFindFirstMock,
+  txProposalFindFirstMock,
+  txSeasonFindFirstMock,
+  transactionMock,
+  updateMock,
+  insertMock,
+  updateSetCalls,
+  insertValuesCalls,
+  revalidateMatchPathsMock,
+} = vi.hoisted(() => {
+  const updateSetCalls: unknown[] = [];
+  const insertValuesCalls: unknown[] = [];
+  return {
+    matchFindManyMock: vi.fn(),
+    txMatchFindFirstMock: vi.fn(),
+    txProposalFindFirstMock: vi.fn(),
+    txSeasonFindFirstMock: vi.fn(),
+    transactionMock: vi.fn(),
+    updateMock: vi.fn(),
+    insertMock: vi.fn(),
+    updateSetCalls,
+    insertValuesCalls,
+    revalidateMatchPathsMock: vi.fn(),
+  };
+});
+
+vi.mock("@/db/client", () => {
+  const tx = {
+    query: {
+      matches: { findFirst: txMatchFindFirstMock },
+      matchTimeProposals: { findFirst: txProposalFindFirstMock },
+      seasons: { findFirst: txSeasonFindFirstMock },
+    },
+    update: updateMock,
+    insert: insertMock,
+  };
+
+  return {
+    db: {
+      query: {
+        matches: { findMany: matchFindManyMock },
+      },
+      transaction: transactionMock.mockImplementation((callback) => callback(tx)),
+    },
+  };
+});
+
+vi.mock("@/db/schema", () => ({
+  matches: {
+    id: "matches.id",
+    status: "matches.status",
+    scheduledAt: "matches.scheduledAt",
+    completionDeadline: "matches.completionDeadline",
+  },
+  matchTimeProposals: {
+    id: "match_time_proposals.id",
+    matchId: "match_time_proposals.matchId",
+    status: "match_time_proposals.status",
+    createdAt: "match_time_proposals.createdAt",
+  },
+  auditLogs: {},
+  seasons: { id: "seasons.id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args: unknown[]) => ({ op: "and", args })),
+  asc: vi.fn((column: unknown) => ({ op: "asc", column })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: "eq", left, right })),
+  isNotNull: vi.fn((column: unknown) => ({ op: "isNotNull", column })),
+  isNull: vi.fn((column: unknown) => ({ op: "isNull", column })),
+  lte: vi.fn((left: unknown, right: unknown) => ({ op: "lte", left, right })),
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateMatchPaths: revalidateMatchPathsMock,
+}));
+
+import { runMatchTimeAutoAwardCron } from "@/actions/matches/scheduling";
+
+describe("runMatchTimeAutoAwardCron", () => {
+  const now = new Date("2026-05-14T12:00:00.000Z");
+  const proposedTime = new Date("2026-05-15T08:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSetCalls.length = 0;
+    insertValuesCalls.length = 0;
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((values) => {
+        updateSetCalls.push(values);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((values) => {
+        insertValuesCalls.push(values);
+        return Promise.resolve();
+      }),
+    }));
+  });
+
+  it("awards the earliest pending proposal after the negotiation cutoff", async () => {
+    matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
+    txMatchFindFirstMock.mockResolvedValue({
+      id: "match-1",
+      seasonId: "season-1",
+      status: "scheduled",
+      scheduledAt: null,
+      completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
+    });
+    txProposalFindFirstMock.mockResolvedValue({
+      id: "proposal-1",
+      proposedBy: "user-1",
+      proposedTime,
+    });
+    txSeasonFindFirstMock.mockResolvedValue({ slug: "spring" });
+
+    const result = await runMatchTimeAutoAwardCron(now);
+
+    expect(result).toEqual({ processed: 1, awarded: 1, skipped: 0 });
+    expect(updateSetCalls).toContainEqual({ scheduledAt: proposedTime, updatedAt: now });
+    expect(updateSetCalls).toContainEqual({ status: "expired", updatedAt: now });
+    expect(updateSetCalls).toContainEqual({
+      status: "accepted",
+      responseAt: now,
+      updatedAt: now,
+    });
+    expect(insertValuesCalls).toContainEqual({
+      seasonId: "season-1",
+      action: "match.auto_award_time",
+      actorId: "system",
+      targetId: "match-1",
+      targetType: "match",
+      meta: {
+        proposalId: "proposal-1",
+        proposedBy: "user-1",
+        scheduledAt: proposedTime.toISOString(),
+      },
+    });
+    expect(revalidateMatchPathsMock).toHaveBeenCalledWith("spring", "match-1");
+  });
+
+  it("skips matches without pending proposals", async () => {
+    matchFindManyMock.mockResolvedValue([{ id: "match-1" }]);
+    txMatchFindFirstMock.mockResolvedValue({
+      id: "match-1",
+      seasonId: "season-1",
+      status: "scheduled",
+      scheduledAt: null,
+      completionDeadline: new Date("2026-05-15T12:00:00.000Z"),
+    });
+    txProposalFindFirstMock.mockResolvedValue(null);
+
+    const result = await runMatchTimeAutoAwardCron(now);
+
+    expect(result).toEqual({ processed: 1, awarded: 0, skipped: 1 });
+    expect(updateSetCalls).toEqual([]);
+    expect(insertValuesCalls).toEqual([]);
+    expect(revalidateMatchPathsMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/actions/team-profile.test.ts
+++ b/tests/unit/actions/team-profile.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+const {
+  requireAuthMock,
+  transactionMock,
+  teamFindFirstMock,
+  registrationFindFirstMock,
+  seasonFindFirstMock,
+  updateMock,
+  insertMock,
+  updateSetCalls,
+  insertValuesCalls,
+  revalidatePathMock,
+} = vi.hoisted(() => {
+  const updateSetCalls: unknown[] = [];
+  const insertValuesCalls: unknown[] = [];
+  return {
+    requireAuthMock: vi.fn(),
+    transactionMock: vi.fn(),
+    teamFindFirstMock: vi.fn(),
+    registrationFindFirstMock: vi.fn(),
+    seasonFindFirstMock: vi.fn(),
+    updateMock: vi.fn(),
+    insertMock: vi.fn(),
+    updateSetCalls,
+    insertValuesCalls,
+    revalidatePathMock: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/auth/session", () => ({
+  auditActorId: vi.fn((session) => session.userId),
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("@/db/client", () => {
+  const tx = {
+    query: {
+      teams: { findFirst: teamFindFirstMock },
+      seasonRegistrations: { findFirst: registrationFindFirstMock },
+      seasons: { findFirst: seasonFindFirstMock },
+    },
+    update: updateMock,
+    insert: insertMock,
+  };
+
+  return {
+    db: {
+      transaction: transactionMock.mockImplementation((callback) => callback(tx)),
+    },
+  };
+});
+
+import { updateTeamName } from "@/actions/teams";
+
+describe("updateTeamName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSetCalls.length = 0;
+    insertValuesCalls.length = 0;
+
+    requireAuthMock.mockResolvedValue({
+      userId: "user-1",
+      email: "captain@example.com",
+      role: "user",
+      adminSeasonIds: [],
+      authSource: "user",
+    });
+    updateMock.mockImplementation(() => ({
+      set: vi.fn((values) => {
+        updateSetCalls.push(values);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      }),
+    }));
+    insertMock.mockImplementation(() => ({
+      values: vi.fn((values) => {
+        insertValuesCalls.push(values);
+        return Promise.resolve();
+      }),
+    }));
+  });
+
+  it("allows the team captain to rename their team and writes audit log", async () => {
+    teamFindFirstMock.mockResolvedValue({
+      id: "team-1",
+      seasonId: "season-1",
+      name: "Old Name",
+      captainRegistrationId: "reg-1",
+    });
+    registrationFindFirstMock.mockResolvedValue({ id: "reg-1" });
+    seasonFindFirstMock.mockResolvedValue({ slug: "spring" });
+
+    const result = await updateTeamName("team-1", "  New Name  ");
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(updateSetCalls).toContainEqual({
+      name: "New Name",
+    });
+    expect(insertValuesCalls).toContainEqual({
+      seasonId: "season-1",
+      action: "team.rename",
+      actorId: "user-1",
+      targetId: "team-1",
+      targetType: "team",
+      meta: { from: "Old Name", to: "New Name" },
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/spring/teams");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/spring/teams/team-1");
+  });
+
+  it("rejects users who are not the team captain", async () => {
+    teamFindFirstMock.mockResolvedValue({
+      id: "team-1",
+      seasonId: "season-1",
+      name: "Old Name",
+      captainRegistrationId: "reg-1",
+    });
+    registrationFindFirstMock.mockResolvedValue({ id: "reg-other" });
+
+    const result = await updateTeamName("team-1", "New Name");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe(ErrorCode.FORBIDDEN);
+    }
+    expect(updateSetCalls).toEqual([]);
+    expect(insertValuesCalls).toEqual([]);
+  });
+});

--- a/tests/unit/api/match-time-auto-award-route.test.ts
+++ b/tests/unit/api/match-time-auto-award-route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runMatchTimeAutoAwardCronMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/actions/matches", () => ({
+  runMatchTimeAutoAwardCron: runMatchTimeAutoAwardCronMock,
+}));
+
+import { GET } from "@/app/api/cron/match-time-auto-award/route";
+
+describe("match time auto-award cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "secret";
+  });
+
+  it("rejects requests without the cron bearer token", async () => {
+    const response = await GET(new Request("http://localhost/api/cron/match-time-auto-award"));
+
+    expect(response.status).toBe(401);
+    expect(runMatchTimeAutoAwardCronMock).not.toHaveBeenCalled();
+  });
+
+  it("runs match time auto-award when authorized", async () => {
+    runMatchTimeAutoAwardCronMock.mockResolvedValue({ processed: 1, awarded: 1, skipped: 0 });
+
+    const response = await GET(
+      new Request("http://localhost/api/cron/match-time-auto-award", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true, processed: 1, awarded: 1, skipped: 0 });
+    expect(runMatchTimeAutoAwardCronMock).toHaveBeenCalledWith();
+  });
+});

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -30,6 +30,7 @@ const baseProps = {
   players: [
     {
       registrationId: "33333333-3333-4333-8333-333333333333",
+      userId: "55555555-5555-4555-8555-555555555555",
       steamName: "Neo",
       primaryPosition: "igl",
       secondaryPosition: "anchor",
@@ -79,5 +80,14 @@ describe("CaptainDraftPanel", () => {
 
     expect(button).toBeDisabled();
     expect(pickPlayerMock).not.toHaveBeenCalled();
+  });
+
+  it("links players to their profile pages", () => {
+    render(<CaptainDraftPanel {...baseProps} />);
+
+    expect(screen.getByRole("link", { name: "Neo" })).toHaveAttribute(
+      "href",
+      `/players/${baseProps.players[0].userId}`,
+    );
   });
 });

--- a/tests/unit/components/draft/PlayerPool.test.tsx
+++ b/tests/unit/components/draft/PlayerPool.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlayerPool } from "@/components/draft/PlayerPool";
+
+describe("PlayerPool", () => {
+  it("links remaining players to their profile pages", () => {
+    render(
+      <PlayerPool
+        seasonPositions={["igl"]}
+        players={[
+          {
+            registrationId: "reg-1",
+            userId: "user-1",
+            steamName: "Neo",
+            primaryPosition: "igl",
+            secondaryPosition: "anchor",
+            peakRank: "S",
+            peakRating: 2.01,
+            mapPreferences: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Neo" })).toHaveAttribute(
+      "href",
+      "/players/user-1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `autoAwardMatchTime` 事务并发化（`Promise.all` 替代串行 `for`-loop）
- `updateTeamName` 复用 `revalidateSeasonPaths` 替代 4 条裸 `revalidatePath`
- `TeamNameForm` 移除冗余 `savedName` 状态和多余的 `router.refresh()`
- 队伍名长度常量 `MIN/MAX_TEAM_NAME_LENGTH` 提取为共享导出

## Why
对 PR #80（比赛时间自动裁定）和 PR #81（选秀选手入口与队伍改名）merge 后的代码进行 simplify 审查，发现 3 处可优化点。

## Test Plan
- `pnpm type-check`
- `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)