### PR TITLE
fix: 删除放开 + 后台赛程布局优化 + 公开页直达链接

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.11.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.13.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。v2 赛制引擎代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.11.0，站点部署在 `match.starfie1d.top`。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.13.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 
@@ -219,14 +219,14 @@ src/
 │   ├── auth.ts       # 邮箱+密码注册/登录/退出
 │   ├── captains.ts   # 队长投票
 │   ├── draft/        # 选秀（state / picks / queries）
-│   ├── matches/      # 赛程（schedule / results / roster / scheduling / score）
+│   ├── matches/      # 赛程（schedule / results / roster / veto / scheduling / score）
 │   ├── player-stats.ts # 玩家数据（OCR 识别 / 保存 / 查询）
 │   ├── register.ts   # 报名提交
 │   ├── seasons.ts    # 赛季 CRUD（create/update/delete/publish）
 │   ├── transitions.ts # 赛季阶段自动推进
 │   └── teams.ts      # 队伍（修改队名/上传图标）
 ├── db/
-│   ├── schema/       # Drizzle 表定义（18 张表）
+│   ├── schema/       # Drizzle 表定义（19 张表，含 match_veto_steps）
 │   ├── client.ts     # Drizzle client 单例（pg Pool，错误处理 + 超时配置）
 │   └── seed.ts       # 种子数据（赛季 + 根管理员 RivalHub_root）
 ├── lib/
@@ -249,7 +249,7 @@ src/
 │   ├── draft/        # 选秀业务组件
 │   ├── captains/     # 队长投票业务组件
 │   ├── teams/        # 队伍展示业务组件
-│   └── matches/      # 赛程 / bracket 业务组件（MatchCard / MatchDetail / MatchTeamFilter / CreateMatchForm / AdminMatchFilter / ScoreInput / MapByMapInput / ScheduledAtInput / MatchStatusBadge / BatchDeadlineCard / StatsOCRPanel）
+│   └── matches/      # 赛程 / bracket 业务组件（MatchCard / MatchTeamFilter / CreateMatchForm / AdminMatchFilter / ScoreInput / MapByMapInput / ScheduledAtInput / MatchStatusBadge / BatchDeadlineCard / StatsOCRPanel / VetoInputDialog / VetoView / AdminRosterDialog / DeleteMatchButton）
 └── types/            # 共享 TypeScript 类型
 ```
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -181,6 +181,17 @@ erDiagram
     timestamp created_at
   }
 
+  match_veto_steps {
+    uuid id PK
+    uuid match_id FK
+    int step_order
+    text action_type "ban | pick | decider"
+    text map_name "如 de_inferno"
+    uuid team_id FK "执行队伍，decider 为 null"
+    side side "t | ct | null"
+    timestamp created_at
+  }
+
   match_mvp_votes {
     uuid id PK
     uuid match_id FK
@@ -235,6 +246,7 @@ erDiagram
   seasons ||--o{ draft_picks : "records"
   seasons ||--o{ matches : "hosts"
   seasons ||--o{ audit_logs : "logs"
+  matches ||--o{ match_veto_steps : "records_veto"
   matches ||--o{ match_maps : "consists_of"
   matches ||--o{ match_player_stats : "has"
   match_maps ||--o{ match_player_stats : "has"
@@ -373,6 +385,7 @@ erDiagram
 | `draft_state` | `UNIQUE(season_id)` |
 | `draft_picks` | `UNIQUE(client_request_id)` |
 | `match_maps` | `UNIQUE(match_id, map_order)` |
+| `match_veto_steps` | `UNIQUE(match_id, step_order)` |
 | `admin_users` | `UNIQUE(username)` |
 | `admin_invites` | `UNIQUE(code)` |
 | `match_player_stats` | `UNIQUE(map_id, perfect_name)` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,11 +61,33 @@ const pgConfig = {
 | `STEAM_API_KEY` | 可选，用于抓取选手 Steam 头像 |
 | `SILICONFLOW_API_KEY` | 可选，用于玩家数据 OCR |
 
+## 生产环境排错
+
+### Vercel Runtime Logs 优先原则
+
+生产环境报错时，**第一步永远是查 Vercel Runtime Logs**，凭堆栈推断错误源很容易猜错（堆栈是 minified 的，没有表名/路由信息）。
+
+使用 MCP `get_runtime_logs` 过滤 `level=error`，看 Method + Path 列确定是哪个路由崩溃，再针对该路由的查询进行排查。
+
+### 数据库迁移
+
+新增表/列后，Schema 定义只在代码中，**生产数据库不会自动同步**：
+
+```bash
+pnpm db:push    # 将 Drizzle schema 推送到 Supabase 生产数据库
+```
+
+### Drizzle 关系查询已知陷阱
+
+`matchRosterPlayers` 是全库唯一没有 `primaryKey()` 的表（用 `unique()` 复合约束）。任何 `db.query.matchRosters.findMany/findFirst({ with: { players: true } })` 都会触发 Drizzle 的 `buildRelationalQueryWithoutPK` 路径。若引用表解析失败会抛 `Cannot read properties of undefined (reading 'referencedTable')`。
+
+**修复方式**：拆为两个独立 `db.select()` + 应用层 join，绕过关系查询构建器。
+
 ## Cron
 
 Cron endpoint 均通过 `Authorization: Bearer $CRON_SECRET` 鉴权。
 
-当前生产调用由 `.github/workflows/cron.yml` 每分钟触发：
+当前生产调用由 `.github/workflows/cron.yml` 每 5 分钟触发：
 
 ```text
 https://match.starfie1d.top/api/cron/draft-timeout
@@ -73,7 +95,7 @@ https://match.starfie1d.top/api/cron/check-registration-deadline
 https://match.starfie1d.top/api/cron/match-time-auto-award
 ```
 
-因此需要同时配置：
+Vercel Cron 当前未使用（依赖 GitHub Actions 调度）。需同时配置：
 
 - Vercel 环境变量：`CRON_SECRET`
 - GitHub Actions Secret：`CRON_SECRET`

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -497,10 +497,6 @@ export async function deleteMatch(matchId: string): Promise<ActionResult<void>> 
     const match = await getMatchOrThrow(matchId);
     const session = await requireSeasonAdmin(match.seasonId);
 
-    if (match.status !== "scheduled") {
-      throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "仅可删除「已排期」状态的比赛");
-    }
-
     if (match.bracketNodeId) {
       throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "无法删除 Bracket 自动生成的比赛");
     }

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -370,36 +370,38 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
+                        <Separator />
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
-                            <Separator />
-                            <AdminRosterDialog
-                              matchId={m.id}
-                              teamAName={teamAName}
-                              teamBName={teamBName}
-                              teamAId={m.teamAId}
-                              teamBId={m.teamBId}
-                              teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
-                              teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
-                              teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                              teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                            />
+                            <div className="flex flex-wrap items-center gap-2">
+                              <AdminRosterDialog
+                                matchId={m.id}
+                                teamAName={teamAName}
+                                teamBName={teamBName}
+                                teamAId={m.teamAId}
+                                teamBId={m.teamBId}
+                                teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
+                                teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
+                                teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                                teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                              />
+                              {m.status === "scheduled" && (
+                                <VetoInputDialog
+                                  matchId={m.id}
+                                  format={m.format as "bo1" | "bo3" | "bo5"}
+                                  teamAName={teamAName}
+                                  teamBName={teamBName}
+                                  teamAId={m.teamAId}
+                                  teamBId={m.teamBId}
+                                  mapPool={mapPool}
+                                />
+                              )}
+                            </div>
                             <ScheduledAtInput
                               matchId={m.id}
                               currentScheduledAt={m.scheduledAt}
                               currentCompletionDeadline={m.completionDeadline}
                             />
-                            {m.status === "scheduled" && (
-                              <VetoInputDialog
-                                matchId={m.id}
-                                format={m.format as "bo1" | "bo3" | "bo5"}
-                                teamAName={teamAName}
-                                teamBName={teamBName}
-                                teamAId={m.teamAId}
-                                teamBId={m.teamBId}
-                                mapPool={mapPool}
-                              />
-                            )}
                             <ScoreInput
                               matchId={m.id}
                               teamAName={teamAName}
@@ -407,17 +409,25 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                               currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                               format={m.format as "bo1" | "bo3" | "bo5"}
                             />
-                            {m.status === "scheduled" && (
-                              <DeleteMatchButton matchId={m.id} />
-                            )}
                           </>
                         )}
                         {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
                           <div key={map.id}>
-                            <Separator />
                             <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
                           </div>
                         ))}
+                        <div className="flex items-center justify-between gap-2">
+                          <Link
+                            href={`/${seasonSlug}/matches/${m.id}`}
+                            className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
+                            target="_blank"
+                          >
+                            查看公开页 ↗
+                          </Link>
+                          {m.bracketNodeId == null && (
+                            <DeleteMatchButton matchId={m.id} />
+                          )}
+                        </div>
                       </Panel>
                     );
                   })}
@@ -458,20 +468,33 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
+                        <Separator />
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
-                            <Separator />
-                            <AdminRosterDialog
-                              matchId={m.id}
-                              teamAName={teamAName}
-                              teamBName={teamBName}
-                              teamAId={m.teamAId}
-                              teamBId={m.teamBId}
-                              teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
-                              teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
-                              teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                              teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                            />
+                            <div className="flex flex-wrap items-center gap-2">
+                              <AdminRosterDialog
+                                matchId={m.id}
+                                teamAName={teamAName}
+                                teamBName={teamBName}
+                                teamAId={m.teamAId}
+                                teamBId={m.teamBId}
+                                teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
+                                teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
+                                teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                                teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                              />
+                              {m.status === "scheduled" && (
+                                <VetoInputDialog
+                                  matchId={m.id}
+                                  format={m.format as "bo1" | "bo3" | "bo5"}
+                                  teamAName={teamAName}
+                                  teamBName={teamBName}
+                                  teamAId={m.teamAId}
+                                  teamBId={m.teamBId}
+                                  mapPool={mapPool}
+                                />
+                              )}
+                            </div>
                             <ScheduledAtInput
                               matchId={m.id}
                               currentScheduledAt={m.scheduledAt}
@@ -496,38 +519,33 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                                 mapPool={mapPool}
                               />
                             ) : (
-                              <>
-                                {m.status === "scheduled" && (
-                                  <VetoInputDialog
-                                    matchId={m.id}
-                                    format={m.format as "bo1" | "bo3" | "bo5"}
-                                    teamAName={teamAName}
-                                    teamBName={teamBName}
-                                    teamAId={m.teamAId}
-                                    teamBId={m.teamBId}
-                                    mapPool={mapPool}
-                                  />
-                                )}
-                                <ScoreInput
-                                  matchId={m.id}
-                                  teamAName={teamAName}
-                                  teamBName={teamBName}
-                                  currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                                  format={m.format as "bo1" | "bo3" | "bo5"}
-                                />
-                                {m.status === "scheduled" && (
-                                  <DeleteMatchButton matchId={m.id} />
-                                )}
-                              </>
+                              <ScoreInput
+                                matchId={m.id}
+                                teamAName={teamAName}
+                                teamBName={teamBName}
+                                currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                                format={m.format as "bo1" | "bo3" | "bo5"}
+                              />
                             )}
                           </>
                         )}
                         {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
                           <div key={map.id}>
-                            <Separator />
                             <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
                           </div>
                         ))}
+                        <div className="flex items-center justify-between gap-2">
+                          <Link
+                            href={`/${seasonSlug}/matches/${m.id}`}
+                            className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
+                            target="_blank"
+                          >
+                            查看公开页 ↗
+                          </Link>
+                          {m.bracketNodeId == null && (
+                            <DeleteMatchButton matchId={m.id} />
+                          )}
+                        </div>
                       </Panel>
                     );
                   })}


### PR DESCRIPTION
## Summary
- **删除放开**：`deleteMatch` 移除 status 限制，所有非 bracket 比赛均可删除（不再仅限 scheduled）
- **后台赛程布局优化**：AdminRosterDialog/VetoInputDialog 按钮排列为 flex 行，ScoreInput/ScheduledAtInput 保持全宽
- **公开页直达链接**：每场比赛底部右侧添加「查看公开页 ↗」链接
- **删除按钮对所有状态可见**：finished/cancelled 比赛也能删除

🤖 Generated with [Claude Code](https://claude.com/claude-code)