### PR TITLE
v1.10.0: 选秀预览模式 + 自动选人优先级升级 + 选手页增强

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.9.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.10.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-05-16
+
+### Added
+- **选秀预览模式**：选秀页在非 drafting 状态展示只读选手池，队长可提前查看选手信息（含风格/备注/经历 hover 卡片）研究阵容
+- **选手个人页信息增强**：`/players/[userId]` 新增"选手自述"区块，展示风格、备注、比赛经历
+
+### Changed
+- **自动选人优先级升级**：从单一 peakRating 改为 5 级排序（peakRank → peakRating → currentRank → currentRating → registrationId），并优先填补队伍完全空缺的位置
+- **sortByRank 排序扩展**：支持可选 currentRank / currentRating 字段，队长面板和选手池排序自动受益
+
 ## [1.9.0] - 2026-05-16
 
 ### Added
@@ -269,6 +279,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.10.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.4...v1.8.0
 [1.7.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.3...v1.7.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.9.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.10.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/draft/picks.ts
+++ b/src/actions/draft/picks.ts
@@ -605,6 +605,9 @@ async function getAutoPickCandidates(
       registrationId: seasonRegistrations.id,
       primaryPosition: seasonRegistrations.primaryPosition,
       peakRating: seasonRegistrations.peakRating,
+      peakRank: seasonRegistrations.peakRank,
+      currentRank: seasonRegistrations.currentSeasonPeakRank,
+      currentRating: seasonRegistrations.currentRating,
     })
     .from(seasonRegistrations)
     .where(
@@ -620,6 +623,9 @@ async function getAutoPickCandidates(
       registrationId: candidate.registrationId,
       primaryPosition: candidate.primaryPosition,
       peakRating: candidate.peakRating,
+      peakRank: candidate.peakRank,
+      currentRank: candidate.currentRank,
+      currentRating: candidate.currentRating,
     }));
 }
 

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -6,6 +6,7 @@ import { seasons } from "@/db/schema";
 import { DraftLiveRoom } from "@/components/draft/DraftLiveRoom";
 import { Panel, Marker } from "@/components/rivalhub";
 import { getDraftData } from "@/lib/draft/data";
+import { SEASON_STATUS_LABELS } from "@/types/season";
 
 export const dynamic = "force-dynamic";
 
@@ -38,23 +39,34 @@ export default async function DraftPage({ params }: DraftPageProps) {
     );
   }
 
+  // 预览模式：选秀未开始，展示只读选手池供队长提前研究
   if (season.status !== "drafting") {
-    const messages: Record<string, string> = {
-      draft: "选秀尚未开放，赛季仍在筹备中。",
-      registration: "报名阶段结束后才会开始选秀，请耐心等待。",
-      voting: "队长投票进行中，投票结束后将进入选秀阶段。",
-      playing: "选秀已结束，赛季正在进行中。",
-      finished: "该赛季已结束。",
-      archived: "该赛季已归档。",
-    };
+    const data = await getDraftData(season.id);
+    const stageLabel = SEASON_STATUS_LABELS[season.status] ?? season.status;
+
     return (
-      <main className="container mx-auto max-w-5xl px-4 py-10">
-        <Panel pad={32}>
-          <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
-          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
-            {messages[season.status] ?? "选秀当前不可用。"}
+      <main className="container mx-auto max-w-7xl px-4 py-10">
+        <Marker sub="选秀开始前，队长可提前查看选手池研究阵容。">
+          选秀预览 · {season.name}
+        </Marker>
+
+        <div className="mb-6 rounded-lg border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5 px-4 py-3">
+          <p className="text-sm text-[var(--color-fg-mid)]">
+            选秀尚未开始 · 当前阶段：{" "}
+            <span className="text-[var(--color-accent)] font-medium">{stageLabel}</span>
           </p>
-        </Panel>
+          <p className="mt-1 text-xs text-[var(--color-fg-dim)]">
+            以下为只读预览，包含已报名选手与队伍信息。选秀开始后页面会自动切换为直播模式。
+          </p>
+        </div>
+
+        <DraftLiveRoom
+          data={data}
+          seasonId={season.id}
+          seasonSlug={seasonSlug}
+          seasonPositions={season.positions}
+          readonly
+        />
       </main>
     );
   }

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -3,6 +3,7 @@ import { eq, or, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users, seasonRegistrations, seasons, teams, teamMembers, matches } from "@/db/schema";
 import { resolveAvatarUrl } from "@/lib/steam";
+import { PLAYER_INFO_FIELDS } from "@/components/draft/PlayerInfoPopover";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { Panel, Stat, PosChip } from "@/components/rivalhub";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
@@ -63,6 +64,9 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         currentRating: seasonRegistrations.currentRating,
         mapPreferences: seasonRegistrations.mapPreferences,
         highlightVideoUrl: seasonRegistrations.highlightVideoUrl,
+        gameplayStyle: seasonRegistrations.gameplayStyle,
+        notes: seasonRegistrations.notes,
+        competitionHistory: seasonRegistrations.competitionHistory,
         status: seasonRegistrations.status,
         seasonName: seasons.name,
         seasonSlug: seasons.slug,
@@ -230,6 +234,42 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
           </Panel>
         </section>
       )}
+
+      {/* 选手自述 */}
+      {latestReg &&
+        (latestReg.gameplayStyle?.trim() ||
+          latestReg.notes?.trim() ||
+          latestReg.competitionHistory?.trim()) && (
+          <section className="space-y-3">
+            <SectionHeading>选手自述</SectionHeading>
+            <Panel pad={16}>
+              <div className="space-y-2">
+                {PLAYER_INFO_FIELDS
+                  .map(({ key, label }) => {
+                    const value = latestReg[key as keyof typeof latestReg] as string | null;
+                    return { value: value?.trim(), label };
+                  })
+                  .filter((s) => s.value)
+                  .map(({ value, label }) => (
+                    <div key={label}>
+                      <span
+                        className="text-xs font-semibold"
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          color: "var(--color-fg-mid)",
+                        }}
+                      >
+                        {label}
+                      </span>
+                      <p className="text-sm text-[var(--color-fg)] mt-0.5">
+                        {value}
+                      </p>
+                    </div>
+                  ))}
+              </div>
+            </Panel>
+          </section>
+        )}
 
       {/* 职业生涯战绩 */}
       {played > 0 && (

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -33,6 +33,7 @@ interface CaptainDraftPanelProps {
   /** Already picked members for roster summary */
   rosterMembers: { steamName: string; perfectName: string | null; displayName: string | null; primaryPosition: string }[];
   captainPosition: string;
+  readonly?: boolean;
 }
 
 export function CaptainDraftPanel({
@@ -49,6 +50,7 @@ export function CaptainDraftPanel({
   seasonPositions,
   rosterMembers,
   captainPosition,
+  readonly: isReadonly,
 }: CaptainDraftPanelProps) {
   const router = useRouter();
   const [filter, setFilter] = useState(FILTER_ALL);
@@ -115,85 +117,89 @@ export function CaptainDraftPanel({
   return (
     <div className="space-y-5">
       {/* Header */}
-      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold text-[var(--color-fg)]">{teamName}</h2>
-            <p className="mt-1 text-sm text-[var(--color-fg-mid)]">
-              {isCurrentCaptainTurn
-                ? `第 ${currentRound ?? "-"} 轮，轮到你选择`
-                : currentTeamName
-                  ? `等待 ${currentTeamName} 选择`
-                  : "等待选秀状态更新"}
-            </p>
+      {!isReadonly && (
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-[var(--color-fg)]">{teamName}</h2>
+              <p className="mt-1 text-sm text-[var(--color-fg-mid)]">
+                {isCurrentCaptainTurn
+                  ? `第 ${currentRound ?? "-"} 轮，轮到你选择`
+                  : currentTeamName
+                    ? `等待 ${currentTeamName} 选择`
+                    : "等待选秀状态更新"}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <Clock className="size-4 text-[var(--color-fg-dim)]" aria-hidden="true" />
+              <DraftCountdown deadline={roundDeadline} isActive={isDraftActive} />
+            </div>
           </div>
-          <div className="flex items-center gap-2 text-sm">
-            <Clock className="size-4 text-[var(--color-fg-dim)]" aria-hidden="true" />
-            <DraftCountdown deadline={roundDeadline} isActive={isDraftActive} />
-          </div>
-        </div>
 
-        {message && (
-          <div
-            className={`mt-3 rounded-md border px-3 py-2 text-sm ${
-              message.type === "success"
-                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                : "border-red-500/30 bg-red-500/10 text-red-300"
-            }`}
-            role="status"
-          >
-            {message.text}
-          </div>
-        )}
-      </div>
+          {message && (
+            <div
+              className={`mt-3 rounded-md border px-3 py-2 text-sm ${
+                message.type === "success"
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                  : "border-red-500/30 bg-red-500/10 text-red-300"
+              }`}
+              role="status"
+            >
+              {message.text}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Roster Summary (collapsible) */}
-      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] overflow-hidden">
-        <button
-          type="button"
-          onClick={() => setRosterOpen(!rosterOpen)}
-          className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium text-[var(--color-fg)] hover:bg-[var(--color-panel-hi)] transition-colors"
-        >
-          {rosterOpen ? (
-            <ChevronDown className="size-4 text-[var(--color-fg-dim)]" />
-          ) : (
-            <ChevronRight className="size-4 text-[var(--color-fg-dim)]" />
-          )}
-          我的阵容（{rosterMembers.length + 1} 人）
-        </button>
-        {rosterOpen && (
-          <div className="border-t border-[var(--color-border)] px-4 py-3 space-y-3">
-            {/* Position occupation */}
-            <div className="flex flex-wrap gap-2 text-xs text-[var(--color-fg-mid)]">
-              {seasonPositions.map((pos) => {
-                const count = positionCounts[pos] ?? 0;
-                const full = !canPickPosition(count);
-                return (
-                  <span
-                    key={pos}
-                    className={full ? "text-red-400" : ""}
-                  >
-                    {positionLabel(pos)} {count}/2
-                  </span>
-                );
-              })}
-            </div>
-            {/* Members list */}
-            <div className="space-y-1">
-              <div className="flex items-center gap-2 text-xs text-[var(--color-fg)]">
-                <PosChip pos={positionLabel(captainPosition)} small />
-                <span className="text-[var(--color-accent)]">队长</span>
+      {!isReadonly && (
+        <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setRosterOpen(!rosterOpen)}
+            className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium text-[var(--color-fg)] hover:bg-[var(--color-panel-hi)] transition-colors"
+          >
+            {rosterOpen ? (
+              <ChevronDown className="size-4 text-[var(--color-fg-dim)]" />
+            ) : (
+              <ChevronRight className="size-4 text-[var(--color-fg-dim)]" />
+            )}
+            我的阵容（{rosterMembers.length + 1} 人）
+          </button>
+          {rosterOpen && (
+            <div className="border-t border-[var(--color-border)] px-4 py-3 space-y-3">
+              {/* Position occupation */}
+              <div className="flex flex-wrap gap-2 text-xs text-[var(--color-fg-mid)]">
+                {seasonPositions.map((pos) => {
+                  const count = positionCounts[pos] ?? 0;
+                  const full = !canPickPosition(count);
+                  return (
+                    <span
+                      key={pos}
+                      className={full ? "text-red-400" : ""}
+                    >
+                      {positionLabel(pos)} {count}/2
+                    </span>
+                  );
+                })}
               </div>
-              {rosterMembers.map((member, i) => (
-                <div key={i} className="flex items-center gap-2 text-xs text-[var(--color-fg)]">
-                  <PosChip pos={positionLabel(member.primaryPosition)} small />
-                  <span>{getDisplayName(member)}</span>
+              {/* Members list */}
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-xs text-[var(--color-fg)]">
+                  <PosChip pos={positionLabel(captainPosition)} small />
+                  <span className="text-[var(--color-accent)]">队长</span>
                 </div>
-              ))}
+                {rosterMembers.map((member, i) => (
+                  <div key={i} className="flex items-center gap-2 text-xs text-[var(--color-fg)]">
+                    <PosChip pos={positionLabel(member.primaryPosition)} small />
+                    <span>{getDisplayName(member)}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
         <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -293,21 +299,23 @@ export function CaptainDraftPanel({
                     />
 
                     {/* Pick button */}
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={disabled}
-                      aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
-                      onClick={() => void handlePick(player)}
-                      className="shrink-0"
-                    >
-                      {isPending ? (
-                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                      ) : positionOpen ? (
-                        <Check className="size-4" aria-hidden="true" />
-                      ) : null}
-                      {positionOpen ? "选择" : "已满"}
-                    </Button>
+                    {!isReadonly && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={disabled}
+                        aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
+                        onClick={() => void handlePick(player)}
+                        className="shrink-0"
+                      >
+                        {isPending ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : positionOpen ? (
+                          <Check className="size-4" aria-hidden="true" />
+                        ) : null}
+                        {positionOpen ? "选择" : "已满"}
+                      </Button>
+                    )}
                   </div>
 
                   <div className="md:hidden space-y-1.5">
@@ -351,21 +359,23 @@ export function CaptainDraftPanel({
                           competitionHistory={player.competitionHistory}
                         />
                       </div>
-                      <Button
-                        type="button"
-                        size="sm"
-                        disabled={disabled}
-                        aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
-                        onClick={() => void handlePick(player)}
-                        className="shrink-0"
-                      >
-                        {isPending ? (
-                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                        ) : positionOpen ? (
-                          <Check className="size-4" aria-hidden="true" />
-                        ) : null}
-                        {positionOpen ? "选择" : "已满"}
-                      </Button>
+                      {!isReadonly && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          disabled={disabled}
+                          aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
+                          onClick={() => void handlePick(player)}
+                          className="shrink-0"
+                        >
+                          {isPending ? (
+                            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                          ) : positionOpen ? (
+                            <Check className="size-4" aria-hidden="true" />
+                          ) : null}
+                          {positionOpen ? "选择" : "已满"}
+                        </Button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -15,6 +15,7 @@ interface DraftLiveRoomProps {
   seasonId: string;
   seasonSlug: string;
   seasonPositions: string[];
+  readonly?: boolean;
 }
 
 interface PickNotification {
@@ -27,6 +28,7 @@ export function DraftLiveRoom({
   seasonId,
   seasonSlug: _seasonSlug,
   seasonPositions,
+  readonly: isReadonly,
 }: DraftLiveRoomProps) {
   const router = useRouter();
   const { state, teams, snakeOrder, remainingPlayers, completedPicks, totalPicks, maxPicks } =
@@ -68,14 +70,16 @@ export function DraftLiveRoom({
     };
   }, []);
 
-  // 轮询兜底（10 秒刷新）
+  // 轮询兜底（10 秒刷新）—— 仅直播模式
   useEffect(() => {
+    if (isReadonly) return;
     const timer = window.setInterval(() => router.refresh(), 10_000);
     return () => window.clearInterval(timer);
-  }, [router]);
+  }, [router, isReadonly]);
 
-  // Realtime 订阅
+  // Realtime 订阅 —— 仅直播模式
   useEffect(() => {
+    if (isReadonly) return;
     const supabase = createBrowserClient();
     const channel = supabase
       .channel(`draft-live:${seasonId}`)
@@ -106,7 +110,7 @@ export function DraftLiveRoom({
     return () => {
       void supabase.removeChannel(channel);
     };
-  }, [router, seasonId]);
+  }, [router, seasonId, isReadonly]);
 
   // Watch for new picks via completedPicks changes
   const prevPickCountRef = useRef(completedPicks.length);
@@ -131,8 +135,8 @@ export function DraftLiveRoom({
 
   return (
     <div className="space-y-6">
-      {/* Pick notification banner */}
-      {notification && (
+      {/* Pick notification banner —— 仅直播模式 */}
+      {!isReadonly && notification && (
         <div
           className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center px-4 py-3 text-sm font-medium text-white transition-opacity duration-300"
           style={{
@@ -147,44 +151,46 @@ export function DraftLiveRoom({
         </div>
       )}
 
-      {/* 顶部状态栏 */}
-      <div className="flex flex-wrap items-center justify-between gap-3 p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)]">
-        <div className="flex items-center gap-4 flex-wrap">
-          <div className="text-sm">
-            <span className="text-[var(--color-fg-mid)]">进度 </span>
-            <span className="text-[var(--color-fg)] font-semibold tabular">
-              {totalPicks} / {maxPicks}
-            </span>
-          </div>
-          {state && (
+      {/* 顶部状态栏 —— 仅直播模式 */}
+      {!isReadonly && (
+        <div className="flex flex-wrap items-center justify-between gap-3 p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)]">
+          <div className="flex items-center gap-4 flex-wrap">
             <div className="text-sm">
-              <span className="text-[var(--color-fg-mid)]">第 </span>
+              <span className="text-[var(--color-fg-mid)]">进度 </span>
               <span className="text-[var(--color-fg)] font-semibold tabular">
-                {state.currentRound}
-              </span>
-              <span className="text-[var(--color-fg-mid)]"> / {DRAFT_TOTAL_ROUNDS} 轮</span>
-            </div>
-          )}
-          {pickingTeam && isLive && (
-            <div className="text-sm">
-              <span className="text-[var(--color-fg-mid)]">当前 </span>
-              <span className="text-[var(--color-accent)] font-semibold">
-                {pickingTeam.teamName}
+                {totalPicks} / {maxPicks}
               </span>
             </div>
-          )}
-        </div>
+            {state && (
+              <div className="text-sm">
+                <span className="text-[var(--color-fg-mid)]">第 </span>
+                <span className="text-[var(--color-fg)] font-semibold tabular">
+                  {state.currentRound}
+                </span>
+                <span className="text-[var(--color-fg-mid)]"> / {DRAFT_TOTAL_ROUNDS} 轮</span>
+              </div>
+            )}
+            {pickingTeam && isLive && (
+              <div className="text-sm">
+                <span className="text-[var(--color-fg-mid)]">当前 </span>
+                <span className="text-[var(--color-accent)] font-semibold">
+                  {pickingTeam.teamName}
+                </span>
+              </div>
+            )}
+          </div>
 
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-[var(--color-fg-dim)]">
-            {isLive ? "倒计时" : "已暂停"}
-          </span>
-          <DraftCountdown
-            deadline={state?.roundDeadline ?? null}
-            isActive={isLive}
-          />
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-[var(--color-fg-dim)]">
+              {isLive ? "倒计时" : "已暂停"}
+            </span>
+            <DraftCountdown
+              deadline={state?.roundDeadline ?? null}
+              isActive={isLive}
+            />
+          </div>
         </div>
-      </div>
+      )}
 
       {/* 队伍网格 */}
       <section>
@@ -199,8 +205,8 @@ export function DraftLiveRoom({
         />
       </section>
 
-      {/* 蛇形顺序指示 */}
-      {isLive && snakeOrder.length > 0 && (
+      {/* 蛇形顺序指示 —— 仅直播模式 */}
+      {!isReadonly && isLive && snakeOrder.length > 0 && (
         <div className="flex items-center gap-1.5 text-xs text-[var(--color-fg-dim)] overflow-x-auto">
           <span>蛇形顺序：</span>
           {snakeOrder.map((tid) => {
@@ -222,8 +228,8 @@ export function DraftLiveRoom({
         </div>
       )}
 
-      {/* 已完成 pick 历史 */}
-      {completedPicks.length > 0 && (
+      {/* 已完成 pick 历史 —— 仅直播模式 */}
+      {!isReadonly && completedPicks.length > 0 && (
         <section>
           <h2 className="text-sm font-semibold text-[var(--color-fg-mid)] mb-3 uppercase tracking-wider">
             选秀记录
@@ -256,7 +262,7 @@ export function DraftLiveRoom({
       {/* 选手池 */}
       <section>
         <h2 className="text-sm font-semibold text-[var(--color-fg-mid)] mb-3 uppercase tracking-wider">
-          剩余选手池 ({remainingPlayers.length})
+          {isReadonly ? "选手池" : "剩余选手池"} ({remainingPlayers.length})
         </h2>
         <PlayerPool players={remainingPlayers} seasonPositions={seasonPositions} />
       </section>

--- a/src/components/draft/PlayerInfoPopover.tsx
+++ b/src/components/draft/PlayerInfoPopover.tsx
@@ -3,6 +3,12 @@
 import React, { useCallback, useRef, useState } from "react";
 import { Info } from "lucide-react";
 
+export const PLAYER_INFO_FIELDS = [
+  { key: "gameplayStyle", label: "风格" },
+  { key: "notes", label: "备注" },
+  { key: "competitionHistory", label: "经历" },
+] as const;
+
 interface PlayerInfoPopoverProps {
   gameplayStyle: string | null;
   notes: string | null;
@@ -15,11 +21,12 @@ export function PlayerInfoPopover({ gameplayStyle, notes, competitionHistory }: 
   const iconRef = useRef<HTMLButtonElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const sections = [
-    { value: gameplayStyle?.trim(), label: "风格" },
-    { value: notes?.trim(), label: "备注" },
-    { value: competitionHistory?.trim(), label: "经历" },
-  ].filter((s) => s.value);
+  const sections = PLAYER_INFO_FIELDS
+    .map(({ key, label }) => {
+      const valueMap: Record<string, string | null> = { gameplayStyle, notes, competitionHistory };
+      return { value: valueMap[key]?.trim() ?? "", label };
+    })
+    .filter((s) => s.value);
 
   const show = useCallback(() => {
     clearTimeout(timerRef.current);

--- a/src/lib/draft/auto-pick.ts
+++ b/src/lib/draft/auto-pick.ts
@@ -1,24 +1,51 @@
 import { canPickPosition } from "./rules";
+import { RANK_ORDER } from "@/lib/validators/registration";
 
 export interface AutoPickCandidate {
   registrationId: string;
   primaryPosition: string;
+  peakRank: string;
   peakRating: number;
+  currentRank: string;
+  currentRating: number;
 }
 
 export function selectAutoPickCandidate(
   candidates: AutoPickCandidate[],
   positionCounts: Record<string, number>,
 ): AutoPickCandidate | null {
-  return [...candidates]
-    .sort(
-      (a, b) =>
-        b.peakRating - a.peakRating ||
-        a.registrationId.localeCompare(b.registrationId),
-    )
-    .find((candidate) =>
-      canPickPosition(positionCounts[candidate.primaryPosition] ?? 0),
+  const sorted = [...candidates].sort((a, b) => {
+    const rankA = RANK_ORDER.indexOf(a.peakRank as (typeof RANK_ORDER)[number]);
+    const rankB = RANK_ORDER.indexOf(b.peakRank as (typeof RANK_ORDER)[number]);
+    if (rankA !== rankB) return rankB - rankA;
+    if (a.peakRating !== b.peakRating) return b.peakRating - a.peakRating;
+
+    const curRankA = a.currentRank
+      ? RANK_ORDER.indexOf(a.currentRank as (typeof RANK_ORDER)[number])
+      : -1;
+    const curRankB = b.currentRank
+      ? RANK_ORDER.indexOf(b.currentRank as (typeof RANK_ORDER)[number])
+      : -1;
+    if (curRankA !== curRankB) return curRankB - curRankA;
+    if (a.currentRating !== b.currentRating) return b.currentRating - a.currentRating;
+
+    return a.registrationId.localeCompare(b.registrationId);
+  });
+
+  // Round 1: prefer positions with zero current members (completely vacant)
+  const firstPick =
+    sorted.find(
+      (candidate) =>
+        (positionCounts[candidate.primaryPosition] ?? 0) === 0,
     ) ?? null;
+  if (firstPick) return firstPick;
+
+  // Round 2: any position below the cap (max 2 per position in draft)
+  return (
+    sorted.find((candidate) =>
+      canPickPosition(positionCounts[candidate.primaryPosition] ?? 0),
+    ) ?? null
+  );
 }
 
 export function createAutoPickRequestId({

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -42,6 +42,8 @@ export interface DraftPlayerRow {
   secondaryPosition: string;
   peakRank: string;
   peakRating: number;
+  currentRank: string;
+  currentRating: number;
   mapPreferences: MapPreference[];
   gameplayStyle: string | null;
   notes: string | null;
@@ -156,6 +158,8 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
       secondaryPosition: seasonRegistrations.secondaryPosition,
       peakRank: seasonRegistrations.peakRank,
       peakRating: seasonRegistrations.peakRating,
+      currentRank: seasonRegistrations.currentSeasonPeakRank,
+      currentRating: seasonRegistrations.currentRating,
       mapPreferences: seasonRegistrations.mapPreferences,
       gameplayStyle: seasonRegistrations.gameplayStyle,
       notes: seasonRegistrations.notes,
@@ -184,6 +188,8 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
       secondaryPosition: r.secondaryPosition,
       peakRank: r.peakRank,
       peakRating: r.peakRating ?? 0,
+      currentRank: r.currentRank,
+      currentRating: r.currentRating ?? 0,
       mapPreferences: r.mapPreferences ?? [],
       gameplayStyle: r.gameplayStyle ?? null,
       notes: r.notes ?? null,

--- a/src/lib/utils/rank.ts
+++ b/src/lib/utils/rank.ts
@@ -1,11 +1,16 @@
 import { RANK_ORDER } from "@/lib/validators/registration";
 
-/** Sort players by peakRank (higher rank = first) then peakRating DESC */
-export function sortByRank<T extends { peakRank: string; peakRating: number }>(items: T[]): T[] {
+/** Sort players by peakRank → peakRating → currentRank → currentRating (DESC) */
+export function sortByRank<T extends { peakRank: string; peakRating: number; currentRank?: string; currentRating?: number }>(items: T[]): T[] {
   return [...items].sort((a, b) => {
     const rankA = RANK_ORDER.indexOf(a.peakRank as (typeof RANK_ORDER)[number]);
     const rankB = RANK_ORDER.indexOf(b.peakRank as (typeof RANK_ORDER)[number]);
     if (rankA !== rankB) return rankB - rankA;
-    return b.peakRating - a.peakRating;
+    if (a.peakRating !== b.peakRating) return b.peakRating - a.peakRating;
+
+    const curRankA = a.currentRank ? RANK_ORDER.indexOf(a.currentRank as (typeof RANK_ORDER)[number]) : -1;
+    const curRankB = b.currentRank ? RANK_ORDER.indexOf(b.currentRank as (typeof RANK_ORDER)[number]) : -1;
+    if (curRankA !== curRankB) return curRankB - curRankA;
+    return (b.currentRating ?? 0) - (a.currentRating ?? 0);
   });
 }

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -39,6 +39,8 @@ const baseProps = {
       secondaryPosition: "anchor",
       peakRank: "S",
       peakRating: 2.01,
+      currentRank: "A+",
+      currentRating: 2.05,
       mapPreferences: [
         { map: "de_mirage", level: "strong" as const },
         { map: "de_nuke", level: "playable" as const },

--- a/tests/unit/components/draft/PlayerPool.test.tsx
+++ b/tests/unit/components/draft/PlayerPool.test.tsx
@@ -20,6 +20,8 @@ describe("PlayerPool", () => {
             secondaryPosition: "anchor",
             peakRank: "S",
             peakRating: 2.01,
+            currentRank: "A+",
+            currentRating: 2.05,
             mapPreferences: [],
             gameplayStyle: null,
             notes: null,

--- a/tests/unit/lib/draft-auto-pick.test.ts
+++ b/tests/unit/lib/draft-auto-pick.test.ts
@@ -6,24 +6,34 @@ const candidates = [
     registrationId: "awp-high",
     primaryPosition: "awper",
     peakRating: 2.3,
+    peakRank: "S",
+    currentRank: "S",
+    currentRating: 2.4,
   },
   {
     registrationId: "igl-best-open-position",
     primaryPosition: "igl",
     peakRating: 2.1,
+    peakRank: "S",
+    currentRank: "A+",
+    currentRating: 2.15,
   },
   {
     registrationId: "anchor-low",
     primaryPosition: "anchor",
     peakRating: 1.6,
+    peakRank: "A",
+    currentRank: "A",
+    currentRating: 1.65,
   },
 ];
 
 describe("selectAutoPickCandidate", () => {
-  it("selects the highest rated eligible player while skipping capped positions", () => {
+  it("selects the highest ranked player at an empty position first, then falls back to any eligible position", () => {
     const selected = selectAutoPickCandidate(candidates, { awper: 2, igl: 1 });
 
-    expect(selected?.registrationId).toBe("igl-best-open-position");
+    // anchor has 0 members (not in positionCounts), so it's picked in round 1
+    expect(selected?.registrationId).toBe("anchor-low");
   });
 
   it("returns null when every remaining player is position capped", () => {


### PR DESCRIPTION
## Summary
- **选秀预览模式**：选秀页非 drafting 状态展示只读选手池，队长提前研究阵容
- **自动选人优先级升级**：5 级排序（peakRank → peakRating → currentRank → currentRating → registrationId），优先填空位置
- **选手个人页增强**：新增风格/备注/经历展示区块
- **sortByRank 排序扩展**：支持可选 currentRank/currentRating
- 选秀选手悬停信息卡片 (v1.9.0)
- release skill 增加文档同步 + PR 创建步骤

## Test plan
- [x] pnpm test (379 passed)
- [x] pnpm tsc --noEmit (0 errors)
- [ ] dev 环境手动验证关键路径