### PR TITLE
feat: 补全审计日志 + 操作日志浏览页面

### DIFF
--- a/src/actions/account.ts
+++ b/src/actions/account.ts
@@ -2,7 +2,7 @@
 
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { users } from "@/db/schema/users";
+import { users, auditLogs } from "@/db/schema";
 import { createServiceClient } from "@/lib/auth/supabase";
 import { requireAuth } from "@/lib/auth/session";
 import { ok, fail, type ActionResult } from "@/types/action";
@@ -41,6 +41,14 @@ export async function changeUserPassword(
     if (updateError) {
       throw new AppError(ErrorCode.INTERNAL_ERROR, "密码更新失败，请重试");
     }
+
+    await db.insert(auditLogs).values({
+      seasonId: null,
+      action: "user.change_password",
+      actorId: session.userId,
+      targetId: session.userId,
+      targetType: "user",
+    });
 
     return ok(undefined);
   } catch (e) {

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -124,6 +124,15 @@ export async function registerAdmin(
       })
       .where(eq(adminInvites.id, invite.id));
 
+    await tx.insert(auditLogs).values({
+      seasonId: null,
+      action: "admin.register",
+      actorId: username,
+      targetId: newAdmin.id,
+      targetType: "admin_user",
+      meta: { role: invite.role, inviteId: invite.id },
+    });
+
     return ok(newAdmin);
   });
 
@@ -281,6 +290,15 @@ export async function createInviteCode(input: {
     })
     .returning({ id: adminInvites.id });
 
+  await db.insert(auditLogs).values({
+    seasonId: inviteSeasonId,
+    action: "admin.create_invite",
+    actorId: auditActorId(admin),
+    targetId: invite.id,
+    targetType: "admin_invite",
+    meta: { role, maxUses, expiresAt: expiresAt?.toISOString() ?? null },
+  });
+
   revalidatePath("/admin/invites");
   return ok({
     id: invite.id,
@@ -293,12 +311,20 @@ export async function createInviteCode(input: {
 }
 
 export async function deactivateInviteCode(inviteId: string) {
-  await requireSuperAdmin();
+  const admin = await requireSuperAdmin();
 
   await db
     .update(adminInvites)
     .set({ isActive: false })
     .where(eq(adminInvites.id, inviteId));
+
+  await db.insert(auditLogs).values({
+    seasonId: null,
+    action: "admin.deactivate_invite",
+    actorId: auditActorId(admin),
+    targetId: inviteId,
+    targetType: "admin_invite",
+  });
 
   revalidatePath("/admin/invites");
   return ok(undefined);
@@ -343,6 +369,14 @@ export async function changePassword(currentPassword: string, newPassword: strin
     .set({ passwordHash: hashPassword(newPassword), updatedAt: new Date() })
     .where(eq(adminUsers.id, user.id));
 
+  await db.insert(auditLogs).values({
+    seasonId: null,
+    action: "admin.change_password",
+    actorId: auditActorId(admin),
+    targetId: user.id,
+    targetType: "admin_user",
+  });
+
   return ok(undefined);
 }
 
@@ -381,17 +415,34 @@ export async function deactivateAdminUser(adminId: string) {
     .set({ isActive: false, updatedAt: new Date() })
     .where(eq(adminUsers.id, adminId));
 
+  await db.insert(auditLogs).values({
+    seasonId: null,
+    action: "admin.deactivate_user",
+    actorId: auditActorId(admin),
+    targetId: adminId,
+    targetType: "admin_user",
+    meta: { targetUsername: target.username },
+  });
+
   revalidatePath("/admin/users");
   return ok(undefined);
 }
 
 export async function reactivateAdminUser(adminId: string) {
-  await requireSuperAdmin();
+  const admin = await requireSuperAdmin();
 
   await db
     .update(adminUsers)
     .set({ isActive: true, updatedAt: new Date() })
     .where(eq(adminUsers.id, adminId));
+
+  await db.insert(auditLogs).values({
+    seasonId: null,
+    action: "admin.reactivate_user",
+    actorId: auditActorId(admin),
+    targetId: adminId,
+    targetType: "admin_user",
+  });
 
   revalidatePath("/admin/users");
   return ok(undefined);

--- a/src/actions/audit.ts
+++ b/src/actions/audit.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import { and, desc, eq, gte, lte, count, like } from "drizzle-orm";
+import { db } from "@/db/client";
+import { auditLogs, seasons } from "@/db/schema";
+import { ok } from "@/types/action";
+import { requireSuperAdmin } from "@/lib/auth/session";
+import { actionError } from "@/lib/action-utils";
+
+function escapeLike(s: string) {
+  return s.replace(/[%_\\]/g, (c) => `\\${c}`);
+}
+
+export interface AuditLogFilters {
+  page?: number;
+  pageSize?: number;
+  seasonId?: string;
+  action?: string;
+  actorId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export async function fetchAuditLogs(filters: AuditLogFilters = {}) {
+  try {
+    await requireSuperAdmin();
+
+    const {
+      page = 1,
+      pageSize = 50,
+      seasonId,
+      action,
+      actorId,
+      dateFrom,
+      dateTo,
+    } = filters;
+
+    const conditions = [];
+    if (seasonId) conditions.push(eq(auditLogs.seasonId, seasonId));
+    if (action) conditions.push(like(auditLogs.action, `%${escapeLike(action)}%`));
+    if (actorId) conditions.push(like(auditLogs.actorId, `%${escapeLike(actorId)}%`));
+    if (dateFrom) conditions.push(gte(auditLogs.createdAt, new Date(dateFrom)));
+    if (dateTo) conditions.push(lte(auditLogs.createdAt, new Date(dateTo)));
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [rows, [totalRow]] = await Promise.all([
+      db
+        .select()
+        .from(auditLogs)
+        .where(where)
+        .orderBy(desc(auditLogs.createdAt))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize),
+      db.select({ count: count() }).from(auditLogs).where(where),
+    ]);
+
+    const logs = rows.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+      meta: r.meta as Record<string, unknown> | null,
+    }));
+
+    return ok({ logs, total: Number(totalRow?.count ?? 0) });
+  } catch (e) {
+    return actionError("fetchAuditLogs", e);
+  }
+}
+
+export async function getAuditSeasons() {
+  try {
+    await requireSuperAdmin();
+    const rows = await db.query.seasons.findMany({
+      columns: { id: true, name: true },
+      orderBy: [desc(seasons.createdAt)],
+    });
+    return ok(rows);
+  } catch (e) {
+    return actionError("getAuditSeasons", e);
+  }
+}

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,8 +4,7 @@ import { revalidatePath } from "next/cache";
 import { eq, sql, type SQL } from "drizzle-orm";
 import { createServiceClient } from "@/lib/auth/supabase";
 import { db } from "@/db/client";
-import { users } from "@/db/schema/users";
-import { adminInvites } from "@/db/schema/admin-invites";
+import { users, adminInvites, auditLogs } from "@/db/schema";
 import { ok, fail } from "@/types/action";
 import { ErrorCode } from "@/lib/errors";
 import type { ActionResult } from "@/types/action";
@@ -207,6 +206,15 @@ export async function claimInviteCode(code: string): Promise<ActionResult<{ role
           usedByUsernames: sql`array_append(${adminInvites.usedByUsernames}, ${session.email})`,
         })
         .where(eq(adminInvites.id, invite.id));
+
+      await tx.insert(auditLogs).values({
+        seasonId: invite.seasonId,
+        action: "user.claim_invite",
+        actorId: session.userId,
+        targetId: session.userId,
+        targetType: "user",
+        meta: { inviteId: invite.id, newRole, email: session.email },
+      });
 
       return ok({ updatedUser, newRole });
     });

--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -93,6 +93,15 @@ export async function castVote(
       return vote.id;
     });
 
+    await db.insert(auditLogs).values({
+      seasonId: null,
+      action: "captain.cast_vote",
+      actorId: session.userId,
+      targetId: parsed.data.candidateRegistrationId,
+      targetType: "captain_vote",
+      meta: { voteId, voterRegistrationId: parsed.data.voterRegistrationId },
+    });
+
     await revalidateCaptainPaths(parsed.data.voterRegistrationId);
     return ok({ voteId });
   } catch (e) {
@@ -148,6 +157,15 @@ export async function retractVote(
             eq(captainVotes.candidateRegistrationId, candidate.id),
           ),
         );
+    });
+
+    await db.insert(auditLogs).values({
+      seasonId: null,
+      action: "captain.retract_vote",
+      actorId: session.userId,
+      targetId: parsed.data.candidateRegistrationId,
+      targetType: "captain_vote",
+      meta: { voterRegistrationId: parsed.data.voterRegistrationId },
     });
 
     await revalidateCaptainPaths(parsed.data.voterRegistrationId);

--- a/src/actions/matches/roster.ts
+++ b/src/actions/matches/roster.ts
@@ -103,6 +103,15 @@ export async function submitMatchRoster(
       return rosterId;
     });
 
+    await db.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.submit_roster",
+      actorId: session.userId,
+      targetId: rosterId,
+      targetType: "match_roster",
+      meta: { matchId, teamId, starters: starterIds.length, substitutes: substituteIds.length },
+    });
+
     const season = await db.query.seasons.findFirst({
       where: eq(seasons.id, match.seasonId),
     });

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -50,6 +50,15 @@ export async function proposeMatchTime(
       })
       .returning({ id: matchTimeProposals.id });
 
+    await db.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.propose_time",
+      actorId: session.userId,
+      targetId: matchId,
+      targetType: "match",
+      meta: { proposalId: proposal.id, proposedTime: proposedTime.toISOString() },
+    });
+
     const season = await getSeasonOrThrow(match.seasonId);
     revalidateMatchPaths(season.slug, matchId);
 
@@ -129,6 +138,15 @@ export async function respondToTimeProposal(
             ),
           );
       }
+    });
+
+    await db.insert(auditLogs).values({
+      seasonId: match.seasonId,
+      action: "match.respond_time_proposal",
+      actorId: session.userId,
+      targetId: proposalId,
+      targetType: "match_time_proposal",
+      meta: { matchId: match.id, action, rejectReason: rejectReason ?? null },
     });
 
     const season = await getSeasonOrThrow(match.seasonId);

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { eq, and, count } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
-import { users, seasons, seasonRegistrations, registrationDrafts } from "@/db/schema";
+import { users, seasons, seasonRegistrations, registrationDrafts, auditLogs } from "@/db/schema";
 import { ok, fail } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { actionError } from "@/lib/action-utils";
@@ -277,6 +277,15 @@ export async function submitRegistration(input: RegistrationFormData) {
           eq(registrationDrafts.email, normalizedEmail),
         ),
       );
+
+    await db.insert(auditLogs).values({
+      seasonId: data.seasonId,
+      action: "registration.submit",
+      actorId: session.userId,
+      targetId: registration.id,
+      targetType: "registration",
+      meta: { email: data.email, primaryPosition: data.primaryPosition },
+    });
 
     revalidatePath(`/${season.slug}/register`);
     return ok({ registrationId: registration.id, email: data.email });

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: "/admin", label: "赛季管理" },
   { href: "/admin/users", label: "用户管理" },
   { href: "/admin/invites", label: "邀请码" },
+  { href: "/admin/logs", label: "操作日志" },
   { href: "/admin/settings", label: "系统设置" },
 ] as const;
 

--- a/src/components/admin/AuditLogTable.tsx
+++ b/src/components/admin/AuditLogTable.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { fetchAuditLogs, type AuditLogFilters } from "@/actions/audit";
+import { formatCST } from "@/lib/utils/date";
+
+interface AuditLog {
+  id: string;
+  seasonId: string | null;
+  action: string;
+  actorId: string | null;
+  targetId: string | null;
+  targetType: string | null;
+  meta: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+interface Props {
+  initialLogs: AuditLog[];
+  initialTotal: number;
+  seasons: { id: string; name: string }[];
+}
+
+const ACTION_CATEGORIES: Record<string, { label: string; color: string }> = {
+  admin: { label: "管理", color: "var(--color-accent)" },
+  registration: { label: "报名", color: "#22c55e" },
+  captain: { label: "投票", color: "#a855f7" },
+  draft: { label: "选秀", color: "#f97316" },
+  match: { label: "赛程", color: "#3b82f6" },
+  season: { label: "赛季", color: "#eab308" },
+  team: { label: "队伍", color: "#06b6d4" },
+  user: { label: "用户", color: "#ec4899" },
+};
+
+function getCategory(action: string) {
+  const prefix = action.split(".")[0];
+  return ACTION_CATEGORIES[prefix] ?? { label: prefix, color: "var(--color-fg-dim)" };
+}
+
+const PAGE_SIZE = 50;
+
+export function AuditLogTable({ initialLogs, initialTotal, seasons }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [logs, setLogs] = useState(initialLogs);
+  const [total, setTotal] = useState(initialTotal);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // 本地输入状态（用于 debounce，避免每次按键触发请求）
+  const [localAction, setLocalAction] = useState(searchParams.get("action") ?? "");
+  const [localActor, setLocalActor] = useState(searchParams.get("actor") ?? "");
+
+  const actionTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const actorTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const currentPage = Number(searchParams.get("page") ?? "1");
+  const currentAction = searchParams.get("action") ?? "";
+  const currentActor = searchParams.get("actor") ?? "";
+  const currentSeason = searchParams.get("seasonId") ?? "";
+  const currentDateFrom = searchParams.get("dateFrom") ?? "";
+  const currentDateTo = searchParams.get("dateTo") ?? "";
+
+  const updateParams = useCallback(
+    (updates: Record<string, string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          params.set(key, value);
+        } else {
+          params.delete(key);
+        }
+      }
+      if (!updates.page) params.set("page", "1");
+      router.push(`/admin/logs?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  const debouncedUpdateParam = useCallback(
+    (key: string, value: string, timerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | undefined>) => {
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        updateParams({ [key]: value });
+      }, 400);
+    },
+    [updateParams],
+  );
+
+  const reload = useCallback(() => {
+    const filters: AuditLogFilters = {
+      page: currentPage,
+      pageSize: PAGE_SIZE,
+    };
+    if (currentAction) filters.action = currentAction;
+    if (currentActor) filters.actorId = currentActor;
+    if (currentSeason) filters.seasonId = currentSeason;
+    if (currentDateFrom) filters.dateFrom = currentDateFrom;
+    if (currentDateTo) filters.dateTo = currentDateTo;
+
+    startTransition(async () => {
+      const result = await fetchAuditLogs(filters);
+      if (result.success) {
+        setLogs(result.data.logs);
+        setTotal(result.data.total);
+      }
+    });
+  }, [currentPage, currentAction, currentActor, currentSeason, currentDateFrom, currentDateTo]);
+
+  const isInitialMount = useRef(true);
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    reload();
+  }, [reload]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(actionTimerRef.current);
+      clearTimeout(actorTimerRef.current);
+    };
+  }, []);
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  return (
+    <div className="space-y-4">
+      {/* filters */}
+      <div
+        className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 rounded-md"
+        style={{ background: "var(--color-panel)", border: "1px solid var(--color-border)" }}
+      >
+        <div>
+          <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
+            操作类型
+          </label>
+          <input
+            type="text"
+            placeholder="如 admin.create_invite"
+            value={localAction}
+            onChange={(e) => {
+              setLocalAction(e.target.value);
+              debouncedUpdateParam("action", e.target.value, actionTimerRef);
+            }}
+            className="w-full px-2 py-1.5 rounded text-xs"
+            style={{
+              background: "var(--color-panel-low)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-fg)",
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
+            操作人
+          </label>
+          <input
+            type="text"
+            placeholder="用户 ID 或邮箱"
+            value={localActor}
+            onChange={(e) => {
+              setLocalActor(e.target.value);
+              debouncedUpdateParam("actor", e.target.value, actorTimerRef);
+            }}
+            className="w-full px-2 py-1.5 rounded text-xs"
+            style={{
+              background: "var(--color-panel-low)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-fg)",
+            }}
+          />
+        </div>
+        <div>
+          <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
+            赛季
+          </label>
+          <select
+            value={currentSeason}
+            onChange={(e) => updateParams({ seasonId: e.target.value })}
+            className="w-full px-2 py-1.5 rounded text-xs"
+            style={{
+              background: "var(--color-panel-low)",
+              border: "1px solid var(--color-border)",
+              color: "var(--color-fg)",
+            }}
+          >
+            <option value="">全部赛季</option>
+            {seasons.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
+              起始日期
+            </label>
+            <input
+              type="date"
+              value={currentDateFrom}
+              onChange={(e) => updateParams({ dateFrom: e.target.value })}
+              className="w-full px-2 py-1.5 rounded text-xs"
+              style={{
+                background: "var(--color-panel-low)",
+                border: "1px solid var(--color-border)",
+                color: "var(--color-fg)",
+              }}
+            />
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
+              结束日期
+            </label>
+            <input
+              type="date"
+              value={currentDateTo}
+              onChange={(e) => updateParams({ dateTo: e.target.value })}
+              className="w-full px-2 py-1.5 rounded text-xs"
+              style={{
+                background: "var(--color-panel-low)",
+                border: "1px solid var(--color-border)",
+                color: "var(--color-fg)",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* summary */}
+      <div className="flex items-center justify-between text-xs" style={{ color: "var(--color-fg-dim)" }}>
+        <span>
+          共 {total} 条记录{totalPages > 1 ? `，第 ${currentPage}/${totalPages} 页` : ""}
+        </span>
+        {isPending && <span style={{ color: "var(--color-accent)" }}>加载中…</span>}
+      </div>
+
+      {/* table */}
+      <div
+        className="rounded-md overflow-hidden"
+        style={{ border: "1px solid var(--color-border)" }}
+      >
+        <table className="w-full text-xs" style={{ fontFamily: "var(--font-mono)" }}>
+          <thead>
+            <tr style={{ background: "var(--color-panel)", borderBottom: "1px solid var(--color-border)" }}>
+              <th className="text-left px-3 py-2 font-medium" style={{ color: "var(--color-fg-mid)" }}>时间</th>
+              <th className="text-left px-3 py-2 font-medium" style={{ color: "var(--color-fg-mid)" }}>操作</th>
+              <th className="text-left px-3 py-2 font-medium" style={{ color: "var(--color-fg-mid)" }}>操作人</th>
+              <th className="text-left px-3 py-2 font-medium" style={{ color: "var(--color-fg-mid)" }}>目标</th>
+              <th className="text-left px-3 py-2 font-medium" style={{ color: "var(--color-fg-mid)" }}>详情</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.length === 0 && (
+              <tr>
+                <td colSpan={5} className="text-center py-8" style={{ color: "var(--color-fg-dim)" }}>
+                  暂无日志记录
+                </td>
+              </tr>
+            )}
+            {logs.map((log) => {
+              const cat = getCategory(log.action);
+              const isExpanded = expandedId === log.id;
+              return (
+                <tr
+                  key={log.id}
+                  className="group"
+                  style={{ borderBottom: "1px solid var(--color-border)" }}
+                >
+                  <td className="px-3 py-2 whitespace-nowrap" style={{ color: "var(--color-fg-mid)" }}>
+                    {formatCST(log.createdAt)}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium mr-1.5"
+                      style={{ background: cat.color, color: "#000", opacity: 0.9 }}
+                    >
+                      {cat.label}
+                    </span>
+                    <span style={{ color: "var(--color-fg)" }}>{log.action}</span>
+                  </td>
+                  <td className="px-3 py-2 truncate max-w-[140px]" style={{ color: "var(--color-fg-mid)" }}>
+                    {log.actorId ?? "-"}
+                  </td>
+                  <td className="px-3 py-2" style={{ color: "var(--color-fg-mid)" }}>
+                    {log.targetType && (
+                      <span className="opacity-60 mr-1">{log.targetType}:</span>
+                    )}
+                    <span className="truncate inline-block max-w-[100px] align-bottom">
+                      {log.targetId?.slice(0, 8) ?? "-"}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    {log.meta ? (
+                      <button
+                        onClick={() => setExpandedId(isExpanded ? null : log.id)}
+                        className="text-[10px] underline"
+                        style={{ color: "var(--color-accent)" }}
+                      >
+                        {isExpanded ? "收起" : "展开"}
+                      </button>
+                    ) : (
+                      <span style={{ color: "var(--color-fg-dim)" }}>-</span>
+                    )}
+                    {isExpanded && log.meta && (
+                      <pre
+                        className="mt-1 p-2 rounded text-[10px] whitespace-pre-wrap break-all"
+                        style={{
+                          background: "var(--color-panel-low)",
+                          color: "var(--color-fg-mid)",
+                          maxWidth: 300,
+                          maxHeight: 200,
+                          overflow: "auto",
+                        }}
+                      >
+                        {JSON.stringify(log.meta, null, 2)}
+                      </pre>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <button
+            disabled={currentPage <= 1}
+            onClick={() => updateParams({ page: String(currentPage - 1) })}
+            className="px-3 py-1 rounded text-xs disabled:opacity-30"
+            style={{ background: "var(--color-panel)", border: "1px solid var(--color-border)", color: "var(--color-fg)" }}
+          >
+            上一页
+          </button>
+          <span className="text-xs" style={{ color: "var(--color-fg-dim)" }}>
+            {currentPage} / {totalPages}
+          </span>
+          <button
+            disabled={currentPage >= totalPages}
+            onClick={() => updateParams({ page: String(currentPage + 1) })}
+            className="px-3 py-1 rounded text-xs disabled:opacity-30"
+            style={{ background: "var(--color-panel)", border: "1px solid var(--color-border)", color: "var(--color-fg)" }}
+          >
+            下一页
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 补全 12 个管理员/用户操作函数的 audit_logs 写入
- 新增 /admin/logs 日志浏览页面（筛选/分页/meta展开）
- AdminSidebar 新增操作日志导航项
- LIKE 转义防通配符注入 + 文本输入 400ms debounce
- 修复首次加载双重请求