### PR TITLE
v1.7.3 — 数据排行页 SQL 别名修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.3] - 2026-05-16
+
+### Fixed
+- 数据排行页 `sortColumn` 使用 Drizzle 列引用解析为全表名，与 SQL 别名 `mps` 冲突导致 Postgres `42P01` 错误
+
 ## [1.7.2] - 2026-05-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
-import { matchPlayerStats } from "@/db/schema/player-stats";
 import { seasonRegistrations } from "@/db/schema/registrations";
 import { teamMembers } from "@/db/schema/teams";
 import { teams } from "@/db/schema/teams";
@@ -37,12 +36,12 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
 
   const sortColumn = (() => {
     switch (sort) {
-      case "adr": return sql`avg(${matchPlayerStats.adr})`;
-      case "kd": return sql`CASE WHEN sum(${matchPlayerStats.deaths}) > 0 THEN round((sum(${matchPlayerStats.kills}) / sum(${matchPlayerStats.deaths}))::numeric, 2) ELSE 0 END`;
-      case "we": return sql`avg(${matchPlayerStats.we})`;
-      case "kpr": return sql`round((sum(${matchPlayerStats.kills}) / count(*))::numeric, 1)`;
+      case "adr": return sql`avg(mps.adr)`;
+      case "kd": return sql`CASE WHEN sum(mps.deaths) > 0 THEN round((sum(mps.kills) / sum(mps.deaths))::numeric, 2) ELSE 0 END`;
+      case "we": return sql`avg(mps.we)`;
+      case "kpr": return sql`round((sum(mps.kills) / count(*))::numeric, 1)`;
       case "maps": return sql`count(*)`;
-      default: return sql`avg(${matchPlayerStats.ratingPro})`;
+      default: return sql`avg(mps.rating_pro)`;
     }
   })();
 


### PR DESCRIPTION
## Summary
- **数据排行页 42P01 修复**：`sortColumn` 中 Drizzle 列引用解析为全表名 `match_player_stats.xxx`，与主查询别名 `mps` 冲突，改为直接用 SQL 别名 `mps.xxx`

## Test plan
- [x] `pnpm tsc --noEmit` 零错误
- [ ] 访问 `/[seasonSlug]/stats` 页面，各排序（rating/adr/kd/we/kpr/maps）不再报 500
- [ ] 位置筛选正常工作