### PR TITLE
v1.10.1: 修复选秀预览时机 + PLAYER_INFO_FIELDS 导入异常

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.10.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.10.1，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2026-05-16
+
+### Fixed
+- **选秀预览模式时机修正**：从 registration/voting 阶段改为 drafting 未激活时展示（此时队伍已组建），非 drafting 恢复简单提示
+- **PLAYER_INFO_FIELDS 导入异常**：`as const` 常量从 `"use client"` 文件移至独立模块，修复 Server Component 中 `map is not a function` 运行时错误
+
 ## [1.10.0] - 2026-05-16
 
 ### Added
@@ -279,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.10.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.7.4...v1.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.10.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.10.1，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -39,21 +39,32 @@ export default async function DraftPage({ params }: DraftPageProps) {
     );
   }
 
-  // 预览模式：选秀未开始，展示只读选手池供队长提前研究
   if (season.status !== "drafting") {
-    const data = await getDraftData(season.id);
     const stageLabel = SEASON_STATUS_LABELS[season.status] ?? season.status;
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-10">
+        <Panel pad={32}>
+          <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
+          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
+            选秀尚未开放 · 当前阶段：{stageLabel}
+          </p>
+        </Panel>
+      </main>
+    );
+  }
 
+  const data = await getDraftData(season.id);
+
+  if (!data.state) {
     return (
       <main className="container mx-auto max-w-7xl px-4 py-10">
-        <Marker sub="选秀开始前，队长可提前查看选手池研究阵容。">
+        <Marker sub="队伍已组建，选秀尚未启动。队长可提前查看选手池研究阵容。">
           选秀预览 · {season.name}
         </Marker>
 
         <div className="mb-6 rounded-lg border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5 px-4 py-3">
           <p className="text-sm text-[var(--color-fg-mid)]">
-            选秀尚未开始 · 当前阶段：{" "}
-            <span className="text-[var(--color-accent)] font-medium">{stageLabel}</span>
+            等待管理员启动选秀，页面会自动刷新。
           </p>
           <p className="mt-1 text-xs text-[var(--color-fg-dim)]">
             以下为只读预览，包含已报名选手与队伍信息。选秀开始后页面会自动切换为直播模式。
@@ -71,95 +82,80 @@ export default async function DraftPage({ params }: DraftPageProps) {
     );
   }
 
-  const data = await getDraftData(season.id);
-
   return (
     <main className="container mx-auto max-w-7xl px-4 py-10">
       <Marker sub="实时更新选秀进度，队伍阵容与选手池自动刷新。">
         选秀直播间 · {season.name}
       </Marker>
 
-      {!data.state ? (
-        <Panel pad={32} className="text-center">
-          <h2 className="text-xl font-semibold text-[var(--color-fg)] mb-2">
-            选秀尚未启动
-          </h2>
-          <p className="text-sm text-[var(--color-fg-mid)]">
-            等待管理员启动选秀，页面会自动刷新。
-          </p>
-        </Panel>
-      ) : (
-        <>
-          {data.state.isActive && (
-            <Panel pad={0}>
-              <div className="grid grid-cols-2 md:grid-cols-4 items-stretch">
-                {/* LIVE indicator */}
-                <div className="flex items-center gap-3.5 min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
-                  <div className="shrink-0" style={{ width: 8, height: 40, background: "var(--color-danger)", boxShadow: "0 0 12px var(--color-danger)" }} />
-                  <div className="min-w-0">
-                    <div className="font-bold uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-danger)", letterSpacing: "var(--tracking-eyebrow)" }}>
-                      ● LIVE
-                    </div>
-                    <div className="font-semibold mt-1 truncate" style={{ fontFamily: "var(--font-display)", fontSize: 18, color: "var(--color-fg)" }}>
-                      选秀直播间
-                    </div>
-                    <div className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)" }}>
-                      观众实时观看
-                    </div>
-                  </div>
+      {data.state.isActive && (
+        <Panel pad={0}>
+          <div className="grid grid-cols-2 md:grid-cols-4 items-stretch">
+            {/* LIVE indicator */}
+            <div className="flex items-center gap-3.5 min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
+              <div className="shrink-0" style={{ width: 8, height: 40, background: "var(--color-danger)", boxShadow: "0 0 12px var(--color-danger)" }} />
+              <div className="min-w-0">
+                <div className="font-bold uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-danger)", letterSpacing: "var(--tracking-eyebrow)" }}>
+                  ● LIVE
                 </div>
+                <div className="font-semibold mt-1 truncate" style={{ fontFamily: "var(--font-display)", fontSize: 18, color: "var(--color-fg)" }}>
+                  选秀直播间
+                </div>
+                <div className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)" }}>
+                  观众实时观看
+                </div>
+              </div>
+            </div>
 
-                {/* Current pick */}
-                <div className="flex items-center gap-3.5 min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
-                  <div className="shrink-0" style={{ width: 56, height: 56, background: "var(--color-accent)22", border: "1px solid var(--color-accent)55", borderRadius: "var(--radius-sm)", display: "grid", placeItems: "center", fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: 20, color: "var(--color-accent)" }}>
-                    P
-                  </div>
-                  <div className="min-w-0">
-                    <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
-                      CURRENT PICK
-                    </div>
-                    <div className="font-semibold mt-1 truncate" style={{ fontFamily: "var(--font-display)", fontSize: 18, color: "var(--color-accent)" }}>
-                      选秀进行中
-                    </div>
-                    <div className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)" }}>
-                      实时同步
-                    </div>
-                  </div>
+            {/* Current pick */}
+            <div className="flex items-center gap-3.5 min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
+              <div className="shrink-0" style={{ width: 56, height: 56, background: "var(--color-accent)22", border: "1px solid var(--color-accent)55", borderRadius: "var(--radius-sm)", display: "grid", placeItems: "center", fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: 20, color: "var(--color-accent)" }}>
+                P
+              </div>
+              <div className="min-w-0">
+                <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
+                  CURRENT PICK
                 </div>
+                <div className="font-semibold mt-1 truncate" style={{ fontFamily: "var(--font-display)", fontSize: 18, color: "var(--color-accent)" }}>
+                  选秀进行中
+                </div>
+                <div className="truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)" }}>
+                  实时同步
+                </div>
+              </div>
+            </div>
 
-                {/* Timer */}
-                <div className="min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
-                  <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
-                    TIMER
-                  </div>
-                  <div className="font-bold mt-1 truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 36, color: "var(--color-accent)", letterSpacing: "-0.04em", lineHeight: 1 }}>
-                    {data.state.roundDeadline ? "计时中" : "--:--"}
-                  </div>
-                  <div className="mt-1.5 h-1 rounded-full overflow-hidden" style={{ background: "var(--color-border)" }}>
-                    <div className="h-full" style={{ width: "32%", background: "var(--color-accent)" }} />
-                  </div>
-                </div>
+            {/* Timer */}
+            <div className="min-w-0 md:border-r border-[var(--color-border)]" style={{ padding: "16px 20px" }}>
+              <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
+                TIMER
+              </div>
+              <div className="font-bold mt-1 truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 36, color: "var(--color-accent)", letterSpacing: "-0.04em", lineHeight: 1 }}>
+                {data.state.roundDeadline ? "计时中" : "--:--"}
+              </div>
+              <div className="mt-1.5 h-1 rounded-full overflow-hidden" style={{ background: "var(--color-border)" }}>
+                <div className="h-full" style={{ width: "32%", background: "var(--color-accent)" }} />
+              </div>
+            </div>
 
-                {/* Round + Pick */}
-                <div className="flex flex-col justify-center gap-1 min-w-0" style={{ padding: "16px 20px" }}>
-                  <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
-                    ROUND · PICK
-                  </div>
-                  <div className="font-bold truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 28, color: "var(--color-fg)", letterSpacing: "-0.02em" }}>
-                    {data.state.currentRound ?? 1} · <span style={{ color: "var(--color-fg-dim)" }}>—/—</span>
-                  </div>
-                </div>
+            {/* Round + Pick */}
+            <div className="flex flex-col justify-center gap-1 min-w-0" style={{ padding: "16px 20px" }}>
+              <div className="uppercase truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
+                ROUND · PICK
+              </div>
+              <div className="font-bold truncate" style={{ fontFamily: "var(--font-mono)", fontSize: 28, color: "var(--color-fg)", letterSpacing: "-0.02em" }}>
+                {data.state.currentRound ?? 1} · <span style={{ color: "var(--color-fg-dim)" }}>—/—</span>
+              </div>
+            </div>
               </div>
             </Panel>
           )}
-          <DraftLiveRoom
-            data={data}
-            seasonId={season.id}
-            seasonSlug={seasonSlug}
-            seasonPositions={season.positions}
-          />
-        </>
-      )}
+        <DraftLiveRoom
+          data={data}
+          seasonId={season.id}
+          seasonSlug={seasonSlug}
+          seasonPositions={season.positions}
+        />
     </main>
   );
 }

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -3,7 +3,7 @@ import { eq, or, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users, seasonRegistrations, seasons, teams, teamMembers, matches } from "@/db/schema";
 import { resolveAvatarUrl } from "@/lib/steam";
-import { PLAYER_INFO_FIELDS } from "@/components/draft/PlayerInfoPopover";
+import { PLAYER_INFO_FIELDS } from "@/lib/utils/player-info-fields";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { Panel, Stat, PosChip } from "@/components/rivalhub";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";

--- a/src/components/draft/PlayerInfoPopover.tsx
+++ b/src/components/draft/PlayerInfoPopover.tsx
@@ -2,12 +2,7 @@
 
 import React, { useCallback, useRef, useState } from "react";
 import { Info } from "lucide-react";
-
-export const PLAYER_INFO_FIELDS = [
-  { key: "gameplayStyle", label: "风格" },
-  { key: "notes", label: "备注" },
-  { key: "competitionHistory", label: "经历" },
-] as const;
+import { PLAYER_INFO_FIELDS } from "@/lib/utils/player-info-fields";
 
 interface PlayerInfoPopoverProps {
   gameplayStyle: string | null;

--- a/src/lib/utils/player-info-fields.ts
+++ b/src/lib/utils/player-info-fields.ts
@@ -1,0 +1,5 @@
+export const PLAYER_INFO_FIELDS = [
+  { key: "gameplayStyle", label: "风格" },
+  { key: "notes", label: "备注" },
+  { key: "competitionHistory", label: "经历" },
+] as const;


### PR DESCRIPTION
## Summary
- **fix**: 选秀预览模式从 registration/voting 改为 drafting 未激活时展示，非 drafting 恢复简单提示
- **fix**: PLAYER_INFO_FIELDS 从 use client 文件移至独立模块，修复 Server Component 运行时错误

## Test plan
- [x] pnpm test (379 passed)
- [x] pnpm tsc --noEmit (0 errors)
- [ ] dev 环境手动验证关键路径