### PR TITLE
fix: BP 录入放开 in_progress + 流程调整（开始→BP→比分）

### DIFF
--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -26,10 +26,10 @@ export async function saveVetoSteps(
     const match = await getMatchOrThrow(matchId);
     const session = await requireSeasonAdmin(match.seasonId);
 
-    if (match.status !== "scheduled") {
+    if (match.status !== "scheduled" && match.status !== "in_progress") {
       throw new AppError(
         ErrorCode.MATCH_INVALID_TRANSITION,
-        "仅 scheduled 状态的比赛可录入 BP",
+        "仅「待进行」或「进行中」状态的比赛可录入 BP",
       );
     }
 

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -374,41 +374,41 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                         {m.status !== "finished" && m.status !== "cancelled" && (
                           <>
                             <div className="flex flex-wrap items-center gap-2">
-                              <AdminRosterDialog
-                                matchId={m.id}
-                                teamAName={teamAName}
-                                teamBName={teamBName}
-                                teamAId={m.teamAId}
-                                teamBId={m.teamBId}
-                                teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
-                                teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
-                                teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                                teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                              />
-                              {m.status === "scheduled" && (
-                                <VetoInputDialog
-                                  matchId={m.id}
-                                  format={m.format as "bo1" | "bo3" | "bo5"}
-                                  teamAName={teamAName}
-                                  teamBName={teamBName}
-                                  teamAId={m.teamAId}
-                                  teamBId={m.teamBId}
-                                  mapPool={mapPool}
-                                />
-                              )}
-                            </div>
-                            <ScheduledAtInput
+                          <AdminRosterDialog
+                            matchId={m.id}
+                            teamAName={teamAName}
+                            teamBName={teamBName}
+                            teamAId={m.teamAId}
+                            teamBId={m.teamBId}
+                            teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
+                            teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
+                            teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                            teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                          />
+                          {(m.status === "scheduled" || m.status === "in_progress") && (
+                            <VetoInputDialog
                               matchId={m.id}
-                              currentScheduledAt={m.scheduledAt}
-                              currentCompletionDeadline={m.completionDeadline}
-                            />
-                            <ScoreInput
-                              matchId={m.id}
+                              format={m.format as "bo1" | "bo3" | "bo5"}
                               teamAName={teamAName}
                               teamBName={teamBName}
-                              currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                              format={m.format as "bo1" | "bo3" | "bo5"}
+                              teamAId={m.teamAId}
+                              teamBId={m.teamBId}
+                              mapPool={mapPool}
                             />
+                          )}
+                        </div>
+                        <ScheduledAtInput
+                          matchId={m.id}
+                          currentScheduledAt={m.scheduledAt}
+                          currentCompletionDeadline={m.completionDeadline}
+                        />
+                        <ScoreInput
+                          matchId={m.id}
+                          teamAName={teamAName}
+                          teamBName={teamBName}
+                          currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                          format={m.format as "bo1" | "bo3" | "bo5"}
+                        />
                           </>
                         )}
                         {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
@@ -483,7 +483,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                                 teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                                 teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                               />
-                              {m.status === "scheduled" && (
+                              {(m.status === "scheduled" || m.status === "in_progress") && (
                                 <VetoInputDialog
                                   matchId={m.id}
                                   format={m.format as "bo1" | "bo3" | "bo5"}


### PR DESCRIPTION
## Summary
- `saveVetoSteps` 允许 `in_progress` 状态录入 BP（之前仅限 `scheduled`）
- VetoInputDialog 在双 Tab 面板中对 `scheduled` 和 `in_progress` 都可见
- 标准流程：开始比赛 → 录入 BP → 逐图录入比分

🤖 Generated with [Claude Code](https://claude.com/claude-code)