### PR TITLE
fix: 名单 2h 窗口锁定 + 窗口外允许自由修改重提交

### DIFF
--- a/src/actions/matches/roster.ts
+++ b/src/actions/matches/roster.ts
@@ -71,10 +71,6 @@ export async function submitMatchRoster(
           eq(matchRosters.teamId, teamId),
         ),
       });
-      if (existing && existing.status === "submitted") {
-        throw new AppError(ErrorCode.VALIDATION_FAILED, "名单已锁定，联系管理员解锁");
-      }
-
       let rosterId: string;
       if (existing) {
         rosterId = existing.id;

--- a/src/components/matches/MatchRosterForm.tsx
+++ b/src/components/matches/MatchRosterForm.tsx
@@ -127,7 +127,8 @@ export function MatchRosterForm({
               key={m.id}
               type="button"
               onClick={() => toggleStarter(m.id)}
-              className={playerBtnClass(selectedStarterIds.includes(m.id))}
+              disabled={isWithin2Hours || isMatchStarted}
+              className={playerBtnClass(selectedStarterIds.includes(m.id), isWithin2Hours || isMatchStarted)}
             >
               <span className="text-sm font-medium">{getDisplayName(m)}</span>
               <PosChip pos={m.primaryPosition} />
@@ -147,10 +148,10 @@ export function MatchRosterForm({
               key={m.id}
               type="button"
               onClick={() => toggleSubstitute(m.id)}
-              disabled={selectedStarterIds.includes(m.id)}
+              disabled={selectedStarterIds.includes(m.id) || isWithin2Hours || isMatchStarted}
               className={playerBtnClass(
                 selectedSubstituteIds.includes(m.id),
-                selectedStarterIds.includes(m.id),
+                selectedStarterIds.includes(m.id) || isWithin2Hours || isMatchStarted,
               )}
             >
               <span className="text-sm font-medium">{getDisplayName(m)}</span>
@@ -163,7 +164,7 @@ export function MatchRosterForm({
         </p>
       </div>
 
-      {!hasExistingRoster && !isWithin2Hours && !isMatchStarted && (
+      {!isWithin2Hours && !isMatchStarted && (
         <Button
           onClick={handleSubmit}
           disabled={isPending || selectedStarterIds.length !== 5}
@@ -172,9 +173,9 @@ export function MatchRosterForm({
           提交名单
         </Button>
       )}
-      {hasExistingRoster && (
+      {isWithin2Hours && hasExistingRoster && (
         <p className="text-xs text-[var(--color-fg-dim)]">
-          名单已提交，如需修改请联系管理员
+          名单已锁定，距开赛不足 2 小时
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- 移除 `submitMatchRoster` 中的 `status === "submitted"` 永久锁定
- 锁定逻辑统一为距开赛 2 小时内不可修改
- 2 小时窗口外可自由修改和重提交
- 锁定期间玩家选择按钮 disabled

## Before
- 提交过一次 → 永久锁定（即使距开赛还有 5 小时）
- 必须管理员 unlock 才能重新提交

## After
- 距开赛 > 2h → 自由提交/修改
- 距开赛 < 2h → 锁定，需管理员解锁

🤖 Generated with [Claude Code](https://claude.com/claude-code)