### PR TITLE
fix(draft): 移除队长面板 PlayerInfoPopover，避免遮挡 pick 按钮

### DIFF
--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -11,7 +11,7 @@ import { canPickPosition } from "@/lib/draft/rules";
 import { positionLabel } from "@/lib/validators/registration";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
 import { PosChip } from "@/components/rivalhub/pos-chip";
-import { PlayerInfoPopover } from "./PlayerInfoPopover";
+
 import { getDisplayName } from "@/lib/utils/display-name";
 import { sortByRank } from "@/lib/utils/rank";
 import { selectAutoPickCandidate } from "@/lib/draft/auto-pick";
@@ -354,12 +354,6 @@ export function CaptainDraftPanel({
                       <MapPreferenceChips preferences={player.mapPreferences} compact minLevel="playable" />
                     </div>
 
-                    <PlayerInfoPopover
-                      gameplayStyle={player.gameplayStyle}
-                      notes={player.notes}
-                      competitionHistory={player.competitionHistory}
-                    />
-
                     {/* Pick button */}
                       <Button
                         type="button"
@@ -431,11 +425,6 @@ export function CaptainDraftPanel({
                         <div className="min-w-0">
                           <MapPreferenceChips preferences={player.mapPreferences} compact minLevel="playable" />
                         </div>
-                        <PlayerInfoPopover
-                          gameplayStyle={player.gameplayStyle}
-                          notes={player.notes}
-                          competitionHistory={player.competitionHistory}
-                        />
                       </div>
                         <Button
                           type="button"


### PR DESCRIPTION
## Summary
- 移除 CaptainDraftPanel 中选手行右侧的 PlayerInfoPopover（桌面 + 移动端）
- 减少布局干扰，确保 pick 按钮不会被压出视野

🎯 选秀进行中紧急修复