### PR TITLE
v1.11.0: 队长选秀面板增强 — 搜索/双段位/auto-pick提示/debounce

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.10.1，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.11.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-05-16
+
+### Added
+- **队长面板选手搜索框**：支持按选手名模糊搜索，可与位置筛选联合使用
+- **超时自动选人提示**：队长轮次时显示 auto-pick 候选人及优先级规则说明
+- **双段位/Rating 显示**：同时展示历史最高段位+当前赛季段位，Rating 不同时并列显示
+
+### Fixed
+- **位置标签统一**：TeamDraftGrid 位置标识从中文混合改为统一英文（IGL/AWPer/Opener/Closer/Anchor）
+- **观众 refresh debounce**：DraftLiveRoom 3s 节流防止 Realtime+轮询突发连接池压力
+
 ## [1.10.1] - 2026-05-16
 
 ### Fixed
@@ -298,6 +309,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
+[1.11.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.10.1...v1.11.0
 [1.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.0...v1.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.10.1，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.11.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -93,10 +93,12 @@ export function CaptainDraftPanel({
     return sortByRank(filtered);
   }, [players, filter, search]);
 
-  // Auto-pick candidate hint
+  // Auto-pick candidate hint (resolve full player for display name)
   const autoPickCandidate = useMemo(() => {
     if (!isDraftActive || !isCurrentCaptainTurn) return null;
-    return selectAutoPickCandidate(players, positionCounts);
+    const candidate = selectAutoPickCandidate(players, positionCounts);
+    if (!candidate) return null;
+    return players.find((p) => p.registrationId === candidate.registrationId) ?? null;
   }, [players, positionCounts, isDraftActive, isCurrentCaptainTurn]);
 
   const canSubmit = isDraftActive && isCurrentCaptainTurn && pendingRegistrationId === null;

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Check, ChevronDown, ChevronRight, Clock, Loader2 } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Clock, Loader2, Search, Zap } from "lucide-react";
 import { pickPlayer } from "@/actions/draft";
 import { Button } from "@/components/ui/button";
 import { DraftCountdown } from "./DraftCountdown";
@@ -14,6 +14,7 @@ import { PosChip } from "@/components/rivalhub/pos-chip";
 import { PlayerInfoPopover } from "./PlayerInfoPopover";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { sortByRank } from "@/lib/utils/rank";
+import { selectAutoPickCandidate } from "@/lib/draft/auto-pick";
 import type { DraftPlayerRow } from "@/lib/draft/data";
 
 const FILTER_ALL = "all";
@@ -54,6 +55,7 @@ export function CaptainDraftPanel({
 }: CaptainDraftPanelProps) {
   const router = useRouter();
   const [filter, setFilter] = useState(FILTER_ALL);
+  const [search, setSearch] = useState("");
   const [pendingRegistrationId, setPendingRegistrationId] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [rosterOpen, setRosterOpen] = useState(false);
@@ -77,12 +79,25 @@ export function CaptainDraftPanel({
   }, [grouped, seasonPositions]);
 
   const sortedPlayers = useMemo(() => {
-    const filtered =
+    let filtered =
       filter === FILTER_ALL
         ? players
         : players.filter((player) => player.primaryPosition === filter);
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      filtered = filtered.filter((player) => {
+        const name = getDisplayName(player).toLowerCase();
+        return name.includes(q);
+      });
+    }
     return sortByRank(filtered);
-  }, [players, filter]);
+  }, [players, filter, search]);
+
+  // Auto-pick candidate hint
+  const autoPickCandidate = useMemo(() => {
+    if (!isDraftActive || !isCurrentCaptainTurn) return null;
+    return selectAutoPickCandidate(players, positionCounts);
+  }, [players, positionCounts, isDraftActive, isCurrentCaptainTurn]);
 
   const canSubmit = isDraftActive && isCurrentCaptainTurn && pendingRegistrationId === null;
 
@@ -202,31 +217,59 @@ export function CaptainDraftPanel({
       )}
 
       <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          <Button
-            type="button"
-            size="sm"
-            variant={filter === FILTER_ALL ? "default" : "secondary"}
-            onClick={() => setFilter(FILTER_ALL)}
-          >
-            全部 {players.length}
-          </Button>
-          {positionOptions.map((position) => {
-            const count = grouped.get(position)?.length ?? 0;
-            const teamCount = positionCounts[position] ?? 0;
-            return (
-              <Button
-                key={position}
-                type="button"
-                size="sm"
-                variant={filter === position ? "default" : "secondary"}
-                disabled={count === 0}
-                onClick={() => setFilter(filter === position ? FILTER_ALL : position)}
-              >
-                {positionLabel(position)} {teamCount}/2 · {count}
-              </Button>
-            );
-          })}
+        {/* Auto-pick candidate hint */}
+        {!isReadonly && autoPickCandidate && isCurrentCaptainTurn && (
+          <div className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+            <div className="flex items-center gap-2">
+              <Zap className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>
+                超时自动选人：<strong>{getDisplayName(autoPickCandidate)}</strong>（{positionLabel(autoPickCandidate.primaryPosition)}，{autoPickCandidate.peakRank}）
+              </span>
+            </div>
+            <p className="mt-1.5 pl-5.5 text-[10px] text-amber-400/70 leading-relaxed">
+              规则：历史最高段位 → 巅峰Rating → 当前段位 → 当前Rating；优先填空位，同位置不超过2人
+            </p>
+          </div>
+        )}
+
+        {/* Search + filters */}
+        <div className="mb-4 space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-[var(--color-fg-dim)]" aria-hidden="true" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="搜索选手名..."
+              className="w-full rounded-md border border-[var(--color-border)] bg-[var(--color-panel-hi)] py-1.5 pl-8 pr-3 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-dim)] focus:border-[var(--color-accent)] focus:outline-none"
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={filter === FILTER_ALL ? "default" : "secondary"}
+              onClick={() => setFilter(FILTER_ALL)}
+            >
+              全部 {players.length}
+            </Button>
+            {positionOptions.map((position) => {
+              const count = grouped.get(position)?.length ?? 0;
+              const teamCount = positionCounts[position] ?? 0;
+              return (
+                <Button
+                  key={position}
+                  type="button"
+                  size="sm"
+                  variant={filter === position ? "default" : "secondary"}
+                  disabled={count === 0}
+                  onClick={() => setFilter(filter === position ? FILTER_ALL : position)}
+                >
+                  {positionLabel(position)} {teamCount}/2 · {count}
+                </Button>
+              );
+            })}
+          </div>
         </div>
 
         {sortedPlayers.length === 0 ? (
@@ -250,18 +293,35 @@ export function CaptainDraftPanel({
                   }`}
                 >
                   <div className="hidden md:flex items-center gap-3">
-                    {/* Rank badge */}
-                    <span
-                      className="inline-flex shrink-0 items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-bold"
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        color: "var(--color-fg)",
-                        borderColor: "var(--color-border)",
-                        background: "var(--color-panel)",
-                      }}
-                    >
-                      {player.peakRank}
-                    </span>
+                    {/* Rank badges: peak + current */}
+                    <div className="flex shrink-0 items-center gap-1">
+                      <span
+                        className="inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-bold"
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          color: "var(--color-fg)",
+                          borderColor: "var(--color-border)",
+                          background: "var(--color-panel)",
+                        }}
+                        title="历史最高段位"
+                      >
+                        {player.peakRank}
+                      </span>
+                      {player.currentRank && player.currentRank !== player.peakRank && (
+                        <span
+                          className="inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-medium opacity-70"
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            color: "var(--color-fg-mid)",
+                            borderColor: "var(--color-border)",
+                            background: "var(--color-panel)",
+                          }}
+                          title="当前赛季段位"
+                        >
+                          {player.currentRank}
+                        </span>
+                      )}
+                    </div>
 
                     {/* Name (clickable) */}
                     <Link
@@ -279,12 +339,15 @@ export function CaptainDraftPanel({
                       副选 {positionLabel(player.secondaryPosition)}
                     </span>
 
-                    {/* Rating */}
+                    {/* Rating: peak / current */}
                     <span
                       className="shrink-0 text-xs tabular-nums text-[var(--color-fg-mid)]"
                       style={{ fontFamily: "var(--font-mono)" }}
+                      title={`巅峰 ${player.peakRating.toFixed(0)} / 当前 ${player.currentRating.toFixed(0)}`}
                     >
-                      {player.peakRating.toFixed(2)}
+                      {player.peakRating.toFixed(0)}{player.currentRating !== player.peakRating && (
+                        <span className="opacity-60"> / {player.currentRating.toFixed(0)}</span>
+                      )}
                     </span>
 
                     {/* Map preferences */}
@@ -320,17 +383,32 @@ export function CaptainDraftPanel({
 
                   <div className="md:hidden space-y-1.5">
                     <div className="flex items-center gap-2">
-                      <span
-                        className="inline-flex shrink-0 items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-bold"
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          color: "var(--color-fg)",
-                          borderColor: "var(--color-border)",
-                          background: "var(--color-panel)",
-                        }}
-                      >
-                        {player.peakRank}
-                      </span>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <span
+                          className="inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-bold"
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            color: "var(--color-fg)",
+                            borderColor: "var(--color-border)",
+                            background: "var(--color-panel)",
+                          }}
+                        >
+                          {player.peakRank}
+                        </span>
+                        {player.currentRank && player.currentRank !== player.peakRank && (
+                          <span
+                            className="inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[10px] font-medium opacity-70"
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              color: "var(--color-fg-mid)",
+                              borderColor: "var(--color-border)",
+                              background: "var(--color-panel)",
+                            }}
+                          >
+                            {player.currentRank}
+                          </span>
+                        )}
+                      </div>
                       <Link
                         href={`/players/${player.userId}`}
                         className="min-w-0 truncate text-sm font-medium text-[var(--color-fg)] hover:text-[var(--color-accent)]"
@@ -347,8 +425,11 @@ export function CaptainDraftPanel({
                         <span
                           className="shrink-0 text-xs tabular-nums text-[var(--color-fg-mid)]"
                           style={{ fontFamily: "var(--font-mono)" }}
+                          title={`巅峰 ${player.peakRating.toFixed(0)} / 当前 ${player.currentRating.toFixed(0)}`}
                         >
-                          {player.peakRating.toFixed(2)}
+                          {player.peakRating.toFixed(0)}{player.currentRating !== player.peakRating && (
+                            <span className="opacity-60"> / {player.currentRating.toFixed(0)}</span>
+                          )}
                         </span>
                         <div className="min-w-0">
                           <MapPreferenceChips preferences={player.mapPreferences} compact minLevel="playable" />

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -42,6 +42,15 @@ export function DraftLiveRoom({
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const removeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Debounce refresh to avoid burst DB pressure from Realtime + polling overlap
+  const lastRefreshRef = useRef(0);
+  const debouncedRefresh = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefreshRef.current < 3000) return;
+    lastRefreshRef.current = now;
+    router.refresh();
+  }, [router]);
+
   const showPickNotification = useCallback(
     (payload: { steamName?: string; displayName?: string | null; perfectName?: string | null; team_id?: string }) => {
       const teamName =
@@ -73,9 +82,9 @@ export function DraftLiveRoom({
   // 轮询兜底（10 秒刷新）—— 仅直播模式
   useEffect(() => {
     if (isReadonly) return;
-    const timer = window.setInterval(() => router.refresh(), 10_000);
+    const timer = window.setInterval(debouncedRefresh, 10_000);
     return () => window.clearInterval(timer);
-  }, [router, isReadonly]);
+  }, [debouncedRefresh, isReadonly]);
 
   // Realtime 订阅 —— 仅直播模式
   useEffect(() => {
@@ -91,7 +100,7 @@ export function DraftLiveRoom({
           table: "draft_state",
           filter: `season_id=eq.${seasonId}`,
         },
-        () => router.refresh(),
+        () => debouncedRefresh(),
       )
       .on(
         "postgres_changes",
@@ -102,7 +111,7 @@ export function DraftLiveRoom({
           filter: `season_id=eq.${seasonId}`,
         },
         () => {
-          router.refresh();
+          debouncedRefresh();
         },
       )
       .subscribe();
@@ -110,7 +119,7 @@ export function DraftLiveRoom({
     return () => {
       void supabase.removeChannel(channel);
     };
-  }, [router, seasonId, isReadonly]);
+  }, [debouncedRefresh, seasonId, isReadonly]);
 
   // Watch for new picks via completedPicks changes
   const prevPickCountRef = useRef(completedPicks.length);

--- a/src/components/draft/TeamDraftGrid.tsx
+++ b/src/components/draft/TeamDraftGrid.tsx
@@ -2,15 +2,8 @@
 
 import { useState } from "react";
 import { getDisplayName } from "@/lib/utils/display-name";
+import { positionLabel } from "@/lib/validators/registration";
 import type { DraftTeamSlot } from "@/lib/draft/data";
-
-const POS_SHORT: Record<string, string> = {
-  igl: "IGL",
-  awper: "AWP",
-  opener: "突破",
-  closer: "自由",
-  anchor: "主防",
-};
 
 interface TeamDraftGridProps {
   teams: DraftTeamSlot[];
@@ -93,8 +86,7 @@ export function TeamDraftGrid({
                       {getDisplayName(team.captain)}
                     </span>
                     <span className="font-mono text-[10px] text-[var(--color-fg-dim)] uppercase">
-                      {POS_SHORT[team.captain.primaryPosition] ??
-                        team.captain.primaryPosition}
+                      {positionLabel(team.captain.primaryPosition)}
                     </span>
                   </div>
                   {/* 已选队员 */}
@@ -110,7 +102,7 @@ export function TeamDraftGrid({
                         )}
                       </span>
                       <span className="font-mono text-[10px] text-[var(--color-fg-dim)] uppercase">
-                        {POS_SHORT[m.primaryPosition] ?? m.primaryPosition}
+                        {positionLabel(m.primaryPosition)}
                       </span>
                     </div>
                   ))}
@@ -173,8 +165,7 @@ export function TeamDraftGrid({
                   {getDisplayName(team.captain)}
                 </span>
                 <span className="text-[var(--color-fg-dim)] ml-1">
-                  {POS_SHORT[team.captain.primaryPosition] ??
-                    team.captain.primaryPosition}
+                  {positionLabel(team.captain.primaryPosition)}
                 </span>
               </div>
 
@@ -186,7 +177,7 @@ export function TeamDraftGrid({
                   </span>
                   <span className="text-[var(--color-fg)]">{getDisplayName(m)}</span>
                   <span className="text-[var(--color-fg-dim)] ml-1">
-                    {POS_SHORT[m.primaryPosition] ?? m.primaryPosition}
+                    {positionLabel(m.primaryPosition)}
                   </span>
                   {m.autoPicked && (
                     <span className="text-amber-400 ml-0.5">⚡</span>


### PR DESCRIPTION
## Summary
- **feat**: 队长面板新增选手名搜索框、超时auto-pick候选人提示、双段位+Rating并列显示
- **fix**: TeamDraftGrid位置标签统一英文（IGL/AWPer/Opener/Closer/Anchor）
- **fix**: DraftLiveRoom refresh 3s debounce 防连接池突发压力

## Test plan
- [x] pnpm test (379 passed)
- [x] pnpm tsc --noEmit (0 errors)
- [ ] dev 环境手动验证队长选秀界面