### PR TITLE
v1.12.0: 管理员快捷入口、赛程筛选、队伍头像、UI 增强与 Bug 修复

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: Cron
 
 on:
   schedule:
-    - cron: "* * * * *"  # 每分钟检查一次
+    - cron: "*/5 * * * *"  # 每5分钟检查一次（GitHub 对更短间隔会隐性限流）
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2026-05-17
+
+### Added
+- **管理员快捷入口**：公开页面（赛季首页/赛程/选秀/队伍）对管理员显示齿轮图标入口，直接跳转到对应后台管理页面
+- **赛程队伍筛选**：赛程总览页支持按队伍筛选比赛（`?team=teamId`），管理员后台支持按阶段/状态筛选
+- **队伍详情即将进行的比赛**：`/[seasonSlug]/teams/[teamId]` 展示该队 scheduled/in_progress 状态的比赛列表
+- **后台新增比赛**：管理后台赛程页新增「新增比赛」Dialog 表单，支持选择队伍/阶段/赛制创建比赛
+- **系统设置 OCR Key**：管理员设置页展示 `SILICONFLOW_API_KEY` 配置状态（有/无）
+- **单场比赛队伍头像**：`MatchDetail` 展示双方队伍 logo，无 logo 时 fallback 为圆形首字母
+
+### Fixed
+- **shadcn/Tailwind v4 颜色桥接**：`@theme` 块补充 shadcn CSS 变量映射，修复按钮/Tab 颜色不渲染
+- **Grand Final 赛制**：双败决赛从 `double`（两场 Grand Final）改为 `simple`（单场 BO5）
+- **Bracket BYE→TBD**：brackets-viewer 中未确定对手从 "BYE" 改为 "TBD"
+- **选秀状态文案**：区分「选秀已结束」（playing/finished）与「选秀尚未开放」，不再一律显示"尚未开放"
+- **近期对决链接**：赛季首页 NEXT MATCHES 链接从赛程列表页改为具体比赛详情页
+- **状态标签措辞**：`scheduled` 从"已排期"改为"待进行"，与"待定"（时间未定）语义区分
+- **赛季导航间距**：SeasonNav 与 Stat 四格之间添加间距
+- **UI 增强**：赛程总览排位赛/正赛 Tab 样式增强（可见边框+背景）；"开始比赛"按钮加 InlineConfirm 二次确认
+- **auto-pick tiebreaker**：段位相同时从随机 UUID 改为 `createdAt` 报名时间比较
+- **Cron 调度修正**：GitHub Actions 从 `* * * * *` 改为 `*/5 * * * *`，避免隐性限流导致实际 1 小时才执行一次
+- **CS2 段位体系**：同步完美平台 2026 年段位更新（序号 S3→S5）
+
 ## [1.11.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.11.1] - 2026-05-17
+## [1.12.0] - 2026-05-17
 
 ### Added
 - **管理员快捷入口**：公开页面（赛季首页/赛程/选秀/队伍）对管理员显示齿轮图标入口，直接跳转到对应后台管理页面

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **UI 增强**：赛程总览排位赛/正赛 Tab 样式增强（可见边框+背景）；"开始比赛"按钮加 InlineConfirm 二次确认
 - **auto-pick tiebreaker**：段位相同时从随机 UUID 改为 `createdAt` 报名时间比较
 - **Cron 调度修正**：GitHub Actions 从 `* * * * *` 改为 `*/5 * * * *`，避免隐性限流导致实际 1 小时才执行一次
-- **CS2 段位体系**：同步完美平台 2026 年段位更新（序号 S3→S5）
 
 ## [1.11.0] - 2026-05-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ git push origin v1.6.0               # 或单独推 tag
 | ORM | Drizzle ORM |
 | 表单 | React Hook Form + Zod（中文校验消息） |
 | 鉴权 | Supabase Auth（email+password；生产关闭邮件确认，不依赖 Magic Link）+ iron-session（双 Cookie：`rivalhub-session` 全用户 + `rivalhub-admin` root 紧急） |
-| 定时任务 | GitHub Actions 每分钟调用 `/api/cron/draft-timeout`（选秀超时自动 pick）+ `/api/cron/check-registration-deadline`（报名截止/满员自动推进）+ `/api/cron/match-time-auto-award`（比赛时间协商截止自动裁定） |
+| 定时任务 | GitHub Actions 每 5 分钟调用 `/api/cron/draft-timeout`（选秀超时自动 pick）+ `/api/cron/check-registration-deadline`（报名截止/满员自动推进）+ `/api/cron/match-time-auto-award`（比赛时间协商截止自动裁定） |
 | Bracket 渲染 | `brackets-manager` + `brackets-viewer`（经 `lib/bracket/` 适配层访问） |
 | 单元/集成测试 | Vitest + React Testing Library + jsdom |
 | E2E 测试 | Playwright |
@@ -219,7 +219,7 @@ src/
 │   ├── auth.ts       # 邮箱+密码注册/登录/退出
 │   ├── captains.ts   # 队长投票
 │   ├── draft/        # 选秀（state / picks / queries）
-│   ├── matches/      # 赛程（schedule / results / roster / scheduling）
+│   ├── matches/      # 赛程（schedule / results / roster / scheduling / score）
 │   ├── player-stats.ts # 玩家数据（OCR 识别 / 保存 / 查询）
 │   ├── register.ts   # 报名提交
 │   ├── seasons.ts    # 赛季 CRUD（create/update/delete/publish）
@@ -238,7 +238,7 @@ src/
 │   ├── validators/   # Zod schema（registration / vote / match）
 │   └── utils/        # date（UTC/CST）+ season（capability 工具）+ password（scrypt）+ cn
 ├── components/
-│   ├── layout/       # Header / Footer
+│   ├── layout/       # Header / Footer / AdminShortcut
 │   ├── ui/           # shadcn 组件（按需 add，已覆盖 button/input/badge/card/skeleton/select）
 │   ├── rivalhub/     # Tactical Grid 组件（15 个：Panel/Btn/Field/Marker/Stat/MiniStat/
 │   │                 #   StatusBanner/InlineConfirm/EmptyState/ErrorState/Skeleton/Spinner/
@@ -249,7 +249,7 @@ src/
 │   ├── draft/        # 选秀业务组件
 │   ├── captains/     # 队长投票业务组件
 │   ├── teams/        # 队伍展示业务组件
-│   └── matches/      # 赛程 / bracket 业务组件
+│   └── matches/      # 赛程 / bracket 业务组件（MatchCard / MatchDetail / MatchTeamFilter / CreateMatchForm / AdminMatchFilter / ScoreInput / MapByMapInput / ScheduledAtInput / MatchStatusBadge / BatchDeadlineCard / StatsOCRPanel）
 └── types/            # 共享 TypeScript 类型
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，覆盖报名、审核、队长投票、蛇形选秀、队伍展示、赛程管理、Bracket、比分录入、数据统计与上线部署。
 
-当前 `1.8.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
+当前 `1.11.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
 
 ## 功能状态
 
@@ -83,7 +83,7 @@ password: RivalHub_password
 5. 在 GitHub Actions Secrets 配置 `CRON_SECRET`。
 6. 合并到 `main` 后由 Vercel 部署生产站点。
 
-当前 GitHub Actions Cron 每分钟触发两个端点（见 `.github/workflows/cron.yml`）：
+当前 GitHub Actions Cron 每 5 分钟触发以下端点（见 `.github/workflows/cron.yml`）：
 
 - `https://match.starfie1d.top/api/cron/draft-timeout` — 选秀超时自动递补
 - `https://match.starfie1d.top/api/cron/check-registration-deadline` — 报名截止/满员自动推进赛季

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/draft/picks.ts
+++ b/src/actions/draft/picks.ts
@@ -608,6 +608,7 @@ async function getAutoPickCandidates(
       peakRank: seasonRegistrations.peakRank,
       currentRank: seasonRegistrations.currentSeasonPeakRank,
       currentRating: seasonRegistrations.currentRating,
+      createdAt: seasonRegistrations.createdAt,
     })
     .from(seasonRegistrations)
     .where(
@@ -626,6 +627,7 @@ async function getAutoPickCandidates(
       peakRank: candidate.peakRank,
       currentRank: candidate.currentRank,
       currentRating: candidate.currentRating,
+      createdAt: candidate.createdAt,
     }));
 }
 

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -70,6 +70,14 @@ export default async function DraftPage({ params }: DraftPageProps) {
             以下为只读预览，包含已报名选手与队伍信息。选秀开始后页面会自动切换为直播模式。
           </p>
         </div>
+        <div className="mb-4">
+          <a
+            href={`/${seasonSlug}/draft/captain`}
+            className="inline-flex items-center gap-2 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-4 py-2 text-sm font-medium text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20 transition-colors"
+          >
+            进入队长选人面板 →
+          </a>
+        </div>
 
         <DraftLiveRoom
           data={data}
@@ -87,6 +95,17 @@ export default async function DraftPage({ params }: DraftPageProps) {
       <Marker sub="实时更新选秀进度，队伍阵容与选手池自动刷新。">
         选秀直播间 · {season.name}
       </Marker>
+
+      {data.state.isActive && (
+        <div className="mt-4">
+          <a
+            href={`/${seasonSlug}/draft/captain`}
+            className="inline-flex items-center gap-2 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-4 py-2 text-sm font-medium text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20 transition-colors"
+          >
+            进入队长选人面板 →
+          </a>
+        </div>
+      )}
 
       {data.state.isActive && (
         <Panel pad={0}>

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -7,6 +7,8 @@ import { DraftLiveRoom } from "@/components/draft/DraftLiveRoom";
 import { Panel, Marker } from "@/components/rivalhub";
 import { getDraftData } from "@/lib/draft/data";
 import { SEASON_STATUS_LABELS } from "@/types/season";
+import { checkAdminSession } from "@/lib/auth/session";
+import { AdminShortcut } from "@/components/layout/AdminShortcut";
 
 export const dynamic = "force-dynamic";
 
@@ -21,9 +23,10 @@ export async function generateMetadata({ params }: DraftPageProps): Promise<Meta
 
 export default async function DraftPage({ params }: DraftPageProps) {
   const { seasonSlug } = await params;
-  const season = await db.query.seasons.findFirst({
-    where: eq(seasons.slug, seasonSlug),
-  });
+  const [season, adminSession] = await Promise.all([
+    db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
+    checkAdminSession(),
+  ]);
   if (!season) notFound();
 
   if (!season.hasDraft) {
@@ -95,9 +98,14 @@ export default async function DraftPage({ params }: DraftPageProps) {
 
   return (
     <main className="container mx-auto max-w-7xl px-4 py-10">
-      <Marker sub="实时更新选秀进度，队伍阵容与选手池自动刷新。">
-        选秀直播间 · {season.name}
-      </Marker>
+      <div className="flex items-center justify-between">
+        <Marker sub="实时更新选秀进度，队伍阵容与选手池自动刷新。">
+          选秀直播间 · {season.name}
+        </Marker>
+        {adminSession && (
+          <AdminShortcut href={`/admin/${seasonSlug}/draft`} />
+        )}
+      </div>
 
       {data.state.isActive && (
         <div className="mt-4">

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -41,12 +41,15 @@ export default async function DraftPage({ params }: DraftPageProps) {
 
   if (season.status !== "drafting") {
     const stageLabel = SEASON_STATUS_LABELS[season.status] ?? season.status;
+    const draftFinished = season.status === "playing" || season.status === "finished";
     return (
       <main className="container mx-auto max-w-5xl px-4 py-10">
         <Panel pad={32}>
           <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
           <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
-            选秀尚未开放 · 当前阶段：{stageLabel}
+            {draftFinished
+              ? "选秀已结束"
+              : `选秀尚未开放 · 当前阶段：${stageLabel}`}
           </p>
         </Panel>
       </main>

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { eq, and, or, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, teams, matchMaps, users, seasonRegistrations, teamMembers } from "@/db/schema";
@@ -239,7 +240,21 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
               {teamA?.name ?? "未知队伍"}
             </div>
           </div>
-          {teamA && <div className="w-12 h-12 sm:w-16 sm:h-16"><TeamBadge team={teamBadgeData(teamA.name, 0)} size={64} /></div>}
+          {teamA && (
+            <div className="w-12 h-12 sm:w-16 sm:h-16 shrink-0">
+              {teamA.logoUrl ? (
+                <Image
+                  src={teamA.logoUrl}
+                  alt={teamA.name}
+                  width={64}
+                  height={64}
+                  className="w-full h-full rounded-full object-cover"
+                />
+              ) : (
+                <TeamBadge team={teamBadgeData(teamA.name, 0)} size={64} />
+              )}
+            </div>
+          )}
         </div>
 
         {/* Score / VS */}
@@ -294,7 +309,21 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
 
         {/* Team B */}
         <div className="flex items-center gap-4">
-          {teamB && <div className="w-12 h-12 sm:w-16 sm:h-16"><TeamBadge team={teamBadgeData(teamB.name, 1)} size={64} /></div>}
+          {teamB && (
+            <div className="w-12 h-12 sm:w-16 sm:h-16 shrink-0">
+              {teamB.logoUrl ? (
+                <Image
+                  src={teamB.logoUrl}
+                  alt={teamB.name}
+                  width={64}
+                  height={64}
+                  className="w-full h-full rounded-full object-cover"
+                />
+              ) : (
+                <TeamBadge team={teamBadgeData(teamB.name, 1)} size={64} />
+              )}
+            </div>
+          )}
           <div className="min-w-0">
             <div
               className="font-bold text-lg sm:text-[28px]"

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -35,14 +35,11 @@ function teamBadgeData(name: string, idx: number): { tag: string; color: string 
 export default async function MatchDetailPage({ params }: MatchDetailPageProps) {
   const { seasonSlug, matchId } = await params;
 
-  const season = await db.query.seasons.findFirst({
-    where: eq(seasons.slug, seasonSlug),
-  });
+  const [season, match] = await Promise.all([
+    db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
+    db.query.matches.findFirst({ where: eq(matches.id, matchId) }),
+  ]);
   if (!season) notFound();
-
-  const match = await db.query.matches.findFirst({
-    where: eq(matches.id, matchId),
-  });
   if (!match || match.seasonId !== season.id) notFound();
 
   const [teamA, teamB, maps] = await Promise.all([

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -8,6 +8,7 @@ import { Panel, Marker } from "@/components/rivalhub";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BracketView } from "@/components/matches/BracketView";
 import { MatchCard } from "@/components/matches/MatchCard";
+import { MatchTeamFilter } from "@/components/matches/MatchTeamFilter";
 import { StandingsTable } from "@/components/matches/StandingsTable";
 import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
@@ -18,10 +19,12 @@ export const dynamic = "force-dynamic";
 
 interface MatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
+  searchParams: Promise<{ team?: string }>;
 }
 
-export default async function MatchesPage({ params }: MatchesPageProps) {
+export default async function MatchesPage({ params, searchParams }: MatchesPageProps) {
   const { seasonSlug } = await params;
+  const { team: filterTeamId } = await searchParams;
 
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),
@@ -46,11 +49,17 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
   const qualifierKey = qualifierStage?.key ?? "qualifier";
   const playoffKey = playoffStage?.key ?? "playoff";
 
-  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
-  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey);
+  const qualifierMatchesAll = allMatches.filter((m) => m.stage === qualifierKey);
+  const playoffMatchesAll = allMatches.filter((m) => m.stage === playoffKey);
 
-  // 积分榜（仅当有 round_robin 排位赛时计算）
-  const finishedQualifierMatches = qualifierMatches.filter((m) => m.status === "finished");
+  // 按队伍筛选
+  const matchFilter = (m: { teamAId: string; teamBId: string }) =>
+    !filterTeamId || m.teamAId === filterTeamId || m.teamBId === filterTeamId;
+  const qualifierMatches = qualifierMatchesAll.filter(matchFilter);
+  const playoffMatches = playoffMatchesAll.filter(matchFilter);
+
+  // 积分榜（仅当有 round_robin 排位赛时计算，使用未筛选的全部排位赛）
+  const finishedQualifierMatches = qualifierMatchesAll.filter((m) => m.status === "finished");
   const standings = qualifierStage && qualifierStage.type !== "swiss"
     ? calculateStandings(allTeams, finishedQualifierMatches)
     : [];
@@ -61,8 +70,8 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
     : null;
 
   const allQualifierFinished =
-    qualifierMatches.length > 0 &&
-    qualifierMatches.every((m) => m.status === "finished" || m.status === "cancelled");
+    qualifierMatchesAll.length > 0 &&
+    qualifierMatchesAll.every((m) => m.status === "finished" || m.status === "cancelled");
 
   // Bracket 数据（用于正赛 bracket 视图）
   const fullBracketData = serializeBracket(
@@ -112,6 +121,10 @@ export default async function MatchesPage({ params }: MatchesPageProps) {
   return (
     <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
       <Marker sub={season.name}>赛程总览</Marker>
+
+      {allTeams.length > 0 && (
+        <MatchTeamFilter teams={allTeams.map((t) => ({ id: t.id, name: t.name }))} />
+      )}
 
       <Panel pad={24}>
       <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey} className="w-full">

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -13,6 +13,8 @@ import { StandingsTable } from "@/components/matches/StandingsTable";
 import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
 import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
+import { checkAdminSession } from "@/lib/auth/session";
+import { AdminShortcut } from "@/components/layout/AdminShortcut";
 import type { Database } from "brackets-manager";
 
 export const dynamic = "force-dynamic";
@@ -26,9 +28,11 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   const { seasonSlug } = await params;
   const { team: filterTeamId } = await searchParams;
 
-  const season = await db.query.seasons.findFirst({
-    where: eq(seasons.slug, seasonSlug),
-  });
+  const [seasonResult, adminSession] = await Promise.all([
+    db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
+    checkAdminSession(),
+  ]);
+  const season = seasonResult;
   if (!season) notFound();
 
   const [allTeams, allMatches] = await Promise.all([
@@ -120,7 +124,12 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
-      <Marker sub={season.name}>赛程总览</Marker>
+      <div className="flex items-center justify-between">
+        <Marker sub={season.name}>赛程总览</Marker>
+        {adminSession && (
+          <AdminShortcut href={`/admin/${seasonSlug}/matches`} />
+        )}
+      </div>
 
       {allTeams.length > 0 && (
         <MatchTeamFilter teams={allTeams.map((t) => ({ id: t.id, name: t.name }))} />
@@ -128,9 +137,9 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
 
       <Panel pad={24}>
       <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey} className="w-full">
-        <TabsList className="mb-6">
-          {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
-          {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}
+        <TabsList className="mb-6 bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
+          {qualifierStage && <TabsTrigger value={qualifierKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{qualifierStage.name}</TabsTrigger>}
+          {playoffStage && <TabsTrigger value={playoffKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{playoffStage.name}</TabsTrigger>}
         </TabsList>
 
         {/* ── 排位赛面板 ─────────────────────────────────────────── */}

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -318,7 +318,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       </div>
 
       {/* Stat 四格 */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
         <Stat label="TEAMS" value={teamCountRow?.value ?? 0} />
         <Stat label="PLAYERS" value={approvedCountRow?.value ?? 0} />
         <Stat

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -259,7 +259,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
           <Marker sub="已安排的比赛">近期对决</Marker>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
             {upcomingMatches.map((match) => (
-              <Link key={match.id} href={`/${seasonSlug}/matches` as never}>
+              <Link key={match.id} href={`/${seasonSlug}/matches/${match.id}` as never}>
                 <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
                   <div className="flex items-center justify-between gap-3">
                     <div className="flex items-center gap-2 min-w-0 flex-1">

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -10,6 +10,8 @@ import { normalizeStagePlan } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
 import { StatusPill, Panel, Marker, ScrollHint, Stat } from "@/components/rivalhub";
+import { checkAdminSession } from "@/lib/auth/session";
+import { AdminShortcut } from "@/components/layout/AdminShortcut";
 
 const STATUS_IDX: Record<SeasonStatus, number> = {
   draft: 0, registration: 1, voting: 2, drafting: 3,
@@ -23,9 +25,10 @@ interface SeasonPageProps {
 export default async function SeasonPage({ params }: SeasonPageProps) {
   const { seasonSlug } = await params;
 
-  const season = await db.query.seasons.findFirst({
-    where: eq(seasons.slug, seasonSlug),
-  });
+  const [season, adminSession] = await Promise.all([
+    db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
+    checkAdminSession(),
+  ]);
   if (!season) notFound();
   const stagePlan = normalizeStagePlan(season.stagePlan);
   const hasMatches = stagePlan.length > 0;
@@ -204,9 +207,14 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
           <StatusPill status={season.status} />
           <span className="text-[var(--color-fg-dim)]">{season.kind}</span>
         </div>
-        <h1 className="text-4xl sm:text-5xl font-bold text-[var(--color-fg)] mb-4 leading-tight">
-          {season.name}
-        </h1>
+        <div className="flex items-center gap-3 mb-4">
+          <h1 className="text-4xl sm:text-5xl font-bold text-[var(--color-fg)] leading-tight">
+            {season.name}
+          </h1>
+          {adminSession && (
+            <AdminShortcut href={`/admin/${seasonSlug}/settings`} />
+          )}
+        </div>
       </div>
 
       {/* Phase tracker */}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -4,6 +4,7 @@ import { db } from "@/db/client";
 import { seasons, teams, teamMembers, seasonRegistrations, users, matches, matchMaps } from "@/db/schema";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { Panel, Stat, Marker, PosChip } from "@/components/rivalhub";
+import { MatchCard } from "@/components/matches/MatchCard";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
 import { TeamNameForm } from "@/components/teams/TeamNameForm";
 import { TeamLogoUpload } from "@/components/teams/TeamLogoUpload";
@@ -46,8 +47,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     : null;
   const canEditTeamName = currentUserRegistration?.id === team.captainRegistrationId;
 
-  // ── 阵容 + 赛果（并行） ──────────────────────────────────────────────
-  const [roster, teamMatches] = await Promise.all([
+  // ── 阵容 + 赛果 + 即将进行的比赛（并行） ─────────────────────────────────
+  const [roster, teamMatches, upcomingMatches] = await Promise.all([
     db
       .select({
         registrationId: teamMembers.registrationId,
@@ -70,6 +71,13 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         or(eq(matches.teamAId, teamId), eq(matches.teamBId, teamId)),
       ),
     }),
+    db.query.matches.findMany({
+      where: and(
+        eq(matches.seasonId, season.id),
+        or(eq(matches.teamAId, teamId), eq(matches.teamBId, teamId)),
+        inArray(matches.status, ["scheduled", "in_progress"]),
+      ),
+    }),
   ]);
 
   const isTeamMember = currentUserRegistration
@@ -85,11 +93,12 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     });
   const subs = roster.filter((r) => !r.isStarter);
 
-  // 对手队名
+  // 对手队名（包含已完成和即将进行的比赛对手）
   const opponentIds = [
-    ...new Set(
-      teamMatches.map((m) => (m.teamAId === teamId ? m.teamBId : m.teamAId))
-    ),
+    ...new Set([
+      ...teamMatches.map((m) => (m.teamAId === teamId ? m.teamBId : m.teamAId)),
+      ...upcomingMatches.map((m) => (m.teamAId === teamId ? m.teamBId : m.teamAId)),
+    ]),
   ];
   const opponentTeams = opponentIds.length
     ? await db.query.teams.findMany({
@@ -257,6 +266,33 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         <Stat label="胜" value={totalWins} />
         <Stat label="负" value={totalLosses} />
       </div>
+
+      {/* 即将进行的比赛 */}
+      {upcomingMatches.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">即将进行的比赛</h2>
+          <div className="space-y-2">
+            {upcomingMatches.map((m) => {
+              const oppId = m.teamAId === teamId ? m.teamBId : m.teamAId;
+              const oppTeam = teamNameMap.get(oppId);
+              return (
+                <MatchCard
+                  key={m.id}
+                  matchId={m.id}
+                  seasonSlug={seasonSlug}
+                  teamAName={m.teamAId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                  teamBName={m.teamBId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                  scoreA={m.scoreA}
+                  scoreB={m.scoreB}
+                  stage={m.stage}
+                  format={m.format as "bo1" | "bo3" | "bo5"}
+                  status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                />
+              );
+            })}
+          </div>
+        </section>
+      )}
 
       {/* 阵容 */}
       <section>

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -6,6 +6,8 @@ import { Panel, Marker } from "@/components/rivalhub";
 import { TeamCard } from "@/components/teams/TeamCard";
 import { CS2_POSITIONS } from "@/types/season";
 import { getDisplayName } from "@/lib/utils/display-name";
+import { checkAdminSession } from "@/lib/auth/session";
+import { AdminShortcut } from "@/components/layout/AdminShortcut";
 
 interface TeamsPageProps {
   params: Promise<{ seasonSlug: string }>;
@@ -14,9 +16,10 @@ interface TeamsPageProps {
 export default async function TeamsPage({ params }: TeamsPageProps) {
   const { seasonSlug } = await params;
 
-  const season = await db.query.seasons.findFirst({
-    where: eq(seasons.slug, seasonSlug),
-  });
+  const [season, adminSession] = await Promise.all([
+    db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
+    checkAdminSession(),
+  ]);
   if (!season) notFound();
 
   const allTeams = await db.query.teams.findMany({
@@ -57,7 +60,12 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
-      <Marker sub={season.name}>参赛队伍</Marker>
+      <div className="flex items-center justify-between">
+        <Marker sub={season.name}>参赛队伍</Marker>
+        {adminSession && (
+          <AdminShortcut href={`/admin/${seasonSlug}/settings`} label="赛季管理" />
+        )}
+      </div>
 
       <Panel pad={20}>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -19,6 +19,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Panel, StatusPill } from "@/components/rivalhub";
 import { Separator } from "@/components/ui/separator";
 import { getFirstStageOfType, normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
+import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -27,8 +28,6 @@ interface AdminMatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
   searchParams: Promise<{ stage?: string; status?: string }>;
 }
-
-const FORMAT_LABELS = { bo1: "BO1", bo3: "BO3", bo5: "BO5" };
 
 export default async function AdminMatchesPage({ params, searchParams }: AdminMatchesPageProps) {
   const { seasonSlug } = await params;
@@ -263,7 +262,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             <span className="font-semibold">{teamBName}</span>
                           </div>
                           <div className="flex items-center gap-2">
-                            <StatusPill status={FORMAT_LABELS[m.format as keyof typeof FORMAT_LABELS]} />
+                            <StatusPill status={MATCH_FORMAT_LABELS[m.format as keyof typeof MATCH_FORMAT_LABELS]} />
                             <MatchStatusBadge
                               status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                             />
@@ -326,7 +325,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             <span className="font-semibold">{teamBName}</span>
                           </div>
                           <div className="flex items-center gap-2">
-                            <StatusPill status={FORMAT_LABELS[m.format as keyof typeof FORMAT_LABELS]} />
+                            <StatusPill status={MATCH_FORMAT_LABELS[m.format as keyof typeof MATCH_FORMAT_LABELS]} />
                             <MatchStatusBadge
                               status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                             />

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -6,6 +6,8 @@ import { requireSeasonAdmin } from "@/lib/auth/session";
 import { calculateStandings } from "@/lib/standings";
 import { GenerateScheduleCard } from "@/components/matches/GenerateScheduleCard";
 import { GeneratePlayoffCard } from "@/components/matches/GeneratePlayoffCard";
+import { CreateMatchForm } from "@/components/matches/CreateMatchForm";
+import { AdminMatchFilter } from "@/components/matches/AdminMatchFilter";
 import { StandingsTable } from "@/components/matches/StandingsTable";
 import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
 import { ScoreInput } from "@/components/matches/ScoreInput";
@@ -23,12 +25,14 @@ export const dynamic = "force-dynamic";
 
 interface AdminMatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
+  searchParams: Promise<{ stage?: string; status?: string }>;
 }
 
 const FORMAT_LABELS = { bo1: "BO1", bo3: "BO3", bo5: "BO5" };
 
-export default async function AdminMatchesPage({ params }: AdminMatchesPageProps) {
+export default async function AdminMatchesPage({ params, searchParams }: AdminMatchesPageProps) {
   const { seasonSlug } = await params;
+  const { stage: filterStage, status: filterStatus } = await searchParams;
 
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),
@@ -71,8 +75,10 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
   const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
   const qualifierKey = qualifierStage?.key ?? "qualifier";
   const playoffKey = playoffStage?.key ?? "playoff";
-  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
-  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey);
+  const statusFilter = (m: { status: string }) =>
+    !filterStatus || filterStatus === "all" || m.status === filterStatus;
+  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey).filter(statusFilter);
+  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey).filter(statusFilter);
 
   // 已完成比赛的地图列表（用于 OCR 录入面板）
   const finishedMatchIds = allMatches
@@ -157,13 +163,27 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
         <h1 className="text-2xl font-bold text-[var(--color-fg)]">
           比赛管理 · {season.name}
         </h1>
-        <Link
-          href={`/${seasonSlug}/matches`}
-          className="text-sm text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] transition-colors"
-        >
-          查看公开赛程 →
-        </Link>
+        <div className="flex items-center gap-3">
+          {allTeams.length >= 2 && stagePlan.length > 0 && (
+            <CreateMatchForm
+              seasonId={season.id}
+              teams={allTeams.map((t) => ({ id: t.id, name: t.name }))}
+              stages={stagePlan.map((s) => ({ key: s.key, name: s.name }))}
+            />
+          )}
+          <Link
+            href={`/${seasonSlug}/matches`}
+            className="text-sm text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] transition-colors"
+          >
+            查看公开赛程 →
+          </Link>
+        </div>
       </div>
+
+      {/* 筛选 */}
+      {matchCount > 0 && (
+        <AdminMatchFilter stages={stagePlan.map((s) => ({ key: s.key, name: s.name }))} />
+      )}
 
       {/* 赛季状态提示 */}
       {season.status !== "playing" && matchCount === 0 && (
@@ -200,7 +220,7 @@ export default async function AdminMatchesPage({ params }: AdminMatchesPageProps
 
       {/* Tab 面板 */}
       {matchCount > 0 && (
-        <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey}>
+        <Tabs defaultValue={filterStage && filterStage !== "all" ? filterStage : (hasQualifier ? qualifierKey : playoffKey)}>
           <TabsList>
             {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
             {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -19,6 +19,12 @@ const ENV_VARS = [
     description: "生产环境选秀超时自动 pick 所需，本地开发可不填。",
     required: false,
   },
+  {
+    key: "SILICONFLOW_API_KEY",
+    label: "SiliconFlow OCR API Key",
+    description: "用于玩家数据截图 OCR 识别。在 SiliconFlow 平台申请。",
+    required: false,
+  },
 ] as const;
 
 export default async function AdminSettingsPage() {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,24 @@
 @import "tailwindcss";
 
 @theme {
+  /* shadcn/ui color bridge — maps `:root` HSL vars to Tailwind v4 --color-* */
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+
   /* Surfaces */
   --color-bg: #0a0c10;
   --color-panel: #10131a;

--- a/src/components/draft/CaptainDraftPanel.tsx
+++ b/src/components/draft/CaptainDraftPanel.tsx
@@ -11,7 +11,7 @@ import { canPickPosition } from "@/lib/draft/rules";
 import { positionLabel } from "@/lib/validators/registration";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
 import { PosChip } from "@/components/rivalhub/pos-chip";
-
+import { PlayerInfoPopover } from "./PlayerInfoPopover";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { sortByRank } from "@/lib/utils/rank";
 import { selectAutoPickCandidate } from "@/lib/draft/auto-pick";
@@ -101,8 +101,10 @@ export function CaptainDraftPanel({
     return players.find((p) => p.registrationId === candidate.registrationId) ?? null;
   }, [players, positionCounts, isDraftActive, isCurrentCaptainTurn]);
 
+  const canSubmit = isDraftActive && isCurrentCaptainTurn && pendingRegistrationId === null;
+
   async function handlePick(player: DraftPlayerRow) {
-    if (!canPickPosition(positionCounts[player.primaryPosition] ?? 0)) return;
+    if (!canSubmit || !canPickPosition(positionCounts[player.primaryPosition] ?? 0)) return;
 
     setPendingRegistrationId(player.registrationId);
     setMessage(null);
@@ -282,6 +284,7 @@ export function CaptainDraftPanel({
               const positionCount = positionCounts[player.primaryPosition] ?? 0;
               const positionOpen = canPickPosition(positionCount);
               const isPending = pendingRegistrationId === player.registrationId;
+              const disabled = !canSubmit || !positionOpen || isPending;
               const displayedName = getDisplayName(player);
 
               return (
@@ -354,11 +357,18 @@ export function CaptainDraftPanel({
                       <MapPreferenceChips preferences={player.mapPreferences} compact minLevel="playable" />
                     </div>
 
+                    <PlayerInfoPopover
+                      gameplayStyle={player.gameplayStyle}
+                      notes={player.notes}
+                      competitionHistory={player.competitionHistory}
+                    />
+
                     {/* Pick button */}
+                    {!isReadonly && (
                       <Button
                         type="button"
                         size="sm"
-                        disabled={isPending || !positionOpen}
+                        disabled={disabled}
                         aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
                         onClick={() => void handlePick(player)}
                         className="shrink-0"
@@ -370,6 +380,7 @@ export function CaptainDraftPanel({
                         ) : null}
                         {positionOpen ? "选择" : "已满"}
                       </Button>
+                    )}
                   </div>
 
                   <div className="md:hidden space-y-1.5">
@@ -425,11 +436,17 @@ export function CaptainDraftPanel({
                         <div className="min-w-0">
                           <MapPreferenceChips preferences={player.mapPreferences} compact minLevel="playable" />
                         </div>
+                        <PlayerInfoPopover
+                          gameplayStyle={player.gameplayStyle}
+                          notes={player.notes}
+                          competitionHistory={player.competitionHistory}
+                        />
                       </div>
+                      {!isReadonly && (
                         <Button
                           type="button"
                           size="sm"
-                          disabled={isPending || !positionOpen}
+                          disabled={disabled}
                           aria-label={positionOpen ? `选择 ${displayedName}` : `${displayedName} 已满`}
                           onClick={() => void handlePick(player)}
                           className="shrink-0"
@@ -441,6 +458,7 @@ export function CaptainDraftPanel({
                           ) : null}
                           {positionOpen ? "选择" : "已满"}
                         </Button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/layout/AdminShortcut.tsx
+++ b/src/components/layout/AdminShortcut.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { Settings } from "lucide-react";
+
+interface AdminShortcutProps {
+  href: string;
+  label?: string;
+}
+
+/**
+ * 管理员快捷入口按钮。仅在服务端确认管理员身份后渲染。
+ */
+export function AdminShortcut({ href, label = "管理" }: AdminShortcutProps) {
+  return (
+    <Link
+      href={href as never}
+      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-panel)] px-3 py-1.5 text-xs font-medium text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] hover:border-[var(--color-border-hi)] transition-colors"
+    >
+      <Settings size={14} />
+      {label}
+    </Link>
+  );
+}

--- a/src/components/layout/AdminShortcut.tsx
+++ b/src/components/layout/AdminShortcut.tsx
@@ -6,9 +6,6 @@ interface AdminShortcutProps {
   label?: string;
 }
 
-/**
- * 管理员快捷入口按钮。仅在服务端确认管理员身份后渲染。
- */
 export function AdminShortcut({ href, label = "管理" }: AdminShortcutProps) {
   return (
     <Link

--- a/src/components/matches/AdminMatchFilter.tsx
+++ b/src/components/matches/AdminMatchFilter.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface StageOption {
+  key: string;
+  name: string;
+}
+
+interface AdminMatchFilterProps {
+  stages: StageOption[];
+}
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "全部状态" },
+  { value: "scheduled", label: "已排期" },
+  { value: "in_progress", label: "进行中" },
+  { value: "finished", label: "已完成" },
+  { value: "cancelled", label: "已取消" },
+];
+
+export function AdminMatchFilter({ stages }: AdminMatchFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentStage = searchParams.get("stage") ?? "all";
+  const currentStatus = searchParams.get("status") ?? "all";
+
+  function updateFilter(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "all") {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    const qs = params.toString();
+    router.push((qs ? `${pathname}?${qs}` : pathname) as never);
+  }
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <Select value={currentStage} onValueChange={(v) => updateFilter("stage", v)}>
+        <SelectTrigger className="w-[140px]">
+          <SelectValue placeholder="阶段筛选" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">全部阶段</SelectItem>
+          {stages.map((s) => (
+            <SelectItem key={s.key} value={s.key}>{s.name}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={currentStatus} onValueChange={(v) => updateFilter("status", v)}>
+        <SelectTrigger className="w-[140px]">
+          <SelectValue placeholder="状态筛选" />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -62,7 +62,22 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         { selector: "#bracket-container", clear: true }
       )
       .then(() => {
-        if (!containerRef.current || !matchNodeMap || !seasonSlug) return;
+        if (!containerRef.current) return;
+
+        // 将 brackets-viewer 默认的 "BYE" 文本替换为 "TBD"
+        const walker = document.createTreeWalker(
+          containerRef.current,
+          NodeFilter.SHOW_TEXT,
+          null,
+        );
+        let node: Text | null;
+        while ((node = walker.nextNode() as Text | null)) {
+          if (node.textContent === "BYE") {
+            node.textContent = "TBD";
+          }
+        }
+
+        if (!matchNodeMap || !seasonSlug) return;
         containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
           const bracketId = el.getAttribute("data-match-id");
           if (!bracketId) return;

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -77,19 +77,30 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
           }
         }
 
-        if (!matchNodeMap || !seasonSlug) return;
-        containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
-          const bracketId = el.getAttribute("data-match-id");
-          if (!bracketId) return;
-          const matchId = matchNodeMap.get(bracketId);
-          if (!matchId) return;
-          el.style.cursor = "pointer";
-          el.title = "点击查看比赛详情";
-          el.addEventListener("click", (e) => {
+        if (matchNodeMap && seasonSlug) {
+          containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
+            const bracketId = el.getAttribute("data-match-id");
+            if (!bracketId) return;
+            if (!matchNodeMap.has(bracketId)) return;
+            el.style.cursor = "pointer";
+            el.title = "点击查看比赛详情";
+          });
+
+          const handleClick = (e: MouseEvent) => {
+            const target = (e.target as HTMLElement).closest<HTMLElement>("[data-match-id]");
+            if (!target) return;
+            const bracketId = target.getAttribute("data-match-id");
+            if (!bracketId) return;
+            const matchId = matchNodeMap.get(bracketId);
+            if (!matchId) return;
             e.stopPropagation();
             router.push(`/${seasonSlug}/matches/${matchId}`);
-          });
-        });
+          };
+          containerRef.current.addEventListener("click", handleClick);
+          return () => {
+            containerRef.current?.removeEventListener("click", handleClick);
+          };
+        }
       })
       .catch(console.error);
   }, [scriptReady, data, matchNodeMap, seasonSlug, router]);

--- a/src/components/matches/CreateMatchForm.tsx
+++ b/src/components/matches/CreateMatchForm.tsx
@@ -78,7 +78,6 @@ export function CreateMatchForm({ seasonId, teams, stages }: CreateMatchFormProp
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {/* 队伍 A */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-[var(--color-fg-mid)]">队伍 A</label>
             <Select value={teamAId} onValueChange={setTeamAId}>
@@ -93,7 +92,6 @@ export function CreateMatchForm({ seasonId, teams, stages }: CreateMatchFormProp
             </Select>
           </div>
 
-          {/* 队伍 B */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-[var(--color-fg-mid)]">队伍 B</label>
             <Select value={teamBId} onValueChange={setTeamBId}>
@@ -108,7 +106,6 @@ export function CreateMatchForm({ seasonId, teams, stages }: CreateMatchFormProp
             </Select>
           </div>
 
-          {/* 阶段 */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-[var(--color-fg-mid)]">阶段</label>
             <Select value={stage} onValueChange={setStage}>
@@ -123,7 +120,6 @@ export function CreateMatchForm({ seasonId, teams, stages }: CreateMatchFormProp
             </Select>
           </div>
 
-          {/* 赛制 */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-[var(--color-fg-mid)]">赛制</label>
             <Select value={format} onValueChange={(v) => setFormat(v as "bo1" | "bo3" | "bo5")}>

--- a/src/components/matches/CreateMatchForm.tsx
+++ b/src/components/matches/CreateMatchForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { createMatch } from "@/actions/matches";
+import { Plus } from "lucide-react";
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface StageOption {
+  key: string;
+  name: string;
+}
+
+interface CreateMatchFormProps {
+  seasonId: string;
+  teams: Team[];
+  stages: StageOption[];
+}
+
+export function CreateMatchForm({ seasonId, teams, stages }: CreateMatchFormProps) {
+  const [open, setOpen] = useState(false);
+  const [teamAId, setTeamAId] = useState("");
+  const [teamBId, setTeamBId] = useState("");
+  const [stage, setStage] = useState(stages[0]?.key ?? "");
+  const [format, setFormat] = useState<"bo1" | "bo3" | "bo5">("bo1");
+  const [isPending, startTransition] = useTransition();
+
+  const canSubmit = teamAId && teamBId && teamAId !== teamBId && stage && format;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    startTransition(async () => {
+      const result = await createMatch(seasonId, teamAId, teamBId, stage, format);
+      if (result.success) {
+        toast.success("比赛创建成功");
+        setOpen(false);
+        setTeamAId("");
+        setTeamBId("");
+      } else {
+        toast.error(result.error?.message ?? "创建失败");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Plus size={14} className="mr-1.5" />
+          新增比赛
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>新增比赛</DialogTitle>
+          <DialogDescription>手动创建一场比赛，不关联 Bracket 节点。</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* 队伍 A */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-[var(--color-fg-mid)]">队伍 A</label>
+            <Select value={teamAId} onValueChange={setTeamAId}>
+              <SelectTrigger>
+                <SelectValue placeholder="选择队伍" />
+              </SelectTrigger>
+              <SelectContent>
+                {teams.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 队伍 B */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-[var(--color-fg-mid)]">队伍 B</label>
+            <Select value={teamBId} onValueChange={setTeamBId}>
+              <SelectTrigger>
+                <SelectValue placeholder="选择队伍" />
+              </SelectTrigger>
+              <SelectContent>
+                {teams.filter((t) => t.id !== teamAId).map((t) => (
+                  <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 阶段 */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-[var(--color-fg-mid)]">阶段</label>
+            <Select value={stage} onValueChange={setStage}>
+              <SelectTrigger>
+                <SelectValue placeholder="选择阶段" />
+              </SelectTrigger>
+              <SelectContent>
+                {stages.map((s) => (
+                  <SelectItem key={s.key} value={s.key}>{s.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 赛制 */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-[var(--color-fg-mid)]">赛制</label>
+            <Select value={format} onValueChange={(v) => setFormat(v as "bo1" | "bo3" | "bo5")}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="bo1">BO1</SelectItem>
+                <SelectItem value="bo3">BO3</SelectItem>
+                <SelectItem value="bo5">BO5</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {teamAId && teamBId && teamAId === teamBId && (
+            <p className="text-xs text-red-500">双方队伍不能相同</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>取消</Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit || isPending}>
+            {isPending ? "创建中..." : "创建比赛"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { MatchStatusBadge } from "./MatchStatusBadge";
+import { MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
+import type { MatchFormat } from "@/types/match";
 
 interface MatchCardProps {
   matchId: string;
@@ -11,12 +13,9 @@ interface MatchCardProps {
   scoreA: number | null;
   scoreB: number | null;
   stage: string;
-  format: "bo1" | "bo3" | "bo5";
+  format: MatchFormat;
   status: "scheduled" | "in_progress" | "finished" | "cancelled";
 }
-
-const STAGE_LABELS: Record<string, string> = { qualifier: "排位赛", playoff: "正赛" };
-const FORMAT_LABELS = { bo1: "BO1", bo3: "BO3", bo5: "BO5" };
 
 export function MatchCard({
   matchId,
@@ -44,10 +43,10 @@ export function MatchCard({
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
-              {STAGE_LABELS[stage] ?? stage}
+              {MATCH_STAGE_LABELS[stage] ?? stage}
             </Badge>
             <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
-              {FORMAT_LABELS[format]}
+              {MATCH_FORMAT_LABELS[format]}
             </Badge>
             <MatchStatusBadge status={status} />
           </div>

--- a/src/components/matches/MatchDetail.tsx
+++ b/src/components/matches/MatchDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -44,8 +45,10 @@ export interface MatchDetailData {
   id: string;
   teamAName: string;
   teamAId: string;
+  teamALogoUrl: string | null;
   teamBName: string;
   teamBId: string;
+  teamBLogoUrl: string | null;
   format: string;
   stage: string;
   status: string;
@@ -99,8 +102,15 @@ export function MatchDetail({ match }: { match: MatchDetailData }) {
         </div>
 
         <div className="flex items-center justify-center gap-6">
-          <Link href={`/${match.seasonSlug}/teams/${match.teamAId}`} className="text-right flex-1 hover:opacity-80 transition-opacity">
+          <Link href={`/${match.seasonSlug}/teams/${match.teamAId}`} className="text-right flex-1 hover:opacity-80 transition-opacity flex items-center justify-end gap-3">
             <p className="text-xl font-bold text-[var(--color-fg)] truncate">{match.teamAName}</p>
+            {match.teamALogoUrl ? (
+              <Image src={match.teamALogoUrl} alt={match.teamAName} width={40} height={40} className="w-10 h-10 rounded-full object-cover shrink-0" />
+            ) : (
+              <div className="w-10 h-10 rounded-full bg-[var(--color-border)] flex items-center justify-center shrink-0">
+                <span className="text-xs font-bold text-[var(--color-fg-mid)]">{match.teamAName.slice(0, 2)}</span>
+              </div>
+            )}
           </Link>
 
           <div className="text-center shrink-0 px-4">
@@ -113,7 +123,14 @@ export function MatchDetail({ match }: { match: MatchDetailData }) {
             )}
           </div>
 
-          <Link href={`/${match.seasonSlug}/teams/${match.teamBId}`} className="text-left flex-1 hover:opacity-80 transition-opacity">
+          <Link href={`/${match.seasonSlug}/teams/${match.teamBId}`} className="text-left flex-1 hover:opacity-80 transition-opacity flex items-center gap-3">
+            {match.teamBLogoUrl ? (
+              <Image src={match.teamBLogoUrl} alt={match.teamBName} width={40} height={40} className="w-10 h-10 rounded-full object-cover shrink-0" />
+            ) : (
+              <div className="w-10 h-10 rounded-full bg-[var(--color-border)] flex items-center justify-center shrink-0">
+                <span className="text-xs font-bold text-[var(--color-fg-mid)]">{match.teamBName.slice(0, 2)}</span>
+              </div>
+            )}
             <p className="text-xl font-bold text-[var(--color-fg)] truncate">{match.teamBName}</p>
           </Link>
         </div>

--- a/src/components/matches/MatchDetail.tsx
+++ b/src/components/matches/MatchDetail.tsx
@@ -6,25 +6,14 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { formatCST } from "@/lib/utils/date";
-import { MATCH_STATUS_LABELS } from "@/types/match";
-import type { MatchStatus } from "@/types/match";
+import { MATCH_STATUS_LABELS, MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
+import type { MatchStatus, MatchFormat } from "@/types/match";
 
-const STATUS_STYLES: Record<string, string> = {
+const STATUS_HERO_STYLES: Record<string, string> = {
   scheduled: "bg-blue-500/10 text-blue-400 border-blue-500/20",
   in_progress: "bg-yellow-500/10 text-yellow-400 border-yellow-500/20",
   finished: "bg-green-500/10 text-green-400 border-green-500/20",
   cancelled: "bg-[var(--color-fg-dim)]/10 text-[var(--color-fg-dim)] border-[var(--color-border)]",
-};
-
-const FORMAT_LABELS: Record<string, string> = {
-  bo1: "BO1",
-  bo3: "BO3",
-  bo5: "BO5",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  qualifier: "排位赛",
-  playoff: "正赛",
 };
 
 const SIDE_LABELS: Record<string, string> = {
@@ -79,14 +68,14 @@ export function MatchDetail({ match }: { match: MatchDetailData }) {
       <Card className="bg-[var(--color-panel)] border-[var(--color-border)] p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2 flex-wrap">
-            <Badge className={`text-xs ${STATUS_STYLES[match.status] ?? ""}`}>
+            <Badge className={`text-xs ${STATUS_HERO_STYLES[match.status] ?? ""}`}>
               {MATCH_STATUS_LABELS[match.status as MatchStatus] ?? match.status}
             </Badge>
             <Badge variant="outline" className="text-xs border-[var(--color-border)] text-[var(--color-fg-mid)]">
-              {FORMAT_LABELS[match.format] ?? match.format}
+              {MATCH_FORMAT_LABELS[match.format as MatchFormat] ?? match.format}
             </Badge>
             <Badge variant="outline" className="text-xs border-[var(--color-border)] text-[var(--color-fg-mid)]">
-              {STAGE_LABELS[match.stage] ?? match.stage}
+              {MATCH_STAGE_LABELS[match.stage] ?? match.stage}
             </Badge>
           </div>
           {match.scheduledAt && !isFinished && (

--- a/src/components/matches/MatchDetail.tsx
+++ b/src/components/matches/MatchDetail.tsx
@@ -64,7 +64,6 @@ export function MatchDetail({ match }: { match: MatchDetailData }) {
         </Link>
       </div>
 
-      {/* 比赛头部 */}
       <Card className="bg-[var(--color-panel)] border-[var(--color-border)] p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2 flex-wrap">
@@ -125,7 +124,6 @@ export function MatchDetail({ match }: { match: MatchDetailData }) {
         </div>
       </Card>
 
-      {/* 地图结果 */}
       {match.maps.length > 0 && (
         <Card className="bg-[var(--color-panel)] border-[var(--color-border)] overflow-hidden">
           <div className="p-4 border-b border-[var(--color-border)]">

--- a/src/components/matches/MatchTeamFilter.tsx
+++ b/src/components/matches/MatchTeamFilter.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface MatchTeamFilterProps {
+  teams: Team[];
+}
+
+export function MatchTeamFilter({ teams }: MatchTeamFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentTeam = searchParams.get("team") ?? "";
+
+  function handleChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "all") {
+      params.delete("team");
+    } else {
+      params.set("team", value);
+    }
+    const qs = params.toString();
+    const url = qs ? `${pathname}?${qs}` : pathname;
+    router.push(url as never);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-[var(--color-fg-mid)] shrink-0">按队伍筛选</span>
+      <Select value={currentTeam || "all"} onValueChange={handleChange}>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="全部队伍" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">全部队伍</SelectItem>
+          {teams.map((t) => (
+            <SelectItem key={t.id} value={t.id}>
+              {t.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/matches/ScoreInput.tsx
+++ b/src/components/matches/ScoreInput.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { InlineConfirm } from "@/components/rivalhub";
 import { recordMatchResult, updateMatchStatus } from "@/actions/matches";
 
 interface ScoreInputProps {
@@ -35,6 +36,7 @@ function validateSeriesScore(format: string, a: number, b: number): string | nul
 export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, format }: ScoreInputProps) {
   const [scoreA, setScoreA] = useState("");
   const [scoreB, setScoreB] = useState("");
+  const [showStartConfirm, setShowStartConfirm] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   function handleStart() {
@@ -87,13 +89,24 @@ export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, forma
   return (
     <div className="space-y-3">
       {currentStatus === "scheduled" && (
-        <div className="flex gap-2">
-          <Button size="sm" onClick={handleStart} disabled={isPending}>
-            开始比赛
-          </Button>
-          <Button size="sm" variant="outline" onClick={handleCancel} disabled={isPending}>
-            取消比赛
-          </Button>
+        <div className="space-y-3">
+          {showStartConfirm ? (
+            <InlineConfirm
+              title="确认开始比赛？"
+              sub="开始后比赛状态将变为「进行中」"
+              onConfirm={handleStart}
+              onCancel={() => setShowStartConfirm(false)}
+            />
+          ) : (
+            <div className="flex gap-2">
+              <Button size="sm" onClick={() => setShowStartConfirm(true)} disabled={isPending}>
+                开始比赛
+              </Button>
+              <Button size="sm" variant="outline" onClick={handleCancel} disabled={isPending}>
+                取消比赛
+              </Button>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -124,7 +124,7 @@ export async function generateBracket(
         ? new Array(teams.length).fill(null)
         : seeding,
       settings: {
-        grandFinal: "double",
+        grandFinal: "simple",
         seedOrdering: ["inner_outer"],
       },
     });

--- a/src/lib/draft/auto-pick.ts
+++ b/src/lib/draft/auto-pick.ts
@@ -8,6 +8,7 @@ export interface AutoPickCandidate {
   peakRating: number;
   currentRank: string;
   currentRating: number;
+  createdAt: Date;
 }
 
 export function selectAutoPickCandidate(
@@ -29,7 +30,7 @@ export function selectAutoPickCandidate(
     if (curRankA !== curRankB) return curRankB - curRankA;
     if (a.currentRating !== b.currentRating) return b.currentRating - a.currentRating;
 
-    return a.registrationId.localeCompare(b.registrationId);
+    return a.createdAt.getTime() - b.createdAt.getTime();
   });
 
   // Round 1: prefer positions with zero current members (completely vacant)

--- a/src/lib/draft/data.ts
+++ b/src/lib/draft/data.ts
@@ -48,6 +48,7 @@ export interface DraftPlayerRow {
   gameplayStyle: string | null;
   notes: string | null;
   competitionHistory: string | null;
+  createdAt: Date;
 }
 
 export interface DraftLiveState {
@@ -164,6 +165,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
       gameplayStyle: seasonRegistrations.gameplayStyle,
       notes: seasonRegistrations.notes,
       competitionHistory: seasonRegistrations.competitionHistory,
+      createdAt: seasonRegistrations.createdAt,
     })
     .from(seasonRegistrations)
     .leftJoin(users, eq(seasonRegistrations.userId, users.id))
@@ -194,6 +196,7 @@ export async function getDraftData(seasonId: string): Promise<DraftFullData> {
       gameplayStyle: r.gameplayStyle ?? null,
       notes: r.notes ?? null,
       competitionHistory: r.competitionHistory ?? null,
+      createdAt: r.createdAt,
     }));
 
   // 5. 组装队伍数据

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -44,7 +44,7 @@ export interface MatchMap {
 // ── 标签 ─────────────────────────────────────────────────────────────────
 
 export const MATCH_STATUS_LABELS: Record<MatchStatus, string> = {
-  scheduled: "已排期",
+  scheduled: "待进行",
   in_progress: "进行中",
   finished: "已结束",
   cancelled: "已取消",

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -49,6 +49,7 @@ const baseProps = {
 		gameplayStyle: "进攻型选手",
 		notes: null,
 		competitionHistory: null,
+		createdAt: new Date("2025-01-01T00:00:00Z"),
     },
   ],
   seasonPositions: ["igl", "anchor"],

--- a/tests/unit/components/draft/PlayerPool.test.tsx
+++ b/tests/unit/components/draft/PlayerPool.test.tsx
@@ -26,6 +26,7 @@ describe("PlayerPool", () => {
             gameplayStyle: null,
             notes: null,
             competitionHistory: null,
+            createdAt: new Date("2025-01-01T00:00:00Z"),
           },
         ]}
       />,

--- a/tests/unit/lib/draft-auto-pick.test.ts
+++ b/tests/unit/lib/draft-auto-pick.test.ts
@@ -9,6 +9,7 @@ const candidates = [
     peakRank: "S",
     currentRank: "S",
     currentRating: 2.4,
+    createdAt: new Date("2025-01-01T00:00:00Z"),
   },
   {
     registrationId: "igl-best-open-position",
@@ -17,6 +18,7 @@ const candidates = [
     peakRank: "S",
     currentRank: "A+",
     currentRating: 2.15,
+    createdAt: new Date("2025-01-02T00:00:00Z"),
   },
   {
     registrationId: "anchor-low",
@@ -25,6 +27,7 @@ const candidates = [
     peakRank: "A",
     currentRank: "A",
     currentRating: 1.65,
+    createdAt: new Date("2025-01-03T00:00:00Z"),
   },
 ];
 


### PR DESCRIPTION
## Summary

- **管理员快捷入口**：公开页面（赛季首页/赛程/选秀/队伍）对管理员显示齿轮图标入口
- **赛程队伍筛选**：赛程总览页支持按队伍筛选 + 管理员后台阶段/状态筛选
- **后台新增比赛**：管理后台赛程页新增「新增比赛」Dialog 表单
- **队伍头像**：单场比赛页展示队伍 logo（无 logo 时 fallback 圆形首字母）
- **队伍详情比赛列表**：展示该队即将进行的比赛
- **shadcn/Tailwind v4 颜色桥接**：修复按钮/Tab 颜色不渲染（根因修复）
- **Grand Final 赛制**：双败决赛从 double 改为 simple（单场 BO5）
- **Bracket BYE→TBD**：未确定对手显示 TBD 而非 BYE
- **auto-pick tiebreaker**：段位相同时改用报名时间而非随机 UUID
- **Cron 调度修正**：GitHub Actions 从每分钟改为每 5 分钟
- **代码审查清理**：消除 FORMAT_LABELS 重复、查询并行化、事件委托、删除冗余注释

## Test plan

- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm test --run` 通过（379 tests）
- [ ] `pnpm build` 通过
- [ ] 管理员快捷入口在各公开页面可见（仅管理员登录后）
- [ ] 赛程页队伍筛选下拉框功能正常
- [ ] 后台新增比赛表单可创建比赛
- [ ] 按钮/Tab 颜色渲染正常（不再与背景融合）
- [ ] Bracket 视图中未确定对手显示 "TBD"

🤖 Generated with [Claude Code](https://claude.com/claude-code)