### PR TITLE
chore: 1.4.1 — 下拉菜单/头像修复 + 用户名统一 + 玩家主页数据增强

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/storage/v1/object/public/**",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.steamstatic.com",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/audit.ts
+++ b/src/actions/audit.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { and, desc, eq, gte, lt, count, like } from "drizzle-orm";
+import { and, desc, eq, gte, lt, or, count, like, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { auditLogs, seasons } from "@/db/schema";
+import { auditLogs, seasons, users } from "@/db/schema";
 import { ok } from "@/types/action";
 import { requireSuperAdmin } from "@/lib/auth/session";
 import { actionError } from "@/lib/action-utils";
@@ -79,7 +79,22 @@ export async function fetchAuditLogs(filters: AuditLogFilters = {}) {
       meta: r.meta as Record<string, unknown> | null,
     }));
 
-    return ok({ logs, total: Number(totalRow?.count ?? 0) });
+    // 构建 actorId → Steam 名称映射
+    const actorIds = [...new Set(logs.map((l) => l.actorId).filter((id): id is string => id != null))];
+    const actorNameMap: Record<string, string> = {};
+    if (actorIds.length) {
+      const actorUsers = await db
+        .select({ id: users.id, email: users.email, steamName: users.steamName })
+        .from(users)
+        .where(or(inArray(users.id, actorIds), inArray(users.email, actorIds)));
+      for (const u of actorUsers) {
+        const name = u.steamName ?? u.email;
+        actorNameMap[u.id] = name;
+        if (u.email) actorNameMap[u.email] = name;
+      }
+    }
+
+    return ok({ logs, total: Number(totalRow?.count ?? 0), actorNameMap });
   } catch (e) {
     return actionError("fetchAuditLogs", e);
   }

--- a/src/app/admin/logs/page.tsx
+++ b/src/app/admin/logs/page.tsx
@@ -45,12 +45,13 @@ export default async function AdminLogsPage({ searchParams }: AdminLogsPageProps
 
   const logs = logsResult.success ? logsResult.data.logs : [];
   const total = logsResult.success ? logsResult.data.total : 0;
+  const actorNameMap = logsResult.success ? (logsResult.data.actorNameMap ?? {}) : {};
   const seasons = seasonsResult.success ? seasonsResult.data : [];
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <Marker>操作日志</Marker>
-      <AuditLogTable initialLogs={logs} initialTotal={total} seasons={seasons} />
+      <AuditLogTable initialLogs={logs} initialTotal={total} seasons={seasons} initialActorNameMap={actorNameMap} />
     </div>
   );
 }

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,3 +1,6 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { users } from "@/db/schema";
 import { checkAdminSession } from "@/lib/auth/session";
 import { ChangePasswordForm } from "@/components/admin/ChangePasswordForm";
 import { Panel, StatusPill, Marker } from "@/components/rivalhub";
@@ -19,11 +22,16 @@ const ENV_VARS = [
 
 export default async function AdminSettingsPage() {
   const admin = (await checkAdminSession())!;
+  const adminUser = await db.query.users.findFirst({
+    where: eq(users.id, admin.userId),
+    columns: { steamName: true },
+  });
+  const adminDisplayName = adminUser?.steamName ?? admin.email;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl space-y-10">
         <div>
-          <Marker sub={`当前登录：${admin.email}`}>系统设置</Marker>
+          <Marker sub={`当前登录：${adminDisplayName}`}>系统设置</Marker>
         </div>
 
         {/* 修改密码 */}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -32,6 +32,7 @@ export default async function AdminUsersPage() {
         users={adminUsers.map((u) => ({
           id: u.id,
           email: u.email,
+          steamName: u.steamName,
           role: u.role as "super_admin" | "season_admin",
           adminSeasonIds: u.adminSeasonIds,
           createdAt: u.createdAt.toISOString(),

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -170,7 +170,8 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             alt={user.steamName ?? "选手头像"}
             width={96}
             height={96}
-            className="rounded-full border border-[var(--color-border)]"
+            unoptimized
+            className="rounded-full border border-[var(--color-border)] object-cover"
           />
         ) : (
           <AvatarFallback name={user.steamName ?? user.email} />

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
+import { matchMvpVotes } from "@/db/schema/mvp-votes";
 
 interface PlayerPageProps {
   params: Promise<{ userId: string }>;
@@ -44,35 +45,73 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   });
   if (!user) notFound();
 
-  // ── 所有已批准的报名记录（按赛季时间降序）─────────────────────────────
-  const registrations = await db
-    .select({
-      id: seasonRegistrations.id,
-      seasonId: seasonRegistrations.seasonId,
-      primaryPosition: seasonRegistrations.primaryPosition,
-      secondaryPosition: seasonRegistrations.secondaryPosition,
-      peakRank: seasonRegistrations.peakRank,
-      peakRankSeason: seasonRegistrations.peakRankSeason,
-      peakRating: seasonRegistrations.peakRating,
-      currentSeasonPeakRank: seasonRegistrations.currentSeasonPeakRank,
-      currentRating: seasonRegistrations.currentRating,
-      mapPreferences: seasonRegistrations.mapPreferences,
-      gameplayStyle: seasonRegistrations.gameplayStyle,
-      competitionHistory: seasonRegistrations.competitionHistory,
-      highlightVideoUrl: seasonRegistrations.highlightVideoUrl,
-      status: seasonRegistrations.status,
-      seasonName: seasons.name,
-      seasonSlug: seasons.slug,
-    })
-    .from(seasonRegistrations)
-    .innerJoin(seasons, eq(seasonRegistrations.seasonId, seasons.id))
-    .where(
-      and(
-        eq(seasonRegistrations.userId, userId),
-        eq(seasonRegistrations.status, "approved"),
+  // ── 并行：报名记录 / MVP / 个人数据 / Steam 头像 ──────────────────────
+  const [registrations, mvpRows, playerStats, avatarUrl] = await Promise.all([
+    db
+      .select({
+        id: seasonRegistrations.id,
+        seasonId: seasonRegistrations.seasonId,
+        primaryPosition: seasonRegistrations.primaryPosition,
+        secondaryPosition: seasonRegistrations.secondaryPosition,
+        peakRank: seasonRegistrations.peakRank,
+        peakRankSeason: seasonRegistrations.peakRankSeason,
+        peakRating: seasonRegistrations.peakRating,
+        peakWe: seasonRegistrations.peakWe,
+        currentSeasonPeakRank: seasonRegistrations.currentSeasonPeakRank,
+        currentRating: seasonRegistrations.currentRating,
+        mapPreferences: seasonRegistrations.mapPreferences,
+        highlightVideoUrl: seasonRegistrations.highlightVideoUrl,
+        status: seasonRegistrations.status,
+        seasonName: seasons.name,
+        seasonSlug: seasons.slug,
+      })
+      .from(seasonRegistrations)
+      .innerJoin(seasons, eq(seasonRegistrations.seasonId, seasons.id))
+      .where(
+        and(
+          eq(seasonRegistrations.userId, userId),
+          eq(seasonRegistrations.status, "approved"),
+        )
       )
-    )
-    .orderBy(asc(seasons.createdAt));
+      .orderBy(asc(seasons.createdAt)),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(matchMvpVotes)
+      .where(eq(matchMvpVotes.playerUserId, userId)),
+    db
+      .select({
+        seasonName: seasons.name,
+        seasonSlug: seasons.slug,
+        seasonCreatedAt: seasons.createdAt,
+        maps: sql<number>`count(distinct ${matchPlayerStats.mapId})::int`,
+        avgKills: sql<number>`round(avg(${matchPlayerStats.kills})::numeric, 1)`,
+        avgDeaths: sql<number>`round(avg(${matchPlayerStats.deaths})::numeric, 1)`,
+        avgAssists: sql<number>`round(avg(${matchPlayerStats.assists})::numeric, 1)`,
+        avgRating: sql<number>`round(avg(${matchPlayerStats.ratingPro})::numeric, 2)`,
+        avgAdr: sql<number>`round(avg(${matchPlayerStats.adr})::numeric, 1)`,
+        avgWe: sql<number>`round(avg(${matchPlayerStats.we})::numeric, 1)`,
+        avgHs: sql<number>`round(avg(${matchPlayerStats.hsPercent})::numeric, 0)`,
+        avgRws: sql<number>`round(avg(${matchPlayerStats.rws})::numeric, 2)`,
+        totalKills: sql<number>`sum(${matchPlayerStats.kills})::int`,
+        totalDeaths: sql<number>`sum(${matchPlayerStats.deaths})::int`,
+        totalFirstKills: sql<number>`sum(${matchPlayerStats.firstKills})::int`,
+        totalMultiKills: sql<number>`sum(${matchPlayerStats.multiKills})::int`,
+        totalClutches: sql<number>`sum(${matchPlayerStats.clutches})::int`,
+      })
+      .from(matchPlayerStats)
+      .innerJoin(matches, eq(matchPlayerStats.matchId, matches.id))
+      .innerJoin(seasons, eq(matches.seasonId, seasons.id))
+      .where(
+        and(
+          eq(matchPlayerStats.userId, userId),
+          sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+        )
+      )
+      .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
+      .orderBy(asc(seasons.createdAt)),
+    user.avatarUrl ?? (user.steam64 ? getSteamAvatar(user.steam64) : null),
+  ]);
+  const mvpRow = mvpRows[0];
 
   // ── 队伍归属（registrationId → team）────────────────────────────────
   const allRegIds = registrations.map((r) => r.id);
@@ -124,40 +163,22 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
 
   const played = totalWins + totalLosses;
 
-  // ── Steam 头像 ────────────────────────────────────────────────────────
-  const avatarUrl = user.avatarUrl ?? (user.steam64 ? await getSteamAvatar(user.steam64) : null);
-
   // 最新报名的主位置
   const latestReg = registrations[registrations.length - 1];
 
-  // ── 个人数据统计（跨赛季）─────────────────────────────────────
-  const playerStats = await db
-    .select({
-      seasonName: seasons.name,
-      seasonSlug: seasons.slug,
-      seasonCreatedAt: seasons.createdAt,
-      maps: sql<number>`count(distinct ${matchPlayerStats.mapId})::int`,
-      avgKills: sql<number>`round(avg(${matchPlayerStats.kills})::numeric, 1)`,
-      avgDeaths: sql<number>`round(avg(${matchPlayerStats.deaths})::numeric, 1)`,
-      avgAssists: sql<number>`round(avg(${matchPlayerStats.assists})::numeric, 1)`,
-      avgRating: sql<number>`round(avg(${matchPlayerStats.ratingPro})::numeric, 2)`,
-      avgAdr: sql<number>`round(avg(${matchPlayerStats.adr})::numeric, 1)`,
-      avgWe: sql<number>`round(avg(${matchPlayerStats.we})::numeric, 1)`,
-      avgHs: sql<number>`round(avg(${matchPlayerStats.hsPercent})::numeric, 0)`,
-      totalKills: sql<number>`sum(${matchPlayerStats.kills})::int`,
-      totalDeaths: sql<number>`sum(${matchPlayerStats.deaths})::int`,
-    })
-    .from(matchPlayerStats)
-    .innerJoin(matches, eq(matchPlayerStats.matchId, matches.id))
-    .innerJoin(seasons, eq(matches.seasonId, seasons.id))
-    .where(
-      and(
-        eq(matchPlayerStats.userId, userId),
-        sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
-      )
-    )
-    .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
-    .orderBy(asc(seasons.createdAt));
+  // ── 生涯总计预计算 ──────────────────────────────────────────────────
+  const totalMaps = playerStats.reduce((s, x) => s + x.maps, 0);
+  const totalKillsAll = playerStats.reduce((s, x) => s + x.totalKills, 0);
+  const totalDeathsAll = playerStats.reduce((s, x) => s + x.totalDeaths, 0);
+  function wAvg(field: (x: (typeof playerStats)[number]) => number, precision = 1) {
+    if (totalMaps === 0) return "—";
+    return (playerStats.reduce((s, x) => s + field(x) * x.maps, 0) / totalMaps).toFixed(precision);
+  }
+  function sAvg(field: (x: (typeof playerStats)[number]) => number, precision = 1) {
+    if (totalMaps === 0) return "—";
+    return (playerStats.reduce((s, x) => s + field(x), 0) / totalMaps).toFixed(precision);
+  }
+  const mvpCount = mvpRow?.count ?? 0;
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl space-y-10">
@@ -170,7 +191,6 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             alt={user.steamName ?? "选手头像"}
             width={96}
             height={96}
-            unoptimized
             className="rounded-full border border-[var(--color-border)] object-cover"
           />
         ) : (
@@ -181,6 +201,11 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
           <h1 className="text-3xl font-black text-[var(--color-fg)]">
             {user.steamName ?? "未知选手"}
           </h1>
+          {user.perfectName && (
+            <p className="text-xs" style={{ fontFamily: "var(--font-mono)", color: "var(--color-fg-dim)" }}>
+              完美平台：{user.perfectName}
+            </p>
+          )}
 
           <div className="flex flex-wrap items-center gap-2">
             {latestReg && (
@@ -216,11 +241,12 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       {played > 0 && (
         <section className="space-y-3">
           <SectionHeading>职业生涯战绩</SectionHeading>
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
             <Stat label="出场" value={played} />
             <Stat label="胜" value={totalWins} />
             <Stat label="负" value={totalLosses} />
             <Stat label="胜率" value={pct(totalWins, played)} />
+            <Stat label="MVP" value={mvpCount > 0 ? mvpCount : "—"} />
           </div>
           {totalNetRounds !== 0 && (
             <p className="text-xs text-[var(--color-fg-mid)] px-1">
@@ -241,55 +267,29 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
           {/* 生涯总计 */}
           <Panel label="生涯总计">
             <span className="text-xs text-[var(--color-fg-mid)]">
-              {playerStats.reduce((s, x) => s + x.maps, 0)} 图
+              {totalMaps} 图
             </span>
-            <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 text-center mt-3">
+            <div className="grid grid-cols-4 sm:grid-cols-5 gap-3 text-center mt-3">
               {[
-                {
-                  label: "Rating",
-                  value: (
-                    playerStats.reduce((s, x) => s + x.avgRating * x.maps, 0) /
-                    playerStats.reduce((s, x) => s + x.maps, 0)
-                  ).toFixed(2),
-                },
-                {
-                  label: "ADR",
-                  value: (
-                    playerStats.reduce((s, x) => s + x.avgAdr * x.maps, 0) /
-                    playerStats.reduce((s, x) => s + x.maps, 0)
-                  ).toFixed(1),
-                },
+                { label: "Rating", value: wAvg((x) => x.avgRating, 2) },
+                { label: "ADR", value: wAvg((x) => x.avgAdr) },
+                { label: "RWS", value: wAvg((x) => x.avgRws, 2) },
                 {
                   label: "K/D",
-                  value:
-                    playerStats.reduce((s, x) => s + x.totalKills, 0) > 0 &&
-                    playerStats.reduce((s, x) => s + x.totalDeaths, 0) > 0
-                      ? (
-                          playerStats.reduce((s, x) => s + x.totalKills, 0) /
-                          playerStats.reduce((s, x) => s + x.totalDeaths, 0)
-                        ).toFixed(2)
-                      : "—",
+                  value: totalKillsAll > 0 && totalDeathsAll > 0
+                    ? (totalKillsAll / totalDeathsAll).toFixed(2)
+                    : "—",
                 },
-                {
-                  label: "WE",
-                  value: (
-                    playerStats.reduce((s, x) => s + x.avgWe * x.maps, 0) /
-                    playerStats.reduce((s, x) => s + x.maps, 0)
-                  ).toFixed(1),
-                },
-                {
-                  label: "场均击杀",
-                  value: (
-                    playerStats.reduce((s, x) => s + x.totalKills, 0) /
-                    playerStats.reduce((s, x) => s + x.maps, 0)
-                  ).toFixed(1),
-                },
+                { label: "WE", value: wAvg((x) => x.avgWe) },
+                { label: "场均击杀", value: sAvg((x) => x.totalKills) },
+                { label: "首杀", value: sAvg((x) => x.totalFirstKills) },
+                { label: "多杀", value: sAvg((x) => x.totalMultiKills) },
+                { label: "残局", value: sAvg((x) => x.totalClutches) },
                 {
                   label: "HS%",
-                  value: Math.round(
-                    playerStats.reduce((s, x) => s + x.avgHs * x.maps, 0) /
-                      playerStats.reduce((s, x) => s + x.maps, 0)
-                  ) + "%",
+                  value: totalMaps > 0
+                    ? Math.round(playerStats.reduce((s, x) => s + x.avgHs * x.maps, 0) / totalMaps) + "%"
+                    : "—",
                 },
               ].map(({ label, value }) => (
                 <div key={label}>
@@ -318,7 +318,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                   {ps.maps} 图 · 场均 {ps.avgKills}-{ps.avgDeaths}-{ps.avgAssists}
                 </span>
               </div>
-              <div className="flex gap-4 text-xs text-[var(--color-fg-mid)]">
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
                 <span>
                   Rating{" "}
                   <span className="text-[var(--color-accent)] font-semibold">
@@ -328,6 +328,10 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                 <span>
                   ADR{" "}
                   <span className="text-[var(--color-fg)]">{ps.avgAdr}</span>
+                </span>
+                <span>
+                  RWS{" "}
+                  <span className="text-[var(--color-fg)]">{ps.avgRws}</span>
                 </span>
                 <span>
                   K/D{" "}
@@ -341,6 +345,10 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                   WE{" "}
                   <span className="text-[var(--color-fg)]">{ps.avgWe}</span>
                 </span>
+                <span>
+                  HS{" "}
+                  <span className="text-[var(--color-fg)]">{ps.avgHs}%</span>
+                </span>
               </div>
             </Panel>
           ))}
@@ -351,16 +359,18 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       {registrations.length > 0 && (
         <section className="space-y-3">
           <SectionHeading>参赛记录</SectionHeading>
-          <div className="space-y-3">
+          <div className="space-y-2">
             {[...registrations].reverse().map((reg) => {
               const teamInfo = regIdToTeam.get(reg.id);
+              const posLabel = POSITION_LABELS[reg.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? reg.primaryPosition;
+              const peakParts = [`${reg.peakRank} (${reg.peakRankSeason})`, `Rating ${reg.peakRating.toFixed(2)}`];
+              if (reg.peakWe != null) peakParts.push(`WE ${reg.peakWe.toFixed(1)}`);
               return (
-                <Panel key={reg.id} pad={20}>
-                  <div className="space-y-3">
-                    {/* 赛季标题行 */}
-                    <div className="flex items-start justify-between gap-2 flex-wrap">
-                      <div className="space-y-0.5">
-                        <p className="font-semibold text-[var(--color-fg)]">{reg.seasonName}</p>
+                <Panel key={reg.id} pad={16}>
+                  <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-semibold text-sm text-[var(--color-fg)]">{reg.seasonName}</span>
                         {teamInfo && (
                           <Link
                             href={`/${teamInfo.seasonSlug}/teams/${teamInfo.teamId}`}
@@ -370,35 +380,19 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                           </Link>
                         )}
                       </div>
-                      <div className="flex gap-2 items-center flex-wrap">
-                        <PosChip pos={POSITION_LABELS[reg.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? reg.primaryPosition} />
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <PosChip pos={posLabel} />
                         <span className="text-xs text-[var(--color-fg-mid)]">
-                          峰值 {reg.peakRank}（{reg.peakRankSeason}）
+                          {peakParts.join(" · ")}
                         </span>
                       </div>
                     </div>
-
-                    {/* 风格描述 */}
-                    {reg.gameplayStyle && (
-                      <p className="text-sm text-[var(--color-fg-mid)] leading-relaxed">
-                        {reg.gameplayStyle}
-                      </p>
-                    )}
-
-                    {/* 参赛历史 */}
-                    {reg.competitionHistory && (
-                      <p className="text-xs text-[var(--color-fg-mid)] opacity-80 leading-relaxed border-t border-[var(--color-border)] pt-2">
-                        {reg.competitionHistory}
-                      </p>
-                    )}
-
-                    {/* 高光视频 */}
                     {reg.highlightVideoUrl && (
                       <a
                         href={reg.highlightVideoUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-xs text-[var(--color-accent)] hover:underline"
+                        className="text-xs text-[var(--color-accent)] hover:underline shrink-0"
                       >
                         🎬 高光视频
                       </a>

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { matchMvpVotes } from "@/db/schema/mvp-votes";
+import { wAvg, sAvg } from "@/lib/utils/stats";
 
 interface PlayerPageProps {
   params: Promise<{ userId: string }>;
@@ -170,14 +171,6 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   const totalMaps = playerStats.reduce((s, x) => s + x.maps, 0);
   const totalKillsAll = playerStats.reduce((s, x) => s + x.totalKills, 0);
   const totalDeathsAll = playerStats.reduce((s, x) => s + x.totalDeaths, 0);
-  function wAvg(field: (x: (typeof playerStats)[number]) => number, precision = 1) {
-    if (totalMaps === 0) return "—";
-    return (playerStats.reduce((s, x) => s + field(x) * x.maps, 0) / totalMaps).toFixed(precision);
-  }
-  function sAvg(field: (x: (typeof playerStats)[number]) => number, precision = 1) {
-    if (totalMaps === 0) return "—";
-    return (playerStats.reduce((s, x) => s + field(x), 0) / totalMaps).toFixed(precision);
-  }
   const mvpCount = mvpRow?.count ?? 0;
 
   return (
@@ -271,20 +264,20 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             </span>
             <div className="grid grid-cols-4 sm:grid-cols-5 gap-3 text-center mt-3">
               {[
-                { label: "Rating", value: wAvg((x) => x.avgRating, 2) },
-                { label: "ADR", value: wAvg((x) => x.avgAdr) },
-                { label: "RWS", value: wAvg((x) => x.avgRws, 2) },
+                { label: "Rating", value: wAvg(playerStats, "avgRating", 2) },
+                { label: "ADR", value: wAvg(playerStats, "avgAdr") },
+                { label: "RWS", value: wAvg(playerStats, "avgRws", 2) },
                 {
                   label: "K/D",
                   value: totalKillsAll > 0 && totalDeathsAll > 0
                     ? (totalKillsAll / totalDeathsAll).toFixed(2)
                     : "—",
                 },
-                { label: "WE", value: wAvg((x) => x.avgWe) },
-                { label: "场均击杀", value: sAvg((x) => x.totalKills) },
-                { label: "首杀", value: sAvg((x) => x.totalFirstKills) },
-                { label: "多杀", value: sAvg((x) => x.totalMultiKills) },
-                { label: "残局", value: sAvg((x) => x.totalClutches) },
+                { label: "WE", value: wAvg(playerStats, "avgWe") },
+                { label: "场均击杀", value: sAvg(playerStats, "totalKills") },
+                { label: "首杀", value: sAvg(playerStats, "totalFirstKills") },
+                { label: "多杀", value: sAvg(playerStats, "totalMultiKills") },
+                { label: "残局", value: sAvg(playerStats, "totalClutches") },
                 {
                   label: "HS%",
                   value: totalMaps > 0

--- a/src/components/admin/AdminUserList.tsx
+++ b/src/components/admin/AdminUserList.tsx
@@ -12,6 +12,7 @@ import { Separator } from "@/components/ui/separator";
 interface AdminUserRow {
   id: string;
   email: string;
+  steamName: string | null;
   role: "super_admin" | "season_admin";
   adminSeasonIds: string[];
   createdAt: string;
@@ -56,7 +57,7 @@ export function AdminUserList({ users, seasonMap, currentUserId }: AdminUserList
         >
           <div className="flex items-center gap-3 min-w-0 flex-wrap">
             <span className="font-medium text-sm truncate">
-              {u.email}
+              {u.steamName ?? u.email}
               {u.id === currentUserId && (
                 <span className="text-xs text-[var(--color-fg-mid)] ml-1">（你）</span>
               )}

--- a/src/components/admin/AuditLogTable.tsx
+++ b/src/components/admin/AuditLogTable.tsx
@@ -20,6 +20,7 @@ interface Props {
   initialLogs: AuditLog[];
   initialTotal: number;
   seasons: { id: string; name: string }[];
+  initialActorNameMap: Record<string, string>;
 }
 
 const ACTION_CATEGORIES: Record<string, { label: string; color: string }> = {
@@ -40,13 +41,14 @@ function getCategory(action: string) {
 
 const PAGE_SIZE = 50;
 
-export function AuditLogTable({ initialLogs, initialTotal, seasons }: Props) {
+export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActorNameMap }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
   const [logs, setLogs] = useState(initialLogs);
   const [total, setTotal] = useState(initialTotal);
+  const [actorNameMap, setActorNameMap] = useState(initialActorNameMap);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   // 本地输入状态（用于 debounce，避免每次按键触发请求）
@@ -110,6 +112,7 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons }: Props) {
       if (result.success) {
         setLogs(result.data.logs);
         setTotal(result.data.total);
+        if (result.data.actorNameMap) setActorNameMap(result.data.actorNameMap);
       }
     });
   }, [currentPage, currentAction, currentActor, currentSeason, currentDateFrom, currentDateTo]);
@@ -290,7 +293,7 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons }: Props) {
                     <span style={{ color: "var(--color-fg)" }}>{log.action}</span>
                   </td>
                   <td className="px-3 py-2 truncate max-w-[140px]" style={{ color: "var(--color-fg-mid)" }}>
-                    {log.actorId ?? "-"}
+                    {log.actorId ? (actorNameMap[log.actorId] ?? log.actorId.slice(0, 8)) : "—"}
                   </td>
                   <td className="px-3 py-2" style={{ color: "var(--color-fg-mid)" }}>
                     {log.targetType && (

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -158,16 +158,13 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
                     <AvatarButton email={session.email} avatarUrl={avatarUrl} />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuContent align="end" className="w-44 bg-[var(--color-panel)] border-[var(--color-border)]">
                   {isAdmin && (
-                    <>
-                      <DropdownMenuItem asChild>
-                        <Link href="/admin" className="cursor-pointer">
-                          管理后台
-                        </Link>
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                    </>
+                    <DropdownMenuItem asChild>
+                      <Link href="/admin" className="cursor-pointer">
+                        管理后台
+                      </Link>
+                    </DropdownMenuItem>
                   )}
                   <DropdownMenuItem asChild>
                     <Link href={`/players/${session.userId}`} className="cursor-pointer">
@@ -186,7 +183,6 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
                       </Link>
                     </DropdownMenuItem>
                   )}
-                  <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="text-red-500 focus:text-red-500 cursor-pointer"
                     onSelect={handleLogout}

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -23,6 +23,7 @@ interface HeaderClientProps {
   seasons: Season[];
   session: UserSession | null;
   avatarUrl?: string | null;
+  steamName?: string | null;
 }
 
 function AvatarButton({ email, avatarUrl }: { email: string; avatarUrl?: string | null }) {
@@ -48,7 +49,7 @@ function AvatarButton({ email, avatarUrl }: { email: string; avatarUrl?: string 
   );
 }
 
-export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps) {
+export function HeaderClient({ seasons, session, avatarUrl, steamName }: HeaderClientProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -155,7 +156,7 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] rounded-full">
-                    <AvatarButton email={session.email} avatarUrl={avatarUrl} />
+                    <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44 bg-[var(--color-panel)] border-[var(--color-border)]">
@@ -242,8 +243,8 @@ export function HeaderClient({ seasons, session, avatarUrl }: HeaderClientProps)
             {session ? (
               <>
                 <div className="flex items-center gap-2 px-3 py-1.5">
-                  <AvatarButton email={session.email} avatarUrl={avatarUrl} />
-                  <span className="text-sm text-[var(--color-fg-dim)] truncate">{session.email}</span>
+                  <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} />
+                  <span className="text-sm text-[var(--color-fg-dim)] truncate">{steamName ?? session.email}</span>
                 </div>
                 {isAdmin && (
                   <Link

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { Season } from "@/db/schema/seasons";

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,9 +17,9 @@ export async function Header() {
   const currentUser = session
     ? await db.query.users.findFirst({
         where: eq(users.id, session.userId),
-        columns: { avatarUrl: true },
+        columns: { avatarUrl: true, steamName: true },
       })
     : null;
 
-  return <HeaderClient seasons={publicSeasons} session={session} avatarUrl={currentUser?.avatarUrl ?? null} />;
+  return <HeaderClient seasons={publicSeasons} session={session} avatarUrl={currentUser?.avatarUrl ?? null} steamName={currentUser?.steamName ?? null} />;
 }

--- a/src/lib/utils/stats.test.ts
+++ b/src/lib/utils/stats.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { wAvg, sAvg } from "@/lib/utils/stats";
+
+type Item = { maps: number;[key: string]: unknown };
+
+const noMaps: Item[] = [];
+
+const singleSeason: Item[] = [
+  { maps: 5, avgRating: 1.25, totalKills: 50 },
+];
+
+const multiSeason: Item[] = [
+  { maps: 3, avgRating: 1.1, totalKills: 33 },
+  { maps: 7, avgRating: 1.3, totalKills: 56 },
+];
+
+describe("wAvg", () => {
+  it("returns '—' when no maps played", () => {
+    expect(wAvg(noMaps, "avgRating")).toBe("—");
+  });
+
+  it("returns the field value directly for single season", () => {
+    expect(wAvg(singleSeason, "avgRating")).toBe("1.3");
+  });
+
+  it("computes weighted average across seasons", () => {
+    // (1.1*3 + 1.3*7) / 10 = (3.3 + 9.1) / 10 = 1.24 → "1.2"
+    expect(wAvg(multiSeason, "avgRating")).toBe("1.2");
+  });
+
+  it("respects precision parameter", () => {
+    expect(wAvg(multiSeason, "avgRating", 2)).toBe("1.24");
+  });
+});
+
+describe("sAvg", () => {
+  it("returns '—' when no maps played", () => {
+    expect(sAvg(noMaps, "totalKills")).toBe("—");
+  });
+
+  it("returns simple average for single season", () => {
+    expect(sAvg(singleSeason, "totalKills")).toBe("10.0");
+  });
+
+  it("computes simple average across seasons", () => {
+    // (33 + 56) / 10 = 89 / 10 = 8.9 → "8.9"
+    expect(sAvg(multiSeason, "totalKills")).toBe("8.9");
+  });
+
+  it("respects precision parameter", () => {
+    expect(sAvg(multiSeason, "totalKills", 2)).toBe("8.90");
+  });
+});

--- a/src/lib/utils/stats.ts
+++ b/src/lib/utils/stats.ts
@@ -1,0 +1,21 @@
+type HasMaps = { maps: number;[key: string]: unknown };
+
+/**
+ * 计算加权平均（按 maps 即图数加权）。
+ * 用于 Rating/ADR/RWS/WE 等场均指标——因为不同赛季图数不同，简单平均会失真。
+ */
+export function wAvg(items: HasMaps[], field: string, precision = 1): string {
+  const totalMaps = items.reduce((s, x) => s + x.maps, 0);
+  if (totalMaps === 0) return "—";
+  return (items.reduce((s, x) => s + (x[field] as number) * x.maps, 0) / totalMaps).toFixed(precision);
+}
+
+/**
+ * 计算简单平均（按图数均分）。
+ * 用于场均击杀/首杀/多杀/残局等计数型指标——每个赛季的 total 已预聚合，直接按赛季图数平均即可。
+ */
+export function sAvg(items: HasMaps[], field: string, precision = 1): string {
+  const totalMaps = items.reduce((s, x) => s + x.maps, 0);
+  if (totalMaps === 0) return "—";
+  return (items.reduce((s, x) => s + (x[field] as number), 0) / totalMaps).toFixed(precision);
+}


### PR DESCRIPTION
## 变更摘要

### UI 修复
- 移除 DropdownMenuSeparator 使菜单项等间距排列
- 为 DropdownMenuContent 添加明确的背景色和边框色

### 头像修复
- 为玩家主页头像添加 object-cover
- 新增 Steam CDN 到 remotePatterns，修复 Next.js Image 无法加载 Steam 头像

### 全站用户名统一
- 所有展示用户名的地方统一为 steamName ?? email
- 审计日志新增 actorNameMap，操作人 ID/邮箱映射为可读名称

### 玩家主页数据增强
- 新增 MVP/RWS/HS%/首杀/多杀/残局等统计
- 报名记录补 peakWe，新增 perfectName 显示
- 提取 wAvg/sAvg 工具函数并添加测试
- 报名/个人数据查询并行化
- 参赛记录卡片重设计

## 测试计划
- [x] 类型检查通过
- [x] 全量测试套件通过 (379 tests)
- [x] wAvg/sAvg 单元测试 (8 case)
- [x] Vercel 预览部署正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)