### PR TITLE
fix: Server Action 数组序列化限制

### DIFF
--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -106,8 +106,9 @@ export async function extractStatsFromScreenshot(
  */
 export async function savePlayerStats(
   mapId: string,
-  stats: PlayerStatsDraft[]
+  input: { rows: PlayerStatsDraft[] }
 ) {
+  const stats = input.rows;
   try {
     const session = await requireAdmin();
     const actor = auditActorId(session);

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -126,7 +126,7 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
   async function handleSave() {
     setSaving(true);
     setError(null);
-    const result = await savePlayerStats(mapId, drafts);
+    const result = await savePlayerStats(mapId, { rows: drafts });
     setSaving(false);
 
     if (!result.success) {


### PR DESCRIPTION
savePlayerStats 的数组参数包在 {rows} 对象中，解决 Maximum array nesting exceeded 报错