### PR TITLE
fix: 修复报名开放期状态与审核流

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -301,7 +301,7 @@ erDiagram
 | `pending` | 待审核 |
 | `approved` | 已通过 |
 | `rejected` | 已拒绝 |
-| `waitlisted` | 等待名单 |
+| `waitlisted` | 候补名单 |
 
 ### `admin_role`
 | 值 | 说明 |

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -61,10 +61,12 @@ waitlisted
   └─ [admin: reject]  → rejected
 
 approved
+  ├─ [admin: revoke]  → pending    ← 仅在赛季 registration 阶段允许
   └─ [admin: reject]  → rejected   ← 仅在赛季 registration 阶段允许
 
 rejected
-  └─ [admin: approve] → approved   ← 仅在赛季 registration 阶段允许
+  ├─ [admin: approve] → approved   ← 仅在赛季 registration 阶段允许
+  └─ [admin: reopen]  → pending    ← 仅在赛季 registration 阶段允许
 ```
 
 ### 合法迁移表
@@ -76,13 +78,13 @@ rejected
 | `pending` | `waitlisted` | admin | 赛季 status = registration |
 | `waitlisted` | `approved` | admin | 赛季 status = registration 或 voting，且位置未满 |
 | `waitlisted` | `rejected` | admin | 任意阶段 |
+| `approved` | `pending` | admin | 赛季 status = registration（撤销通过，回到待审核） |
 | `approved` | `rejected` | admin | 赛季 status = registration（已进入 voting/drafting 后不允许） |
 | `rejected` | `approved` | admin | 赛季 status = registration，且位置未满 |
+| `rejected` | `pending` | admin | 赛季 status = registration |
 
 ### 禁止迁移
 
-- `approved → pending`（不允许回到待审核）
-- `rejected → pending`（不允许回到待审核）
 - 赛季进入 `voting` 或之后，禁止 `approved → rejected`
 
 ---

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -138,14 +138,14 @@ export async function registerAdmin(
 
 interface ReviewInput {
   registrationId: string;
-  status: "approved" | "rejected" | "waitlisted";
+  status: "pending" | "approved" | "rejected" | "waitlisted";
   reason?: string;
 }
 
 export async function reviewRegistration(input: ReviewInput) {
   const { registrationId, status: targetStatus, reason } = input;
 
-  if (!["approved", "rejected", "waitlisted"].includes(targetStatus)) {
+  if (!["pending", "approved", "rejected", "waitlisted"].includes(targetStatus)) {
     return fail({ code: ErrorCode.VALIDATION_FAILED, message: "无效的审核状态" });
   }
 

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, count } from "drizzle-orm";
+import { and, count, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { users, seasons, seasonRegistrations, registrationDrafts } from "@/db/schema";
@@ -189,8 +189,8 @@ export async function submitRegistration(input: RegistrationFormData) {
         eq(seasonRegistrations.seasonId, data.seasonId)
       ),
     });
-    if (existing) {
-      throw new AppError(ErrorCode.REGISTRATION_DUPLICATE, ERROR_MESSAGES.REGISTRATION_DUPLICATE);
+    if (existing?.status === "approved") {
+      throw new AppError(ErrorCode.REGISTRATION_DUPLICATE, "报名已审核通过，无法自行修改。如确需调整请联系管理员。");
     }
 
     const [totalCount] = await db
@@ -202,19 +202,23 @@ export async function submitRegistration(input: RegistrationFormData) {
           eq(seasonRegistrations.status, "approved"),
         ),
       );
-    if (Number(totalCount?.count ?? 0) >= registrationConfig.maxTotal) {
+    if (!existing && Number(totalCount?.count ?? 0) >= registrationConfig.maxTotal) {
       throw new AppError(ErrorCode.REGISTRATION_FULL, ERROR_MESSAGES.REGISTRATION_FULL);
+    }
+
+    const positionFilters = [
+      eq(seasonRegistrations.seasonId, data.seasonId),
+      eq(seasonRegistrations.primaryPosition, data.primaryPosition),
+      ne(seasonRegistrations.status, "rejected"),
+    ];
+    if (existing) {
+      positionFilters.push(ne(seasonRegistrations.id, existing.id));
     }
 
     const [posCount] = await db
       .select({ count: count() })
       .from(seasonRegistrations)
-      .where(
-        and(
-          eq(seasonRegistrations.seasonId, data.seasonId),
-          eq(seasonRegistrations.primaryPosition, data.primaryPosition)
-        )
-      );
+      .where(and(...positionFilters));
     if (Number(posCount?.count ?? 0) >= registrationConfig.maxPerPosition) {
       throw new AppError(ErrorCode.POSITION_FULL, ERROR_MESSAGES.POSITION_FULL);
     }
@@ -244,30 +248,44 @@ export async function submitRegistration(input: RegistrationFormData) {
       throw new AppError(ErrorCode.INTERNAL_ERROR, ERROR_MESSAGES.INTERNAL_ERROR);
     }
 
-    const [registration] = await db
-      .insert(seasonRegistrations)
-      .values({
-        userId: user.id,
-        seasonId: data.seasonId,
-        playerType: data.playerType,
-        primaryPosition: data.primaryPosition,
-        secondaryPosition: data.secondaryPosition,
-        peakRank: data.peakRank,
-        peakRankSeason: data.peakRankSeason,
-        peakRating: data.peakRating,
-        peakWe: data.peakWe,
-        currentSeasonPeakRank: data.currentSeasonPeakRank,
-        currentRating: data.currentRating,
-        currentWe: data.currentWe,
-        screenshotUrls: data.screenshotUrls,
-        mapPreferences: data.mapPreferences,
-        gameplayStyle: data.gameplayStyle,
-        competitionHistory: data.competitionHistory,
-        highlightVideoUrl: data.highlightVideoUrl,
-        willingToBeCaptain: data.willingToBeCaptain,
-        notes: data.notes,
-      })
-      .returning();
+    const registrationValues = {
+      playerType: data.playerType,
+      primaryPosition: data.primaryPosition,
+      secondaryPosition: data.secondaryPosition,
+      peakRank: data.peakRank,
+      peakRankSeason: data.peakRankSeason,
+      peakRating: data.peakRating,
+      peakWe: data.peakWe,
+      currentSeasonPeakRank: data.currentSeasonPeakRank,
+      currentRating: data.currentRating,
+      currentWe: data.currentWe,
+      screenshotUrls: data.screenshotUrls,
+      mapPreferences: data.mapPreferences,
+      gameplayStyle: data.gameplayStyle,
+      competitionHistory: data.competitionHistory,
+      highlightVideoUrl: data.highlightVideoUrl,
+      willingToBeCaptain: data.willingToBeCaptain,
+      notes: data.notes,
+    };
+
+    const [registration] = existing
+      ? await db
+          .update(seasonRegistrations)
+          .set({
+            ...registrationValues,
+            status: "pending",
+            updatedAt: new Date(),
+          })
+          .where(eq(seasonRegistrations.id, existing.id))
+          .returning()
+      : await db
+          .insert(seasonRegistrations)
+          .values({
+            userId: user.id,
+            seasonId: data.seasonId,
+            ...registrationValues,
+          })
+          .returning();
 
     await db
       .delete(registrationDrafts)
@@ -297,7 +315,12 @@ export async function getPositionCounts(
       count: count(),
     })
     .from(seasonRegistrations)
-    .where(eq(seasonRegistrations.seasonId, seasonId))
+    .where(
+      and(
+        eq(seasonRegistrations.seasonId, seasonId),
+        ne(seasonRegistrations.status, "rejected"),
+      ),
+    )
     .groupBy(seasonRegistrations.primaryPosition);
 
   return Object.fromEntries(rows.map((r) => [r.position, Number(r.count)]));

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -1,11 +1,12 @@
 import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons } from "@/db/schema";
+import { seasons, seasonRegistrations, users } from "@/db/schema";
 import { getPositionCounts, getApprovedCount } from "@/actions/register";
 import { RegistrationForm } from "@/components/register/RegistrationForm";
 import { normalizeRegistrationConfig } from "@/types/season";
+import { REGISTRATION_STATUS_LABELS } from "@/types/registration";
 import { Panel, StatusBanner, PosChip } from "@/components/rivalhub";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { getRegistrationWindowState, getWindowTone } from "@/lib/registration/window";
@@ -65,10 +66,53 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
     redirect(`/login?next=/${seasonSlug}/register`);
   }
 
-  const positionCounts = await getPositionCounts(season.id);
-  const approvedCount = await getApprovedCount(season.id);
+  const [positionCounts, approvedCount, currentRegistration, currentUser] = await Promise.all([
+    getPositionCounts(season.id),
+    getApprovedCount(season.id),
+    db.query.seasonRegistrations.findFirst({
+      where: and(
+        eq(seasonRegistrations.seasonId, season.id),
+        eq(seasonRegistrations.userId, userSession.userId),
+      ),
+    }),
+    db.query.users.findFirst({
+      where: eq(users.id, userSession.userId),
+    }),
+  ]);
   const regConfig = normalizeRegistrationConfig(season.registrationConfig);
   const maxPerPos = regConfig.maxPerPosition;
+  const existingStatus = currentRegistration?.status ?? null;
+  const existingStatusLabel = existingStatus ? REGISTRATION_STATUS_LABELS[existingStatus] : null;
+  const canEditExisting = !!currentRegistration && currentRegistration.status !== "approved";
+  const initialValues = currentRegistration
+    ? {
+        email: userSession.email,
+        studentId: currentUser?.studentId ?? "",
+        qq: currentUser?.qq ?? "",
+        perfectName: currentUser?.perfectName ?? "",
+        steamName: currentUser?.steamName ?? "",
+        steam64: currentUser?.steam64 ?? "",
+        steamProfileUrl: currentUser?.steamProfileUrl ?? "",
+        playerType: currentRegistration.playerType,
+        primaryPosition: currentRegistration.primaryPosition,
+        secondaryPosition: currentRegistration.secondaryPosition,
+        peakRank: currentRegistration.peakRank,
+        peakRankSeason: currentRegistration.peakRankSeason,
+        peakRating: currentRegistration.peakRating,
+        peakWe: currentRegistration.peakWe ?? undefined,
+        currentSeasonPeakRank: currentRegistration.currentSeasonPeakRank,
+        currentRating: currentRegistration.currentRating,
+        currentWe: currentRegistration.currentWe ?? undefined,
+        screenshotUrls: currentRegistration.screenshotUrls,
+        mapPreferences: currentRegistration.mapPreferences,
+        gameplayStyle: currentRegistration.gameplayStyle,
+        competitionHistory: currentRegistration.competitionHistory ?? "",
+        highlightVideoUrl: currentRegistration.highlightVideoUrl ?? "",
+        willingToBeCaptain: currentRegistration.willingToBeCaptain,
+        notes: currentRegistration.notes ?? "",
+        antiCheatPledge: true as const,
+      }
+    : undefined;
 
   // 位置容量数据
   const capacityEntries = season.positions.map((pos) => {
@@ -141,20 +185,45 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
         </Panel>
       </div>
 
+      {currentRegistration && (
+        <div className="mb-6">
+          <StatusBanner
+            tone={currentRegistration.status === "approved" ? "success" : currentRegistration.status === "rejected" ? "warn" : "info"}
+            title={`你的报名状态：${existingStatusLabel}`}
+            sub={
+              currentRegistration.status === "approved"
+                ? "审核已通过，报名信息已锁定。如确需调整请联系管理员。"
+                : "你可以在下方修改已提交的信息；重新提交后状态会回到待审核。"
+            }
+          />
+        </div>
+      )}
+
       <Panel pad={24}>
-        <RegistrationForm
-          seasonId={season.id}
-          seasonName={season.name}
-          positionCounts={positionCounts}
-          positions={season.positions}
-          registrationConfig={regConfig}
-          windowState={registrationWindow}
-          currentUserEmail={userSession?.email ?? null}
-        />
+        {currentRegistration?.status === "approved" ? (
+          <div className="py-10 text-center">
+            <h2 className="text-xl font-bold text-[var(--color-fg)]">报名已通过</h2>
+            <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
+              你已经进入本赛季名单，审核通过后暂不支持自行修改报名信息。
+            </p>
+          </div>
+        ) : (
+          <RegistrationForm
+            seasonId={season.id}
+            seasonName={season.name}
+            positionCounts={positionCounts}
+            positions={season.positions}
+            registrationConfig={regConfig}
+            windowState={registrationWindow}
+            currentUserEmail={userSession?.email ?? null}
+            initialValues={initialValues}
+            submitLabel={canEditExisting ? "更新报名" : undefined}
+          />
+        )}
       </Panel>
 
       <p className="text-xs text-[var(--color-fg-dim)] text-center mt-6">
-        提交即视为同意参赛规则。报名信息提交后不可自行修改，如需更改请联系管理员。
+        提交即视为同意参赛规则。审核通过前可自行修改；审核通过后如需更改请联系管理员。
       </p>
     </div>
   );

--- a/src/app/admin/[seasonSlug]/registrations/page.tsx
+++ b/src/app/admin/[seasonSlug]/registrations/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { eq, desc } from "drizzle-orm";
+import { asc, desc, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, seasonRegistrations, users, registrationDrafts } from "@/db/schema";
 import { Marker } from "@/components/rivalhub";
@@ -52,7 +52,7 @@ export default async function AdminRegistrationsPage({ params }: PageProps) {
       .from(seasonRegistrations)
       .leftJoin(users, eq(seasonRegistrations.userId, users.id))
       .where(eq(seasonRegistrations.seasonId, season.id))
-      .orderBy(desc(seasonRegistrations.createdAt)),
+      .orderBy(asc(seasonRegistrations.createdAt)),
     db
       .select()
       .from(registrationDrafts)

--- a/src/components/admin/RegistrationReviewList.tsx
+++ b/src/components/admin/RegistrationReviewList.tsx
@@ -80,7 +80,7 @@ export function RegistrationReviewList({ registrations }: Props) {
     waitlisted: registrations.filter((r) => r.status === "waitlisted").length,
   };
 
-  function handleReview(registrationId: string, status: "approved" | "rejected" | "waitlisted") {
+  function handleReview(registrationId: string, status: "pending" | "approved" | "rejected" | "waitlisted") {
     const label = REGISTRATION_STATUS_LABELS[status];
     startTransition(async () => {
       const result = await reviewRegistration({ registrationId, status });
@@ -97,7 +97,7 @@ export function RegistrationReviewList({ registrations }: Props) {
     { key: "pending", label: "待审核" },
     { key: "approved", label: "已通过" },
     { key: "rejected", label: "已拒绝" },
-    { key: "waitlisted", label: "等待名单" },
+    { key: "waitlisted", label: "候补名单" },
   ];
 
   return (
@@ -219,7 +219,7 @@ export function RegistrationReviewList({ registrations }: Props) {
                         disabled={isPending}
                         onClick={() => handleReview(r.id, "waitlisted")}
                       >
-                        等待
+                        候补
                       </Button>
                       <Button
                         size="sm"
@@ -256,20 +256,30 @@ export function RegistrationReviewList({ registrations }: Props) {
                       size="sm"
                       variant="ghost"
                       disabled={isPending}
-                      onClick={() => handleReview(r.id, "rejected")}
+                      onClick={() => handleReview(r.id, "pending")}
                     >
-                      撤销通过
+                      撤回待审
                     </Button>
                   )}
                   {r.status === "rejected" && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={isPending}
-                      onClick={() => handleReview(r.id, "approved")}
-                    >
-                      改为通过
-                    </Button>
+                    <>
+                      <Button
+                        size="sm"
+                        variant="default"
+                        disabled={isPending}
+                        onClick={() => handleReview(r.id, "approved")}
+                      >
+                        改为通过
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={isPending}
+                        onClick={() => handleReview(r.id, "pending")}
+                      >
+                        回到待审
+                      </Button>
+                    </>
                   )}
                 </div>
               </div>

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -170,6 +170,11 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
                     </>
                   )}
                   <DropdownMenuItem asChild>
+                    <Link href={`/players/${session.userId}`} className="cursor-pointer">
+                      我的主页
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
                     <Link href={"/settings/password" as never} className="cursor-pointer">
                       修改密码
                     </Link>
@@ -253,6 +258,13 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
                     管理后台
                   </Link>
                 )}
+                <Link
+                  href={`/players/${session.userId}`}
+                  onClick={() => setMobileOpen(false)}
+                  className="px-3 py-2 rounded-md text-sm text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] hover:bg-[var(--color-panel-hi)]"
+                >
+                  我的主页
+                </Link>
                 <Link
                   href={"/settings/password" as never}
                   onClick={() => setMobileOpen(false)}

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -43,6 +43,8 @@ interface RegistrationFormProps {
   registrationConfig: RegistrationConfig;
   windowState: RegistrationWindowState;
   currentUserEmail?: string | null;
+  initialValues?: Partial<RegistrationInput>;
+  submitLabel?: string;
 }
 
 export function RegistrationForm({
@@ -53,6 +55,8 @@ export function RegistrationForm({
   registrationConfig: inputRegistrationConfig,
   windowState,
   currentUserEmail,
+  initialValues,
+  submitLabel,
 }: RegistrationFormProps) {
   const { canSaveDraft, canSubmit, message: windowMessage } = windowState;
   const [submitted, setSubmitted] = useState(false);
@@ -82,12 +86,16 @@ export function RegistrationForm({
   } = useForm<RegistrationInput, unknown, RegistrationFormData>({
     resolver: zodResolver(schema),
     defaultValues: {
+      ...initialValues,
       seasonId,
-      email: currentUserEmail ?? "",
-      willingToBeCaptain: false,
-      playerType: registrationConfig.allowedPlayerTypes[0],
-      screenshotUrls: Array.from({ length: registrationConfig.screenshotCount }, () => ""),
-      mapPreferences: defaultMapPreferences(registrationConfig.mapPool),
+      email: initialValues?.email ?? currentUserEmail ?? "",
+      willingToBeCaptain: initialValues?.willingToBeCaptain ?? false,
+      playerType: initialValues?.playerType ?? registrationConfig.allowedPlayerTypes[0],
+      screenshotUrls: initialValues?.screenshotUrls ?? Array.from({ length: registrationConfig.screenshotCount }, () => ""),
+      mapPreferences: normalizeMapPreferences(
+        initialValues?.mapPreferences,
+        registrationConfig.mapPool,
+      ),
     },
   });
 
@@ -806,6 +814,7 @@ export function RegistrationForm({
           <input
             id="antiCheatPledge"
             type="checkbox"
+            defaultChecked={!!initialValues?.antiCheatPledge}
             className="mt-0.5 h-4 w-4 accent-amber-400"
             onChange={(e) =>
               setValue("antiCheatPledge", e.target.checked as true, {
@@ -855,7 +864,7 @@ export function RegistrationForm({
               提交中…
             </>
           ) : (
-            canSubmit ? "提交报名" : windowMessage ?? "报名提交暂未开放"
+            canSubmit ? submitLabel ?? "提交报名" : windowMessage ?? "报名提交暂未开放"
           )}
         </Button>
       </div>

--- a/src/lib/registration-transitions.ts
+++ b/src/lib/registration-transitions.ts
@@ -15,8 +15,10 @@ export const TRANSITION_RULES: Partial<Record<TransitionKey, TransitionRule>> = 
   "pending→waitlisted":  { allowedSeasonStatuses: ["registration"] },
   "waitlisted→approved": { allowedSeasonStatuses: ["registration", "voting"] },
   "waitlisted→rejected": { allowedSeasonStatuses: [] },
+  "approved→pending":    { allowedSeasonStatuses: ["registration"] },
   "approved→rejected":   { allowedSeasonStatuses: ["registration"] },
   "rejected→approved":   { allowedSeasonStatuses: ["registration"] },
+  "rejected→pending":    { allowedSeasonStatuses: ["registration"] },
 };
 
 export function validateTransition(

--- a/src/types/registration.ts
+++ b/src/types/registration.ts
@@ -30,7 +30,7 @@ export const REGISTRATION_STATUS_LABELS: Record<RegistrationStatus, string> = {
   pending: "待审核",
   approved: "已通过",
   rejected: "已拒绝",
-  waitlisted: "等待名单",
+  waitlisted: "候补名单",
 };
 
 /** 每个位置的报名上限 */

--- a/tests/unit/actions/register.test.ts
+++ b/tests/unit/actions/register.test.ts
@@ -271,16 +271,52 @@ describe("submitRegistration()", () => {
     }
   });
 
-  it("已报名返回 REGISTRATION_DUPLICATE", async () => {
+  it("已通过报名返回 REGISTRATION_DUPLICATE", async () => {
     setupHappyPathBase();
     userFindFirstMock.mockResolvedValue(USER);
-    registrationFindFirstMock.mockResolvedValue({ id: REG_ID });
+    registrationFindFirstMock.mockResolvedValue({ id: REG_ID, status: "approved" });
 
     const result = await submitRegistration(VALID_INPUT as never);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe(ErrorCode.REGISTRATION_DUPLICATE);
     }
+  });
+
+  it("待审核报名可更新并保持待审核", async () => {
+    setupHappyPathBase();
+    userFindFirstMock.mockResolvedValue(USER);
+    registrationFindFirstMock.mockResolvedValue({ id: REG_ID, status: "pending" });
+
+    mockSelectCount(0);
+    mockSelectCount(0);
+    mockUpdateReturning([{ ...USER, steam64: VALID_INPUT.steam64 }]);
+
+    updateMock.mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: REG_ID, status: "pending" }]),
+        }),
+      }),
+    });
+
+    deleteMock.mockReturnValueOnce({
+      where: vi.fn().mockResolvedValue(undefined),
+    });
+
+    insertMock.mockReturnValueOnce({
+      values: vi.fn((vals: unknown) => {
+        insertValuesCalls.push(vals);
+        return Promise.resolve();
+      }),
+    });
+
+    const result = await submitRegistration(VALID_INPUT as never);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.registrationId).toBe(REG_ID);
+    }
+    expectAuditLog(insertValuesCalls, "registration.submit", { actorId: USER_ID, targetId: REG_ID });
   });
 
   it("正常提交成功：insert registration + delete draft + audit_log", async () => {


### PR DESCRIPTION
## Summary
- 头像菜单新增我的主页入口
- 报名页显示当前用户报名状态，审核通过前允许修改，审核通过后锁定
- 审核列表按提交时间升序展示，撤销通过回到待审核
- 将等待名单文案统一为候补名单，并更新状态机文档

## Verification
- pnpm type-check
- pnpm test -- register admin-transitions RegistrationForm
- pnpm build