### PR TITLE
fix: admin matches page Drizzle 关系查询构建器崩溃（第二次修复）

### DIFF
--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -200,10 +200,28 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
         .innerJoin(users, eq(seasonRegistrations.userId, users.id))
         .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id))),
       displayedMatchIds.length > 0
-        ? db.query.matchRosters.findMany({
-            where: inArray(matchRosters.matchId, displayedMatchIds),
-            with: { players: true },
-          })
+        ? (async () => {
+            const rosters = await db
+              .select()
+              .from(matchRosters)
+              .where(inArray(matchRosters.matchId, displayedMatchIds));
+            if (rosters.length === 0) return [] as typeof rosters & { players: (typeof matchRosterPlayers.$inferSelect)[] }[];
+            const rosterIds = rosters.map((r) => r.id);
+            const players = await db
+              .select()
+              .from(matchRosterPlayers)
+              .where(inArray(matchRosterPlayers.rosterId, rosterIds));
+            const playerMap = new Map<string, (typeof matchRosterPlayers.$inferSelect)[]>();
+            for (const p of players) {
+              const list = playerMap.get(p.rosterId) ?? [];
+              list.push(p);
+              playerMap.set(p.rosterId, list);
+            }
+            return rosters.map((r) => ({
+              ...r,
+              players: playerMap.get(r.id) ?? [],
+            }));
+          })()
         : ([] as (typeof matchRosters.$inferSelect & {
             players: (typeof matchRosterPlayers.$inferSelect)[];
           })[]),


### PR DESCRIPTION
## Summary
- Admin matches page 的 roster 查询从 `db.query.matchRosters.findMany({ with: { players: true } })` 改为两个独立 `db.select()` + 应用层 join

## Root Cause
`matchRosterPlayers` 表无 `primaryKey()`（仅复合 `unique()`），任何经过 `db.query.xxx.findMany({ with: { players: true } })` 的查询都会触发 Drizzle 的 `buildRelationalQueryWithoutPK` 路径，导致 `referencedTable` 解析失败。

通过 Vercel Runtime Logs 确认所有错误都来自 `/admin/2026-nju-rivals/matches` 路由。

## Fix
将关系查询拆为两个独立 SQL 查询（`db.select().from(matchRosters)` + `db.select().from(matchRosterPlayers)`），应用层组装，完全绕过 Drizzle 关系查询构建器。

🤖 Generated with [Claude Code](https://claude.com/claude-code)