### PR TITLE
fix: 修复队伍详情页 500 报错 + 队长投票展示增强与确认防护

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main  # 读 main 最新 CHANGELOG，避免 tag 指向 npm version commit 时无 changelog 条目
 
       - name: Extract changelog for this version
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@ npm version minor    # 1.3.2 → 1.4.0
 npm version major    # 1.4.0 → 2.0.0
 ```
 
+**push 时必须带 tag**：`npm version` 只创建本地 tag，普通 `git push` 不会推送。GitHub Release workflow（`.github/workflows/release.yml`）由 `v*` tag 触发，tag 不到远程就不会发布。
+
+```bash
+git push origin dev --follow-tags    # ✅ 推送提交并带上本地 tag
+git push origin v1.6.0               # 或单独推 tag
+```
+
 每次 main 合并都需经过 `pnpm type-check` + `pnpm test` + `pnpm build` 全绿。
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-05-15
+
+### Fixed
+- 队伍详情页 `db.execute()` 返回类型错误：未取 `.rows` 直接当数组迭代，无比赛数据时 500 报错
+
+### Added
+- 队长投票页：候选人卡片新增最高分段（Peak A+/S 等）与 RT 双字段展示
+- 投票页说明：选秀第一轮逆向进行（排位最后的最先选人），引导按实力投票
+- 确认队长二次弹窗：点击按钮后弹出不可撤销警告 + 队长名单确认，防误触
+- 确认队长服务端校验：至少 3 票才允许确认，投票不足时返回 `VOTING_MINIMUM_NOT_MET`
+
 ## [1.6.0] - 2026-05-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ npm version minor    # 1.3.2 → 1.4.0
 npm version major    # 1.4.0 → 2.0.0
 ```
 
+**push 时必须带 tag**：`npm version` 只创建本地 tag，普通 `git push` 不会推送。GitHub Release workflow（`.github/workflows/release.yml`）由 `v*` tag 触发，tag 不到远程就不会发布。
+
+```bash
+git push origin dev --follow-tags    # ✅ 推送提交并带上本地 tag
+git push origin v1.6.0               # 或单独推 tag
+```
+
 每次 main 合并都需经过 `pnpm type-check` + `pnpm test` + `pnpm build` 全绿。
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/validators/vote";
 import {
   CAPTAIN_TEAM_COUNT,
+  MIN_VOTES_FOR_CONFIRM,
   selectCaptainSeeds,
   validateCaptainVote,
 } from "@/lib/captains/rules";
@@ -208,6 +209,23 @@ export async function confirmCaptains(
         .where(eq(teams.seasonId, season.id));
       if (Number(existingTeamCount?.count ?? 0) > 0) {
         throw new AppError(ErrorCode.VALIDATION_FAILED, "该赛季已生成队伍");
+      }
+
+      // 防止投票尚未开始或参与不足就确认队长
+      const [voteCountRow] = await tx
+        .select({ count: count() })
+        .from(captainVotes)
+        .innerJoin(
+          seasonRegistrations,
+          eq(captainVotes.candidateRegistrationId, seasonRegistrations.id),
+        )
+        .where(eq(seasonRegistrations.seasonId, season.id));
+      const totalVotes = Number(voteCountRow?.count ?? 0);
+      if (totalVotes < MIN_VOTES_FOR_CONFIRM) {
+        throw new AppError(
+          ErrorCode.VOTING_MINIMUM_NOT_MET,
+          `当前仅有 ${totalVotes} 票，至少需要 ${MIN_VOTES_FOR_CONFIRM} 票才能确认队长`,
+        );
       }
 
       const candidates = await tx

--- a/src/app/[seasonSlug]/captains/page.tsx
+++ b/src/app/[seasonSlug]/captains/page.tsx
@@ -68,6 +68,18 @@ export default async function CaptainsPage({ params }: CaptainsPageProps) {
         </p>
       </div>
 
+      {season.status === "voting" && (
+        <div className="mb-6 rounded-sm border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5 p-4 text-sm text-[var(--color-fg-mid)]">
+          <p className="font-medium text-[var(--color-fg)] mb-1">关于选秀顺序</p>
+          <p>
+            第一轮选秀将<strong className="text-[var(--color-fg)]">逆向进行</strong>
+            ——排位最靠后的队伍最先选人，依次轮到排位靠前的队伍。
+            请根据候选人的<strong className="text-[var(--color-fg)]">实际实力</strong>（而非关系远近）进行投票，
+            以确保选秀公平。
+          </p>
+        </div>
+      )}
+
       <CaptainVotingPanel
         seasonName={season.name}
         seasonStatus={season.status}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -151,7 +151,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   const played = totalWins + totalLosses;
 
   // ── 队伍聚合统计 ──────────────────────────────────────────────────
-  const teamStatRows = roster.length
+  const teamStatResult = roster.length
     ? await db.execute(sql`
         SELECT
           round(avg(mps.rating_pro)::numeric, 2) as avg_rating,
@@ -169,7 +169,9 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           AND mps.verified_by_admin IS NOT NULL
         GROUP BY sr.primary_position, mps.perfect_name, mps.rating_pro
       `)
-    : [];
+    : null;
+
+  const teamStatRows: Record<string, unknown>[] = teamStatResult?.rows ?? [];
 
   interface TeamStatRow {
     avg_rating: number;

--- a/src/components/captains/CaptainConfirmPanel.tsx
+++ b/src/components/captains/CaptainConfirmPanel.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { useTransition } from "react";
-import { CheckCircle2, ShieldCheck } from "lucide-react";
+import { useTransition, useState } from "react";
+import { CheckCircle2, ShieldCheck, AlertTriangle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { confirmCaptains } from "@/actions/captains";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { CAPTAIN_TEAM_COUNT } from "@/lib/captains/rules";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import type { CaptainCandidateRow } from "@/lib/captains/data";
@@ -27,6 +35,7 @@ export function CaptainConfirmPanel({
 }: CaptainConfirmPanelProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const seeds = candidates.slice(0, CAPTAIN_TEAM_COUNT);
   const canConfirm =
     seasonStatus === "voting" &&
@@ -36,6 +45,7 @@ export function CaptainConfirmPanel({
   function handleConfirm() {
     startTransition(async () => {
       const result = await confirmCaptains({ seasonId });
+      setShowConfirmDialog(false);
       if (!result.success) {
         toast.error(result.error.message);
         return;
@@ -117,7 +127,7 @@ export function CaptainConfirmPanel({
               type="button"
               className="w-full"
               disabled={!canConfirm || isPending}
-              onClick={handleConfirm}
+              onClick={() => setShowConfirmDialog(true)}
             >
               <CheckCircle2 />
               确认前 {CAPTAIN_TEAM_COUNT}
@@ -131,6 +141,54 @@ export function CaptainConfirmPanel({
           </div>
         </Card>
       </aside>
+
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="size-5 text-amber-500" />
+              确认队长
+            </DialogTitle>
+            <DialogDescription className="space-y-3 pt-2">
+              <p>
+                即将确认前 <strong>{CAPTAIN_TEAM_COUNT}</strong> 名队长并生成队伍，
+                赛季将从 <strong>voting</strong> 推进到 <strong>drafting</strong>。
+              </p>
+              <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+                <p className="font-medium text-amber-600 dark:text-amber-400">
+                  此操作不可撤销
+                </p>
+                <ul className="mt-1 list-inside list-disc space-y-0.5 text-[var(--color-fg-mid)]">
+                  <li>将生成 {CAPTAIN_TEAM_COUNT} 支队伍并写入队长成员</li>
+                  <li>生成后无法回退到投票阶段</li>
+                  <li>选秀顺位由当前票数决定</li>
+                </ul>
+              </div>
+              <p className="text-sm text-[var(--color-fg-mid)]">
+                队长列表：
+                {seeds.map((s, i) => (
+                  <span key={s.id}>
+                    {i > 0 && "、"}
+                    {s.displayName}
+                  </span>
+                ))}
+              </p>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirmDialog(false)}
+              disabled={isPending}
+            >
+              取消
+            </Button>
+            <Button onClick={handleConfirm} disabled={isPending}>
+              {isPending ? "确认中..." : "确认生成队伍"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/captains/CaptainVotingPanel.tsx
+++ b/src/components/captains/CaptainVotingPanel.tsx
@@ -178,7 +178,7 @@ export function CaptainVotingPanel({
 
                   {/* 位置信息 */}
                   <p className="text-xs text-[var(--color-fg-mid)] mb-2">
-                    {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRating} · Current {candidate.currentRating}
+                    {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRank} · RT {candidate.peakRating} · Current RT {candidate.currentRating}
                   </p>
 
                   {/* 票数进度条 */}
@@ -228,7 +228,7 @@ export function CaptainVotingPanel({
                   <div className="rounded-md border border-[var(--color-border)] p-3 text-sm">
                     <p className="font-medium">{currentVoter.displayName}</p>
                     <p className="mt-0.5 text-[var(--color-fg-mid)]">
-                      {positionLabel(currentVoter.primaryPosition)} · Peak {currentVoter.peakRating}
+                      {positionLabel(currentVoter.primaryPosition)} · Peak {currentVoter.peakRank} · RT {currentVoter.peakRating}
                     </p>
                   </div>
 
@@ -310,8 +310,8 @@ export function CaptainVotingPanel({
                           )}
                         </div>
                         <p className="mt-1 text-sm text-[var(--color-fg-mid)]">
-                          {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRating} ·
-                          Current {candidate.currentRating}
+                          {positionLabel(candidate.primaryPosition)} · Peak {candidate.peakRank} ·
+                          RT {candidate.peakRating} · Current RT {candidate.currentRating}
                         </p>
                         <div className="mt-3 h-2 rounded-full bg-muted">
                           <div

--- a/src/lib/captains/data.ts
+++ b/src/lib/captains/data.ts
@@ -8,6 +8,7 @@ export interface CaptainVoterOption {
   displayName: string;
   email: string;
   primaryPosition: string;
+  peakRank: string;
   peakRating: number;
 }
 
@@ -34,6 +35,7 @@ export async function getCaptainVotingData(seasonId: string): Promise<CaptainVot
     .select({
       id: seasonRegistrations.id,
       primaryPosition: seasonRegistrations.primaryPosition,
+      peakRank: seasonRegistrations.peakRank,
       peakRating: seasonRegistrations.peakRating,
       currentRating: seasonRegistrations.currentRating,
       willingToBeCaptain: seasonRegistrations.willingToBeCaptain,
@@ -76,6 +78,7 @@ export async function getCaptainVotingData(seasonId: string): Promise<CaptainVot
     displayName: r.steamName ?? r.email ?? "未命名选手",
     email: r.email ?? "",
     primaryPosition: r.primaryPosition,
+    peakRank: r.peakRank,
     peakRating: r.peakRating,
   }));
 
@@ -87,6 +90,7 @@ export async function getCaptainVotingData(seasonId: string): Promise<CaptainVot
       displayName: r.steamName ?? r.email ?? "未命名选手",
       email: r.email ?? "",
       primaryPosition: r.primaryPosition,
+      peakRank: r.peakRank,
       peakRating: r.peakRating,
       currentRating: r.currentRating,
       createdAt: r.createdAt.toISOString(),

--- a/src/lib/captains/rules.ts
+++ b/src/lib/captains/rules.ts
@@ -2,6 +2,8 @@ import { ErrorCode, type ErrorCode as ErrorCodeValue } from "@/lib/errors";
 
 export const MAX_CAPTAIN_VOTES = 3;
 export const CAPTAIN_TEAM_COUNT = 8;
+/** 确认队长前至少需要的总投票数（防止投票尚未开始就确认） */
+export const MIN_VOTES_FOR_CONFIRM = 3;
 
 export interface CaptainVoteSeason {
   status: string;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -41,6 +41,7 @@ export const ErrorCode = {
   VOTE_SELF: "VOTE_SELF",
   VOTE_DUPLICATE: "VOTE_DUPLICATE",
   CAPTAIN_NOT_ELIGIBLE: "CAPTAIN_NOT_ELIGIBLE",
+  VOTING_MINIMUM_NOT_MET: "VOTING_MINIMUM_NOT_MET",
 
   // ── Draft ───────────────────────────────────────
   DRAFT_NOT_ACTIVE: "DRAFT_NOT_ACTIVE",
@@ -96,6 +97,7 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
   VOTE_SELF: "不能给自己投票",
   VOTE_DUPLICATE: "您已为该候选人投票",
   CAPTAIN_NOT_ELIGIBLE: "该候选人不符合队长资格",
+  VOTING_MINIMUM_NOT_MET: "投票数不足，至少需要一定数量的投票后才能确认队长",
 
   DRAFT_NOT_ACTIVE: "选秀未进行中",
   DRAFT_NOT_YOUR_TURN: "当前轮次不是您的队伍",


### PR DESCRIPTION
## Summary
- **Bugfix**: `teams/[teamId]` 页 `db.execute()` 返回 `{ rows }` 对象但代码直接当数组迭代，无比赛数据时抛 500
- **Feature**: 投票页候选人卡片新增 Peak 段位（A+/S 等）+ RT 双字段展示
- **Feature**: 投票页顶部新增选秀逆序说明（首轮最后排位最先选人，引导按实力投票）
- **Guard**: `confirmCaptains` 加最少 3 票服务端校验 + 二次确认弹窗防误触

## Details
1. 数据库已回滚：赛季 `2026-nju-rivals` 从 `drafting` 回退到 `voting`，8 个队伍已删除
2. 队伍详情页 bug 已在 Vercel 上复现并验证修复（digest `2070416823`）

## Test plan
- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm test` 49 files / 379 tests 全绿
- [x] Vercel 生产环境 `/2026-nju-rivals/teams` 返回 200
- [ ] Vercel 预览部署验证投票页面 Peak 段位展示
- [ ] Vercel 预览部署验证确认队长二次弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)