### PR TITLE
v1.14.1 — OCR 校验放宽 + 赛程时间显示 + 队伍页历史战绩

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.1] - 2026-05-17
+
+### Fixed
+- **OCR 校验彻底放宽**：顶层仅校验数组结构（不再因单行缺字段整批丢弃），行级仅要求玩家名称非空，数值字段自动转换（`"15"` → `15`、`"N/A"` → `null`），移除所有范围上限
+- **赛程总览显示比赛时间**：MatchCard 已排期显示日期、未排期显示「未排期」
+- **队伍详情页补全**：新增「历史战绩」列表（比分/BO1·BO3/阶段/详情链接），调整顺序为阵容→即将进行→历史战绩
+
 ## [1.14.0] - 2026-05-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -202,7 +202,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                           <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                             teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
                             scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                            scheduledAt={m.scheduledAt} />
                         )) : (
                           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
                         )}
@@ -212,7 +213,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                           <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                             teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
                             scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                            scheduledAt={m.scheduledAt} />
                         )) : (
                           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
                         )}
@@ -260,7 +262,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                       <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                         teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
                         scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                        scheduledAt={m.scheduledAt} />
                     )) : (
                       <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
                     )}
@@ -270,7 +273,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                       <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                         teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
                         scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                        scheduledAt={m.scheduledAt} />
                     )) : (
                       <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
                     )}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -267,33 +267,6 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         <Stat label="负" value={totalLosses} />
       </div>
 
-      {/* 即将进行的比赛 */}
-      {upcomingMatches.length > 0 && (
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-[var(--color-fg)]">即将进行的比赛</h2>
-          <div className="space-y-2">
-            {upcomingMatches.map((m) => {
-              const oppId = m.teamAId === teamId ? m.teamBId : m.teamAId;
-              const oppTeam = teamNameMap.get(oppId);
-              return (
-                <MatchCard
-                  key={m.id}
-                  matchId={m.id}
-                  seasonSlug={seasonSlug}
-                  teamAName={m.teamAId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
-                  teamBName={m.teamBId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
-                  scoreA={m.scoreA}
-                  scoreB={m.scoreB}
-                  stage={m.stage}
-                  format={m.format as "bo1" | "bo3" | "bo5"}
-                  status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                />
-              );
-            })}
-          </div>
-        </section>
-      )}
-
       {/* 阵容 */}
       <section>
         <Panel label="阵容" pad={20}>
@@ -335,6 +308,68 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           </div>
         </Panel>
       </section>
+
+      {/* 即将进行的比赛 */}
+      {upcomingMatches.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">即将进行的比赛</h2>
+          <div className="space-y-2">
+            {upcomingMatches.map((m) => {
+              const oppId = m.teamAId === teamId ? m.teamBId : m.teamAId;
+              const oppTeam = teamNameMap.get(oppId);
+              return (
+                <MatchCard
+                  key={m.id}
+                  matchId={m.id}
+                  seasonSlug={seasonSlug}
+                  teamAName={m.teamAId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                  teamBName={m.teamBId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                  scoreA={m.scoreA}
+                  scoreB={m.scoreB}
+                  stage={m.stage}
+                  format={m.format as "bo1" | "bo3" | "bo5"}
+                  status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                  scheduledAt={m.scheduledAt}
+                />
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* 历史战绩 */}
+      {teamMatches.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">历史战绩</h2>
+          <div className="space-y-2">
+            {[...teamMatches]
+              .sort((a, b) => {
+                const aTime = a.scheduledAt?.getTime() ?? a.createdAt.getTime();
+                const bTime = b.scheduledAt?.getTime() ?? b.createdAt.getTime();
+                return bTime - aTime;
+              })
+              .map((m) => {
+                const oppId = m.teamAId === teamId ? m.teamBId : m.teamAId;
+                const oppTeam = teamNameMap.get(oppId);
+                return (
+                  <MatchCard
+                    key={m.id}
+                    matchId={m.id}
+                    seasonSlug={seasonSlug}
+                    teamAName={m.teamAId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                    teamBName={m.teamBId === teamId ? team.name : (oppTeam?.name ?? "TBD")}
+                    scoreA={m.scoreA}
+                    scoreB={m.scoreB}
+                    stage={m.stage}
+                    format={m.format as "bo1" | "bo3" | "bo5"}
+                    status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                    scheduledAt={m.scheduledAt}
+                  />
+                );
+              })}
+          </div>
+        </section>
+      )}
 
       {/* 队内联系方式（仅同队成员可见） */}
       {isTeamMember && (

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { MatchStatusBadge } from "./MatchStatusBadge";
 import { MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
+import { formatCSTShortDate } from "@/lib/utils/date";
 import type { MatchFormat } from "@/types/match";
 
 interface MatchCardProps {
@@ -15,6 +16,7 @@ interface MatchCardProps {
   stage: string;
   format: MatchFormat;
   status: "scheduled" | "in_progress" | "finished" | "cancelled";
+  scheduledAt?: Date | string | null;
 }
 
 export function MatchCard({
@@ -27,7 +29,15 @@ export function MatchCard({
   stage,
   format,
   status,
+  scheduledAt,
 }: MatchCardProps) {
+  const timeText =
+    status === "scheduled" && scheduledAt
+      ? formatCSTShortDate(scheduledAt)
+      : status === "scheduled" && !scheduledAt
+        ? "未排期"
+        : null;
+
   return (
     <Link href={`/${seasonSlug}/matches/${matchId}`}>
       <Card className="p-4 hover:bg-[var(--color-panel-hi)] transition-colors cursor-pointer">
@@ -42,6 +52,9 @@ export function MatchCard({
             <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            {timeText && (
+              <span className="text-xs text-[var(--color-fg-mid)]">{timeText}</span>
+            )}
             <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
               {MATCH_STAGE_LABELS[stage] ?? stage}
             </Badge>

--- a/src/lib/ocr/siliconflow.ts
+++ b/src/lib/ocr/siliconflow.ts
@@ -1,4 +1,4 @@
-import { ocrResponseSchema, playerRowSchema, type ScoreboardOCRResult, type OCRProvider } from "./types";
+import { ocrResponseSchema, playerRowLenientSchema, type ScoreboardOCRResult, type OCRProvider, type PlayerRowOCR } from "./types";
 
 const DEFAULT_API_URL = "https://api.siliconflow.cn/v1/chat/completions";
 const DEFAULT_MODEL = "PaddlePaddle/PaddleOCR-VL-1.5";
@@ -141,15 +141,18 @@ async function extract(base64Image: string, mimeType: string): Promise<Scoreboar
     throw new Error(`OCR 结果格式校验失败: ${issues}`);
   }
 
-  // 逐行宽松校验：单行失败则丢弃，不拖累整批
-  const validPlayers = structure.data.players.filter((row, idx) => {
-    const r = playerRowSchema.safeParse(row);
+  // 逐行校验：仅丢弃无法识别玩家名称的行，数值字段尽力转换
+  const validPlayers: PlayerRowOCR[] = [];
+  let idx = 0;
+  for (const row of structure.data.players) {
+    const r = playerRowLenientSchema.safeParse(row);
     if (!r.success) {
-      console.warn(`[OCR] 第 ${idx + 1} 行校验失败，已丢弃`, r.error.issues);
-      return false;
+      console.warn(`[OCR] 第 ${idx + 1} 行无有效玩家名称，已丢弃`, r.error.issues);
+    } else {
+      validPlayers.push(r.data);
     }
-    return true;
-  });
+    idx++;
+  }
 
   if (validPlayers.length === 0) {
     throw new Error("OCR 结果格式校验失败：没有可用的玩家数据行");

--- a/src/lib/ocr/types.ts
+++ b/src/lib/ocr/types.ts
@@ -1,5 +1,20 @@
 import { z } from "zod";
 
+// 尽力将任意值转为 number，无法转换则返回 null
+const numOrNull = z.preprocess(
+  (v) => {
+    if (v === null || v === undefined) return null;
+    if (typeof v === "number" && !Number.isNaN(v)) return v;
+    if (typeof v === "string") {
+      const n = Number(v);
+      if (!Number.isNaN(n)) return n;
+    }
+    return null;
+  },
+  z.number().nullable().default(null),
+);
+
+// 严格版（保留供参考）
 export const playerRowSchema = z.object({
   perfectName: z.string(),
   kills: z.number().int().nonnegative().nullable().default(null),
@@ -15,12 +30,30 @@ export const playerRowSchema = z.object({
   we: z.number().min(0).max(16).nullable().default(null),
 });
 
-export const ocrResponseSchema = z.object({
-  players: z.array(playerRowSchema).min(1).max(20),
+// 宽松版：仅要求 perfectName 非空，数值字段尽力转换，不设上下限
+export const playerRowLenientSchema = z.object({
+  perfectName: z.string().min(1),
+  kills: numOrNull,
+  deaths: numOrNull,
+  assists: numOrNull,
+  hsPercent: numOrNull,
+  firstKills: numOrNull,
+  multiKills: numOrNull,
+  clutches: numOrNull,
+  adr: numOrNull,
+  rws: numOrNull,
+  ratingPro: numOrNull,
+  we: numOrNull,
 });
 
-export type PlayerRowOCR = z.infer<typeof playerRowSchema>;
-export type ScoreboardOCRResult = z.infer<typeof ocrResponseSchema>;
+export const ocrResponseSchema = z.object({
+  // 顶层仅校验 players 是数组（1-20 个元素），不做逐行字段校验
+  // 逐行过滤在 siliconflow.ts 中用 playerRowLenientSchema 完成
+  players: z.array(z.unknown()).min(1).max(20),
+});
+
+export type PlayerRowOCR = z.infer<typeof playerRowLenientSchema>;
+export type ScoreboardOCRResult = { players: PlayerRowOCR[] };
 
 export interface OCRProvider {
   name: string;

--- a/tests/unit/lib/ocr.test.ts
+++ b/tests/unit/lib/ocr.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { playerRowSchema, ocrResponseSchema } from "@/lib/ocr/types";
+import { playerRowSchema, playerRowLenientSchema, ocrResponseSchema } from "@/lib/ocr/types";
 import type { OCRProvider } from "@/lib/ocr/types";
 
-describe("ocrResponseSchema", () => {
+describe("ocrResponseSchema (宽松)", () => {
   it("接受合法 OCR 结果", () => {
     const data = {
       players: [
@@ -54,15 +54,51 @@ describe("ocrResponseSchema", () => {
     expect(r.success).toBe(false);
   });
 
-  it("拒绝缺少 perfectName", () => {
+  it("顶层仅校验数组结构，不拒绝缺少 perfectName 的行（由行级过滤处理）", () => {
     const r = ocrResponseSchema.safeParse({
       players: [{ kills: 10 }],
     });
+    // 顶层通过，缺少 perfectName 的行在 siliconflow.ts 行级过滤中丢弃
+    expect(r.success).toBe(true);
+  });
+
+  it("超出传统范围的值仍然接受", () => {
+    const r = ocrResponseSchema.safeParse({
+      players: [{ perfectName: "x", hsPercent: 150, we: 20 }],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("playerRowLenientSchema", () => {
+  it("字符串数值自动转换", () => {
+    const r = playerRowLenientSchema.safeParse({
+      perfectName: "x", kills: "15", adr: "85.5",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.kills).toBe(15);
+      expect(r.data.adr).toBe(85.5);
+    }
+  });
+
+  it("不可转换的字符串置为 null", () => {
+    const r = playerRowLenientSchema.safeParse({
+      perfectName: "x", kills: "N/A",
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.kills).toBeNull();
+    }
+  });
+
+  it("拒绝空 perfectName", () => {
+    const r = playerRowLenientSchema.safeParse({ perfectName: "" });
     expect(r.success).toBe(false);
   });
 });
 
-describe("playerRowSchema", () => {
+describe("playerRowSchema (严格)", () => {
   it("we 范围 0-16", () => {
     expect(playerRowSchema.safeParse({ perfectName: "x", we: 0 }).success).toBe(true);
     expect(playerRowSchema.safeParse({ perfectName: "x", we: 16 }).success).toBe(true);


### PR DESCRIPTION
## Summary
- OCR 校验彻底放宽：顶层仅校验数组结构，行级仅要求玩家名称非空，数值字段自动转换（`"15"` → `15`、`"N/A"` → `null`），移除所有范围上限
- 赛程总览 MatchCard 显示比赛时间：已排期显示日期，未排期显示「未排期」
- 队伍详情页新增「历史战绩」列表（比分/赛制/阶段/详情链接），调整顺序为阵容→即将进行→历史战绩

## Test plan
- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm test` 383 passed
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)