### PR TITLE
hotfix: v1.3.1 — fix missing team_logo_url migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-14
+
+### Fixed
+- 管理后台选秀控制/赛程管理页面崩溃：`teams` 表缺 `logo_url` 列导致 Postgres 查询报错（补迁移 `0015_team_logo_url.sql`）
+
 ## [1.3.0] - 2026-05-14
 
 ### Added

--- a/drizzle/migrations/0015_team_logo_url.sql
+++ b/drizzle/migrations/0015_team_logo_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "teams" ADD COLUMN "logo_url" text;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
## Summary

v1.3.0 的 `teams` 表新增了 `logo_url` 字段但遗漏了 Drizzle 迁移文件，导致生产数据库缺列。任何查询 `teams` 表的管理页面（选秀控制、赛程管理）都抛出 Postgres 错误。

### Fixed
- 补迁移 `0015_team_logo_url.sql`：`ALTER TABLE teams ADD COLUMN logo_url text`
- 生产 DB 已通过 `db:push` 即时修复，此 PR 补版本库中的迁移文件

### Version
1.3.0 → **1.3.1** (PATCH)

### 合并后待办
- [ ] `git tag v1.3.1` 指向此 merge commit（tag 已随分支推送，合并后注意确认）
- [ ] Cherry-pick 到 `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)