### PR TITLE
release: v1.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.3] - 2026-05-17
+
+### Added
+- **OCR 面板始终可见**：不再依赖识别结果才显示编辑表格，新增「添加行」按钮支持纯手动录入
+
+### Fixed
+- **OCR 大截图序列化崩溃**：extractStatsFromScreenshot 参数装箱，修复 React Flight 对数组内大字符串按 `.length` 计入 arraySizeLimit（1e6）导致的 "Maximum array nesting exceeded" 错误
+- **Server Action 数组序列化**：savePlayerStats / saveVetoSteps / submitMatchRoster / updateMatchRoster 数组参数统一包在对象中，避免 Next.js 序列化限制
+- **OCR 调试日志恢复**：移除过度的 DEBUG gate，日志恢复无条件输出以便生产排查
+
+### Changed
+- **数据库连接切 Transaction Pooler**：端口 5432 → 6543，`prepare: false`，连接池 max 1 → 3
+
 ## [1.14.2] - 2026-05-17
 
 ### Fixed
@@ -406,6 +419,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
+[1.14.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.14.2...v1.14.3
+[1.14.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.14.1...v1.14.2
+[1.14.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.14.0...v1.14.1
+[1.14.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.13.1...v1.14.0
+[1.13.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.10.1...v1.11.0
 [1.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.1...v1.3.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.13.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.14.3，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -32,10 +32,13 @@ export type PlayerOption = {
  * 同时返回赛季中所有已匹配玩家列表供下拉选择。
  */
 export async function extractStatsFromScreenshot(
-  mapId: string,
-  base64Image: string,
-  mimeType: "image/jpeg" | "image/png" | "image/webp" = "image/jpeg"
+  input: {
+    mapId: string;
+    base64Image: string;
+    mimeType: "image/jpeg" | "image/png" | "image/webp";
+  },
 ) {
+  const { mapId, base64Image, mimeType } = input;
   try {
     await requireAdmin();
 

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -75,7 +75,7 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
     try {
       const base64 = await fileToBase64(file);
       const mimeType = file.type as "image/jpeg" | "image/png" | "image/webp";
-      const result = await extractStatsFromScreenshot(mapId, base64, mimeType);
+      const result = await extractStatsFromScreenshot({ mapId, base64Image: base64, mimeType });
 
       if (!result.success) {
         setError(result.error.message);


### PR DESCRIPTION
## Summary
- **OCR 大截图崩溃修复**：`extractStatsFromScreenshot` 参数装箱，修复 React Flight 对数组内大字符串按 `.length` 计入 `arraySizeLimit`（1e6）导致的 "Maximum array nesting exceeded" 错误
- CHANGELOG 补齐 v1.12.0–v1.14.3 比较链接
- CLAUDE.md 版本号同步至 v1.14.3

## Changes since v1.14.2
- `src/actions/player-stats.ts`: `extractStatsFromScreenshot` 三参数改为单对象参数
- `src/components/matches/StatsOCRPanel.tsx`: 调用方同步更新
- `CHANGELOG.md`: 新增 v1.14.3 条目 + 补齐 7 条比较链接
- `CLAUDE.md`: 版本号 v1.13.0 → v1.14.3

## Test plan
- [ ] OCR 大截图（>1MB PNG）不再报 "Maximum array nesting exceeded"
- [ ] OCR 小截图正常识别
- [ ] 手动添加行 + 保存功能正常
- [ ] 类型检查通过 (`pnpm tsc --noEmit`)