### PR TITLE
fix(draft): 蛇形选秀第一轮改为反序（后位先选）

### DIFF
--- a/docs/draft-flow.md
+++ b/docs/draft-flow.md
@@ -14,12 +14,12 @@ completed
   → 自动触发 season.status = playing
 ```
 
-蛇形顺序（round 奇数正向，偶数反向）：
+蛇形顺序（round 奇数反向即后位先选，偶数正向）：
 ```
-Round 1: team[0] → team[1] → ... → team[7]
-Round 2: team[7] → team[6] → ... → team[0]
+Round 1: team[7] → team[6] → ... → team[0]
+Round 2: team[0] → team[1] → ... → team[7]
 ...
-Round 6: team[7] → ...
+Round 6: team[0] → ... → team[7]
 ```
 
 ---

--- a/src/lib/draft/rules.test.ts
+++ b/src/lib/draft/rules.test.ts
@@ -27,49 +27,47 @@ const teams = [
 ];
 
 describe("getSnakeOrder", () => {
-  it("round 1: lowest draftOrder picks first (forward)", () => {
+  it("round 1: highest draftOrder picks first (reverse)", () => {
     const order = getSnakeOrder(teams, 1);
-    expect(order.map((t) => t.draftOrder)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(order.map((t) => t.draftOrder)).toEqual([8, 7, 6, 5, 4, 3, 2, 1]);
   });
 
-  it("round 2: reverse order", () => {
+  it("round 2: forward order", () => {
     const order = getSnakeOrder(teams, 2);
-    expect(order.map((t) => t.draftOrder)).toEqual([8, 7, 6, 5, 4, 3, 2, 1]);
-  });
-
-  it("round 3: forward again", () => {
-    const order = getSnakeOrder(teams, 3);
     expect(order.map((t) => t.draftOrder)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
-  it("round 4: reverse", () => {
-    const order = getSnakeOrder(teams, 4);
+  it("round 3: reverse again", () => {
+    const order = getSnakeOrder(teams, 3);
     expect(order.map((t) => t.draftOrder)).toEqual([8, 7, 6, 5, 4, 3, 2, 1]);
+  });
+
+  it("round 4: forward", () => {
+    const order = getSnakeOrder(teams, 4);
+    expect(order.map((t) => t.draftOrder)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 });
 
 describe("getNextTeamId", () => {
   it("advances to next team within same round", () => {
-    const result = getNextTeamId(teams, "t1", 1);
-    expect(result).toEqual({ teamId: "t2", nextRound: 1 });
-  });
-
-  it("at end of forward round, flips to next round with reverse order", () => {
     const result = getNextTeamId(teams, "t8", 1);
-    expect(result).toEqual({ teamId: "t8", nextRound: 2 });
+    expect(result).toEqual({ teamId: "t7", nextRound: 1 });
   });
 
-  it("at end of reverse round, flips to forward next round", () => {
-    // Round 2 is reverse, last to pick is t1
-    const result = getNextTeamId(teams, "t1", 2);
-    expect(result).toEqual({ teamId: "t1", nextRound: 3 });
+  it("at end of reverse round, flips to next round with forward order", () => {
+    const result = getNextTeamId(teams, "t1", 1);
+    expect(result).toEqual({ teamId: "t1", nextRound: 2 });
   });
 
-  it("returns null when draft is complete (round > 6)", () => {
-    // DRAFT_TOTAL_ROUNDS = 6, last pick in round 6 is the last pick
-    // After that, getNextTeamId should return null
-    // Actually round 6 end returns nextRound=7 which exceeds total
-    const result = getNextTeamId(teams, "t8", 7);
+  it("at end of forward round, flips to reverse next round", () => {
+    // Round 2 is forward, last to pick is t8
+    const result = getNextTeamId(teams, "t8", 2);
+    expect(result).toEqual({ teamId: "t8", nextRound: 3 });
+  });
+
+  it("returns null when draft is complete (end of round 6)", () => {
+    // Round 6 is even (forward), last to pick is t8
+    const result = getNextTeamId(teams, "t8", 6);
     expect(result).toBeNull();
   });
 

--- a/src/lib/draft/rules.ts
+++ b/src/lib/draft/rules.ts
@@ -12,14 +12,14 @@ export interface DraftTeamOrder {
 
 /**
  * 获取指定轮次的蛇形选秀顺序
- * 奇数轮正向（draftOrder 升序），偶数轮反向（draftOrder 降序）
+ * 奇数轮反向（draftOrder 降序，后位先选），偶数轮正向（draftOrder 升序）
  */
 export function getSnakeOrder(
   teams: DraftTeamOrder[],
   round: number,
 ): DraftTeamOrder[] {
   const sorted = [...teams].sort((a, b) => a.draftOrder - b.draftOrder);
-  return round % 2 === 1 ? sorted : sorted.reverse();
+  return round % 2 === 1 ? sorted.reverse() : sorted;
 }
 
 /**

--- a/tests/unit/lib/draft-rules.test.ts
+++ b/tests/unit/lib/draft-rules.test.ts
@@ -25,24 +25,24 @@ const ALL_TEAMS = [
 ];
 
 describe("getSnakeOrder", () => {
-  it("round 1 (odd) returns forward order", () => {
+  it("round 1 (odd) returns reverse order", () => {
     const order = getSnakeOrder(ALL_TEAMS, 1);
-    expect(order.map((t) => t.id)).toEqual([
-      "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8",
-    ]);
-  });
-
-  it("round 2 (even) returns reverse order", () => {
-    const order = getSnakeOrder(ALL_TEAMS, 2);
     expect(order.map((t) => t.id)).toEqual([
       "t8", "t7", "t6", "t5", "t4", "t3", "t2", "t1",
     ]);
   });
 
-  it("round 3 (odd) returns forward order again", () => {
-    const order = getSnakeOrder(ALL_TEAMS, 3);
+  it("round 2 (even) returns forward order", () => {
+    const order = getSnakeOrder(ALL_TEAMS, 2);
     expect(order.map((t) => t.id)).toEqual([
       "t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8",
+    ]);
+  });
+
+  it("round 3 (odd) returns reverse order again", () => {
+    const order = getSnakeOrder(ALL_TEAMS, 3);
+    expect(order.map((t) => t.id)).toEqual([
+      "t8", "t7", "t6", "t5", "t4", "t3", "t2", "t1",
     ]);
   });
 
@@ -54,29 +54,31 @@ describe("getSnakeOrder", () => {
 });
 
 describe("getNextTeamId", () => {
-  it("advances to next team in same round (forward)", () => {
-    const next = getNextTeamId(ALL_TEAMS, "t3", 1);
+  it("advances to next team in same round (reverse, round 1)", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t5", 1);
     expect(next).toEqual({ teamId: "t4", nextRound: 1 });
   });
 
-  it("advances to next team in same round (reverse)", () => {
-    const next = getNextTeamId(ALL_TEAMS, "t5", 2);
+  it("advances to next team in same round (forward, round 2)", () => {
+    const next = getNextTeamId(ALL_TEAMS, "t3", 2);
     expect(next).toEqual({ teamId: "t4", nextRound: 2 });
   });
 
-  it("wraps to next round when last team in forward round", () => {
-    const next = getNextTeamId(ALL_TEAMS, "t8", 1);
-    expect(next).toEqual({ teamId: "t8", nextRound: 2 });
+  it("wraps to next round when last team in reverse round", () => {
+    // Round 1 is odd (reverse), last to pick is t1
+    const next = getNextTeamId(ALL_TEAMS, "t1", 1);
+    expect(next).toEqual({ teamId: "t1", nextRound: 2 });
   });
 
-  it("wraps to next round when last team in reverse round", () => {
-    const next = getNextTeamId(ALL_TEAMS, "t1", 2);
-    expect(next).toEqual({ teamId: "t1", nextRound: 3 });
+  it("wraps to next round when last team in forward round", () => {
+    // Round 2 is even (forward), last to pick is t8
+    const next = getNextTeamId(ALL_TEAMS, "t8", 2);
+    expect(next).toEqual({ teamId: "t8", nextRound: 3 });
   });
 
   it("returns null when draft is complete (round 6, last team)", () => {
-    // Round 6 is even, reverse: t8, t7, ..., t1. Last is t1.
-    const next = getNextTeamId(ALL_TEAMS, "t1", 6);
+    // Round 6 is even (forward), last to pick is t8
+    const next = getNextTeamId(ALL_TEAMS, "t8", 6);
     expect(next).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- 蛇形选秀顺序翻转：奇数轮反向（draftOrder 高的先选），偶数轮正向
- 修复第一轮错误使用正序的问题，符合选秀补偿机制设计

## Test plan
- [x] pnpm test (379 passed)

🎯 紧急修复，当前正在选秀中