### PR TITLE
v1.13.1: hotfix 合集 — 删除放开/自动填名单/UI提示/查询崩溃修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-05-17
+
+### Added
+- **开赛自动填名单**：点「开始比赛」时自动为两队取前 5 人作为默认首发（若队长未提交）
+- **队长名单时间提示**：比赛详情页显示距开赛剩余时间、2 小时内锁警告、裁判检查提醒
+- **时间协商名单提醒**：队长未提交名单时显示黄色警告条「请先提交赛前名单」
+
+### Fixed
+- **删除放开**：`deleteMatch` 移除 status 限制，所有非 bracket 比赛均可删除
+- **后台布局优化**：AdminRosterDialog/VetoInputDialog 同行排列 + 每场比赛底部「查看公开页 ↗」链接
+- **Drizzle 关系查询崩溃**：`VetoView` 和 admin roster 查询改用 `db.select()` 绕过 `buildRelationalQueryWithoutPK`
+- **TOCTOU 竞态**：`recordMapResult` 地图重复检查移入事务内部
+- **hasSubmittedRoster 默认值**：从 `true` 改为 `false`，忘记传 prop 时不会静默隐藏名单提醒
+- **auto-fill 确定性**：默认队员按 `joinedAt` 排序，移除未用变量
+
 ## [1.13.0] - 2026-05-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -77,32 +77,34 @@ export async function updateMatchStatus(
 
       // 开赛时自动为两队填充默认名单（若尚未提交）
       if (nextStatus === "in_progress") {
+        const existingRosters = await tx.query.matchRosters.findMany({
+          where: and(
+            eq(matchRosters.matchId, matchId),
+            inArray(matchRosters.teamId, [match.teamAId, match.teamBId]),
+          ),
+        });
+        const existingTeamIds = new Set(existingRosters.map((r) => r.teamId));
+
         for (const teamId of [match.teamAId, match.teamBId]) {
-          const existing = await tx.query.matchRosters.findFirst({
-            where: and(
-              eq(matchRosters.matchId, matchId),
-              eq(matchRosters.teamId, teamId),
-            ),
-          });
-          if (!existing) {
-            const starterIds = await tx
-              .select({ id: teamMembers.id })
-              .from(teamMembers)
-              .where(eq(teamMembers.teamId, teamId))
-              .limit(5);
-            if (starterIds.length > 0) {
-              const [roster] = await tx
-                .insert(matchRosters)
-                .values({ matchId, teamId, submittedBy: session.userId })
-                .returning({ id: matchRosters.id });
-              await tx.insert(matchRosterPlayers).values(
-                starterIds.map((s, i) => ({
-                  rosterId: roster.id,
-                  teamMemberId: s.id,
-                  isStarter: true,
-                })),
-              );
-            }
+          if (existingTeamIds.has(teamId)) continue;
+          const starterIds = await tx
+            .select({ id: teamMembers.id })
+            .from(teamMembers)
+            .where(eq(teamMembers.teamId, teamId))
+            .orderBy(asc(teamMembers.joinedAt))
+            .limit(5);
+          if (starterIds.length > 0) {
+            const [roster] = await tx
+              .insert(matchRosters)
+              .values({ matchId, teamId, submittedBy: session.userId })
+              .returning({ id: matchRosters.id });
+            await tx.insert(matchRosterPlayers).values(
+              starterIds.map((s) => ({
+                rosterId: roster.id,
+                teamMemberId: s.id,
+                isStarter: true,
+              })),
+            );
           }
         }
       }
@@ -215,7 +217,7 @@ export async function recordMatchResult(
   }
 }
 
-// ── 录入单图结果（BO3/BO5） ───────────────────────────────────────────────
+// ── 录入单图结果（BO1/BO3/BO5） ───────────────────────────────────────────────
 
 /**
  * 录入一张地图的比赛结果。

--- a/src/actions/matches/roster.ts
+++ b/src/actions/matches/roster.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchRosters, matchRosterPlayers, teamMembers, seasons, auditLogs } from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
@@ -14,12 +14,9 @@ async function validateTeamMembers(teamId: string, memberIds: string[]): Promise
   const rows = await db
     .select({ id: teamMembers.id })
     .from(teamMembers)
-    .where(eq(teamMembers.teamId, teamId));
-  const validIds = new Set(rows.map((r) => r.id));
-  for (const id of memberIds) {
-    if (!validIds.has(id)) {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "队员不属于本队");
-    }
+    .where(and(eq(teamMembers.teamId, teamId), inArray(teamMembers.id, memberIds)));
+  if (rows.length !== new Set(memberIds).size) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "队员不属于本队");
   }
 }
 

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -370,7 +370,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
-                        <Separator />
+                        {m.status !== "cancelled" && <Separator />}
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
                             <div className="flex flex-wrap items-center gap-2">
@@ -468,7 +468,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
-                        <Separator />
+                        {m.status !== "cancelled" && <Separator />}
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
                             <div className="flex flex-wrap items-center gap-2">

--- a/src/components/matches/MatchTimeNegotiation.tsx
+++ b/src/components/matches/MatchTimeNegotiation.tsx
@@ -22,7 +22,7 @@ interface MatchTimeNegotiationProps {
   currentScheduledAt: Date | null;
   currentCompletionDeadline: Date | null;
   initialProposals: Proposal[];
-  hasSubmittedRoster?: boolean;
+  hasSubmittedRoster: boolean;
 }
 
 export function MatchTimeNegotiation({
@@ -34,7 +34,7 @@ export function MatchTimeNegotiation({
   currentScheduledAt,
   currentCompletionDeadline,
   initialProposals,
-  hasSubmittedRoster = true,
+  hasSubmittedRoster = false,
 }: MatchTimeNegotiationProps) {
   const [isPending, startTransition] = useTransition();
   const [proposedTime, setProposedTime] = useState("");


### PR DESCRIPTION
## Summary
- 开赛自动填名单（无 roster 时取前 5 人）
- 队长名单时间提示 + 时间协商名单提醒
- deleteMatch 放开所有非 bracket 比赛
- 后台布局优化 + 公开页直达链接
- Drizzle `buildRelationalQueryWithoutPK` 崩溃修复（2 处）
- TOCTOU 竞态修复 + hasSubmittedRoster 默认值修正
- auto-fill 确定性排序 + Separator 孤立修复 + validateTeamMembers SQL 优化

🤖 Generated with [Claude Code](https://claude.com/claude-code)