### PR TITLE
v1.14.0: 在线人数 + 赛程子Tab + OCR宽松解析 + 名单2h窗口

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2026-05-17
+
+### Added
+- **在线人数统计**：`user_sessions` 表 + `OnlineCounter` 组件，每 2 分钟心跳，5 分钟内有活动的用户计为在线
+- **赛程总览子 Tab**：排位赛/正赛内分「待进行」「已结束」子 Tab，已排期比赛按时间由近及远排序
+- **BP 选边归属修正**：decider 步骤选边由对方选择时正确翻转 Team A 起始边
+- **OCR 逐行宽松解析**：单行校验失败跳过而非整批丢弃，兼容不同格式截图
+- **名单 2 小时窗口锁定**：距开赛 >2h 自由提交/修改，<2h 锁定，玩家按钮同步禁用
+
+### Fixed
+- **BP 录入放开 in_progress**：saveVetoSteps 允许 in_progress 状态，标准流程「开始→BP→比分」
+- **VetoInputDialog 双 Tab 面板同步**：排位赛和正赛都可见
+- **名单 UI 状态修正**：StatusPill "finished" 绿色误导 → 纯文字 "已提交"，倒计时文案加 2h 锁定警告
+
+### Changed
+- **Simplify 审查修复**：预索引 teamMembersByTeam（O(1) 查表）、移除冗余 new Date()、提取 resolveTeamASide helper
+
 ## [1.13.1] - 2026-05-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -86,7 +86,9 @@ export async function saveVetoSteps(
             mapOrder: i + 1,
             mapName: s.mapName,
             pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
-            teamAStartSide: s.side ?? null,
+            teamAStartSide: s.side
+              ? s.teamId === match.teamAId ? s.side : s.side === "t" ? "ct" : "t"
+              : null,
           })),
         );
       }

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -11,6 +11,12 @@ import { revalidateMatchPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig } from "@/types/season";
 import type { VetoActionType } from "@/types/match";
 
+function resolveTeamASide(selectedSide: string, selectingTeamId: string | null, teamAId: string): "t" | "ct" | null {
+  if (!selectedSide || !selectingTeamId) return null;
+  if (selectingTeamId === teamAId) return selectedSide as "t" | "ct";
+  return selectedSide === "t" ? "ct" : "t";
+}
+
 export interface VetoStepInput {
   actionType: VetoActionType;
   mapName: string;
@@ -86,9 +92,7 @@ export async function saveVetoSteps(
             mapOrder: i + 1,
             mapName: s.mapName,
             pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
-            teamAStartSide: s.side
-              ? s.teamId === match.teamAId ? s.side : s.side === "t" ? "ct" : "t"
-              : null,
+            teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
           })),
         );
       }

--- a/src/actions/online.ts
+++ b/src/actions/online.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { db } from "@/db/client";
+import { userSessions } from "@/db/schema";
+import { getUserSession } from "@/lib/auth/session";
+
+export async function touchSession(): Promise<void> {
+  const session = await getUserSession();
+  if (!session?.userId) return;
+
+  await db
+    .insert(userSessions)
+    .values({ userId: session.userId, lastActiveAt: new Date() })
+    .onConflictDoUpdate({
+      target: userSessions.userId,
+      set: { lastActiveAt: new Date() },
+    });
+}

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { eq, and, asc, count } from "drizzle-orm";
+import { eq, asc } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, teams } from "@/db/schema";
 import { serializeBracket } from "@/lib/bracket";
@@ -68,7 +68,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
       const aTime = a.scheduledAt?.getTime() ?? Infinity;
       const bTime = b.scheduledAt?.getTime() ?? Infinity;
       if (aTime !== bTime) return aTime - bTime;
-      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      return a.createdAt.getTime() - b.createdAt.getTime();
     });
 
   const splitMatches = (list: typeof allMatches) => ({

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -62,6 +62,23 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   const qualifierMatches = qualifierMatchesAll.filter(matchFilter);
   const playoffMatches = playoffMatchesAll.filter(matchFilter);
 
+  // 排序：已排期（由近及远）→ 未排期
+  const sortMatchList = (list: typeof allMatches) =>
+    [...list].sort((a, b) => {
+      const aTime = a.scheduledAt?.getTime() ?? Infinity;
+      const bTime = b.scheduledAt?.getTime() ?? Infinity;
+      if (aTime !== bTime) return aTime - bTime;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+
+  const splitMatches = (list: typeof allMatches) => ({
+    active: sortMatchList(list.filter((m) => m.status !== "finished" && m.status !== "cancelled")),
+    done: sortMatchList(list.filter((m) => m.status === "finished" || m.status === "cancelled")),
+  });
+
+  const { active: qualifierActive, done: qualifierDone } = splitMatches(qualifierMatches);
+  const { active: playoffActive, done: playoffDone } = splitMatches(playoffMatches);
+
   // 积分榜（仅当有 round_robin 排位赛时计算，使用未筛选的全部排位赛）
   const finishedQualifierMatches = qualifierMatchesAll.filter((m) => m.status === "finished");
   const standings = qualifierStage && qualifierStage.type !== "swiss"
@@ -173,29 +190,38 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                 )}
 
                 {/* 赛程列表 */}
-                {qualifierMatches.length > 0 && (
+                {qualifierMatchesAll.length > 0 && (
                   <section className="space-y-3">
-                    <h2 className="text-lg font-semibold text-[var(--color-fg)]">赛程</h2>
-                    <div className="space-y-2">
-                      {qualifierMatches.map((m) => (
-                        <MatchCard
-                          key={m.id}
-                          matchId={m.id}
-                          seasonSlug={seasonSlug}
-                          teamAName={teamMap.get(m.teamAId) ?? "未知队伍"}
-                          teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
-                          scoreA={m.scoreA}
-                          scoreB={m.scoreB}
-                          stage={qualifierKey}
-                          format={m.format as "bo1" | "bo3" | "bo5"}
-                          status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                        />
-                      ))}
-                    </div>
+                    <Tabs defaultValue="active" className="w-full">
+                      <TabsList className="bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
+                        <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
+                        <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
+                      </TabsList>
+                      <TabsContent value="active" className="mt-4 space-y-2">
+                        {qualifierActive.length > 0 ? qualifierActive.map((m) => (
+                          <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
+                            teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
+                            scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
+                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                        )) : (
+                          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
+                        )}
+                      </TabsContent>
+                      <TabsContent value="done" className="mt-4 space-y-2">
+                        {qualifierDone.length > 0 ? qualifierDone.map((m) => (
+                          <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
+                            teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
+                            scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
+                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                        )) : (
+                          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
+                        )}
+                      </TabsContent>
+                    </Tabs>
                   </section>
                 )}
 
-                {qualifierMatches.length === 0 && (
+                {qualifierMatchesAll.length === 0 && (
                   <div className="text-center py-16 text-[var(--color-fg-mid)]">
                     排位赛赛程尚未生成
                   </div>
@@ -222,29 +248,38 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
             )}
 
             {/* 正赛赛程列表 */}
-            {playoffMatches.length > 0 && (
+            {playoffMatchesAll.length > 0 && (
               <section className="space-y-3">
-                <h2 className="text-lg font-semibold text-[var(--color-fg)]">赛程</h2>
-                <div className="space-y-2">
-                  {playoffMatches.map((m) => (
-                    <MatchCard
-                      key={m.id}
-                      matchId={m.id}
-                      seasonSlug={seasonSlug}
-                      teamAName={teamMap.get(m.teamAId) ?? "TBD"}
-                      teamBName={teamMap.get(m.teamBId) ?? "TBD"}
-                      scoreA={m.scoreA}
-                      scoreB={m.scoreB}
-                      stage={playoffKey}
-                      format={m.format as "bo1" | "bo3" | "bo5"}
-                      status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                    />
-                  ))}
-                </div>
+                <Tabs defaultValue="active" className="w-full">
+                  <TabsList className="bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
+                    <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
+                    <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="active" className="mt-4 space-y-2">
+                    {playoffActive.length > 0 ? playoffActive.map((m) => (
+                      <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
+                        teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
+                        scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
+                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                    )) : (
+                      <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
+                    )}
+                  </TabsContent>
+                  <TabsContent value="done" className="mt-4 space-y-2">
+                    {playoffDone.length > 0 ? playoffDone.map((m) => (
+                      <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
+                        teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
+                        scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
+                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                    )) : (
+                      <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
+                    )}
+                  </TabsContent>
+                </Tabs>
               </section>
             )}
 
-            {playoffMatches.length === 0 && (
+            {playoffMatchesAll.length === 0 && (
               <div className="text-center py-16 text-[var(--color-fg-mid)]">
                 {allQualifierFinished
                   ? "正赛即将开始，敬请期待"

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -176,6 +176,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   }
   let allTeamMembers: TeamMemberData[] = [];
   const rosterByMatch = new Map<string, Map<string, RosterData>>();
+  const teamMembersByTeam = new Map<string, TeamMemberData[]>();
 
   if (matchCount > 0) {
     const displayedMatchIds = qualifierMatches
@@ -235,6 +236,12 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
       perfectName: r.perfectName ?? null,
       primaryPosition: r.primaryPosition,
     }));
+
+    for (const t of allTeamMembers) {
+      const arr = teamMembersByTeam.get(t.teamId) ?? [];
+      arr.push(t);
+      teamMembersByTeam.set(t.teamId, arr);
+    }
 
     for (const roster of rosters) {
       const matchMap =
@@ -380,8 +387,8 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             teamBName={teamBName}
                             teamAId={m.teamAId}
                             teamBId={m.teamBId}
-                            teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
-                            teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
+                            teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                            teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
                             teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                             teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                           />
@@ -478,8 +485,8 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                                 teamBName={teamBName}
                                 teamAId={m.teamAId}
                                 teamBId={m.teamBId}
-                                teamAMembers={allTeamMembers.filter((t) => t.teamId === m.teamAId)}
-                                teamBMembers={allTeamMembers.filter((t) => t.teamId === m.teamBId)}
+                                teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                                teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
                                 teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                                 teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                               />

--- a/src/app/api/online-count/route.ts
+++ b/src/app/api/online-count/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db/client";
+import { userSessions } from "@/db/schema";
+import { sql } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(userSessions)
+    .where(sql`${userSessions.lastActiveAt} > ${fiveMinAgo.toISOString()}`);
+  return NextResponse.json({ count: rows[0]?.count ?? 0 });
+}

--- a/src/components/layout/OnlineCounter.tsx
+++ b/src/components/layout/OnlineCounter.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { touchSession } from "@/actions/online";
+
+export function OnlineCounter() {
+  const [count, setCount] = useState<number | null>(null);
+
+  const fetchCount = useCallback(async () => {
+    const res = await fetch("/api/online-count", { cache: "no-store" });
+    if (res.ok) {
+      const data = await res.json();
+      setCount(data.count);
+    }
+  }, []);
+
+  useEffect(() => {
+    touchSession().then(() => fetchCount());
+    const id = setInterval(() => {
+      touchSession().then(() => fetchCount());
+    }, 120_000); // 每 2 分钟心跳
+    return () => clearInterval(id);
+  }, [fetchCount]);
+
+  if (count === null) return null;
+
+  return (
+    <span className="text-xs text-[var(--color-fg-dim)]">
+      {count} 人在线
+    </span>
+  );
+}

--- a/src/components/layout/OnlineCounter.tsx
+++ b/src/components/layout/OnlineCounter.tsx
@@ -15,11 +15,12 @@ export function OnlineCounter() {
   }, []);
 
   useEffect(() => {
-    touchSession().then(() => fetchCount());
+    let mounted = true;
+    touchSession().then(() => { if (mounted) fetchCount(); });
     const id = setInterval(() => {
-      touchSession().then(() => fetchCount());
+      touchSession().then(() => { if (mounted) fetchCount(); });
     }, 120_000); // 每 2 分钟心跳
-    return () => clearInterval(id);
+    return () => { clearInterval(id); mounted = false; };
   }, [fetchCount]);
 
   if (count === null) return null;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,6 +3,7 @@ import { seasons, users } from "@/db/schema";
 import { getUserSession } from "@/lib/auth/session";
 import { resolveAvatarUrl } from "@/lib/steam";
 import { HeaderClient } from "./header-client";
+import { OnlineCounter } from "./OnlineCounter";
 import { eq } from "drizzle-orm";
 
 export async function Header() {
@@ -37,12 +38,15 @@ export async function Header() {
   }
 
   return (
-    <HeaderClient
-      seasons={publicSeasons}
-      session={session}
-      avatarUrl={avatarUrl}
-      steamName={currentUser?.steamName ?? null}
-      displayName={currentUser?.displayName ?? null}
-    />
+    <>
+      <HeaderClient
+        seasons={publicSeasons}
+        session={session}
+        avatarUrl={avatarUrl}
+        steamName={currentUser?.steamName ?? null}
+        displayName={currentUser?.displayName ?? null}
+      />
+      <OnlineCounter />
+    </>
   );
 }

--- a/src/components/matches/MatchRosterForm.tsx
+++ b/src/components/matches/MatchRosterForm.tsx
@@ -102,7 +102,7 @@ export function MatchRosterForm({
       ) : hoursUntilMatch !== null ? (
         <div className="rounded border border-[var(--color-border)] bg-[var(--color-panel)] p-2">
           <p className="text-xs text-[var(--color-fg-dim)]">
-            距开赛还有 {hoursUntilMatch} 小时，请在确认比赛时间前提交名单。裁判在正式开赛时会检查队员信息，队员不正确将无法进行比赛。
+            距开赛还有 {hoursUntilMatch} 小时。开赛前 2 小时名单将锁定，届时无法修改，请在此之前提交名单。裁判在开赛时会检查队员信息，队员不正确将无法进行比赛。
           </p>
         </div>
       ) : (

--- a/src/components/matches/MatchRosterForm.tsx
+++ b/src/components/matches/MatchRosterForm.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { submitMatchRoster } from "@/actions/matches/roster";
 import { Button } from "@/components/ui/button";
-import { PosChip, StatusPill } from "@/components/rivalhub";
+import { PosChip } from "@/components/rivalhub";
 
 import { getDisplayName } from "@/lib/utils/display-name";
 

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -16,3 +16,4 @@ export * from "./mvp-votes";
 export * from "./match-time-proposals";
 export * from "./match-rosters";
 export * from "./match-veto-steps";
+export * from "./user-sessions";

--- a/src/db/schema/user-sessions.ts
+++ b/src/db/schema/user-sessions.ts
@@ -1,0 +1,8 @@
+import { pgTable, uuid, timestamp } from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+/** 用户活跃心跳表 — 用于在线人数统计，非鉴权用途 */
+export const userSessions = pgTable("user_sessions", {
+  userId: uuid("user_id").primaryKey().references(() => users.id),
+  lastActiveAt: timestamp("last_active_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/src/lib/ocr/siliconflow.ts
+++ b/src/lib/ocr/siliconflow.ts
@@ -1,4 +1,4 @@
-import { ocrResponseSchema, type ScoreboardOCRResult, type OCRProvider } from "./types";
+import { ocrResponseSchema, playerRowSchema, type ScoreboardOCRResult, type OCRProvider } from "./types";
 
 const DEFAULT_API_URL = "https://api.siliconflow.cn/v1/chat/completions";
 const DEFAULT_MODEL = "PaddlePaddle/PaddleOCR-VL-1.5";
@@ -134,13 +134,28 @@ async function extract(base64Image: string, mimeType: string): Promise<Scoreboar
   }
 
   const parsed = extractJson(result.content);
-  const validated = ocrResponseSchema.safeParse(parsed);
-  if (!validated.success) {
-    const issues = validated.error.issues.map((i) => i.message).join("; ");
+  const structure = ocrResponseSchema.safeParse(parsed);
+  if (!structure.success) {
+    // 顶层结构不对（players 不是数组或为空），直接报错
+    const issues = structure.error.issues.map((i) => i.message).join("; ");
     throw new Error(`OCR 结果格式校验失败: ${issues}`);
   }
 
-  return validated.data;
+  // 逐行宽松校验：单行失败则丢弃，不拖累整批
+  const validPlayers = structure.data.players.filter((row, idx) => {
+    const r = playerRowSchema.safeParse(row);
+    if (!r.success) {
+      console.warn(`[OCR] 第 ${idx + 1} 行校验失败，已丢弃`, r.error.issues);
+      return false;
+    }
+    return true;
+  });
+
+  if (validPlayers.length === 0) {
+    throw new Error("OCR 结果格式校验失败：没有可用的玩家数据行");
+  }
+
+  return { players: validPlayers };
 }
 
 export const siliconflowProvider: OCRProvider = {


### PR DESCRIPTION
## Summary
- 在线人数统计（user_sessions 表 + OnlineCounter 组件）
- 赛程总览「待进行/已结束」子 Tab + 按开赛时间排序
- BP decider 选边归属修正
- OCR 逐行宽松解析（单行失败不拖累整批）
- 名单 2h 窗口锁定（>2h 自由修改，<2h 锁定）
- BP 录入放开 in_progress
- 多项 simplify 审查修复

## Issues Closed
- Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)