### PR TITLE
v1.7.4 — 审计日志可读性增强 + 文档同步

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.4] - 2026-05-16
+
+### Fixed
+- 审计日志 `actorId` 为 `"system"` 等非 UUID 字符串时触发 Postgres `22P02` 类型转换错误
+
+### Added
+- 审计日志目标列可读名称解析：按 targetType 批量查询对应表，显示用户名/赛季名/队名/比赛对阵等（替代截断 UUID）
+- 审计日志 40+ action 中文别名映射，hover 显示原始字符串
+- 操作类型筛选改为 `<optgroup>` 分组下拉菜单（管理/报名/投票/选秀/赛程/赛季/队伍/用户）
+
+### Changed
+- CLAUDE.md、README.md、docs/architecture.md 同步至 v1.7.4：补齐 actions 目录索引、cron 端点
+
 ## [1.7.3] - 2026-05-16
 
 ### Fixed
@@ -232,6 +245,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.7.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.3...v1.7.4
+[1.7.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.2...v1.7.3
+[1.7.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.1...v1.7.2
+[1.7.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.0...v1.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.6.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.7.4，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 
@@ -59,7 +59,7 @@ git push origin v1.6.0               # 或单独推 tag
 | ORM | Drizzle ORM |
 | 表单 | React Hook Form + Zod（中文校验消息） |
 | 鉴权 | Supabase Auth（email+password；生产关闭邮件确认，不依赖 Magic Link）+ iron-session（双 Cookie：`rivalhub-session` 全用户 + `rivalhub-admin` root 紧急） |
-| 定时任务 | GitHub Actions 每分钟调用 `/api/cron/draft-timeout`（选秀超时自动 pick）+ `/api/cron/match-time-auto-award`（比赛时间协商截止自动裁定） |
+| 定时任务 | GitHub Actions 每分钟调用 `/api/cron/draft-timeout`（选秀超时自动 pick）+ `/api/cron/check-registration-deadline`（报名截止/满员自动推进）+ `/api/cron/match-time-auto-award`（比赛时间协商截止自动裁定） |
 | Bracket 渲染 | `brackets-manager` + `brackets-viewer`（经 `lib/bracket/` 适配层访问） |
 | 单元/集成测试 | Vitest + React Testing Library + jsdom |
 | E2E 测试 | Playwright |
@@ -215,12 +215,15 @@ src/
 ├── actions/          # Server Actions（所有业务逻辑入口）
 │   ├── account.ts    # 用户账号（修改密码）
 │   ├── admin.ts      # 管理员操作（审核/邀请码/撤销权限）
+│   ├── audit.ts      # 审计日志查询（含 actor/target 可读名称解析）
 │   ├── auth.ts       # 邮箱+密码注册/登录/退出
 │   ├── captains.ts   # 队长投票
 │   ├── draft/        # 选秀（state / picks / queries）
-│   ├── matches/      # 赛程（schedule / results / roster）
+│   ├── matches/      # 赛程（schedule / results / roster / scheduling）
+│   ├── player-stats.ts # 玩家数据（OCR 识别 / 保存 / 查询）
 │   ├── register.ts   # 报名提交
 │   ├── seasons.ts    # 赛季 CRUD（create/update/delete/publish）
+│   ├── transitions.ts # 赛季阶段自动推进
 │   └── teams.ts      # 队伍（修改队名/上传图标）
 ├── db/
 │   ├── schema/       # Drizzle 表定义（18 张表）

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，覆盖报名、审核、队长投票、蛇形选秀、队伍展示、赛程管理、Bracket、比分录入、数据统计与上线部署。
 
-当前 `1.7.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
+当前 `1.7.4` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
 
 ## 功能状态
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,9 @@ Next.js App Router (Vercel Edge / Node.js)
   │     ├── src/db/client
   │     └── src/lib/auth/session (iron-session)
   ├── API Route (Cron only)
-  │     └── /api/cron/draft-timeout
+  │     ├── /api/cron/draft-timeout
+  │     ├── /api/cron/check-registration-deadline
+  │     └── /api/cron/match-time-auto-award
   └── Client Components ("use client")
         └── Supabase Realtime (ws)
               └── Supabase Postgres (LISTEN/NOTIFY)
@@ -62,7 +64,11 @@ Next.js App Router (Vercel Edge / Node.js)
 | `matches/schedule.ts` | 赛程生成（generateSchedule / initializeStage / generatePlayoff / createMatch） |
 | `matches/results.ts` | 比赛结果（recordMatchResult / recordMapResult / updateMatchStatus / updateMatchScheduledAt） |
 | `seasons.ts` | 赛季 CRUD（createSeason / updateSeason / deleteSeason / publishSeason） |
+| `transitions.ts` | 赛季阶段自动推进（autoAdvanceSeason） |
+| `audit.ts` | 审计日志查询（fetchAuditLogs / getAuditSeasons），含 actor/target 可读名称批量解析 |
 | `player-stats.ts` | OCR 识别记分板截图（extractStatsFromScreenshot）、保存玩家数据（savePlayerStats）、查询地图数据（getPlayerStatsByMap） |
+| `matches/scheduling.ts` | 比赛时间协商（proposeMatchTime / respondToTimeProposal / forceSetMatchTime / autoAwardMatchTime） |
+| `matches/roster.ts` | 比赛阵容提交与解锁（submitMatchRoster / unlockMatchRoster） |
 
 ### DB 层（`src/db/`）
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/audit.ts
+++ b/src/actions/audit.ts
@@ -3,7 +3,7 @@
 import { and, desc, eq, gte, lt, or, count, like, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { getDisplayName } from "@/lib/utils/display-name";
-import { auditLogs, seasons, users } from "@/db/schema";
+import { auditLogs, seasons, users, teams, matches, seasonRegistrations, captainVotes, draftPicks, draftState, adminInvites } from "@/db/schema";
 import { ok } from "@/types/action";
 import { requireSuperAdmin } from "@/lib/auth/session";
 import { actionError } from "@/lib/action-utils";
@@ -84,18 +84,151 @@ export async function fetchAuditLogs(filters: AuditLogFilters = {}) {
     const actorIds = [...new Set(logs.map((l) => l.actorId).filter((id): id is string => id != null))];
     const actorNameMap: Record<string, string> = {};
     if (actorIds.length) {
-      const actorUsers = await db
-        .select({ id: users.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
-        .from(users)
-        .where(or(inArray(users.id, actorIds), inArray(users.email, actorIds)));
-      for (const u of actorUsers) {
-        const name = getDisplayName(u);
-        actorNameMap[u.id] = name;
-        if (u.email) actorNameMap[u.email] = name;
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const uuidIds = actorIds.filter((id) => UUID_RE.test(id));
+      const nonUuidIds = actorIds.filter((id) => !UUID_RE.test(id));
+
+      const clauses = [];
+      if (uuidIds.length) clauses.push(inArray(users.id, uuidIds));
+      if (nonUuidIds.length) clauses.push(inArray(users.email, nonUuidIds));
+
+      if (clauses.length) {
+        const actorUsers = await db
+          .select({ id: users.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
+          .from(users)
+          .where(or(...clauses));
+        for (const u of actorUsers) {
+          const name = getDisplayName(u);
+          actorNameMap[u.id] = name;
+          if (u.email) actorNameMap[u.email] = name;
+        }
       }
     }
 
-    return ok({ logs, total: Number(totalRow?.count ?? 0), actorNameMap });
+    // 构建 targetId → 可读名称映射
+    const targetNameMap: Record<string, string> = {};
+    const byType = new Map<string, string[]>();
+    for (const l of logs) {
+      if (!l.targetId || !l.targetType) continue;
+      const list = byType.get(l.targetType) ?? [];
+      list.push(l.targetId);
+      byType.set(l.targetType, list);
+    }
+
+    const resolvers: Promise<void>[] = [];
+
+    const userTypeIds = [...new Set([...(byType.get("user") ?? []), ...(byType.get("admin_user") ?? [])])];
+    if (userTypeIds.length) {
+      resolvers.push(
+        db.select({ id: users.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
+          .from(users).where(inArray(users.id, userTypeIds))
+          .then((rows) => { for (const u of rows) targetNameMap[u.id] = getDisplayName(u); }),
+      );
+    }
+
+    const seasonIds = [...new Set([...(byType.get("season") ?? []), ...(byType.get("draft_state") ?? [])])];
+    if (seasonIds.length) {
+      resolvers.push(
+        db.select({ id: seasons.id, name: seasons.name }).from(seasons).where(inArray(seasons.id, seasonIds))
+          .then((rows) => { for (const s of rows) targetNameMap[s.id] = s.name; }),
+      );
+    }
+
+    const teamIds = byType.get("team");
+    if (teamIds?.length) {
+      resolvers.push(
+        db.select({ id: teams.id, name: teams.name }).from(teams).where(inArray(teams.id, teamIds))
+          .then((rows) => { for (const t of rows) targetNameMap[t.id] = t.name; }),
+      );
+    }
+
+    const regIds = byType.get("registration");
+    if (regIds?.length) {
+      resolvers.push(
+        db.select({ id: seasonRegistrations.id, uid: users.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
+          .from(seasonRegistrations).innerJoin(users, eq(seasonRegistrations.userId, users.id))
+          .where(inArray(seasonRegistrations.id, regIds))
+          .then((rows) => { for (const r of rows) targetNameMap[r.id] = getDisplayName(r); }),
+      );
+    }
+
+    const matchIds = byType.get("match");
+    if (matchIds?.length) {
+      const tA = db.$with("ta").as(db.select({ id: teams.id, name: teams.name }).from(teams));
+      const tB = db.$with("tb").as(db.select({ id: teams.id, name: teams.name }).from(teams));
+      resolvers.push(
+        db.select({ id: matches.id, aName: teams.name, bId: matches.teamBId })
+          .from(matches)
+          .innerJoin(teams, eq(matches.teamAId, teams.id))
+          .where(inArray(matches.id, matchIds))
+          .then(async (rows) => {
+            const bIds = [...new Set(rows.map((r) => r.bId))];
+            const bMap: Record<string, string> = {};
+            if (bIds.length) {
+              const bRows = await db.select({ id: teams.id, name: teams.name }).from(teams).where(inArray(teams.id, bIds));
+              for (const b of bRows) bMap[b.id] = b.name;
+            }
+            for (const r of rows) targetNameMap[r.id] = `${r.aName} vs ${bMap[r.bId] ?? "?"}`;
+          }),
+      );
+    }
+
+    const inviteIds = byType.get("admin_invite");
+    if (inviteIds?.length) {
+      resolvers.push(
+        db.select({ id: adminInvites.id, code: adminInvites.code }).from(adminInvites).where(inArray(adminInvites.id, inviteIds))
+          .then((rows) => { for (const i of rows) targetNameMap[i.id] = `邀请码 ${i.code}`; }),
+      );
+    }
+
+    const voteIds = byType.get("captain_vote");
+    if (voteIds?.length) {
+      resolvers.push(
+        db.select({
+          id: captainVotes.id,
+          voterId: captainVotes.voterRegistrationId,
+          candidateId: captainVotes.candidateRegistrationId,
+        }).from(captainVotes).where(inArray(captainVotes.id, voteIds))
+          .then(async (rows) => {
+            const allRegIds = [...new Set(rows.flatMap((r) => [r.voterId, r.candidateId]))];
+            const regMap: Record<string, string> = {};
+            if (allRegIds.length) {
+              const regRows = await db.select({ id: seasonRegistrations.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
+                .from(seasonRegistrations).innerJoin(users, eq(seasonRegistrations.userId, users.id))
+                .where(inArray(seasonRegistrations.id, allRegIds));
+              for (const r of regRows) regMap[r.id] = getDisplayName(r);
+            }
+            for (const v of rows) targetNameMap[v.id] = `${regMap[v.voterId] ?? "?"} → ${regMap[v.candidateId] ?? "?"}`;
+          }),
+      );
+    }
+
+    const pickIds = byType.get("draft_pick");
+    if (pickIds?.length) {
+      resolvers.push(
+        db.select({ id: draftPicks.id, regId: draftPicks.registrationId, teamId: draftPicks.teamId, round: draftPicks.round })
+          .from(draftPicks).where(inArray(draftPicks.id, pickIds))
+          .then(async (rows) => {
+            const rIds = [...new Set(rows.map((r) => r.regId))];
+            const tIds = [...new Set(rows.map((r) => r.teamId))];
+            const [regRows, teamRows] = await Promise.all([
+              rIds.length ? db.select({ id: seasonRegistrations.id, email: users.email, steamName: users.steamName, displayName: users.displayName, perfectName: users.perfectName })
+                .from(seasonRegistrations).innerJoin(users, eq(seasonRegistrations.userId, users.id))
+                .where(inArray(seasonRegistrations.id, rIds)) : [],
+              tIds.length ? db.select({ id: teams.id, name: teams.name }).from(teams).where(inArray(teams.id, tIds)) : [],
+            ]);
+            const regMap: Record<string, string> = {};
+            for (const r of regRows) regMap[r.id] = getDisplayName(r);
+            const tMap: Record<string, string> = {};
+            for (const t of teamRows) tMap[t.id] = t.name;
+            for (const p of rows) targetNameMap[p.id] = `${regMap[p.regId] ?? "?"} → ${tMap[p.teamId] ?? "?"}`;
+          }),
+      );
+    }
+
+    await Promise.all(resolvers);
+
+    return ok({ logs, total: Number(totalRow?.count ?? 0), actorNameMap, targetNameMap });
   } catch (e) {
     return actionError("fetchAuditLogs", e);
   }

--- a/src/app/admin/logs/page.tsx
+++ b/src/app/admin/logs/page.tsx
@@ -41,12 +41,13 @@ export default async function AdminLogsPage({ searchParams }: AdminLogsPageProps
   const logs = logsResult.success ? logsResult.data.logs : [];
   const total = logsResult.success ? logsResult.data.total : 0;
   const actorNameMap = logsResult.success ? (logsResult.data.actorNameMap ?? {}) : {};
+  const targetNameMap = logsResult.success ? (logsResult.data.targetNameMap ?? {}) : {};
   const seasons = seasonsResult.success ? seasonsResult.data : [];
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <Marker>操作日志</Marker>
-      <AuditLogTable initialLogs={logs} initialTotal={total} seasons={seasons} initialActorNameMap={actorNameMap} />
+      <AuditLogTable initialLogs={logs} initialTotal={total} seasons={seasons} initialActorNameMap={actorNameMap} initialTargetNameMap={targetNameMap} />
     </div>
   );
 }

--- a/src/components/admin/AuditLogTable.tsx
+++ b/src/components/admin/AuditLogTable.tsx
@@ -13,6 +13,7 @@ interface Props {
   initialTotal: number;
   seasons: { id: string; name: string }[];
   initialActorNameMap: Record<string, string>;
+  initialTargetNameMap: Record<string, string>;
 }
 
 const ACTION_CATEGORIES: Record<string, { label: string; color: string }> = {
@@ -32,9 +33,52 @@ function getCategory(action: string) {
   return ACTION_CATEGORIES[prefix] ?? { label: prefix, color: "var(--color-fg-dim)" };
 }
 
+const ACTION_LABELS: Record<string, string> = {
+  "admin.create_invite": "创建邀请码",
+  "admin.deactivate_invite": "停用邀请码",
+  "admin.register": "管理员注册",
+  "admin.change_password": "修改密码",
+  "admin.revoke_role": "撤销权限",
+  "admin.deactivate_user": "停用用户",
+  "admin.reactivate_user": "恢复用户",
+  "registration.submit": "提交报名",
+  "captain.cast_vote": "投票",
+  "captain.retract_vote": "撤回投票",
+  "captain.confirm": "确认队长",
+  "draft.start": "开始选秀",
+  "draft.pick": "选秀选人",
+  "draft.skip_turn": "跳过回合",
+  "draft.pause": "暂停选秀",
+  "draft.resume": "恢复选秀",
+  "match.generate_schedule": "生成赛程",
+  "match.initialize_stage": "初始化阶段",
+  "match.create": "创建比赛",
+  "match.record_result": "录入比分",
+  "match.record_map_result": "录入地图比分",
+  "match.save_player_stats": "录入选手数据",
+  "match.status_update": "更新比赛状态",
+  "match.submit_roster": "提交阵容",
+  "match.unlock_roster": "解锁阵容",
+  "match.propose_time": "提议比赛时间",
+  "match.respond_time_proposal": "回应时间提议",
+  "match.force_set_time": "强制设定时间",
+  "match.auto_award_time": "自动裁定时间",
+  "match.update_scheduled_at": "更新比赛时间",
+  "match.update_completion_deadline": "更新完赛截止",
+  "season.create": "创建赛季",
+  "season.update": "更新赛季",
+  "season.publish": "发布赛季",
+  "season.deleted": "删除赛季",
+  "season.auto_advance": "自动推进阶段",
+  "team.rename": "队伍改名",
+  "team.upload_logo": "上传队标",
+  "user.change_password": "修改密码",
+  "user.claim_invite": "使用邀请码",
+};
+
 const PAGE_SIZE = 50;
 
-export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActorNameMap }: Props) {
+export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActorNameMap, initialTargetNameMap }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
@@ -42,13 +86,11 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
   const [logs, setLogs] = useState(initialLogs);
   const [total, setTotal] = useState(initialTotal);
   const [actorNameMap, setActorNameMap] = useState(initialActorNameMap);
+  const [targetNameMap, setTargetNameMap] = useState(initialTargetNameMap);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  // 本地输入状态（用于 debounce，避免每次按键触发请求）
-  const [localAction, setLocalAction] = useState(searchParams.get("action") ?? "");
   const [localActor, setLocalActor] = useState(searchParams.get("actor") ?? "");
 
-  const actionTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const actorTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const currentPage = Number(searchParams.get("page") ?? "1");
@@ -59,9 +101,8 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
   const currentDateTo = searchParams.get("dateTo") ?? "";
 
   useEffect(() => {
-    setLocalAction(currentAction);
     setLocalActor(currentActor);
-  }, [currentAction, currentActor]);
+  }, [currentActor]);
 
   const updateParams = useCallback(
     (updates: Record<string, string>) => {
@@ -106,6 +147,7 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
         setLogs(result.data.logs);
         setTotal(result.data.total);
         if (result.data.actorNameMap) setActorNameMap(result.data.actorNameMap);
+        if (result.data.targetNameMap) setTargetNameMap(result.data.targetNameMap);
       }
     });
   }, [currentPage, currentAction, currentActor, currentSeason, currentDateFrom, currentDateTo]);
@@ -121,7 +163,6 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
 
   useEffect(() => {
     return () => {
-      clearTimeout(actionTimerRef.current);
       clearTimeout(actorTimerRef.current);
     };
   }, []);
@@ -139,21 +180,31 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
           <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
             操作类型
           </label>
-          <input
-            type="text"
-            placeholder="如 admin.create_invite"
-            value={localAction}
-            onChange={(e) => {
-              setLocalAction(e.target.value);
-              debouncedUpdateParam("action", e.target.value, actionTimerRef);
-            }}
+          <select
+            value={currentAction}
+            onChange={(e) => updateParams({ action: e.target.value })}
             className="w-full px-2 py-1.5 rounded text-xs"
             style={{
               background: "var(--color-panel-low)",
               border: "1px solid var(--color-border)",
               color: "var(--color-fg)",
             }}
-          />
+          >
+            <option value="">全部操作</option>
+            {Object.entries(ACTION_CATEGORIES).reduce<[string, [string, string][]][]>((groups, [prefix, cat]) => {
+              const items = Object.entries(ACTION_LABELS).filter(([k]) => k.startsWith(prefix + "."));
+              if (items.length && !groups.some(([label]) => label === cat.label)) {
+                groups.push([cat.label, items]);
+              }
+              return groups;
+            }, []).map(([groupLabel, items]) => (
+              <optgroup key={groupLabel} label={groupLabel}>
+                {items.map(([key, label]) => (
+                  <option key={key} value={key}>{label}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
         </div>
         <div>
           <label className="block text-xs mb-1" style={{ color: "var(--color-fg-dim)" }}>
@@ -283,7 +334,7 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
                     >
                       {cat.label}
                     </span>
-                    <span style={{ color: "var(--color-fg)" }}>{log.action}</span>
+                    <span title={log.action} style={{ color: "var(--color-fg)" }}>{ACTION_LABELS[log.action] ?? log.action}</span>
                   </td>
                   <td className="px-3 py-2 truncate max-w-[140px]" style={{ color: "var(--color-fg-mid)" }}>
                     {log.actorId ? (actorNameMap[log.actorId] ?? log.actorId.slice(0, 8)) : "—"}
@@ -292,8 +343,8 @@ export function AuditLogTable({ initialLogs, initialTotal, seasons, initialActor
                     {log.targetType && (
                       <span className="opacity-60 mr-1">{log.targetType}:</span>
                     )}
-                    <span className="truncate inline-block max-w-[100px] align-bottom">
-                      {log.targetId?.slice(0, 8) ?? "-"}
+                    <span className="truncate inline-block max-w-[160px] align-bottom" title={log.targetId ?? undefined}>
+                      {(log.targetId && targetNameMap[log.targetId]) || log.targetId?.slice(0, 8) || "-"}
                     </span>
                   </td>
                   <td className="px-3 py-2">


### PR DESCRIPTION
## Summary
- **审计日志 UUID 安全修复**：`actorId` 为 `"system"` 等非 UUID 字符串时不再触发 Postgres `22P02` 错误
- **审计日志目标名称解析**：按 targetType 批量查询对应表，显示可读名称（用户名/赛季名/队名/比赛对阵/邀请码/投票→候选人/选手→队伍）替代截断 UUID
- **审计日志 action 中文别名**：40+ action 映射中文标签，操作类型筛选改为 optgroup 分组下拉菜单
- **文档同步至 v1.7.4**：CLAUDE.md / README / docs/architecture.md 补齐 actions 目录索引（audit/transitions/player-stats/scheduling/roster）、3 个 cron 端点；CHANGELOG 补 1.4.1–1.7.3 缺失的 compare link references

## Test plan
- [ ] 访问 `/admin/logs` 审计日志页面，目标列显示可读名称而非截断 UUID
- [ ] 操作类型下拉菜单按分类分组，选择后正确筛选
- [ ] hover action 标签显示原始字符串（如 `captain.cast_vote`）
- [ ] 包含 `actorId = "system"` 的日志页面不再报 500