### PR TITLE
feat: map performance panel, MatchTabsSection, type guards (#125 #126 #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2026-05-18
+
+### Fixed
+- **MVP 次数统计修正**：选手个人页 MVP 计数从「总票数」改为「单场 MVP 获奖次数」；新增 `matches.mvp_winner_user_id` 持久化缓存，避免每次页面访问遍历全表投票记录；UI 标签改为「单场MVP」
+
+### Added
+- `ensureMvpWinner(matchId)` — 投票截止后首次访问比赛页时自动锁定 MVP 胜者（幂等）
+
 ## [1.15.0] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-05-18
+
+### Added
+- **MVP 投票重构**：候选人由全部选手改为 Rating 前 4 名；候选人大卡展示完整数据（K/D/A/ADR/RWS/HS%/FK/MK/残局/Rating/WE）；多地图数据智能聚合（击杀类求和、场均类取均值、HS% 按击杀加权）；比赛结束 24 小时后自动截止投票并展示最终 MVP
+- **赛程管理队伍筛选**：AdminMatchFilter 新增队伍下拉筛选；赛程按「进行中→已排期(越近越靠前)→已完成→已取消」排序
+- **地图结果表格** PlayerStatsTable 新增 HS%/FK/MK/残局列
+- `sumNums` / `avgNums` / `weightedAvgNums` 通用聚合函数（`src/lib/utils/stats.ts`）
+- `MVP_DEADLINE_MS` 共享常量 + `getMatchPlayerOptions` / `getMatchVetoSteps` action
+- **管理后台比赛详情增加队伍筛选** + 按开赛时间排序
+
+### Changed
+- **BP 录入流程优化**：BP 仅在比赛「进行中」时可用；打开对话框自动回填已保存数据（不再每次重置）
+- **OCR 面板视图/编辑双模式**：已有数据时显示只读表格 +「重新录入」按钮；挂载时自动加载已保存数据
+- **管理后台比赛列表增加队伍筛选** + 按开赛时间排序
+
+### Fixed
+- **管理后台 OCR「暂无数据」**：公开页已有数据但管理后台显示空白的 bug
+- **BP 对话框错误处理**：异步加载失败不再卡 loading
+- **StatsOCRPanel useEffect**：加 cleanup 标志防止卸载后 setState
+
 ## [1.14.3] - 2026-05-17
 
 ### Added

--- a/drizzle/migrations/0018_mvp_winner.sql
+++ b/drizzle/migrations/0018_mvp_winner.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches ADD COLUMN mvp_winner_user_id uuid;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -79,12 +79,61 @@
       "tag": "0010_match_time_and_rosters",
       "breakpoints": true
     },
-    {"idx":11,"version":"7","when":1715000000000,"tag":"0011_registration_drafts_and_deadline","breakpoints":true},
-    {"idx":12,"version":"7","when":1715000000000,"tag":"0012_match_completion_deadline","breakpoints":true},
-    {"idx":13,"version":"7","when":1715000000000,"tag":"0013_registration_map_preferences","breakpoints":true},
-    {"idx":14,"version":"7","when":1715000000000,"tag":"0014_user_avatar_url","breakpoints":true},
-    {"idx":15,"version":"7","when":1715000000000,"tag":"0015_team_logo_url","breakpoints":true},
-    {"idx":16,"version":"7","when":1715000000000,"tag":"0016_match_veto_steps","breakpoints":true},
-    {"idx":17,"version":"7","when":1715000000000,"tag":"0017_side_enum","breakpoints":true}
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0011_registration_drafts_and_deadline",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0012_match_completion_deadline",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0013_registration_map_preferences",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0014_user_avatar_url",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0015_team_logo_url",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0016_match_veto_steps",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1715000000000,
+      "tag": "0017_side_enum",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1715100000000,
+      "tag": "0018_mvp_winner",
+      "breakpoints": true
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.49.4",
+    "@vercel/analytics": "^2.0.1",
     "brackets-manager": "^1.9.1",
     "brackets-memory-db": "^1.0.5",
     "brackets-model": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.4
         version: 2.105.3
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       brackets-manager:
         specifier: ^1.9.1
         version: 1.9.1
@@ -1692,6 +1695,35 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -4141,6 +4173,11 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
+
+  '@vercel/analytics@2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    optionalDependencies:
+      next: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -14,7 +14,7 @@ import {
   assertMatchTransition,
   resolveMatchFormat,
 } from "@/lib/match-transitions";
-import { getMaxMaps, getWinThreshold } from "@/types/match";
+import { getMaxMaps, getWinThreshold, isMatchStatus } from "@/types/match";
 import { actionError, getSeasonOrThrow, getMatchOrThrow } from "@/lib/action-utils";
 import { revalidateMatchPaths, revalidateSeasonPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
@@ -66,7 +66,10 @@ export async function updateMatchStatus(
   try {
     const match = await getMatchOrThrow(matchId);
     const session = await requireSeasonAdmin(match.seasonId);
-    assertMatchTransition(match.status as MatchStatus, nextStatus);
+    if (!isMatchStatus(match.status)) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, `无效的比赛状态: ${match.status}`);
+    }
+    assertMatchTransition(match.status, nextStatus);
 
     const seasonForStatus = await getSeasonOrThrow(match.seasonId);
     await db.transaction(async (tx) => {
@@ -161,7 +164,10 @@ export async function recordMatchResult(
       }
     }
     const session = await requireSeasonAdmin(match.seasonId);
-    assertMatchTransition(match.status as MatchStatus, "finished");
+    if (!isMatchStatus(match.status)) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, `无效的比赛状态: ${match.status}`);
+    }
+    assertMatchTransition(match.status, "finished");
 
     const season = await getSeasonOrThrow(match.seasonId);
 

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -115,3 +115,13 @@ export async function saveVetoSteps(
     return actionError("saveVetoSteps", e);
   }
 }
+
+/**
+ * 查询某场比赛已保存的 BP 步骤（按顺序）
+ */
+export async function getMatchVetoSteps(matchId: string) {
+  return db.query.matchVetoSteps.findMany({
+    where: eq(matchVetoSteps.matchId, matchId),
+    orderBy: (t, { asc }) => [asc(t.stepOrder)],
+  });
+}

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -260,6 +260,33 @@ export async function castMatchMvpVote(
   }
 }
 
+/** 确定并持久化比赛 MVP 胜者。已锁定时直接返回；投票未截止则返回 null。幂等。 */
+export async function ensureMvpWinner(matchId: string): Promise<string | null> {
+  try {
+    const match = await db.query.matches.findFirst({
+      where: eq(matches.id, matchId),
+      columns: { id: true, status: true, completedAt: true, mvpWinnerUserId: true },
+    });
+    if (!match || match.status !== "finished" || !match.completedAt) return null;
+    if (match.mvpWinnerUserId) return match.mvpWinnerUserId;
+    if (Date.now() < match.completedAt.getTime() + MVP_DEADLINE_MS) return null;
+
+    const results = await getMatchMvpResults(matchId);
+    if (results.length === 0) return null;
+    const winner = results[0]; // 已按 count DESC 排
+
+    await db
+      .update(matches)
+      .set({ mvpWinnerUserId: winner.playerUserId, updatedAt: new Date() })
+      .where(eq(matches.id, matchId));
+
+    return winner.playerUserId;
+  } catch (e) {
+    console.error("[ensureMvpWinner]", e);
+    return null;
+  }
+}
+
 export async function getMatchMvpResults(matchId: string) {
   const votes = await db
     .select({

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -13,6 +13,7 @@ import { teamMembers } from "@/db/schema/teams";
 import { ok, fail } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { actionError } from "@/lib/action-utils";
+import { MVP_DEADLINE_MS } from "@/lib/utils/date";
 import { extractScoreboardFromBase64 } from "@/lib/ocr";
 import type { PlayerRowOCR } from "@/lib/ocr";
 import { requireAdmin, auditActorId, requireAuth } from "@/lib/auth/session";
@@ -179,6 +180,40 @@ export async function getPlayerStatsByMap(mapId: string) {
   });
 }
 
+/**
+ * 获取某张地图对应比赛的两队选手列表（用于 OCR 编辑时的下拉匹配）
+ */
+export async function getMatchPlayerOptions(mapId: string): Promise<PlayerOption[]> {
+  try {
+    await requireAdmin();
+    const map = await db.query.matchMaps.findFirst({ where: eq(matchMaps.id, mapId) });
+    if (!map) return [];
+    const match = await db.query.matches.findFirst({ where: eq(matches.id, map.matchId) });
+    if (!match) return [];
+
+    const teamMemberRows = await db
+      .select({ registrationId: teamMembers.registrationId })
+      .from(teamMembers)
+      .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId]));
+
+    const teamRegistrationIds = teamMemberRows.map((r) => r.registrationId);
+    if (!teamRegistrationIds.length) return [];
+
+    const seasonPlayers = await db
+      .select({ userId: users.id, perfectName: users.perfectName })
+      .from(users)
+      .innerJoin(seasonRegistrations, eq(seasonRegistrations.userId, users.id))
+      .where(inArray(seasonRegistrations.id, teamRegistrationIds));
+
+    return seasonPlayers.map((p) => ({
+      userId: p.userId,
+      perfectName: p.perfectName ?? "(未填写昵称)",
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function castMatchMvpVote(
   matchId: string,
   playerUserId: string | null,
@@ -196,6 +231,14 @@ export async function castMatchMvpVote(
     if (!match) throw new AppError(ErrorCode.MATCH_NOT_FOUND, ERROR_MESSAGES.MATCH_NOT_FOUND);
     if (match.status !== "finished") {
       return fail({ code: ErrorCode.MATCH_INVALID_TRANSITION, message: "比赛尚未结束" });
+    }
+
+    // 比赛结束 24 小时后停止投票
+    if (match.completedAt) {
+      const deadline = match.completedAt.getTime() + MVP_DEADLINE_MS;
+      if (Date.now() >= deadline) {
+        return fail({ code: ErrorCode.MATCH_INVALID_TRANSITION, message: "MVP 投票已截止" });
+      }
     }
 
     await db.insert(matchMvpVotes).values({

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -19,7 +19,7 @@ import { MatchTimeNegotiation } from "@/components/matches/MatchTimeNegotiation"
 import { MatchRosterView } from "@/components/matches/MatchRosterView";
 import { MatchRosterForm } from "@/components/matches/MatchRosterForm";
 import { VetoView } from "@/components/matches/VetoView";
-import { getMatchMvpResults } from "@/actions/player-stats";
+import { getMatchMvpResults, ensureMvpWinner } from "@/actions/player-stats";
 import { getTimeProposals } from "@/actions/matches/scheduling";
 import { getMatchRoster } from "@/actions/matches/roster";
 import { sumNums, avgNums, weightedAvgNums } from "@/lib/utils/stats";
@@ -117,6 +117,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       .slice(0, 4);
 
     mvpVoteResults = await getMatchMvpResults(match.id);
+    ensureMvpWinner(match.id); // 懒加载持久化 MVP 胜者（不阻塞渲染）
 
     if (userSession?.userId) {
       const existingVote = await db.query.matchMvpVotes.findFirst({

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -22,6 +22,7 @@ import { VetoView } from "@/components/matches/VetoView";
 import { getMatchMvpResults } from "@/actions/player-stats";
 import { getTimeProposals } from "@/actions/matches/scheduling";
 import { getMatchRoster } from "@/actions/matches/roster";
+import { sumNums, avgNums, weightedAvgNums } from "@/lib/utils/stats";
 import { getUserSession } from "@/lib/auth/session";
 
 interface MatchDetailPageProps {
@@ -65,7 +66,17 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   let mvpCandidates: {
     userId: string | null;
     perfectName: string;
+    kills: number | null;
+    deaths: number | null;
+    assists: number | null;
+    hsPercent: number | null;
+    firstKills: number | null;
+    multiKills: number | null;
+    clutches: number | null;
+    adr: number | null;
+    rws: number | null;
     ratingPro: number | null;
+    we: number | null;
   }[] = [];
   let mvpVoteResults: Awaited<ReturnType<typeof getMatchMvpResults>> = [];
   let userVoted: string | null = null;
@@ -75,19 +86,35 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       where: eq(matchPlayerStats.matchId, match.id),
     });
 
-    const seen = new Set<string>();
-    mvpCandidates = allStats
-      .filter((s) => {
-        const key = s.userId ?? s.perfectName;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .map((s) => ({
-        userId: s.userId,
-        perfectName: s.perfectName,
-        ratingPro: s.ratingPro,
-      }));
+    // 按玩家分组，跨地图聚合
+    const groupMap = new Map<string, typeof allStats>();
+    for (const s of allStats) {
+      const key = s.userId ?? `name:${s.perfectName}`;
+      const list = groupMap.get(key) ?? [];
+      list.push(s);
+      groupMap.set(key, list);
+    }
+
+    const aggregated = Array.from(groupMap.values()).map((rows) => ({
+      userId: rows[0].userId,
+      perfectName: rows[0].perfectName,
+      kills: sumNums(rows.map((r) => r.kills)),
+      deaths: sumNums(rows.map((r) => r.deaths)),
+      assists: sumNums(rows.map((r) => r.assists)),
+      hsPercent: weightedAvgNums(rows.map((r) => r.hsPercent), rows.map((r) => r.kills)),
+      firstKills: sumNums(rows.map((r) => r.firstKills)),
+      multiKills: sumNums(rows.map((r) => r.multiKills)),
+      clutches: sumNums(rows.map((r) => r.clutches)),
+      adr: avgNums(rows.map((r) => r.adr)),
+      rws: avgNums(rows.map((r) => r.rws)),
+      ratingPro: avgNums(rows.map((r) => r.ratingPro)),
+      we: avgNums(rows.map((r) => r.we)),
+    }));
+
+    // 按平均 Rating 降序，取前 4
+    mvpCandidates = aggregated
+      .sort((a, b) => (b.ratingPro ?? 0) - (a.ratingPro ?? 0))
+      .slice(0, 4);
 
     mvpVoteResults = await getMatchMvpResults(match.id);
 
@@ -479,6 +506,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
           candidates={mvpCandidates}
           currentVotes={mvpVoteResults}
           userVotedPlayerName={userVoted}
+          completedAt={match.completedAt?.toISOString() ?? null}
         />
       )}
     </div>

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -7,13 +7,12 @@ import { calculateStandings } from "@/lib/standings";
 import { Panel, Marker } from "@/components/rivalhub";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BracketView } from "@/components/matches/BracketView";
-import { MatchCard } from "@/components/matches/MatchCard";
 import { MatchTeamFilter } from "@/components/matches/MatchTeamFilter";
 import { StandingsTable } from "@/components/matches/StandingsTable";
 import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
 import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
-import { isMatchFormat, isMatchStatus } from "@/types/match";
+import { MatchTabsSection } from "@/components/matches/MatchTabsSection";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
 import type { Database } from "brackets-manager";
@@ -193,34 +192,13 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                 {/* 赛程列表 */}
                 {qualifierMatchesAll.length > 0 && (
                   <section className="space-y-3">
-                    <Tabs defaultValue="active" className="w-full">
-                      <TabsList className="bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
-                        <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
-                        <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
-                      </TabsList>
-                      <TabsContent value="active" className="mt-4 space-y-2">
-                        {qualifierActive.length > 0 ? qualifierActive.map((m) => (
-                          <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
-                            teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
-                            scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
-                            scheduledAt={m.scheduledAt} />
-                        )) : (
-                          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
-                        )}
-                      </TabsContent>
-                      <TabsContent value="done" className="mt-4 space-y-2">
-                        {qualifierDone.length > 0 ? qualifierDone.map((m) => (
-                          <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
-                            teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
-                            scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
-                            scheduledAt={m.scheduledAt} />
-                        )) : (
-                          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
-                        )}
-                      </TabsContent>
-                    </Tabs>
+                    <MatchTabsSection
+                      activeMatches={qualifierActive}
+                      doneMatches={qualifierDone}
+                      stage={qualifierKey}
+                      seasonSlug={seasonSlug}
+                      teamMap={teamMap}
+                    />
                   </section>
                 )}
 
@@ -253,34 +231,14 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
             {/* 正赛赛程列表 */}
             {playoffMatchesAll.length > 0 && (
               <section className="space-y-3">
-                <Tabs defaultValue="active" className="w-full">
-                  <TabsList className="bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
-                    <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
-                    <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
-                  </TabsList>
-                  <TabsContent value="active" className="mt-4 space-y-2">
-                    {playoffActive.length > 0 ? playoffActive.map((m) => (
-                      <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
-                        teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
-                        scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
-                        scheduledAt={m.scheduledAt} />
-                    )) : (
-                      <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
-                    )}
-                  </TabsContent>
-                  <TabsContent value="done" className="mt-4 space-y-2">
-                    {playoffDone.length > 0 ? playoffDone.map((m) => (
-                      <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
-                        teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
-                        scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
-                        scheduledAt={m.scheduledAt} />
-                    )) : (
-                      <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
-                    )}
-                  </TabsContent>
-                </Tabs>
+                <MatchTabsSection
+                  activeMatches={playoffActive}
+                  doneMatches={playoffDone}
+                  stage={playoffKey}
+                  seasonSlug={seasonSlug}
+                  teamMap={teamMap}
+                  unknownTeamName="TBD"
+                />
               </section>
             )}
 

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -13,6 +13,7 @@ import { StandingsTable } from "@/components/matches/StandingsTable";
 import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
 import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
+import { isMatchFormat, isMatchStatus } from "@/types/match";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
 import type { Database } from "brackets-manager";
@@ -202,7 +203,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                           <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                             teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
                             scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                            format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
                             scheduledAt={m.scheduledAt} />
                         )) : (
                           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
@@ -213,7 +214,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                           <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                             teamAName={teamMap.get(m.teamAId) ?? "未知队伍"} teamBName={teamMap.get(m.teamBId) ?? "未知队伍"}
                             scoreA={m.scoreA} scoreB={m.scoreB} stage={qualifierKey}
-                            format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                            format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
                             scheduledAt={m.scheduledAt} />
                         )) : (
                           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
@@ -262,7 +263,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                       <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                         teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
                         scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                        format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
                         scheduledAt={m.scheduledAt} />
                     )) : (
                       <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
@@ -273,7 +274,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                       <MatchCard key={m.id} matchId={m.id} seasonSlug={seasonSlug}
                         teamAName={teamMap.get(m.teamAId) ?? "TBD"} teamBName={teamMap.get(m.teamBId) ?? "TBD"}
                         scoreA={m.scoreA} scoreB={m.scoreB} stage={playoffKey}
-                        format={m.format as "bo1" | "bo3" | "bo5"} status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                        format={isMatchFormat(m.format) ? m.format : "bo1"} status={isMatchStatus(m.status) ? m.status : "scheduled"}
                         scheduledAt={m.scheduledAt} />
                     )) : (
                       <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { eq, or, and, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, teamMembers, seasonRegistrations, users, matches, matchMaps } from "@/db/schema";
+import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { Panel, Stat, Marker, PosChip } from "@/components/rivalhub";
 import { MatchCard } from "@/components/matches/MatchCard";
@@ -10,9 +10,11 @@ import { TeamNameForm } from "@/components/teams/TeamNameForm";
 import { TeamLogoUpload } from "@/components/teams/TeamLogoUpload";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
-import { CS2_POSITIONS } from "@/types/season";
+import { CS2_POSITIONS, DEFAULT_CS2_MAP_POOL } from "@/types/season";
 import { getUserSession } from "@/lib/auth/session";
 import { getDisplayName } from "@/lib/utils/display-name";
+import { getTeamMapWinStats, getTeamBanStats } from "@/lib/teams/data";
+import { mapLabel } from "@/lib/maps";
 
 interface TeamDetailPageProps {
   params: Promise<{ seasonSlug: string; teamId: string }>;
@@ -118,35 +120,12 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     else totalLosses++;
   }
 
-  // ── 地图统计 ──────────────────────────────────────────────────────────
+  // ── 地图表现统计 ──────────────────────────────────────────────────────────
   const matchIds = teamMatches.map((m) => m.id);
-  const allMaps = matchIds.length
-    ? await db.query.matchMaps.findMany({
-        where: and(
-          inArray(matchMaps.matchId, matchIds),
-          // 只统计有比分的图
-        ),
-      })
-    : [];
-
-  // 每图胜率（需要知道 teamA/B 关系）
-  const matchTeamMap = new Map(teamMatches.map((m) => [m.id, m]));
-  interface MapStat { wins: number; played: number }
-  const mapStats = new Map<string, MapStat>();
-  for (const mp of allMaps) {
-    if (mp.scoreA === null || mp.scoreB === null) continue;
-    const match = matchTeamMap.get(mp.matchId);
-    if (!match) continue;
-    const isA = match.teamAId === teamId;
-    const myScore = isA ? mp.scoreA : mp.scoreB;
-    const oppScore = isA ? mp.scoreB : mp.scoreA;
-    const prev = mapStats.get(mp.mapName) ?? { wins: 0, played: 0 };
-    mapStats.set(mp.mapName, {
-      wins: prev.wins + (myScore > oppScore ? 1 : 0),
-      played: prev.played + 1,
-    });
-  }
-  const sortedMaps = [...mapStats.entries()].sort((a, b) => b[1].played - a[1].played);
+  const [mapStats, { banCount, bpMatchCount }] = await Promise.all([
+    getTeamMapWinStats(teamId, teamMatches),
+    getTeamBanStats(teamId, matchIds),
+  ]);
 
   // ── 历史对阵（按对手分组） ─────────────────────────────────────────────
   interface HeadToHead { opponentId: string; wins: number; losses: number }
@@ -420,39 +399,59 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 地图胜率 */}
-      {sortedMaps.length > 0 && (
-        <section>
-          <Panel pad={0} className="overflow-hidden" label="地图胜率">
-            <div className="overflow-x-auto">
-            <table className="w-full text-sm min-w-[400px]">
+      {/* 地图表现 */}
+      <section>
+        <Panel pad={0} className="overflow-hidden" label="地图表现">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[340px]">
               <thead>
                 <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
                   <th className="px-5 py-3 text-left font-medium">地图</th>
-                  <th className="px-5 py-3 text-center font-medium">出场</th>
-                  <th className="px-5 py-3 text-center font-medium">胜</th>
-                  <th className="px-5 py-3 text-center font-medium">负</th>
-                  <th className="px-5 py-3 text-right font-medium">胜率</th>
+                  <th className="px-5 py-3 text-center font-medium">胜率</th>
+                  <th className="px-5 py-3 text-center font-medium">ban 率</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--color-border)]">
-                {sortedMaps.map(([mapName, stat]) => (
-                  <tr key={mapName}>
-                    <td className="px-5 py-3 font-medium text-[var(--color-fg)]">{mapName}</td>
-                    <td className="px-5 py-3 text-center text-[var(--color-fg-mid)]">{stat.played}</td>
-                    <td className="px-5 py-3 text-center text-green-500">{stat.wins}</td>
-                    <td className="px-5 py-3 text-center text-red-500">{stat.played - stat.wins}</td>
-                    <td className="px-5 py-3 text-right font-semibold text-[var(--color-fg)]">
-                      {pct(stat.wins, stat.played)}
-                    </td>
-                  </tr>
-                ))}
+                {DEFAULT_CS2_MAP_POOL.map((mapName) => {
+                  const stat = mapStats.get(mapName);
+                  const bans = banCount.get(mapName) ?? 0;
+                  return (
+                    <tr key={mapName}>
+                      <td className="px-5 py-3 font-medium text-[var(--color-fg)]">
+                        {mapLabel(mapName)}
+                      </td>
+                      <td className="px-5 py-3 text-center">
+                        {stat !== undefined ? (
+                          <>
+                            <div className="font-semibold text-[var(--color-fg)]">
+                              {pct(stat.wins, stat.played)}
+                            </div>
+                            <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
+                          </>
+                        ) : (
+                          <span className="text-[var(--color-fg-muted)]">—</span>
+                        )}
+                      </td>
+                      <td className="px-5 py-3 text-center">
+                        {bpMatchCount > 0 ? (
+                          <>
+                            <div className="font-semibold text-[var(--color-fg)]">
+                              {pct(bans, bpMatchCount)}
+                            </div>
+                            <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
+                          </>
+                        ) : (
+                          <span className="text-[var(--color-fg-muted)]">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
-            </div>
-          </Panel>
-        </section>
-      )}
+          </div>
+        </Panel>
+      </section>
 
       {/* 历史对阵 */}
       {h2hList.length > 0 && (

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -28,14 +28,36 @@ import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
+const STATUS_SORT_ORDER: Record<string, number> = {
+  in_progress: 0,
+  scheduled: 1,
+  finished: 2,
+  cancelled: 3,
+};
+
+function sortMatches<T extends { status: string; scheduledAt: Date | null }>(list: T[]): T[] {
+  return [...list].sort((a, b) => {
+    const diff = (STATUS_SORT_ORDER[a.status] ?? 9) - (STATUS_SORT_ORDER[b.status] ?? 9);
+    if (diff !== 0) return diff;
+    // 同状态：有排期的按时间升序，null 排最后
+    if (a.status === "scheduled" || a.status === "in_progress") {
+      if (!a.scheduledAt && !b.scheduledAt) return 0;
+      if (!a.scheduledAt) return 1;
+      if (!b.scheduledAt) return -1;
+      return a.scheduledAt.getTime() - b.scheduledAt.getTime();
+    }
+    return 0;
+  });
+}
+
 interface AdminMatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
-  searchParams: Promise<{ stage?: string; status?: string }>;
+  searchParams: Promise<{ stage?: string; status?: string; team?: string }>;
 }
 
 export default async function AdminMatchesPage({ params, searchParams }: AdminMatchesPageProps) {
   const { seasonSlug } = await params;
-  const { stage: filterStage, status: filterStatus } = await searchParams;
+  const { stage: filterStage, status: filterStatus, team: filterTeam } = await searchParams;
 
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),
@@ -80,8 +102,14 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   const playoffKey = playoffStage?.key ?? "playoff";
   const statusFilter = (m: { status: string }) =>
     !filterStatus || filterStatus === "all" || m.status === filterStatus;
-  const qualifierMatches = allMatches.filter((m) => m.stage === qualifierKey).filter(statusFilter);
-  const playoffMatches = allMatches.filter((m) => m.stage === playoffKey).filter(statusFilter);
+  const teamFilter = (m: { teamAId: string; teamBId: string }) =>
+    !filterTeam || filterTeam === "all" || m.teamAId === filterTeam || m.teamBId === filterTeam;
+  const qualifierMatches = sortMatches(
+    allMatches.filter((m) => m.stage === qualifierKey).filter(statusFilter).filter(teamFilter)
+  );
+  const playoffMatches = sortMatches(
+    allMatches.filter((m) => m.stage === playoffKey).filter(statusFilter).filter(teamFilter)
+  );
 
   // 已完成比赛的地图列表（用于 OCR 录入面板）
   const finishedMatchIds = allMatches
@@ -290,7 +318,10 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
 
       {/* 筛选 */}
       {matchCount > 0 && (
-        <AdminMatchFilter stages={stagePlan.map((s) => ({ key: s.key, name: s.name }))} />
+        <AdminMatchFilter
+          stages={stagePlan.map((s) => ({ key: s.key, name: s.name }))}
+          teams={allTeams.map((t) => ({ id: t.id, name: t.name }))}
+        />
       )}
 
       {/* 赛季状态提示 */}
@@ -392,7 +423,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                             teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                           />
-                          {(m.status === "scheduled" || m.status === "in_progress") && (
+                          {m.status === "in_progress" && (
                             <VetoInputDialog
                               matchId={m.id}
                               format={m.format as "bo1" | "bo3" | "bo5"}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, JetBrains_Mono, Noto_Sans_SC } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
+import { Analytics } from "@vercel/analytics/next";
 import { Toaster } from "@/components/ui/sonner";
 import { APP_BRAND } from "@/lib/branding";
 
@@ -51,6 +52,7 @@ export default function RootLayout({
         <main className="flex-1">{children}</main>
         <Footer />
         <Toaster richColors position="top-right" />
+        <Analytics />
       </body>
     </html>
   );

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -11,8 +11,18 @@ import Image from "next/image";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
-import { matchMvpVotes } from "@/db/schema/mvp-votes";
 import { wAvg, sAvg } from "@/lib/utils/stats";
+
+/**
+ * 统计玩家 MVP 获胜次数（从 matches.mvp_winner_user_id 直读，已持久化缓存）。
+ */
+async function getMvpWinCount(userId: string): Promise<number> {
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(matches)
+    .where(eq(matches.mvpWinnerUserId, userId));
+  return rows[0]?.count ?? 0;
+}
 
 interface PlayerPageProps {
   params: Promise<{ userId: string }>;
@@ -48,8 +58,8 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   });
   if (!user) notFound();
 
-  // ── 并行：报名记录 / MVP / 个人数据 / Steam 头像 ──────────────────────
-  const [registrations, mvpRows, playerStats, avatarUrl] = await Promise.all([
+  // ── 并行：报名记录 / MVP 胜场 / 个人数据 / Steam 头像 ──────────────────
+  const [registrations, mvpWinCount, playerStats, avatarUrl] = await Promise.all([
     db
       .select({
         id: seasonRegistrations.id,
@@ -80,10 +90,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         )
       )
       .orderBy(asc(seasons.createdAt)),
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(matchMvpVotes)
-      .where(eq(matchMvpVotes.playerUserId, userId)),
+    getMvpWinCount(userId),
     db
       .select({
         seasonName: seasons.name,
@@ -117,7 +124,6 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       .orderBy(asc(seasons.createdAt)),
     resolveAvatarUrl({ avatarUrl: user.avatarUrl, steam64: user.steam64 }),
   ]);
-  const mvpRow = mvpRows[0];
 
   // ── 队伍归属（registrationId → team）────────────────────────────────
   const allRegIds = registrations.map((r) => r.id);
@@ -176,7 +182,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   const totalMaps = playerStats.reduce((s, x) => s + x.maps, 0);
   const totalKillsAll = playerStats.reduce((s, x) => s + x.totalKills, 0);
   const totalDeathsAll = playerStats.reduce((s, x) => s + x.totalDeaths, 0);
-  const mvpCount = mvpRow?.count ?? 0;
+  const mvpCount = mvpWinCount;
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl space-y-10">
@@ -280,7 +286,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             <Stat label="胜" value={totalWins} />
             <Stat label="负" value={totalLosses} />
             <Stat label="胜率" value={pct(totalWins, played)} />
-            <Stat label="MVP" value={mvpCount > 0 ? mvpCount : "—"} />
+            <Stat label="单场MVP" value={mvpCount > 0 ? mvpCount : "—"} />
           </div>
           {totalNetRounds !== 0 && (
             <p className="text-xs text-[var(--color-fg-mid)] px-1">

--- a/src/components/matches/AdminMatchFilter.tsx
+++ b/src/components/matches/AdminMatchFilter.tsx
@@ -14,8 +14,14 @@ interface StageOption {
   name: string;
 }
 
+interface TeamOption {
+  id: string;
+  name: string;
+}
+
 interface AdminMatchFilterProps {
   stages: StageOption[];
+  teams?: TeamOption[];
 }
 
 const STATUS_OPTIONS = [
@@ -26,12 +32,13 @@ const STATUS_OPTIONS = [
   { value: "cancelled", label: "已取消" },
 ];
 
-export function AdminMatchFilter({ stages }: AdminMatchFilterProps) {
+export function AdminMatchFilter({ stages, teams }: AdminMatchFilterProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentStage = searchParams.get("stage") ?? "all";
   const currentStatus = searchParams.get("status") ?? "all";
+  const currentTeam = searchParams.get("team") ?? "all";
 
   function updateFilter(key: string, value: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -68,6 +75,20 @@ export function AdminMatchFilter({ stages }: AdminMatchFilterProps) {
           ))}
         </SelectContent>
       </Select>
+
+      {teams && teams.length > 0 && (
+        <Select value={currentTeam} onValueChange={(v) => updateFilter("team", v)}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="队伍筛选" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">全部队伍</SelectItem>
+            {teams.map((t) => (
+              <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
     </div>
   );
 }

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -1,13 +1,24 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { Card } from "@/components/ui/card";
 import { castMatchMvpVote } from "@/actions/player-stats";
+import { isDeadlinePassed, MVP_DEADLINE_MS } from "@/lib/utils/date";
 
 interface MvpCandidate {
   userId: string | null;
   perfectName: string;
+  kills: number | null;
+  deaths: number | null;
+  assists: number | null;
+  hsPercent: number | null;
+  firstKills: number | null;
+  multiKills: number | null;
+  clutches: number | null;
+  adr: number | null;
+  rws: number | null;
   ratingPro: number | null;
+  we: number | null;
 }
 
 interface MatchMvpVoteProps {
@@ -15,6 +26,7 @@ interface MatchMvpVoteProps {
   candidates: MvpCandidate[];
   currentVotes: { playerUserId: string | null; playerName: string; count: number }[];
   userVotedPlayerName: string | null;
+  completedAt: string | null;
 }
 
 export function MatchMvpVote({
@@ -22,62 +34,139 @@ export function MatchMvpVote({
   candidates,
   currentVotes,
   userVotedPlayerName,
+  completedAt,
 }: MatchMvpVoteProps) {
   const [optimisticVotes, setOptimisticVotes] = useState(currentVotes);
   const [votedName, setVotedName] = useState(userVotedPlayerName);
+  const [now, setNow] = useState(Date.now());
   const [isPending, startTransition] = useTransition();
 
+  const deadline = completedAt
+    ? new Date(new Date(completedAt).getTime() + MVP_DEADLINE_MS)
+    : null;
+  const votingClosed = deadline ? isDeadlinePassed(deadline) : false;
+  const timeLeft = deadline && !votingClosed
+    ? Math.max(0, deadline.getTime() - now)
+    : 0;
+  const hoursLeft = Math.floor(timeLeft / (60 * 60 * 1000));
+  const minsLeft = Math.floor((timeLeft % (60 * 60 * 1000)) / (60 * 1000));
+
+  // 每 30s 刷新倒计时；截止时切到结果视图
+  useEffect(() => {
+    if (!deadline || votingClosed) return;
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, 30_000);
+    return () => clearInterval(timer);
+  }, [deadline, votingClosed]);
+
   async function handleVote(playerUserId: string | null, playerName: string) {
-    if (votedName) return;
+    if (votedName || votingClosed) return;
     startTransition(async () => {
       const result = await castMatchMvpVote(matchId, playerUserId, playerName);
       if (result.success) {
         setVotedName(playerName);
         setOptimisticVotes((prev) =>
           prev.map((v) =>
-            v.playerName === playerName
-              ? { ...v, count: v.count + 1 }
-              : v
-          )
+            v.playerName === playerName ? { ...v, count: v.count + 1 } : v,
+          ),
         );
       }
     });
   }
 
-  const leading = optimisticVotes.length > 0
-    ? optimisticVotes.reduce((a, b) => (a.count > b.count ? a : b))
-    : null;
+  const allVotes = [...optimisticVotes];
+  for (const c of candidates) {
+    if (!allVotes.find((v) => v.playerName === c.perfectName)) {
+      allVotes.push({ playerUserId: c.userId, playerName: c.perfectName, count: 0 });
+    }
+  }
+  const mvp = allVotes.reduce((a, b) => (a.count >= b.count ? a : b), allVotes[0]);
+  const mvpStats = candidates.find((c) => c.perfectName === mvp?.playerName);
 
-  const sorted = [...candidates].sort(
-    (a, b) => (b.ratingPro ?? 0) - (a.ratingPro ?? 0)
-  );
+  // ── 投票截止：展示 MVP 结果 ──
+  if (votingClosed) {
+    return (
+      <Card className="p-6 space-y-5 border-[var(--color-border)]">
+        <div className="text-center space-y-1">
+          <p className="text-sm text-[var(--color-fg-mid)]">本场 MVP</p>
+          <p className="text-2xl font-bold text-[var(--color-accent)]">
+            {mvp?.playerName ?? "—"}
+          </p>
+          <p className="text-sm text-[var(--color-fg-mid)]">
+            {mvp?.count ?? 0} 票
+          </p>
+        </div>
+
+        {mvpStats && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr>
+                  {STAT_COLS.map((c) => (
+                    <th key={c.key} className="pb-1 text-[10px] text-[var(--color-fg-dim)] font-normal text-center">
+                      {c.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-[var(--color-border)]">
+                  {STAT_COLS.map((c) => {
+                    const v = mvpStats[c.key];
+                    const val = v != null ? (c.fmt ? c.fmt(v as never) : String(v)) : "—";
+                    return (
+                      <td key={c.key} className="py-1.5 tabular-nums text-center text-[var(--color-fg)]">
+                        {val}
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {allVotes.filter((v) => v.playerName !== mvp?.playerName).length > 0 && (
+          <div className="text-xs space-y-1">
+            <p className="text-[var(--color-fg-dim)]">其他候选人</p>
+            {allVotes
+              .filter((v) => v.playerName !== mvp?.playerName)
+              .sort((a, b) => b.count - a.count)
+              .map((v) => (
+                <div key={v.playerName} className="flex justify-between text-[var(--color-fg-mid)]">
+                  <span>{v.playerName}</span>
+                  <span className="tabular-nums">{v.count} 票</span>
+                </div>
+              ))}
+          </div>
+        )}
+      </Card>
+    );
+  }
+
+  // ── 投票中 ──
+  function cardStyle(isVoted: boolean, hasVoted: boolean): string {
+    const base = "rounded-lg p-4 text-left transition-colors";
+    if (isVoted) return `${base} bg-[rgba(255,107,26,0.12)] ring-1 ring-inset ring-[var(--color-accent)]`;
+    if (hasVoted) return `${base} bg-[var(--color-panel-hi)] cursor-not-allowed opacity-60`;
+    return `${base} bg-[var(--color-panel-hi)] hover:bg-[var(--color-panel)] cursor-pointer`;
+  }
 
   return (
     <Card className="p-5 space-y-4 border-[var(--color-border)]">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <h3 className="text-base font-semibold text-[var(--color-fg)]">
           本场 MVP 投票
         </h3>
-        {votedName && (
-          <span className="text-xs text-[var(--color-fg-mid)]">
-            你已投票: <span className="text-[var(--primary)]">{votedName}</span>
-          </span>
-        )}
-        {leading && (
-          <span className="text-xs text-[var(--color-fg-mid)]">
-            当前领先:{" "}
-            <span className="text-[var(--color-accent)] font-semibold">
-              {leading.playerName} ({leading.count} 票)
-            </span>
-          </span>
-        )}
+        <span className="text-xs text-[var(--color-fg-mid)]">
+          剩余 {hoursLeft}h {minsLeft}m
+        </span>
       </div>
 
-      <div className="grid grid-cols-2 gap-2 text-sm">
-        {sorted.map((c) => {
-          const v = optimisticVotes.find(
-            (x) => x.playerName === c.perfectName
-          );
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {candidates.map((c) => {
+          const v = optimisticVotes.find((x) => x.playerName === c.perfectName);
           const count = v?.count ?? 0;
           const isVoted = votedName === c.perfectName;
 
@@ -86,27 +175,45 @@ export function MatchMvpVote({
               key={c.perfectName}
               disabled={!!votedName || isPending}
               onClick={() => handleVote(c.userId, c.perfectName)}
-              className={`flex items-center justify-between rounded-md p-2.5 text-left transition-colors ${
-                isVoted
-                  ? "bg-[rgba(255, 107, 26,0.12)] ring-1 ring-inset ring-[var(--color-accent)]"
-                  : votedName
-                  ? "bg-[var(--color-panel-hi)] cursor-not-allowed"
-                  : "bg-[var(--color-panel-hi)] hover:bg-[var(--color-panel)] cursor-pointer"
-              }`}
+              className={cardStyle(isVoted, !!votedName)}
             >
-              <span className="text-[var(--color-fg)]">
-                {c.perfectName}
-                <span className="text-[11px] text-[var(--color-fg-dim)] ml-1.5">
-                  ({c.ratingPro?.toFixed(2) ?? "—"})
+              <div className="flex items-center justify-between mb-2">
+                <span className="font-semibold text-[var(--color-fg)]">
+                  {c.perfectName}
                 </span>
-              </span>
-              <span
-                className={`tabular-nums text-xs font-semibold ${
-                  isVoted ? "text-[var(--color-accent)]" : "text-[var(--color-fg-mid)]"
-                }`}
-              >
-                {count} 票
-              </span>
+                <span
+                  className="text-lg font-bold tabular-nums"
+                  style={{
+                    color: c.ratingPro != null && c.ratingPro >= 1.2
+                      ? "var(--color-accent)"
+                      : "var(--color-fg)",
+                  }}
+                >
+                  {c.ratingPro != null ? c.ratingPro.toFixed(2) : "—"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-5 gap-1 text-center text-xs mb-2">
+                <StatCell label="K" value={c.kills} />
+                <StatCell label="D" value={c.deaths} />
+                <StatCell label="A" value={c.assists} />
+                <StatCell label="ADR" value={c.adr} fmt={(v) => v.toFixed(1)} />
+                <StatCell label="RWS" value={c.rws} fmt={(v) => v.toFixed(1)} />
+              </div>
+
+              <div className="grid grid-cols-4 gap-1 text-center text-[11px] mb-2">
+                <StatCell label="HS%" value={c.hsPercent} fmt={(v) => `${v}%`} />
+                <StatCell label="FK" value={c.firstKills} />
+                <StatCell label="MK" value={c.multiKills} />
+                <StatCell label="残局" value={c.clutches} />
+              </div>
+
+              <div className="flex items-center justify-between border-t border-[var(--color-border)] pt-2">
+                <span className={`text-xs font-semibold tabular-nums ${isVoted ? "text-[var(--color-accent)]" : "text-[var(--color-fg-mid)]"}`}>
+                  {count} 票
+                </span>
+                {isVoted && <span className="text-xs text-[var(--color-accent)]">已投票</span>}
+              </div>
             </button>
           );
         })}
@@ -114,3 +221,35 @@ export function MatchMvpVote({
     </Card>
   );
 }
+
+function StatCell({
+  label,
+  value,
+  fmt,
+}: {
+  label: string;
+  value: number | null;
+  fmt?: (v: number) => string;
+}) {
+  return (
+    <div>
+      <span className="text-[var(--color-fg-dim)]">{label}</span>
+      <span className="tabular-nums block text-[var(--color-fg)]">
+        {value != null ? (fmt ? fmt(value) : String(value)) : "—"}
+      </span>
+    </div>
+  );
+}
+
+const STAT_COLS = [
+  { key: "kills" as const,     label: "K",    fmt: undefined as ((v: number) => string) | undefined },
+  { key: "deaths" as const,    label: "D",    fmt: undefined },
+  { key: "assists" as const,   label: "A",    fmt: undefined },
+  { key: "hsPercent" as const, label: "HS%",  fmt: (v: number) => `${v}%` },
+  { key: "firstKills" as const,label: "FK",   fmt: undefined },
+  { key: "multiKills" as const,label: "MK",   fmt: undefined },
+  { key: "clutches" as const,  label: "残局", fmt: undefined },
+  { key: "adr" as const,       label: "ADR",  fmt: (v: number) => v.toFixed(1) },
+  { key: "rws" as const,       label: "RWS",  fmt: (v: number) => v.toFixed(1) },
+  { key: "ratingPro" as const, label: "Rating", fmt: (v: number) => v.toFixed(2) },
+];

--- a/src/components/matches/MatchTabsSection.tsx
+++ b/src/components/matches/MatchTabsSection.tsx
@@ -1,0 +1,80 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MatchCard } from "@/components/matches/MatchCard";
+import { isMatchFormat, isMatchStatus } from "@/types/match";
+
+interface MatchRow {
+  id: string;
+  teamAId: string;
+  teamBId: string;
+  scoreA: number | null;
+  scoreB: number | null;
+  format: string;
+  status: string;
+  scheduledAt: Date | null;
+}
+
+interface MatchTabsSectionProps {
+  activeMatches: MatchRow[];
+  doneMatches: MatchRow[];
+  stage: string;
+  seasonSlug: string;
+  teamMap: Map<string, string>;
+  /** 队伍名未找到时的 fallback 文案，默认"未知队伍" */
+  unknownTeamName?: string;
+}
+
+export function MatchTabsSection({
+  activeMatches,
+  doneMatches,
+  stage,
+  seasonSlug,
+  teamMap,
+  unknownTeamName = "未知队伍",
+}: MatchTabsSectionProps) {
+  return (
+    <Tabs defaultValue="active" className="w-full">
+      <TabsList className="bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
+        <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
+        <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
+      </TabsList>
+      <TabsContent value="active" className="mt-4 space-y-2">
+        {activeMatches.length > 0 ? activeMatches.map((m) => (
+          <MatchCard
+            key={m.id}
+            matchId={m.id}
+            seasonSlug={seasonSlug}
+            teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
+            teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
+            scoreA={m.scoreA}
+            scoreB={m.scoreB}
+            stage={stage}
+            format={isMatchFormat(m.format) ? m.format : "bo1"}
+            status={isMatchStatus(m.status) ? m.status : "scheduled"}
+            scheduledAt={m.scheduledAt}
+          />
+        )) : (
+          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
+        )}
+      </TabsContent>
+      <TabsContent value="done" className="mt-4 space-y-2">
+        {doneMatches.length > 0 ? doneMatches.map((m) => (
+          <MatchCard
+            key={m.id}
+            matchId={m.id}
+            seasonSlug={seasonSlug}
+            teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
+            teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
+            scoreA={m.scoreA}
+            scoreB={m.scoreB}
+            stage={stage}
+            format={isMatchFormat(m.format) ? m.format : "bo1"}
+            status={isMatchStatus(m.status) ? m.status : "scheduled"}
+            scheduledAt={m.scheduledAt}
+          />
+        )) : (
+          <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/components/matches/PlayerStatsTable.tsx
+++ b/src/components/matches/PlayerStatsTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { eq, and, inArray, or } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { teamMembers } from "@/db/schema/teams";
@@ -53,7 +53,6 @@ async function getStatsGroupedByTeam(mapId: string, matchId: string) {
 
   const teamA = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === matchData.teamAId);
   const teamB = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === matchData.teamBId);
-
   const unmatched = stats.filter((s) => !s.userId || !userIdToTeam.has(s.userId));
   const half = Math.ceil(unmatched.length / 2);
 
@@ -70,9 +69,7 @@ export async function PlayerStatsTable({ matchId, mapId }: PlayerStatsTableProps
 
   if (teamA.length === 0 && teamB.length === 0) {
     return (
-      <p className="text-xs text-[var(--color-fg-dim)] py-2">
-        暂无玩家数据
-      </p>
+      <p className="text-xs text-[var(--color-fg-dim)] py-2">暂无玩家数据</p>
     );
   }
 
@@ -80,8 +77,8 @@ export async function PlayerStatsTable({ matchId, mapId }: PlayerStatsTableProps
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2">
-      <StatTeamBlock label="Team A" players={teamA} cols={cols} />
-      <StatTeamBlock label="Team B" players={teamB} cols={cols} />
+      <StatTeamBlock label="队伍 A" players={teamA} cols={cols} />
+      <StatTeamBlock label="队伍 B" players={teamB} cols={cols} />
     </div>
   );
 }

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useMemo } from "react";
+import { useState, useRef, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -21,6 +21,8 @@ import {
 import {
   extractStatsFromScreenshot,
   savePlayerStats,
+  getPlayerStatsByMap,
+  getMatchPlayerOptions,
   type PlayerStatsDraft,
   type PlayerOption,
 } from "@/actions/player-stats";
@@ -55,7 +57,49 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
   const [extracting, setExtracting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
+  // viewMode=true：只读展示；false：编辑录入
+  const [viewMode, setViewMode] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+
+  // 挂载时加载已保存数据
+  useEffect(() => {
+    let cancelled = false;
+    getPlayerStatsByMap(mapId)
+      .then((rows) => {
+        if (cancelled) return;
+        if (rows.length > 0) {
+          setDrafts(
+            rows.map((r) => ({
+              perfectName: r.perfectName,
+              userId: r.userId ?? null,
+              kills: r.kills ?? null,
+              deaths: r.deaths ?? null,
+              assists: r.assists ?? null,
+              hsPercent: r.hsPercent ?? null,
+              firstKills: r.firstKills ?? null,
+              multiKills: r.multiKills ?? null,
+              clutches: r.clutches ?? null,
+              adr: r.adr ?? null,
+              rws: r.rws ?? null,
+              ratingPro: r.ratingPro ?? null,
+              we: r.we ?? null,
+            })),
+          );
+          setViewMode(true);
+        }
+        setInitialLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setInitialLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [mapId]);
+
+  async function enterEditMode() {
+    const options = await getMatchPlayerOptions(mapId);
+    setPlayerOptions(options);
+    setViewMode(false);
+  }
 
   async function handleExtract() {
     const file = fileRef.current?.files?.[0];
@@ -70,7 +114,6 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
 
     setError(null);
     setExtracting(true);
-    setSaved(false);
 
     try {
       const base64 = await fileToBase64(file);
@@ -133,7 +176,7 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
       setError(result.error.message);
       return;
     }
-    setSaved(true);
+    setViewMode(true);
   }
 
   const assignedUserIdsByRow = useMemo(
@@ -149,128 +192,184 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
     [drafts],
   );
 
+  if (initialLoading) {
+    return (
+      <div className="mt-4">
+        <p className="text-sm text-[var(--color-fg-mid)]">加载中…</p>
+      </div>
+    );
+  }
+
   return (
     <div className="mt-4 space-y-4">
-      <h4 className="font-semibold text-sm">
-        {mapName} — 玩家数据录入（OCR 识别）
-      </h4>
-
-      <div className="flex gap-2 items-center flex-wrap">
-        <input
-          ref={fileRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          className="text-sm"
-        />
-        <Button
-          size="sm"
-          onClick={handleExtract}
-          disabled={extracting}
-        >
-          {extracting ? "识别中…" : "OCR 识别截图"}
-        </Button>
-        <Button size="sm" variant="outline" onClick={handleAddRow}>
-          添加行
-        </Button>
-        {saved && <span className="text-xs text-green-500">已保存</span>}
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="font-semibold text-sm">
+          {mapName} — 玩家数据
+        </h4>
+        {viewMode && drafts.length > 0 && (
+          <Button size="sm" variant="outline" onClick={enterEditMode}>
+            重新录入
+          </Button>
+        )}
       </div>
 
-      {error && (
-        <p className="text-sm text-red-500">{error}</p>
+      {/* ── 只读视图 ── */}
+      {viewMode && drafts.length > 0 && (
+        <div className="overflow-x-auto rounded border">
+          <Table className="text-xs">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-36">昵称</TableHead>
+                {NUM_FIELDS.map((f) => (
+                  <TableHead key={f.key} className="w-16 text-center">
+                    {f.label}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {drafts.map((row, idx) => (
+                <TableRow key={idx}>
+                  <TableCell className="font-medium">{row.perfectName as string}</TableCell>
+                  {NUM_FIELDS.map((f) => (
+                    <TableCell key={f.key} className="text-center tabular-nums">
+                      {(row[f.key] as number | null) ?? "—"}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       )}
 
-      {drafts.length > 0 ? (
+      {/* ── 编辑视图 ── */}
+      {!viewMode && (
         <>
-          <div className="overflow-x-auto rounded border">
-            <Table className="text-xs">
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-36">昵称</TableHead>
-                  <TableHead className="w-40">匹配用户</TableHead>
-                  {NUM_FIELDS.map((f) => (
-                    <TableHead key={f.key} className="w-16 text-center">
-                      {f.label}
-                    </TableHead>
-                  ))}
-                  <TableHead className="w-10" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {drafts.map((row, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell>
-                      <Input
-                        className="h-7 text-xs"
-                        value={row.perfectName as string}
-                        onChange={(e) => handleNameChange(idx, e.target.value)}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Select
-                        value={row.userId ?? "__none__"}
-                        onValueChange={(v) => handleUserChange(idx, v)}
-                      >
-                        <SelectTrigger className="h-7 text-xs">
-                          <SelectValue placeholder="未匹配" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__none__">— 未匹配 —</SelectItem>
-                          {playerOptions
-                            .filter((p) => !assignedUserIdsByRow[idx].has(p.userId))
-                            .map((p) => (
-                              <SelectItem key={p.userId} value={p.userId}>
-                                {p.perfectName}
-                              </SelectItem>
-                            ))}
-                        </SelectContent>
-                      </Select>
-                    </TableCell>
-                    {NUM_FIELDS.map((f) => (
-                      <TableCell key={f.key} className="text-center p-1">
-                        <Input
-                          className="h-7 text-xs text-center w-14"
-                          type="number"
-                          value={(row[f.key] as number | null) ?? ""}
-                          onChange={(e) =>
-                            handleNumChange(idx, f.key, e.target.value)
-                          }
-                        />
-                      </TableCell>
-                    ))}
-                    <TableCell className="p-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 w-7 p-0 text-red-400"
-                        onClick={() => handleDeleteRow(idx)}
-                        title="删除此行"
-                      >
-                        ×
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          <div className="flex gap-2 items-center">
+          <div className="flex gap-2 items-center flex-wrap">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="text-sm"
+            />
             <Button
               size="sm"
-              onClick={handleSave}
-              disabled={saving}
+              onClick={handleExtract}
+              disabled={extracting}
             >
-              {saving ? "保存中…" : "确认保存"}
+              {extracting ? "识别中…" : "OCR 识别截图"}
             </Button>
-            {saved && (
-              <span className="text-sm text-green-600">已保存 {drafts.length} 条数据</span>
-            )}
+            <Button size="sm" variant="outline" onClick={handleAddRow}>
+              添加行
+            </Button>
           </div>
+
+          {error && (
+            <p className="text-sm text-red-500">{error}</p>
+          )}
+
+          {drafts.length > 0 ? (
+            <>
+              <div className="overflow-x-auto rounded border">
+                <Table className="text-xs">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-36">昵称</TableHead>
+                      <TableHead className="w-40">匹配用户</TableHead>
+                      {NUM_FIELDS.map((f) => (
+                        <TableHead key={f.key} className="w-16 text-center">
+                          {f.label}
+                        </TableHead>
+                      ))}
+                      <TableHead className="w-10" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {drafts.map((row, idx) => (
+                      <TableRow key={idx}>
+                        <TableCell>
+                          <Input
+                            className="h-7 text-xs"
+                            value={row.perfectName as string}
+                            onChange={(e) => handleNameChange(idx, e.target.value)}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Select
+                            value={row.userId ?? "__none__"}
+                            onValueChange={(v) => handleUserChange(idx, v)}
+                          >
+                            <SelectTrigger className="h-7 text-xs">
+                              <SelectValue placeholder="未匹配" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="__none__">— 未匹配 —</SelectItem>
+                              {playerOptions
+                                .filter((p) => !assignedUserIdsByRow[idx].has(p.userId))
+                                .map((p) => (
+                                  <SelectItem key={p.userId} value={p.userId}>
+                                    {p.perfectName}
+                                  </SelectItem>
+                                ))}
+                            </SelectContent>
+                          </Select>
+                        </TableCell>
+                        {NUM_FIELDS.map((f) => (
+                          <TableCell key={f.key} className="text-center p-1">
+                            <Input
+                              className="h-7 text-xs text-center w-14"
+                              type="number"
+                              value={(row[f.key] as number | null) ?? ""}
+                              onChange={(e) =>
+                                handleNumChange(idx, f.key, e.target.value)
+                              }
+                            />
+                          </TableCell>
+                        ))}
+                        <TableCell className="p-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0 text-red-400"
+                            onClick={() => handleDeleteRow(idx)}
+                            title="删除此行"
+                          >
+                            ×
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="flex gap-2 items-center">
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={saving}
+                >
+                  {saving ? "保存中…" : "确认保存"}
+                </Button>
+                {drafts.length > 0 && viewMode === false && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setViewMode(true)}
+                    disabled={saving}
+                  >
+                    取消
+                  </Button>
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-[var(--color-fg-mid)] py-4">
+              暂无数据。点击「OCR 识别截图」自动提取，或点击「添加行」手动录入。
+            </p>
+          )}
         </>
-      ) : (
-        <p className="text-sm text-[var(--color-fg-mid)] py-4">
-          暂无数据。点击「OCR 识别截图」自动提取，或点击「添加行」手动录入。
-        </p>
       )}
     </div>
   );
@@ -281,7 +380,6 @@ async function fileToBase64(file: File): Promise<string> {
     const reader = new FileReader();
     reader.onload = () => {
       const result = reader.result as string;
-      // 去掉 data:image/xxx;base64, 前缀
       resolve(result.split(",")[1]);
     };
     reader.onerror = reject;

--- a/src/components/matches/VetoInputDialog.tsx
+++ b/src/components/matches/VetoInputDialog.tsx
@@ -18,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { saveVetoSteps, type VetoStepInput } from "@/actions/matches/veto";
+import { saveVetoSteps, getMatchVetoSteps, type VetoStepInput } from "@/actions/matches/veto";
 import { mapLabel } from "@/lib/maps";
 import type { VetoActionType } from "@/types/match";
 import { SIDE_LABELS } from "@/types/match";
@@ -104,6 +104,7 @@ export function VetoInputDialog({
   const [steps, setSteps] = useState<StepEdit[]>(() =>
     buildTemplate(format, teamAId, teamBId),
   );
+  const [loading, setLoading] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   function teamName(teamId: string | null) {
@@ -161,12 +162,32 @@ export function VetoInputDialog({
     });
   }
 
-  function handleOpenChange(next: boolean) {
+  async function handleOpenChange(next: boolean) {
     if (next) {
-      // 每次打开对话框时重置为模板
-      setSteps(buildTemplate(format, teamAId, teamBId));
+      setLoading(true);
+      setOpen(true);
+      try {
+        const existing = await getMatchVetoSteps(matchId);
+        if (existing.length > 0) {
+          setSteps(
+            existing.map((s) => ({
+              actionType: s.actionType as VetoActionType,
+              mapName: s.mapName,
+              teamId: s.teamId,
+              side: s.side as "t" | "ct" | null,
+            })),
+          );
+        } else {
+          setSteps(buildTemplate(format, teamAId, teamBId));
+        }
+      } catch {
+        setSteps(buildTemplate(format, teamAId, teamBId));
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      setOpen(false);
     }
-    setOpen(next);
   }
 
   return (
@@ -183,6 +204,9 @@ export function VetoInputDialog({
           </DialogTitle>
         </DialogHeader>
 
+        {loading ? (
+          <p className="text-sm text-[var(--color-fg-mid)] py-4">加载中…</p>
+        ) : null}
         <div className="space-y-3">
           {steps.map((step, i) => (
             <div

--- a/src/db/schema/matches.ts
+++ b/src/db/schema/matches.ts
@@ -37,6 +37,7 @@ export const matches = pgTable("matches", {
   scheduledAt: timestamp("scheduled_at", { withTimezone: true }),
   completionDeadline: timestamp("completion_deadline", { withTimezone: true }),
   completedAt: timestamp("completed_at", { withTimezone: true }),
+  mvpWinnerUserId: uuid("mvp_winner_user_id"), // 投票截止后锁定的 MVP 胜者
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({

--- a/src/lib/teams/data.ts
+++ b/src/lib/teams/data.ts
@@ -1,0 +1,106 @@
+import { db } from "@/db/client";
+import { matchMaps, matchVetoSteps } from "@/db/schema";
+import { and, inArray, eq } from "drizzle-orm";
+
+interface MatchRef {
+  id: string;
+  teamAId: string;
+  teamBId: string;
+  format: string;
+  scoreA: number | null;
+  scoreB: number | null;
+}
+
+export interface MapWinStats {
+  wins: number;
+  played: number;
+}
+
+/** 每图胜率，兼容 BO1（via decider veto step）和 BO3/BO5（via matchMaps） */
+export async function getTeamMapWinStats(
+  teamId: string,
+  teamMatches: MatchRef[],
+): Promise<Map<string, MapWinStats>> {
+  if (!teamMatches.length) return new Map();
+  const matchRef = new Map(teamMatches.map((m) => [m.id, m]));
+  const bo1Matches = teamMatches.filter((m) => m.format === "bo1");
+  const bo35Matches = teamMatches.filter((m) => m.format !== "bo1");
+  const mapStats = new Map<string, MapWinStats>();
+
+  if (bo35Matches.length) {
+    const maps = await db.query.matchMaps.findMany({
+      where: inArray(matchMaps.matchId, bo35Matches.map((m) => m.id)),
+    });
+    for (const mp of maps) {
+      if (mp.scoreA === null || mp.scoreB === null) continue;
+      const match = matchRef.get(mp.matchId);
+      if (!match) continue;
+      const isA = match.teamAId === teamId;
+      const myScore = isA ? mp.scoreA : mp.scoreB;
+      const oppScore = isA ? mp.scoreB : mp.scoreA;
+      const prev = mapStats.get(mp.mapName) ?? { wins: 0, played: 0 };
+      mapStats.set(mp.mapName, {
+        wins: prev.wins + (myScore > oppScore ? 1 : 0),
+        played: prev.played + 1,
+      });
+    }
+  }
+
+  if (bo1Matches.length) {
+    const deciders = await db
+      .select({ matchId: matchVetoSteps.matchId, mapName: matchVetoSteps.mapName })
+      .from(matchVetoSteps)
+      .where(
+        and(
+          inArray(matchVetoSteps.matchId, bo1Matches.map((m) => m.id)),
+          eq(matchVetoSteps.actionType, "decider"),
+        ),
+      );
+    for (const d of deciders) {
+      const match = matchRef.get(d.matchId);
+      if (!match) continue;
+      const isA = match.teamAId === teamId;
+      const myScore = isA ? (match.scoreA ?? 0) : (match.scoreB ?? 0);
+      const oppScore = isA ? (match.scoreB ?? 0) : (match.scoreA ?? 0);
+      const prev = mapStats.get(d.mapName) ?? { wins: 0, played: 0 };
+      mapStats.set(d.mapName, {
+        wins: prev.wins + (myScore > oppScore ? 1 : 0),
+        played: prev.played + 1,
+      });
+    }
+  }
+
+  return mapStats;
+}
+
+/** Ban 统计：返回每图 ban 次数 + 参与 BP 的对局总数（ban 率分母） */
+export async function getTeamBanStats(
+  teamId: string,
+  matchIds: string[],
+): Promise<{ banCount: Map<string, number>; bpMatchCount: number }> {
+  if (!matchIds.length) return { banCount: new Map(), bpMatchCount: 0 };
+
+  const [bpMatches, bans] = await Promise.all([
+    db
+      .selectDistinct({ matchId: matchVetoSteps.matchId })
+      .from(matchVetoSteps)
+      .where(inArray(matchVetoSteps.matchId, matchIds)),
+    db
+      .select({ mapName: matchVetoSteps.mapName })
+      .from(matchVetoSteps)
+      .where(
+        and(
+          inArray(matchVetoSteps.matchId, matchIds),
+          eq(matchVetoSteps.actionType, "ban"),
+          eq(matchVetoSteps.teamId, teamId),
+        ),
+      ),
+  ]);
+
+  const banCount = new Map<string, number>();
+  for (const b of bans) {
+    banCount.set(b.mapName, (banCount.get(b.mapName) ?? 0) + 1);
+  }
+
+  return { banCount, bpMatchCount: bpMatches.length };
+}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -42,6 +42,9 @@ export function isDeadlinePassed(deadline: Date | string): boolean {
   return d.getTime() <= Date.now();
 }
 
+/** MVP 投票截止窗口：比赛结束后 24 小时 */
+export const MVP_DEADLINE_MS = 24 * 60 * 60 * 1000;
+
 export function formatCSTShortDate(date: Date | string): string {
   const d = typeof date === "string" ? new Date(date) : date;
   return d.toLocaleDateString(CST_LOCALE, { timeZone: CST_TZ, month: "short", day: "numeric" });

--- a/src/lib/utils/stats.ts
+++ b/src/lib/utils/stats.ts
@@ -19,3 +19,31 @@ export function sAvg(items: HasMaps[], field: string, precision = 1): string {
   if (totalMaps === 0) return "—";
   return (items.reduce((s, x) => s + (x[field] as number), 0) / totalMaps).toFixed(precision);
 }
+
+/** 对数组合并取和，全 null 返回 null */
+export function sumNums(vals: (number | null)[]): number | null {
+  const nums = vals.filter((v) => v != null) as number[];
+  return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) : null;
+}
+
+/** 对数组值取平均，全 null 返回 null */
+export function avgNums(vals: (number | null)[]): number | null {
+  const nums = vals.filter((v) => v != null) as number[];
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+/** 按权重（如击杀数）对值做加权平均 */
+export function weightedAvgNums(vals: (number | null)[], weights: (number | null)[]): number | null {
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (let i = 0; i < vals.length; i++) {
+    const v = vals[i];
+    const w = weights[i];
+    if (v != null && w != null && w > 0) {
+      weightedSum += v * w;
+      totalWeight += w;
+    }
+  }
+  return totalWeight > 0 ? weightedSum / totalWeight : null;
+}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -102,3 +102,15 @@ export function getWinThreshold(format: MatchFormat): number {
     case "bo5": return 3;
   }
 }
+
+// ── 类型守卫 ─────────────────────────────────────────────────────────────────
+
+const _MATCH_STATUSES = ["scheduled", "in_progress", "finished", "cancelled"] as const;
+const _MATCH_FORMATS = ["bo1", "bo3", "bo5"] as const;
+
+export function isMatchStatus(v: string): v is MatchStatus {
+  return (_MATCH_STATUSES as readonly string[]).includes(v);
+}
+export function isMatchFormat(v: string): v is MatchFormat {
+  return (_MATCH_FORMATS as readonly string[]).includes(v);
+}


### PR DESCRIPTION
## Summary

- **#126** 新增 `isMatchStatus` / `isMatchFormat` 类型守卫，消除全库内联 `as` cast
- **#125** 提取 `MatchTabsSection` 组件，移除 ~50 行重复 JSX
- **#142** 队伍详情页新增「地图表现」面板（胜率 + ban 率），修复 BO1 地图数据丢失 bug

## Changes

- `src/types/match.ts` — 追加类型守卫函数
- `src/actions/matches/results.ts` — 用守卫替换 `as MatchStatus`
- `src/app/[seasonSlug]/matches/page.tsx` — 用 `MatchTabsSection` 替换重复块
- `src/components/matches/MatchTabsSection.tsx` — 新组件
- `src/lib/teams/data.ts` — 新查询文件（`getTeamMapWinStats` / `getTeamBanStats`）
- `src/app/[seasonSlug]/teams/[teamId]/page.tsx` — 地图表现区块重写