### PR TITLE
v1.14.2 — OCR 模型修复 + 下拉优化 + 容错

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2026-05-17
+
+### Fixed
+- **OCR 模型切换**：PaddleOCR-VL-1.5 / DeepSeek-OCR 均无法正确理解记分板表格，切换为 Qwen3-VL-8B-Instruct
+- **OCR 兼容多种 JSON 格式**：手动提取 players 数组，兼容直接数组 / `{players}` / `{data:{players}}` 三种 LLM 返回格式
+- **OCR 下拉仅显示两队队员**：从全赛季选手缩小为本场比赛两队成员（≤10 人），排除已被其他行匹配的玩家
+- **OnlineCounter 容错**：`touchSession` 和 API 调用失败时静默跳过，不再阻塞页面渲染
+
+### Changed
+- **OCR 调试日志 gated**：`console.error` 改为 `DEBUG` 门控 `console.log/warn`，仅 dev 或 `OCR_DEBUG=true` 时输出
+- **Code review 清理**：提取 `extractPlayersArray` helper，`useMemo(Set)` 优化下拉过滤 O(n²) → O(n)
+
 ## [1.14.1] - 2026-05-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- OCR 模型切换为 Qwen3-VL-8B-Instruct，正确识别记分板表格
- OCR 兼容多种 LLM JSON 格式（数组/`{players}`/`{data:{players}}`）
- OCR 下拉仅显示两队队员（≤10人），排除已匹配玩家
- OnlineCounter 失败时静默跳过
- Debug 日志加 DEV/OCR_DEBUG gate
- Code review 清理（extractPlayersArray helper、useMemo 优化）

## Test plan
- [x] `pnpm type-check` 通过
- [x] `pnpm test` 383 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)