### PR TITLE
v1.7.1 — avatar fallback + 位置英文标签 + 代码去重

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main  # 读 main 最新 CHANGELOG，避免 tag 指向 npm version commit 时无 changelog 条目
+        # 不指定 ref，默认 checkout 触发此 workflow 的 tag 所在 commit。
+        # 前提：CHANGELOG 更新必须在 `npm version` 之前完成，
+        # 这样 tag 指向的 commit 就已包含对应版本的 CHANGELOG 条目。
 
       - name: Extract changelog for this version
         run: |
@@ -28,6 +29,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes-file /tmp/release-notes.md
+          if gh release view "$GITHUB_REF_NAME" &>/dev/null; then
+            echo "Release $GITHUB_REF_NAME already exists, updating notes..."
+            gh release edit "$GITHUB_REF_NAME" --notes-file /tmp/release-notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file /tmp/release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-05-15
+
+### Fixed
+- Header 头像过期 CDN 链接显示浏览器蓝色问号：AvatarButton 增加 onError 回退 + Header 服务端增加 `getSteamAvatar()` 实时拉取回退（与选手页统一）
+- Header mobile menu 关闭重开时 imgError 状态重置导致重复加载失败图片
+- 选手名单页位置筛选项仅含 3 个中文标签，改为全部 5 个 positionValues 英文标签（IGL / AWPer / Opener / Closer / Anchor）
+- 选手名单卡片 Position 标签改为英文 `positionLabel()`
+- 赛季导航 `hasPlayers` 计数比较增加 `Number()` 包裹，防 bigint→string 类型失效
+
+### Changed
+- 注册页位置标签切换 `positionLabel()` 替代内联 `POSITION_LABELS[].en`
+- 提取 `resolveAvatarUrl()` 共享函数到 `steam.ts`，消除 Header 与选手页重复
+
 ## [1.7.0] - 2026-05-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ npm version minor    # 1.3.2 → 1.4.0
 npm version major    # 1.4.0 → 2.0.0
 ```
 
+**CHANGELOG 必须在 `npm version` 之前更新并提交**，否则 release workflow checkout tag commit 时找不到对应版本的条目，导致 GitHub Release body 为空。
+
 **push 时必须带 tag**：`npm version` 只创建本地 tag，普通 `git push` 不会推送。GitHub Release workflow（`.github/workflows/release.yml`）由 `v*` tag 触发，tag 不到远程就不会发布。
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，覆盖报名、审核、队长投票、蛇形选秀、队伍展示、赛程管理、Bracket、比分录入、数据统计与上线部署。
 
-当前 `1.6.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
+当前 `1.7.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
 
 ## 功能状态
 
-| 模块 | 1.6.0 能力 |
+| 模块 | 1.7.0 能力 |
 |---|----|
 | 赛季管理 | capability 驱动的多赛事模型，`/[seasonSlug]` 路由，动态 PhaseTracker 阶段追踪，NEXT MATCHES 面板 + Stat 四格（playing 阶段）；SeasonNav / PhaseTracker 应用 ScrollHint 横滚提示 |
 | 报名 | 邮箱密码账号、自动草稿恢复、Zod 校验、位置/人数上限（仅统计 approved）、NJUBox 截图链接 |
 | 审核 | 管理员审核、候补名单、邀请码提权、审批通过自动推进赛季状态、操作审计 |
+| 选手 | `/[seasonSlug]/players` 选手名单页，按位置筛选，卡片展示段位/Rating/所属队伍 |
 | 队长投票 | 每人最多 3 票，Realtime 刷新票数；移动端切换卡片列表（`CaptainVotingPanel` 双模式） |
-| 选秀 | 队长面板、围观直播间、倒计时、事务行锁、幂等 pick、超时自动递补；移动端 `TeamDraftGrid` 手风琴列表 |
-| 队伍 | 阵容展示、首发/替补、队长标识、队伍图标上传 |
+| 选秀 | 队长面板按段位+Rt 排序统一列表、满员位置灰显禁用、可折叠阵容摘要；围观直播间 pick 通知 Banner 3 秒淡出；事务行锁、幂等 pick、超时自动递补 |
+| 队伍 | 阵容展示、首发/替补、队长标识、队伍图标上传；同队成员可见 QQ/邮箱联系方式 |
 | 比赛 | 赛程、Bracket（Tactical Grid 暗色主题）、地图结果、比分录入 |
 | 协商 | 比赛时间提议/接受/拒绝、管理员强制设定、协商截止自动裁定、阵容提交（视觉重设计） |
-| 账号 | 邮箱+密码注册/登录、修改密码 |
+| 账号 | 邮箱+密码注册/登录、自定义昵称（display_name 系统，Header 橙色未设置提示）、修改密码、`getDisplayName()` 统一展示名派生 |
 | 数据 | 完美平台截图 OCR、比赛数据表、MVP 投票、选手/队伍统计、后台操作日志 |
-| 部署 | Vercel + Supabase + GitHub Actions Cron（选秀超时 + 报名截止自动推进） |
+| 部署 | Vercel + Supabase + GitHub Actions Cron（选秀超时 + 报名截止自动推进 + 比赛时间协商自动裁定） |
 
 ## 技术栈
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/layout.tsx
+++ b/src/app/[seasonSlug]/layout.tsx
@@ -44,7 +44,7 @@ export default async function SeasonLayout({ children, params }: SeasonLayoutPro
         eq(seasonRegistrations.status, "approved"),
       ),
     );
-  const hasPlayers = (approvedResult?.cnt ?? 0) > 0;
+  const hasPlayers = Number(approvedResult?.cnt ?? 0) > 0;
 
   const themeColor = season.themeColor ?? "#f97316";
 

--- a/src/app/[seasonSlug]/players/page.tsx
+++ b/src/app/[seasonSlug]/players/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { db } from "@/db/client";
 import { seasons, seasonRegistrations, users, teams, teamMembers } from "@/db/schema";
 import { Marker, PosChip, Panel } from "@/components/rivalhub";
-import { POSITION_LABELS, POS_ABBR } from "@/lib/validators/registration";
+import { POS_ABBR, positionLabel, positionValues } from "@/lib/validators/registration";
 import { getDisplayName } from "@/lib/utils/display-name";
 import type { Metadata } from "next";
 
@@ -75,11 +75,9 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
 
   const teamByRegId = new Map(teamMemberRows.map((r) => [r.registrationId, r.teamName]));
 
-  const positions = [
-    { value: "", label: "全部" },
-    { value: "opener", label: POSITION_LABELS["opener"]?.cn ?? "Opener" },
-    { value: "closer", label: POSITION_LABELS["closer"]?.cn ?? "Closer" },
-    { value: "anchor", label: POSITION_LABELS["anchor"]?.cn ?? "Anchor" },
+  const positionFilters = [
+    { value: "", label: "All" },
+    ...positionValues.map((p) => ({ value: p, label: positionLabel(p) })),
   ];
 
   return (
@@ -88,7 +86,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
 
       {/* 位置筛选 */}
       <div className="flex gap-2 flex-wrap">
-        {positions.map(({ value, label }) => {
+        {positionFilters.map(({ value, label }) => {
           const isActive = position === value;
           const href = value ? `/${seasonSlug}/players?position=${value}` : `/${seasonSlug}/players`;
           return (
@@ -115,7 +113,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
           {registrations.map((reg) => {
             const displayName = getDisplayName(reg);
             const teamName = teamByRegId.get(reg.registrationId);
-            const posLabel = POSITION_LABELS[reg.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? reg.primaryPosition;
+            const posLabel = positionLabel(reg.primaryPosition);
 
             return (
               <Link
@@ -128,11 +126,11 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
                     <span className="font-semibold text-[var(--color-fg)] truncate text-base">
                       {displayName}
                     </span>
-                    <PosChip pos={(POS_ABBR[reg.primaryPosition] ?? reg.primaryPosition.slice(0, 1).toUpperCase()) as "O" | "C" | "A"} small />
+                    <PosChip pos={POS_ABBR[reg.primaryPosition] ?? reg.primaryPosition.slice(0, 1).toUpperCase()} small />
                   </div>
                   <div className="space-y-1 text-sm text-[var(--color-fg-mid)]">
                     <div className="flex justify-between">
-                      <span>位置</span>
+                      <span>Position</span>
                       <span className="text-[var(--color-fg)]">{posLabel}</span>
                     </div>
                     <div className="flex justify-between">

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -8,7 +8,7 @@ import { RegistrationForm } from "@/components/register/RegistrationForm";
 import { normalizeRegistrationConfig } from "@/types/season";
 import { REGISTRATION_STATUS_LABELS } from "@/types/registration";
 import { Panel, StatusBanner, PosChip } from "@/components/rivalhub";
-import { POSITION_LABELS } from "@/lib/validators/registration";
+import { positionLabel } from "@/lib/validators/registration";
 import { getRegistrationWindowState, getWindowTone } from "@/lib/registration/window";
 import { formatCST } from "@/lib/utils/date";
 import { getUserSession } from "@/lib/auth/session";
@@ -117,7 +117,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   // 位置容量数据
   const capacityEntries = season.positions.map((pos) => {
     const cur = positionCounts[pos] ?? 0;
-    const label = POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.en ?? pos;
+    const label = positionLabel(pos);
     return { pos, label, cur, max: maxPerPos };
   });
 

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { eq, or, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users, seasonRegistrations, seasons, teams, teamMembers, matches } from "@/db/schema";
-import { getSteamAvatar } from "@/lib/steam";
+import { resolveAvatarUrl } from "@/lib/steam";
 import { Panel, Stat, PosChip } from "@/components/rivalhub";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
 import Image from "next/image";
@@ -110,7 +110,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       )
       .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
       .orderBy(asc(seasons.createdAt)),
-    user.avatarUrl ?? (user.steam64 ? getSteamAvatar(user.steam64) : null),
+    resolveAvatarUrl({ avatarUrl: user.avatarUrl, steam64: user.steam64 }),
   ]);
   const mvpRow = mvpRows[0];
 

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -28,13 +28,16 @@ interface HeaderClientProps {
 
 function AvatarButton({ email, avatarUrl }: { email: string; avatarUrl?: string | null }) {
   const initial = email.charAt(0).toUpperCase();
-  if (avatarUrl) {
+  const [imgError, setImgError] = useState(false);
+
+  if (avatarUrl && !imgError) {
     return (
       <img
         src={avatarUrl}
         alt={email}
         className="inline-flex w-8 h-8 rounded-full border border-[var(--color-border)] object-cover"
         referrerPolicy="no-referrer"
+        onError={() => setImgError(true)}
       />
     );
   }

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -26,9 +26,13 @@ interface HeaderClientProps {
   displayName?: string | null;
 }
 
-function AvatarButton({ email, avatarUrl }: { email: string; avatarUrl?: string | null }) {
+function AvatarButton({ email, avatarUrl, imgError, onImgError }: {
+  email: string;
+  avatarUrl?: string | null;
+  imgError: boolean;
+  onImgError: () => void;
+}) {
   const initial = email.charAt(0).toUpperCase();
-  const [imgError, setImgError] = useState(false);
 
   if (avatarUrl && !imgError) {
     return (
@@ -37,7 +41,7 @@ function AvatarButton({ email, avatarUrl }: { email: string; avatarUrl?: string 
         alt={email}
         className="inline-flex w-8 h-8 rounded-full border border-[var(--color-border)] object-cover"
         referrerPolicy="no-referrer"
-        onError={() => setImgError(true)}
+        onError={onImgError}
       />
     );
   }
@@ -56,6 +60,7 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
   const pathname = usePathname();
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
 
   useEffect(() => {
     setMobileOpen(false);
@@ -163,7 +168,7 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] rounded-full">
-                    <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} />
+                    <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} imgError={imgError} onImgError={() => setImgError(true)} />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44 bg-[var(--color-panel)] border-[var(--color-border)]">
@@ -258,7 +263,7 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
             {session ? (
               <>
                 <div className="flex items-center gap-2 px-3 py-1.5">
-                  <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} />
+                  <AvatarButton email={steamName ?? session.email} avatarUrl={avatarUrl} imgError={imgError} onImgError={() => setImgError(true)} />
                   <span className="text-sm text-[var(--color-fg-dim)] truncate">{steamName ?? session.email}</span>
                 </div>
                 {isAdmin && (

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 import { db } from "@/db/client";
 import { seasons, users } from "@/db/schema";
 import { getUserSession } from "@/lib/auth/session";
-import { getSteamAvatar } from "@/lib/steam";
+import { resolveAvatarUrl } from "@/lib/steam";
 import { HeaderClient } from "./header-client";
 import { eq } from "drizzle-orm";
 
@@ -22,9 +22,10 @@ export async function Header() {
       })
     : null;
 
-  // 与选手个人页面保持一致：缓存 avatarUrl 优先，null 时从 Steam API 实时拉取
-  const avatarUrl = currentUser?.avatarUrl
-    ?? (currentUser?.steam64 ? await getSteamAvatar(currentUser.steam64) : null);
+  const avatarUrl = await resolveAvatarUrl({
+    avatarUrl: currentUser?.avatarUrl,
+    steam64: currentUser?.steam64,
+  });
 
   return (
     <HeaderClient

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import { db } from "@/db/client";
 import { seasons, users } from "@/db/schema";
 import { getUserSession } from "@/lib/auth/session";
+import { getSteamAvatar } from "@/lib/steam";
 import { HeaderClient } from "./header-client";
 import { eq } from "drizzle-orm";
 
@@ -17,15 +18,19 @@ export async function Header() {
   const currentUser = session
     ? await db.query.users.findFirst({
         where: eq(users.id, session.userId),
-        columns: { avatarUrl: true, steamName: true, displayName: true },
+        columns: { avatarUrl: true, steamName: true, displayName: true, steam64: true },
       })
     : null;
+
+  // 与选手个人页面保持一致：缓存 avatarUrl 优先，null 时从 Steam API 实时拉取
+  const avatarUrl = currentUser?.avatarUrl
+    ?? (currentUser?.steam64 ? await getSteamAvatar(currentUser.steam64) : null);
 
   return (
     <HeaderClient
       seasons={publicSeasons}
       session={session}
-      avatarUrl={currentUser?.avatarUrl ?? null}
+      avatarUrl={avatarUrl}
       steamName={currentUser?.steamName ?? null}
       displayName={currentUser?.displayName ?? null}
     />

--- a/src/lib/steam.ts
+++ b/src/lib/steam.ts
@@ -23,3 +23,11 @@ export async function getSteamAvatar(steam64: string): Promise<string | null> {
     return null;
   }
 }
+
+/** DB 缓存的 avatarUrl 优先，为 null 时从 Steam API 实时拉取 */
+export async function resolveAvatarUrl(user: {
+  avatarUrl?: string | null;
+  steam64?: string | null;
+}): Promise<string | null> {
+  return user.avatarUrl ?? (user.steam64 ? await getSteamAvatar(user.steam64) : null);
+}


### PR DESCRIPTION
## Summary
- **头像系统修复**：过期 Steam CDN 链接不再显示蓝色问号（onError 回退 + Header 服务端 getSteamAvatar 实时拉取）
- **Header mobile menu**：imgError 状态提升到 HeaderClient，关闭重开不再重复加载失败图片
- **选手名单页**：位置筛选从硬编码 3 个中文改为全部 5 个英文标签（IGL / AWPer / Opener / Closer / Anchor）
- **resolveAvatarUrl()** 共享函数提取，消除 Header 与选手页头像回退重复
- **positionLabel()** 统一注册页位置标签调用

## Test plan
- [x] `pnpm tsc --noEmit` 零错误
- [x] `pnpm test` 49 files / 379 tests 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)