### PR TITLE
fix: VetoView 生产环境 Drizzle 查询构建器崩溃

### DIFF
--- a/src/components/matches/VetoView.tsx
+++ b/src/components/matches/VetoView.tsx
@@ -1,6 +1,6 @@
 import { db } from "@/db/client";
 import { matchVetoSteps } from "@/db/schema/match-veto-steps";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { SIDE_LABELS } from "@/types/match";
 import { mapLabel } from "@/lib/maps";
 import { Panel } from "@/components/rivalhub";
@@ -34,10 +34,11 @@ export async function VetoView({
   teamAId,
   teamBId,
 }: Props) {
-  const steps = await db.query.matchVetoSteps.findMany({
-    where: eq(matchVetoSteps.matchId, matchId),
-    orderBy: (t, { asc }) => [asc(t.stepOrder)],
-  });
+  const steps = await db
+    .select()
+    .from(matchVetoSteps)
+    .where(eq(matchVetoSteps.matchId, matchId))
+    .orderBy(asc(matchVetoSteps.stepOrder));
 
   if (steps.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- VetoView 改用 `db.select()` 替代 `db.query.xxx.findMany()`，绕过 Drizzle 关系查询构建器的 `buildRelationalQueryWithoutPK` 崩溃

## Root Cause
`matchRosterPlayers` 表无 `primaryKey()`（仅复合 `unique()`），Drizzle 对其走 `buildRelationalQueryWithoutPK` 路径。当新部署增加 `db.query.matchVetoSteps.findMany()` 等查询时，关系自动发现过程中引用表解析失败，导致 `Cannot read properties of undefined (reading 'referencedTable')`。

## Fix
将 `VetoView` 从 Drizzle relational API 改为 plain SQL API (`db.select().from().where().orderBy()`)，完全绕过关系查询构建器。

🤖 Generated with [Claude Code](https://claude.com/claude-code)