### PR TITLE
feat: UI optimization v2 — 全站视觉增强

### DIFF
--- a/docs/ui-tokens.md
+++ b/docs/ui-tokens.md
@@ -1,6 +1,6 @@
 # 设计 Tokens
 
-> 所有 token 已在 `src/app/globals.css` 中以 CSS 自定义属性定义，并在 `tailwind.config.ts` 中映射为 Tailwind class。
+> 所有 token 在 `src/app/globals.css` 的 `@theme` 块中定义，Tailwind v4 自动将 `--color-*` 映射为 class（如 `text-[var(--color-accent)]`）。
 
 ---
 
@@ -10,45 +10,47 @@
 
 | Token | 值 | 用途 |
 |---|---|---|
-| `--bg-base` | `#0d0f14` | 页面底色（body 背景） |
-| `--bg-elevated` | `#161b22` | 卡片、侧边栏、下拉菜单 |
-| `--bg-overlay` | `#1e2530` | Modal、Tooltip、悬浮层 |
+| `--color-bg` | `#0a0c10` | 页面底色（body 背景） |
+| `--color-panel` | `#10131a` | 卡片、Panel 默认背景 |
+| `--color-panel-hi` | `#161a24` | 高亮 Panel（hover、当前步骤） |
+| `--color-panel-low` | `#0d1016` | 沉降背景（表头等） |
+
+### 边框（两层）
+
+| Token | 值 | 用途 |
+|---|---|---|
+| `--color-border` | `#1f2530` | 默认边框 |
+| `--color-border-hi` | `#2c3340` | hover 高亮边框 |
 
 ### 文字（三层）
 
 | Token | 值 | 用途 |
 |---|---|---|
-| `--text-primary` | `#e6edf3` | 正文、标题 |
-| `--text-secondary` | `#8b949e` | 辅助说明、元信息 |
-| `--text-muted` | `#484f58` | 占位符、禁用态文字 |
+| `--color-fg` | `#e7ecf3` | 正文、标题 |
+| `--color-fg-mid` | `#8e96a3` | 辅助说明、元信息 |
+| `--color-fg-dim` | `#525a6a` | 占位符、禁用态、标签 |
 
-### 分隔线
+### 强调色（Accent）
 
 | Token | 值 | 用途 |
 |---|---|---|
-| `--border` | `#30363d` | 卡片边框、分割线、表格行线 |
-
-### 赛季动态主题色
-
-每个赛季通过 `seasons.theme_color` 配置独立主题色，在赛季 layout 中注入 `--season-primary` CSS 变量。业务组件统一使用 `var(--season-primary)`，无需关心具体颜色值。
-
-示例主题色参考：
-
-| 风格 | 值 | 适用场景 |
-|---|---|---|
-| 橙色 | `#f97316` | 选秀联赛等活力型赛事 |
-| 红色 | `#ef4444` | 杯赛等竞技型赛事 |
-| 蓝色 | `#3b82f6` | 休闲赛等友好型赛事 |
-| 青色 | `#06b6d4` | 表演赛等娱乐型赛事 |
+| `--color-accent` | `#ff6b1a` | 主 CTA、当前状态、高亮 |
+| `--color-accent-soft` | `rgba(255,107,26,0.12)` | 浅底色背景 |
+| `--color-accent-edge` | `rgba(255,107,26,0.34)` | 边框高亮 |
+| `--color-accent-fg` | `#0a0c10` | accent 背景上的文字色 |
 
 ### 语义色
 
-| 用途 | 值 |
-|---|---|
-| 成功（绿） | `#22c55e` |
-| 警告（黄） | `#eab308` |
-| 错误（红） | `#ef4444` |
-| 信息（蓝） | `#3b82f6` |
+| Token | 值 | 用途 |
+|---|---|---|
+| `--color-ok` | `#4dd47a` | 成功、完成、胜利 |
+| `--color-warn` | `#ffc44d` | 警告、进行中、待定 |
+| `--color-danger` | `#ff5470` | 错误、禁止、失败 |
+| `--color-info` | `#4a9eff` | 信息型辅助标注（地图标签、决胜图、系统操作） |
+| `--color-info-soft` | `rgba(74,158,255,0.12)` | info 浅底色 |
+| `--color-info-edge` | `rgba(74,158,255,0.34)` | info 边框 |
+
+> `--color-info` 不替换 accent/ok/warn/danger 的语义，仅用于非 CTA 的辅助标注。
 
 ---
 
@@ -58,48 +60,21 @@
 
 | 字体 | CSS 变量 | 用途 |
 |---|---|---|
-| Inter | `var(--font-inter)` | 英文、数字 |
+| Geist | `var(--font-geist)` | 英文、数字（主字体） |
 | Noto Sans SC | `var(--font-noto-sans-sc)` | 中文 |
+| JetBrains Mono | `"JetBrains Mono"` | 标签、eyebrow、monospace 数值 |
 
-`font-family: var(--font-inter), var(--font-noto-sans-sc), sans-serif;`
+`--font-sans: var(--font-geist), var(--font-noto-sans-sc), system-ui, sans-serif;`
 
-### 字号阶梯
+### 字间距
 
-| 级别 | 尺寸 | 行高 | 使用场景 |
-|---|---|---|---|
-| `text-xs` | 12px | 1.5 | 时间戳、标签 |
-| `text-sm` | 14px | 1.5 | 辅助文字、按钮 |
-| `text-base` | 16px | 1.6 | 正文 |
-| `text-lg` | 18px | 1.5 | 小标题 |
-| `text-xl` | 20px | 1.4 | 卡片标题 |
-| `text-2xl` | 24px | 1.3 | 页面副标题 |
-| `text-3xl` | 30px | 1.3 | 页面主标题 |
-| `text-4xl` | 36px | 1.2 | 英雄区大标题 |
-
-### 字重
-
-| 级别 | 值 | 使用场景 |
+| Token | 值 | 用途 |
 |---|---|---|
-| `font-normal` | 400 | 正文、说明 |
-| `font-medium` | 500 | 强调正文 |
-| `font-semibold` | 600 | 按钮、小标题 |
-| `font-bold` | 700 | 标题、数据展示 |
-
----
-
-## 间距阶梯
-
-使用 Tailwind 默认 4px 基准：`p-1=4px / p-2=8px / p-3=12px / p-4=16px / p-6=24px / p-8=32px`
-
-| 用途 | 推荐间距 |
-|---|---|
-| 组件内边距（卡片） | `p-4`（16px）或 `p-6`（24px） |
-| 按钮内边距 | `px-4 py-2` |
-| 表单字段间距 | `space-y-4` |
-| 段落间距 | `space-y-3` |
-| 卡片网格 gap | `gap-4`（16px）或 `gap-6` |
-| 页面容器 | `container mx-auto px-4` |
-| 页面上下边距 | `py-8`（32px）或 `py-16` |
+| `--tracking-tight-2` | `-0.02em` | 大标题 |
+| `--tracking-tight-1` | `-0.01em` | 中标题 |
+| `--tracking-label` | `0.12em` | mono 标签、表头 |
+| `--tracking-ticker` | `0.08em` | 状态 ticker |
+| `--tracking-eyebrow` | `0.18em` | eyebrow 标签 |
 
 ---
 
@@ -107,22 +82,22 @@
 
 | Token | 值 | 用途 |
 |---|---|---|
-| `--radius` | `0.5rem`（8px） | 标准圆角（卡片、输入框）|
-| `rounded-sm` | 6px | 小元素（badge、tag） |
-| `rounded-md` | 6px（calc(--radius - 2px)） | 中等元素 |
-| `rounded-lg` | 8px | 卡片、面板 |
-| `rounded-full` | 9999px | 圆形按钮、头像 |
+| `--radius` | `3px` | 全局标准圆角（卡片、输入框） |
+| `--radius-sm` | `0px` | 无圆角（标签 pill） |
+| `--radius-md` | `2px` | 小元素 |
+| `--radius-lg` | `3px` | 卡片、Panel |
 
 ---
 
-## 阴影
+## 网格背景
 
-| 用途 | Tailwind class |
-|---|---|
-| 卡片默认 | 无阴影（靠 border 区分层次） |
-| 卡片悬停 | `shadow-md`（按需添加） |
-| Modal/Overlay | `shadow-xl` |
-| Dropdown | `shadow-lg` |
+页面底层有 32×32px 格线纹理：
+
+```css
+background-image: linear-gradient(rgba(31,37,48,0.4) 1px, transparent 1px),
+                  linear-gradient(90deg, rgba(31,37,48,0.4) 1px, transparent 1px);
+background-size: 32px 32px;
+```
 
 ---
 
@@ -133,5 +108,5 @@
 - 渐变 Logo / 渐变标题文字（`bg-gradient-to-r` on text）
 - 表情符号（emoji）出现在 UI 组件中
 - 白色背景页面（全站深色基底）
-- 圆角 > 16px（除 `rounded-full` 外）
+- 圆角 > 3px（除特殊情况外，勿用 `rounded-md` 以上）
 - 高饱和度色块大面积背景

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -379,6 +379,17 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
               {maps.map((map) => (
                 <TabsTrigger key={map.id} value={map.id} className="text-xs">
                   {mapLabel(map.mapName)}
+                  {map.pickedByTeamId && (
+                    <span
+                      className="ml-1 text-[10px] font-mono px-1 py-0.5"
+                      style={{ background: "rgba(77,212,122,0.12)", color: "var(--color-ok)" }}
+                    >
+                      {map.pickedByTeamId === match.teamAId
+                        ? teamA?.name?.slice(0, 3).toUpperCase()
+                        : teamB?.name?.slice(0, 3).toUpperCase()}{" "}
+                      PICK
+                    </span>
+                  )}
                 </TabsTrigger>
               ))}
             </TabsList>

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -9,9 +9,11 @@ import { formatCSTShortDate } from "@/lib/utils/date";
 import { normalizeStagePlan } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
-import { StatusPill, Panel, Marker, ScrollHint, Stat, PhaseStep } from "@/components/rivalhub";
+import { StatusPill, Panel, Marker, ScrollHint, Stat, PhaseStep, Btn } from "@/components/rivalhub";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
+import { StandingsTable } from "@/components/matches/StandingsTable";
+import { getStandings } from "@/lib/data/standings";
 
 const STATUS_IDX: Record<SeasonStatus, number> = {
   draft: 0, registration: 1, voting: 2, drafting: 3,
@@ -79,6 +81,12 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       }).from(matches).where(eq(matches.seasonId, season.id)),
       upcomingMatchesQuery ?? Promise.resolve([] as { id: string; status: string; scheduledAt: Date | null; stage: string; teamAName: string | null; teamBName: string | null }[]),
     ]);
+
+  // 积分榜（仅 playing 状态有实际数据）
+  const standings =
+    season.status === "playing"
+      ? await getStandings(season.id)
+      : [];
 
   // ── 动态阶段列表 ──────────────────────────────────────────
   interface Phase {
@@ -235,44 +243,102 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
         </ScrollHint>
       </Panel>
 
-      {/* NEXT MATCHES */}
-      {upcomingMatches.length > 0 && (
-        <>
-          <Marker sub="已安排的比赛">近期对决</Marker>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-            {upcomingMatches.map((match) => (
-              <Link key={match.id} href={`/${seasonSlug}/matches/${match.id}` as never}>
-                <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
-                      <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
-                        {match.teamAName ?? "TBD"}
-                      </span>
-                      <span className="font-mono text-xs text-[var(--color-fg-dim)] shrink-0">VS</span>
-                      <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
-                        {match.teamBName ?? "TBD"}
-                      </span>
+      {/* NEXT MATCHES + STANDINGS — dual column layout */}
+      {(upcomingMatches.length > 0 || standings.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-[1.5fr_1fr] gap-4">
+          {/* Left: 近期比赛 */}
+          {upcomingMatches.length > 0 && (
+            <Panel
+              label={
+                <div className="flex items-center justify-between w-full">
+                  <span>NEXT MATCHES</span>
+                  <Btn small ghost asChild>
+                    <Link href={`/${seasonSlug}/matches`}>VIEW ALL →</Link>
+                  </Btn>
+                </div>
+              }
+            >
+              <div className="grid gap-2">
+                {upcomingMatches.map((match) => (
+                  <Link key={match.id} href={`/${seasonSlug}/matches/${match.id}` as never}>
+                    <div
+                      className="flex items-center gap-2.5 p-2.5 rounded-sm transition-colors"
+                      style={{
+                        background: "var(--color-panel-low)",
+                        border: "1px solid var(--color-border)",
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.borderColor = "var(--color-border-hi)";
+                        e.currentTarget.style.background = "var(--color-panel-hi)";
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.borderColor = "var(--color-border)";
+                        e.currentTarget.style.background = "var(--color-panel-low)";
+                      }}
+                    >
+                      <div className="flex items-center gap-8">
+                        <div className="min-w-0 flex-1 flex items-center justify-end gap-2">
+                          <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
+                            {match.teamAName ?? "TBD"}
+                          </span>
+                        </div>
+                        <span className="font-mono text-xs text-[var(--color-fg-dim)] shrink-0">vs</span>
+                        <div className="min-w-0 flex-1 flex items-center gap-2">
+                          <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
+                            {match.teamBName ?? "TBD"}
+                          </span>
+                        </div>
+                        <div className="shrink-0">
+                          {match.status === "in_progress" ? (
+                            <span className="font-mono text-[11px] text-[var(--color-ok)]">● LIVE</span>
+                          ) : match.scheduledAt ? (
+                            <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">
+                              {formatCSTShortDate(match.scheduledAt)}
+                            </span>
+                          ) : (
+                            <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">待定</span>
+                          )}
+                        </div>
+                      </div>
+                      <div className="mt-1.5 font-mono text-[10px] text-[var(--color-fg-dim)] uppercase tracking-wider">
+                        {match.stage}
+                      </div>
                     </div>
-                    <div className="shrink-0 text-right">
-                      {match.status === "in_progress" ? (
-                        <span className="font-mono text-[11px] text-[var(--color-ok)]">● LIVE</span>
-                      ) : match.scheduledAt ? (
-                        <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">
-                          {formatCSTShortDate(match.scheduledAt)}
-                        </span>
-                      ) : (
-                        <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">待定</span>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-1.5 font-mono text-[10px] text-[var(--color-fg-dim)] uppercase tracking-wider">
-                    {match.stage}
-                  </div>
-                </Panel>
-              </Link>
-            ))}
-          </div>
-        </>
+                  </Link>
+                ))}
+              </div>
+            </Panel>
+          )}
+
+          {/* Right: 积分榜 TOP 4 */}
+          {standings.length > 0 && (
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h3
+                  className="font-semibold text-sm"
+                  style={{
+                    fontFamily: "var(--font-sans)",
+                    color: "var(--color-fg)",
+                  }}
+                >
+                  STANDINGS · TOP 4
+                </h3>
+              </div>
+              <StandingsTable
+                standings={standings.slice(0, 4)}
+                seasonSlug={seasonSlug}
+                isFinal={false}
+              />
+              <div className="mt-3">
+                <Btn full ghost asChild>
+                  <Link href={`/${seasonSlug}/matches`} className="w-full">
+                    查看完整排名 →
+                  </Link>
+                </Btn>
+              </div>
+            </div>
+          )}
+        </div>
       )}
 
       <Marker sub="快速访问各功能模块">赛季导航</Marker>

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -221,9 +221,9 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       </div>
 
       {/* Phase tracker */}
-      <Panel pad={0}>
+      <Panel pad={24}>
         <ScrollHint fromColor="var(--color-panel)">
-          <div className="flex">
+          <div className="flex items-start">
             {phases.map((phase, i) => (
               <PhaseStep
                 key={phase.key}

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -69,7 +69,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
         .limit(4)
     : null;
 
-  const [[teamCountRow], [approvedCountRow], [matchCountRow], upcomingMatches] =
+  const [[teamCountRow], [approvedCountRow], [matchCountRow], upcomingMatches, standings] =
     await Promise.all([
       db.select({ value: count() }).from(teams).where(eq(teams.seasonId, season.id)),
       db.select({ value: count() }).from(seasonRegistrations).where(
@@ -80,13 +80,8 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
         finished: sql<number>`count(*) filter (where ${matches.status} = 'finished')`,
       }).from(matches).where(eq(matches.seasonId, season.id)),
       upcomingMatchesQuery ?? Promise.resolve([] as { id: string; status: string; scheduledAt: Date | null; stage: string; teamAName: string | null; teamBName: string | null }[]),
+      season.status === "playing" ? getStandings(season.id) : Promise.resolve([]),
     ]);
-
-  // 积分榜（仅 playing 状态有实际数据）
-  const standings =
-    season.status === "playing"
-      ? await getStandings(season.id)
-      : [];
 
   // ── 动态阶段列表 ──────────────────────────────────────────
   interface Phase {
@@ -262,18 +257,10 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
                 {upcomingMatches.map((match) => (
                   <Link key={match.id} href={`/${seasonSlug}/matches/${match.id}` as never}>
                     <div
-                      className="flex items-center gap-2.5 p-2.5 rounded-sm transition-colors"
+                      className="flex items-center gap-2.5 p-2.5 rounded-sm transition-colors hover:bg-[var(--color-panel-hi)] hover:border-[var(--color-border-hi)]"
                       style={{
                         background: "var(--color-panel-low)",
                         border: "1px solid var(--color-border)",
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.borderColor = "var(--color-border-hi)";
-                        e.currentTarget.style.background = "var(--color-panel-hi)";
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.borderColor = "var(--color-border)";
-                        e.currentTarget.style.background = "var(--color-panel-low)";
                       }}
                     >
                       <div className="flex items-center gap-8">

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -9,7 +9,7 @@ import { formatCSTShortDate } from "@/lib/utils/date";
 import { normalizeStagePlan } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
-import { StatusPill, Panel, Marker, ScrollHint, Stat } from "@/components/rivalhub";
+import { StatusPill, Panel, Marker, ScrollHint, Stat, PhaseStep } from "@/components/rivalhub";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
 
@@ -220,44 +220,18 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       {/* Phase tracker */}
       <Panel pad={0}>
         <ScrollHint fromColor="var(--color-panel)">
-        <div className="flex">
-          {phases.map((phase, i) => {
-            const isCurrent = i === currentPhaseIdx;
-            const isDone = phase.done;
-            return (
-              <div key={phase.key}
-                className="relative flex-1 min-w-[120px]"
-                style={{
-                  padding: "18px 16px",
-                  borderRight: i < phases.length - 1 ? "1px solid var(--color-border)" : "none",
-                  background: isCurrent ? "var(--color-panel-hi)" : "transparent",
-                }}
-              >
-                <div className="flex items-center gap-2 mb-1.5">
-                  <div className="grid place-items-center font-bold rounded-sm" style={{
-                    width: 16, height: 16,
-                    border: `1px solid ${isDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-border)"}`,
-                    background: isDone ? "var(--color-ok)22" : isCurrent ? "var(--color-accent)22" : "transparent",
-                    fontFamily: "var(--font-mono)", fontSize: 10,
-                    color: isDone ? "var(--color-ok)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-dim)",
-                  }}>
-                    {isDone ? "✓" : i + 1}
-                  </div>
-                  <div className="uppercase" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
-                    STEP {i + 1}
-                  </div>
-                </div>
-                <div className="font-semibold" style={{
-                  fontFamily: "var(--font-display)", fontSize: 14,
-                  color: isDone ? "var(--color-fg)" : isCurrent ? "var(--color-accent)" : "var(--color-fg-mid)",
-                  letterSpacing: "0.04em",
-                }}>
-                  {phase.label}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+          <div className="flex">
+            {phases.map((phase, i) => (
+              <PhaseStep
+                key={phase.key}
+                label={phase.label}
+                stepNumber={i + 1}
+                isDone={phase.done}
+                isCurrent={i === currentPhaseIdx}
+                isLast={i === phases.length - 1}
+              />
+            ))}
+          </div>
         </ScrollHint>
       </Panel>
 
@@ -303,10 +277,10 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
 
       <Marker sub="快速访问各功能模块">赛季导航</Marker>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {quickLinks.map(({ href, label, description, icon: Icon }) => (
           <Link key={href} href={href as never} className="group">
-            <Panel>
+            <Panel hoverable>
               <div className="flex flex-col gap-2">
                 <div
                   className="inline-flex items-center justify-center w-10 h-10 rounded-md mb-1 transition-colors"

--- a/src/app/[seasonSlug]/players/page.tsx
+++ b/src/app/[seasonSlug]/players/page.tsx
@@ -125,7 +125,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
                 href={`/players/${reg.userId}` as never}
                 className="block"
               >
-                <Panel className="h-full hover:border-[var(--color-accent)] transition-colors cursor-pointer">
+                <Panel hoverable className="h-full cursor-pointer">
                   <div className="flex items-start justify-between gap-2 mb-3">
                     <span className="font-semibold text-[var(--color-fg)] truncate text-base">
                       {displayName}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -21,7 +21,7 @@ interface TeamDetailPageProps {
 }
 
 function pct(n: number, d: number) {
-  if (d === 0) return { text: "—", color: "var(--color-fg-muted)" as string };
+  if (d === 0) return { text: "—", color: "var(--color-fg-dim)" };
   const v = Math.round((n / d) * 100);
   const color = v >= 60 ? "var(--color-ok)" : v <= 40 ? "var(--color-danger)" : "var(--color-fg)";
   return { text: `${v}%`, color };
@@ -423,17 +423,20 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         {mapLabel(mapName)}
                       </td>
                       <td className="px-5 py-3 text-center">
-                        {stat !== undefined ? (
-                          <>
-                            <div
-                              className="font-semibold"
-                              style={{ color: pct(stat.wins, stat.played).color }}
-                            >
-                              {pct(stat.wins, stat.played).text}
-                            </div>
-                            <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
-                          </>
-                        ) : (
+                        {stat !== undefined ? (() => {
+                          const { text, color } = pct(stat.wins, stat.played);
+                          return (
+                            <>
+                              <div
+                                className="font-semibold"
+                                style={{ color }}
+                              >
+                                {text}
+                              </div>
+                              <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
+                            </>
+                          );
+                        })() : (
                           <span className="text-[var(--color-fg-muted)]">—</span>
                         )}
                       </td>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -424,20 +424,20 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                       </td>
                       <td className="px-5 py-3 text-center">
                         {stat !== undefined ? (() => {
-                          const { text, color } = pct(stat.wins, stat.played);
+                          const wr = pct(stat.wins, stat.played);
                           return (
                             <>
                               <div
                                 className="font-semibold"
-                                style={{ color }}
+                                style={{ color: wr.color }}
                               >
-                                {text}
+                                {wr.text}
                               </div>
                               <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
                             </>
                           );
                         })() : (
-                          <span className="text-[var(--color-fg-muted)]">—</span>
+                          <span className="text-[var(--color-fg-dim)]">—</span>
                         )}
                       </td>
                       <td className="px-5 py-3 text-center">
@@ -449,7 +449,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                             <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
                           </>
                         ) : (
-                          <span className="text-[var(--color-fg-muted)]">—</span>
+                          <span className="text-[var(--color-fg-dim)]">—</span>
                         )}
                       </td>
                     </tr>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -251,7 +251,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         <Panel label="阵容" pad={20}>
           <div className="space-y-3">
             {starters.map((p) => (
-              <div key={p.registrationId} className="flex items-center justify-between gap-2">
+              <div key={p.registrationId} className="flex items-center justify-between gap-2 hover:bg-[var(--color-panel-hi)] transition-colors rounded px-2 -mx-2">
                 <div className="flex items-center gap-2 sm:gap-3 min-w-0">
                   {p.registrationId === team.captainRegistrationId && (
                     <PosChip pos="C" small />
@@ -275,7 +275,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
               <div className="border-t border-[var(--color-border)] pt-3 space-y-2">
                 <p className="text-xs text-[var(--color-fg-mid)] font-medium uppercase tracking-wide">替补</p>
                 {subs.map((p) => (
-                  <div key={p.registrationId} className="flex items-center justify-between gap-2 opacity-70">
+                  <div key={p.registrationId} className="flex items-center justify-between gap-2 opacity-70 hover:bg-[var(--color-panel-hi)] transition-colors rounded px-2 -mx-2">
                     <span className="text-sm text-[var(--color-fg)] truncate">{getDisplayName(p)}</span>
                     <span className="text-xs text-[var(--color-fg-mid)] shrink-0">
                       {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -21,8 +21,10 @@ interface TeamDetailPageProps {
 }
 
 function pct(n: number, d: number) {
-  if (d === 0) return "—";
-  return `${Math.round((n / d) * 100)}%`;
+  if (d === 0) return { text: "—", color: "var(--color-fg-muted)" as string };
+  const v = Math.round((n / d) * 100);
+  const color = v >= 60 ? "var(--color-ok)" : v <= 40 ? "var(--color-danger)" : "var(--color-fg)";
+  return { text: `${v}%`, color };
 }
 
 export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
@@ -423,8 +425,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                       <td className="px-5 py-3 text-center">
                         {stat !== undefined ? (
                           <>
-                            <div className="font-semibold text-[var(--color-fg)]">
-                              {pct(stat.wins, stat.played)}
+                            <div
+                              className="font-semibold"
+                              style={{ color: pct(stat.wins, stat.played).color }}
+                            >
+                              {pct(stat.wins, stat.played).text}
                             </div>
                             <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
                           </>
@@ -436,7 +441,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         {bpMatchCount > 0 ? (
                           <>
                             <div className="font-semibold text-[var(--color-fg)]">
-                              {pct(bans, bpMatchCount)}
+                              {pct(bans, bpMatchCount).text}
                             </div>
                             <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
                           </>
@@ -485,7 +490,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                       <td className="px-5 py-3 text-center text-green-500">{h.wins}</td>
                       <td className="px-5 py-3 text-center text-red-500">{h.losses}</td>
                       <td className="px-5 py-3 text-right font-semibold text-[var(--color-fg)]">
-                        {pct(h.wins, h.wins + h.losses)}
+                        {pct(h.wins, h.wins + h.losses).text}
                       </td>
                     </tr>
                   );

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -21,6 +21,7 @@ import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
 import { BatchDeadlineCard } from "@/components/matches/BatchDeadlineCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Panel, StatusPill } from "@/components/rivalhub";
+import { cn } from "@/lib/utils/cn";
 import { Separator } from "@/components/ui/separator";
 import { getFirstStageOfType, normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
 import { MATCH_FORMAT_LABELS } from "@/types/match";
@@ -390,7 +391,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "未知队伍";
                     const teamBName = teamMap.get(m.teamBId) ?? "未知队伍";
                     return (
-                      <Panel key={m.id} pad={16} className={`space-y-3${m.status === "in_progress" ? " border-l-[3px] border-[var(--color-accent)]" : ""}`}>
+                      <Panel key={m.id} pad={16} className={cn("space-y-3", m.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]")}>
                         <div className="flex items-center justify-between gap-4 flex-wrap">
                           <div className="flex items-center gap-3">
                             <span className="font-semibold">{teamAName}</span>
@@ -497,7 +498,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "TBD";
                     const teamBName = teamMap.get(m.teamBId) ?? "TBD";
                     return (
-                      <Panel key={m.id} pad={16} className={`space-y-3${m.status === "in_progress" ? " border-l-[3px] border-[var(--color-accent)]" : ""}`}>
+                      <Panel key={m.id} pad={16} className={cn("space-y-3", m.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]")}>
                         <div className="flex items-center justify-between gap-4 flex-wrap">
                           <div className="flex items-center gap-3">
                             <span className="font-semibold">{teamAName}</span>

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -390,7 +390,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "未知队伍";
                     const teamBName = teamMap.get(m.teamBId) ?? "未知队伍";
                     return (
-                      <Panel key={m.id} pad={16} className="space-y-3">
+                      <Panel key={m.id} pad={16} className={`space-y-3${m.status === "in_progress" ? " border-l-[3px] border-[var(--color-accent)]" : ""}`}>
                         <div className="flex items-center justify-between gap-4 flex-wrap">
                           <div className="flex items-center gap-3">
                             <span className="font-semibold">{teamAName}</span>
@@ -408,52 +408,61 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
-                        {m.status !== "cancelled" && <Separator />}
-                        {m.status !== "finished" && m.status !== "cancelled" && (
-                          <>
-                            <div className="flex flex-wrap items-center gap-2">
-                          <AdminRosterDialog
-                            matchId={m.id}
-                            teamAName={teamAName}
-                            teamBName={teamBName}
-                            teamAId={m.teamAId}
-                            teamBId={m.teamBId}
-                            teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
-                            teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
-                            teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                            teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                          />
-                          {m.status === "in_progress" && (
-                            <VetoInputDialog
-                              matchId={m.id}
-                              format={m.format as "bo1" | "bo3" | "bo5"}
-                              teamAName={teamAName}
-                              teamBName={teamBName}
-                              teamAId={m.teamAId}
-                              teamBId={m.teamBId}
-                              mapPool={mapPool}
-                            />
-                          )}
-                        </div>
-                        <ScheduledAtInput
-                          matchId={m.id}
-                          currentScheduledAt={m.scheduledAt}
-                          currentCompletionDeadline={m.completionDeadline}
-                        />
-                        <ScoreInput
-                          matchId={m.id}
-                          teamAName={teamAName}
-                          teamBName={teamBName}
-                          currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                          format={m.format as "bo1" | "bo3" | "bo5"}
-                        />
-                          </>
+                        {m.status !== "cancelled" && (
+                          <details open={m.status === "in_progress" ? true : undefined}>
+                            <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
+                              {m.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
+                            </summary>
+                            <div className="space-y-3 pt-2">
+                              <Separator />
+                              {m.status !== "finished" && (
+                                <>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <AdminRosterDialog
+                                      matchId={m.id}
+                                      teamAName={teamAName}
+                                      teamBName={teamBName}
+                                      teamAId={m.teamAId}
+                                      teamBId={m.teamBId}
+                                      teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                                      teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+                                      teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                                      teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                                    />
+                                    {m.status === "in_progress" && (
+                                      <VetoInputDialog
+                                        matchId={m.id}
+                                        format={m.format as "bo1" | "bo3" | "bo5"}
+                                        teamAName={teamAName}
+                                        teamBName={teamBName}
+                                        teamAId={m.teamAId}
+                                        teamBId={m.teamBId}
+                                        mapPool={mapPool}
+                                      />
+                                    )}
+                                  </div>
+                                  <ScheduledAtInput
+                                    matchId={m.id}
+                                    currentScheduledAt={m.scheduledAt}
+                                    currentCompletionDeadline={m.completionDeadline}
+                                  />
+                                  <ScoreInput
+                                    matchId={m.id}
+                                    teamAName={teamAName}
+                                    teamBName={teamBName}
+                                    currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                                    format={m.format as "bo1" | "bo3" | "bo5"}
+                                  />
+                                </>
+                              )}
+                              {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
+                                <div key={map.id}>
+                                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                                </div>
+                              ))}
+                            </div>
+                          </details>
                         )}
-                        {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
-                          <div key={map.id}>
-                            <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                          </div>
-                        ))}
                         <div className="flex items-center justify-between gap-2">
                           <Link
                             href={`/${seasonSlug}/matches/${m.id}`}
@@ -488,7 +497,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "TBD";
                     const teamBName = teamMap.get(m.teamBId) ?? "TBD";
                     return (
-                      <Panel key={m.id} pad={16} className="space-y-3">
+                      <Panel key={m.id} pad={16} className={`space-y-3${m.status === "in_progress" ? " border-l-[3px] border-[var(--color-accent)]" : ""}`}>
                         <div className="flex items-center justify-between gap-4 flex-wrap">
                           <div className="flex items-center gap-3">
                             <span className="font-semibold">{teamAName}</span>
@@ -506,72 +515,81 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                             />
                           </div>
                         </div>
-                        {m.status !== "cancelled" && <Separator />}
-                        {m.status !== "finished" && m.status !== "cancelled" && (
-                          <>
-                            <div className="flex flex-wrap items-center gap-2">
-                              <AdminRosterDialog
-                                matchId={m.id}
-                                teamAName={teamAName}
-                                teamBName={teamBName}
-                                teamAId={m.teamAId}
-                                teamBId={m.teamBId}
-                                teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
-                                teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
-                                teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                                teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                              />
-                              {(m.status === "scheduled" || m.status === "in_progress") && (
-                                <VetoInputDialog
-                                  matchId={m.id}
-                                  format={m.format as "bo1" | "bo3" | "bo5"}
-                                  teamAName={teamAName}
-                                  teamBName={teamBName}
-                                  teamAId={m.teamAId}
-                                  teamBId={m.teamBId}
-                                  mapPool={mapPool}
-                                />
+                        {m.status !== "cancelled" && (
+                          <details open={m.status === "in_progress" ? true : undefined}>
+                            <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
+                              {m.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
+                            </summary>
+                            <div className="space-y-3 pt-2">
+                              <Separator />
+                              {m.status !== "finished" && (
+                                <>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <AdminRosterDialog
+                                      matchId={m.id}
+                                      teamAName={teamAName}
+                                      teamBName={teamBName}
+                                      teamAId={m.teamAId}
+                                      teamBId={m.teamBId}
+                                      teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                                      teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+                                      teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                                      teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                                    />
+                                    {(m.status === "scheduled" || m.status === "in_progress") && (
+                                      <VetoInputDialog
+                                        matchId={m.id}
+                                        format={m.format as "bo1" | "bo3" | "bo5"}
+                                        teamAName={teamAName}
+                                        teamBName={teamBName}
+                                        teamAId={m.teamAId}
+                                        teamBId={m.teamBId}
+                                        mapPool={mapPool}
+                                      />
+                                    )}
+                                  </div>
+                                  <ScheduledAtInput
+                                    matchId={m.id}
+                                    currentScheduledAt={m.scheduledAt}
+                                    currentCompletionDeadline={m.completionDeadline}
+                                  />
+                                  {m.status === "in_progress" ? (
+                                    <MapByMapInput
+                                      matchId={m.id}
+                                      format={m.format as "bo1" | "bo3" | "bo5"}
+                                      teamAName={teamAName}
+                                      teamBName={teamBName}
+                                      teamAId={m.teamAId}
+                                      teamBId={m.teamBId}
+                                      completedMaps={(mapsByMatchId.get(m.id) ?? []).map((r) => ({
+                                        mapOrder: r.mapOrder,
+                                        mapName: r.mapName,
+                                        scoreA: r.scoreA ?? 0,
+                                        scoreB: r.scoreB ?? 0,
+                                        pickedByTeamId: r.pickedByTeamId,
+                                        teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+                                      }))}
+                                      mapPool={mapPool}
+                                    />
+                                  ) : (
+                                    <ScoreInput
+                                      matchId={m.id}
+                                      teamAName={teamAName}
+                                      teamBName={teamBName}
+                                      currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                                      format={m.format as "bo1" | "bo3" | "bo5"}
+                                    />
+                                  )}
+                                </>
                               )}
+                              {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
+                                <div key={map.id}>
+                                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                                </div>
+                              ))}
                             </div>
-                            <ScheduledAtInput
-                              matchId={m.id}
-                              currentScheduledAt={m.scheduledAt}
-                              currentCompletionDeadline={m.completionDeadline}
-                            />
-                            {m.status === "in_progress" ? (
-                              <MapByMapInput
-                                matchId={m.id}
-                                format={m.format as "bo1" | "bo3" | "bo5"}
-                                teamAName={teamAName}
-                                teamBName={teamBName}
-                                teamAId={m.teamAId}
-                                teamBId={m.teamBId}
-                                completedMaps={(mapsByMatchId.get(m.id) ?? []).map((r) => ({
-                                  mapOrder: r.mapOrder,
-                                  mapName: r.mapName,
-                                  scoreA: r.scoreA ?? 0,
-                                  scoreB: r.scoreB ?? 0,
-                                  pickedByTeamId: r.pickedByTeamId,
-                                  teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
-                                }))}
-                                mapPool={mapPool}
-                              />
-                            ) : (
-                              <ScoreInput
-                                matchId={m.id}
-                                teamAName={teamAName}
-                                teamBName={teamBName}
-                                currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                                format={m.format as "bo1" | "bo3" | "bo5"}
-                              />
-                            )}
-                          </>
+                          </details>
                         )}
-                        {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
-                          <div key={map.id}>
-                            <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                          </div>
-                        ))}
                         <div className="flex items-center justify-between gap-2">
                           <Link
                             href={`/${seasonSlug}/matches/${m.id}`}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -19,48 +19,90 @@ export default async function AdminDashboardPage() {
             .orderBy(seasons.createdAt)
         : [];
 
+  const isActive = (s: (typeof allSeasons)[number]) =>
+    s.status !== "archived" && s.status !== "finished" && s.status !== "draft";
+
   return (
     <div className="p-8 max-w-2xl">
       <div className="flex items-center justify-between mb-6">
-          <Marker>赛季管理</Marker>
-          {admin.role === "super_admin" && (
-            <div className="flex items-center gap-2">
-              <Btn small asChild>
-                <Link href="/admin/seasons/new">新建赛季</Link>
-              </Btn>
-            </div>
-          )}
-        </div>
-
-        {allSeasons.length === 0 ? (
-          <p className="text-[var(--color-fg-mid)]">暂无赛季数据</p>
-        ) : (
-          <div className="space-y-3">
-            {allSeasons.map((s) => (
-              <Panel key={s.id} pad={16} className="flex items-center justify-between gap-4">
-                <Link
-                  href={`/admin/${s.slug}/registrations`}
-                  className="min-w-0 flex-1 hover:text-[var(--color-fg)] transition-colors"
-                >
-                  <div>
-                    <span className="font-medium">{s.name}</span>
-                    <span className="text-sm text-[var(--color-fg-mid)] ml-2">
-                      {s.slug}
-                    </span>
-                  </div>
-                </Link>
-                <div className="flex items-center gap-2">
-                  <StatusPill status={s.status} />
-                  {admin.role === "super_admin" && (
-                    <Btn small asChild>
-                      <Link href={`/admin/${s.slug}/settings`}>设置</Link>
-                    </Btn>
-                  )}
-                </div>
-              </Panel>
-            ))}
-          </div>
+        <Marker>赛季管理</Marker>
+        {admin.role === "super_admin" && (
+          <Btn small asChild>
+            <Link href="/admin/seasons/new">新建赛季</Link>
+          </Btn>
         )}
       </div>
+
+      {allSeasons.length === 0 ? (
+        <p className="text-[var(--color-fg-mid)]">暂无赛季数据</p>
+      ) : (
+        <div className="space-y-3">
+          {allSeasons.map((s) => {
+            const active = isActive(s);
+            const hasMatches = (s.stagePlan as unknown[]).length > 0;
+            return (
+              <Panel key={s.id} pad={16}>
+                <div className="flex items-center justify-between gap-4 flex-wrap">
+                  <Link
+                    href={`/admin/${s.slug}/matches`}
+                    className="min-w-0 flex-1 hover:text-[var(--color-fg)] transition-colors"
+                  >
+                    <div>
+                      <span className="font-medium">{s.name}</span>
+                      <span className="text-sm text-[var(--color-fg-mid)] ml-2">
+                        {s.slug}
+                      </span>
+                    </div>
+                  </Link>
+
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <StatusPill status={s.status} />
+
+                    {active ? (
+                      <>
+                        <Btn small asChild>
+                          <Link href={`/admin/${s.slug}/matches`}>比赛管理</Link>
+                        </Btn>
+                        <Btn small asChild>
+                          <Link href={`/admin/${s.slug}/registrations`}>报名审核</Link>
+                        </Btn>
+                        {s.hasDraft && (
+                          <Btn small ghost asChild>
+                            <Link href={`/admin/${s.slug}/draft`}>选秀</Link>
+                          </Btn>
+                        )}
+                        {s.hasCaptainVoting && (
+                          <Btn small ghost asChild>
+                            <Link href={`/admin/${s.slug}/captains`}>队长投票</Link>
+                          </Btn>
+                        )}
+                        {admin.role === "super_admin" && (
+                          <Btn small ghost asChild>
+                            <Link href={`/admin/${s.slug}/settings`}>设置</Link>
+                          </Btn>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        {hasMatches && (
+                          <Btn small asChild>
+                            <Link href={`/admin/${s.slug}/matches`}>查看赛季</Link>
+                          </Btn>
+                        )}
+                        {admin.role === "super_admin" && (
+                          <Btn small ghost asChild>
+                            <Link href={`/admin/${s.slug}/settings`}>设置</Link>
+                          </Btn>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </Panel>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,11 @@
   --color-warn: #ffc44d;
   --color-danger: #ff5470;
 
+  /* Info */
+  --color-info: #4a9eff;
+  --color-info-soft: rgba(74, 158, 255, 0.12);
+  --color-info-edge: rgba(74, 158, 255, 0.34);
+
   /* Typography */
   --font-sans: var(--font-geist), var(--font-noto-sans-sc), system-ui, sans-serif;
   --font-display: var(--font-geist), var(--font-noto-sans-sc), system-ui, sans-serif;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -258,11 +258,15 @@ export default async function HomePage() {
           </div>
           <div
             aria-hidden
-            className="absolute inset-0 opacity-50"
+            className="absolute inset-0 opacity-50 pointer-events-none"
             style={{
               background: `
-                radial-gradient(circle at 90% 10%, #ff6b1a22 0, transparent 40%),
-                repeating-linear-gradient(0deg, transparent 0 32px, #1f253040 32px 33px)
+                radial-gradient(circle at 90% 10%, ${
+                  featured.status === "registration" ? "rgba(77,212,122,0.09)"
+                    : featured.status === "voting" ? "rgba(255,196,77,0.09)"
+                    : "rgba(255,107,26,0.13)"
+                } 0, transparent 40%),
+                repeating-linear-gradient(0deg, transparent 0 32px, rgba(31,37,48,0.25) 32px 33px)
               `,
             }}
           />
@@ -326,73 +330,59 @@ export default async function HomePage() {
             </div>
           </Panel>
         ) : featured.status === "voting" ? (
-          <Panel label="CAPTAIN VOTING">
-            <div className="grid gap-3.5">
-              <div>
-                <div
-                  className="uppercase"
-                  style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: 10,
-                    color: "var(--color-fg-dim)",
-                    letterSpacing: "var(--tracking-label)",
-                  }}
-                >
-                  {SEASON_STATUS_LABELS[featured.status]}
-                </div>
-                <div
-                  className="mt-1 font-semibold"
-                  style={{
-                    fontFamily: "var(--font-display)",
-                    fontSize: 20,
-                    color: "var(--color-fg)",
-                  }}
-                >
-                  {featured.name}
-                </div>
-              </div>
-              <div className="grid gap-2 py-3 border-y border-[var(--color-border)]">
-                {topCandidatesWithNames.length > 0 ? (
-                  topCandidatesWithNames.map((c, i) => (
-                    <div key={i} className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <span
-                          style={{
-                            fontFamily: "var(--font-mono)",
-                            fontSize: 11,
-                            color: i === 0 ? "var(--color-accent)" : "var(--color-fg-dim)",
-                            minWidth: 20,
-                          }}
-                        >
-                          #{i + 1}
-                        </span>
-                        <span style={{ fontFamily: "var(--font-sans)", fontSize: 14, color: "var(--color-fg)" }}>
-                          {c.name}
-                        </span>
-                      </div>
-                      <span
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: 12,
-                          color: "var(--color-fg-mid)",
-                        }}
-                      >
-                        {c.voteCount} 票
-                      </span>
+          <Panel label="投票排行 · TOP 3">
+            <div className="grid gap-3">
+              {topCandidatesWithNames.length > 0 ? (
+                topCandidatesWithNames.map((c, i) => (
+                  <div
+                    key={i}
+                    className="grid items-center gap-3"
+                    style={{
+                      gridTemplateColumns: "auto 1fr auto",
+                      padding: "10px 12px",
+                      background: i === 0 ? "rgba(255,107,26,0.04)" : "var(--color-panel-low)",
+                      border: `1px solid ${i === 0 ? "rgba(255,107,26,0.27)" : "var(--color-border)"}`,
+                      borderRadius: "var(--radius-sm, 2px)",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 20,
+                        fontWeight: 700,
+                        color: i === 0 ? "var(--color-accent)" : "var(--color-fg-mid)",
+                      }}
+                    >
+                      {String(i + 1).padStart(2, "0")}
                     </div>
-                  ))
-                ) : (
-                  <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-dim)" }}>
-                    暂无投票数据
+                    <div>
+                      <div style={{ fontWeight: 600, fontSize: 14, color: "var(--color-fg)" }}>
+                        {c.name}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 18,
+                        fontWeight: 700,
+                        color: "var(--color-fg)",
+                      }}
+                    >
+                      {c.voteCount}
+                    </div>
                   </div>
-                )}
-              </div>
-              <Btn full asChild>
-                <Link href={`/${featured.slug}/captains`} className="w-full">
-                  前往投票 →
-                </Link>
-              </Btn>
+                ))
+              ) : (
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-dim)" }}>
+                  暂无投票数据
+                </div>
+              )}
             </div>
+            <Btn full asChild style={{ marginTop: 14 }}>
+              <Link href={`/${featured.slug}/captains`} className="w-full">
+                查看全部候选人 →
+              </Link>
+            </Btn>
           </Panel>
         ) : featured.status === "playing" ? (
           <Panel label="LIVE MATCHES">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-export const dynamic = "force-dynamic";
-
 import Link from "next/link";
 import { and, eq, not, count, or, desc, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
@@ -26,13 +24,6 @@ export default async function HomePage() {
   const featured = activeSeasons[0];
   const others = activeSeasons.slice(1);
 
-  const archivedSeasons = await db
-    .select()
-    .from(seasons)
-    .where(eq(seasons.status, "archived"))
-    .orderBy(desc(seasons.createdAt))
-    .limit(6);
-
   if (!featured) {
     return (
       <div className="mx-auto px-4 lg:px-9 py-8 max-w-[1240px]">
@@ -45,6 +36,14 @@ export default async function HomePage() {
       </div>
     );
   }
+
+  // 历届已归档赛季
+  const archivedSeasons = await db
+    .select({ id: seasons.id, name: seasons.name, slug: seasons.slug, kind: seasons.kind, status: seasons.status })
+    .from(seasons)
+    .where(eq(seasons.status, "archived"))
+    .orderBy(desc(seasons.createdAt))
+    .limit(6);
 
   // 并行查询：基础统计 + 按状态的动态数据
   const [
@@ -101,7 +100,12 @@ export default async function HomePage() {
     // 仅 playing 状态时查询 LIVE + 下一场
     featured.status === "playing"
       ? db
-          .select()
+          .select({
+            id: matches.id,
+            status: matches.status,
+            scheduledAt: matches.scheduledAt,
+            format: matches.format,
+          })
           .from(matches)
           .where(
             and(
@@ -114,7 +118,7 @@ export default async function HomePage() {
           )
           .orderBy(matches.scheduledAt)
           .limit(2)
-      : Promise.resolve([] as (typeof matches.$inferSelect)[]),
+      : Promise.resolve([] as { id: string; status: string; scheduledAt: Date | null; format: string }[]),
   ]);
 
   // voting 状态：查询候选人名字

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,14 @@
 export const dynamic = "force-dynamic";
 
 import Link from "next/link";
-import { and, eq, not, count } from "drizzle-orm";
+import { and, eq, not, count, or, desc, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, seasonRegistrations } from "@/db/schema";
+import { seasons, teams, seasonRegistrations, users } from "@/db/schema";
+import { captainVotes } from "@/db/schema/votes";
+import { matches } from "@/db/schema/matches";
 import { APP_BRAND } from "@/lib/branding";
 import { SEASON_STATUS_LABELS } from "@/types/season";
+import { normalizeRegistrationConfig } from "@/types/season";
 import { Panel, Btn, Marker, StatusPill, EmptyState, MiniStat } from "@/components/rivalhub";
 
 export default async function HomePage() {
@@ -36,12 +39,162 @@ export default async function HomePage() {
     );
   }
 
-  const [[featuredTeamCount], [featuredPlayerCount]] = await Promise.all([
+  // 并行查询：基础统计 + 按状态的动态数据
+  const [
+    [featuredTeamCount],
+    [featuredPlayerCount],
+    registrationCounts,
+    topVoteCandidates,
+    liveAndUpcomingMatches,
+  ] = await Promise.all([
     db.select({ value: count() }).from(teams).where(eq(teams.seasonId, featured.id)),
     db.select({ value: count() }).from(seasonRegistrations).where(
       and(eq(seasonRegistrations.seasonId, featured.id), eq(seasonRegistrations.status, "approved"))
     ),
+    // 仅 registration 状态时查询
+    featured.status === "registration"
+      ? db
+          .select({
+            position: seasonRegistrations.primaryPosition,
+            cnt: count(),
+          })
+          .from(seasonRegistrations)
+          .where(
+            and(
+              eq(seasonRegistrations.seasonId, featured.id),
+              or(
+                eq(seasonRegistrations.status, "approved"),
+                eq(seasonRegistrations.status, "pending")
+              )
+            )
+          )
+          .groupBy(seasonRegistrations.primaryPosition)
+      : Promise.resolve([] as { position: string; cnt: number }[]),
+    // 仅 voting 状态时查询 TOP 3 候选人
+    featured.status === "voting"
+      ? db
+          .select({
+            candidateRegistrationId: captainVotes.candidateRegistrationId,
+            voteCount: count(),
+          })
+          .from(captainVotes)
+          .where(
+            inArray(
+              captainVotes.candidateRegistrationId,
+              db
+                .select({ id: seasonRegistrations.id })
+                .from(seasonRegistrations)
+                .where(eq(seasonRegistrations.seasonId, featured.id))
+            )
+          )
+          .groupBy(captainVotes.candidateRegistrationId)
+          .orderBy(desc(count()))
+          .limit(3)
+      : Promise.resolve([] as { candidateRegistrationId: string; voteCount: number }[]),
+    // 仅 playing 状态时查询 LIVE + 下一场
+    featured.status === "playing"
+      ? db
+          .select()
+          .from(matches)
+          .where(
+            and(
+              eq(matches.seasonId, featured.id),
+              or(
+                eq(matches.status, "in_progress"),
+                eq(matches.status, "scheduled")
+              )
+            )
+          )
+          .orderBy(matches.scheduledAt)
+          .limit(2)
+      : Promise.resolve([] as (typeof matches.$inferSelect)[]),
   ]);
+
+  // voting 状态：查询候选人名字
+  let topCandidatesWithNames: { name: string; voteCount: number }[] = [];
+  if (featured.status === "voting" && topVoteCandidates.length > 0) {
+    const regIds = topVoteCandidates.map((v) => v.candidateRegistrationId);
+    const regRows = await db
+      .select({
+        id: seasonRegistrations.id,
+        userId: seasonRegistrations.userId,
+      })
+      .from(seasonRegistrations)
+      .where(inArray(seasonRegistrations.id, regIds));
+
+    const userIds = regRows.map((r) => r.userId);
+    const userRows = await db
+      .select({ id: users.id, perfectName: users.perfectName, displayName: users.displayName })
+      .from(users)
+      .where(inArray(users.id, userIds));
+
+    topCandidatesWithNames = topVoteCandidates.map((v) => {
+      const reg = regRows.find((r) => r.id === v.candidateRegistrationId);
+      const user = reg ? userRows.find((u) => u.id === reg.userId) : undefined;
+      const name = user?.displayName ?? user?.perfectName ?? "未知选手";
+      return { name, voteCount: Number(v.voteCount) };
+    });
+  }
+
+  // registration 状态：整理位置报名数据
+  const regConfig = normalizeRegistrationConfig(featured.registrationConfig);
+  const maxPerPosition = regConfig.maxPerPosition;
+  const positionCountMap = new Map<string, number>(
+    registrationCounts.map((r) => [r.position, Number(r.cnt)])
+  );
+
+  // 构建动态 eyebrow 和右侧面板类型
+  const eyebrow = (() => {
+    if (featured.status === "registration") {
+      return { text: "● REGISTRATION OPEN", color: "var(--color-ok)" };
+    }
+    if (featured.status === "voting") {
+      return { text: "● CAPTAIN VOTING", color: "var(--color-warn)" };
+    }
+    if (featured.status === "playing") {
+      return { text: "● SEASON IN PROGRESS", color: "var(--color-ok)" };
+    }
+    return {
+      text: `[ RIVALHUB / ${featured.slug.replace(/-/g, " ").toUpperCase()} ]`,
+      color: "var(--color-accent)",
+    };
+  })();
+
+  // 分层导航数据
+  const allNavEntries = [
+    { key: "register", href: `/${featured.slug}/register`, label: "报名参赛", mono: "REGISTER", meta: "个人报名", show: featured.registrationMode === "solo" },
+    { key: "captains", href: `/${featured.slug}/captains`, label: "队长投票", mono: "CAPTAINS", meta: "实时票数", show: featured.hasCaptainVoting },
+    { key: "draft", href: `/${featured.slug}/draft`, label: "选秀直播间", mono: "DRAFT ROOM", meta: "● LIVE", show: featured.hasDraft },
+    { key: "teams", href: `/${featured.slug}/teams`, label: "战队阵容", mono: "TEAMS", meta: "战队展示", show: true },
+    { key: "matches", href: `/${featured.slug}/matches`, label: "赛程对决", mono: "MATCHES", meta: "Bracket · 赛果", show: true },
+    { key: "stats", href: `/${featured.slug}/stats`, label: "数据排行", mono: "STATS", meta: "Rating · ADR", show: true },
+    { key: "seasons", href: "/seasons", label: "历史赛季", mono: "ARCHIVE", meta: "浏览回顾", show: true },
+    { key: "login", href: "/login", label: "登录后台", mono: "LOGIN", meta: "管理员 · 队长", show: true },
+  ].filter((e) => e.show);
+
+  // Tier 1：根据状态决定主入口
+  const tier1Key = (() => {
+    if (featured.status === "registration") return "register";
+    if (featured.status === "voting") return "captains";
+    if (featured.status === "playing") return "matches";
+    return null;
+  })();
+
+  const tier1Entry = tier1Key
+    ? allNavEntries.find((e) => e.key === tier1Key) ?? null
+    : null;
+
+  // Tier 2：从剩余中取4个（排除 tier1、login、seasons）
+  const tier2Candidates = allNavEntries.filter(
+    (e) => e.key !== tier1Key && e.key !== "login" && e.key !== "seasons"
+  );
+  const tier2Entries = tier2Candidates.slice(0, 4);
+
+  // Tier 3：次要入口（login + seasons 以及 tier2 溢出部分）
+  const tier3Entries = [
+    ...tier2Candidates.slice(4),
+    ...allNavEntries.filter((e) => e.key === "seasons" || e.key === "login"),
+  ];
 
   return (
     <div className="mx-auto px-4 lg:px-9 py-8 max-w-[1240px] grid gap-7">
@@ -54,11 +207,11 @@ export default async function HomePage() {
               style={{
                 fontFamily: "var(--font-mono)",
                 fontSize: 11,
-                color: "var(--color-accent)",
+                color: eyebrow.color,
                 letterSpacing: "var(--tracking-eyebrow)",
               }}
             >
-              [ RIVALHUB / {featured.slug.replace(/-/g, " ").toUpperCase()} ]
+              {eyebrow.text}
             </div>
             <h1
               className="font-semibold leading-[0.95] m-0 text-4xl lg:text-[56px]"
@@ -104,78 +257,13 @@ export default async function HomePage() {
           />
         </Panel>
 
-        {/* LIVE Panel */}
-        <Panel label="CURRENT SEASON">
-          <div className="grid gap-3.5">
-            <div>
-              <div
-                className="uppercase"
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 10,
-                  color: "var(--color-fg-dim)",
-                  letterSpacing: "var(--tracking-label)",
-                }}
-              >
-                {SEASON_STATUS_LABELS[featured.status]}
-              </div>
-              <div
-                className="mt-1 font-semibold"
-                style={{
-                  fontFamily: "var(--font-display)",
-                  fontSize: 20,
-                  color: "var(--color-fg)",
-                }}
-              >
-                {featured.name}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <StatusPill status={featured.status} />
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 11,
-                  color: "var(--color-fg-mid)",
-                }}
-              >
-                {featured.kind}
-              </span>
-            </div>
-            <div className="grid grid-cols-3 gap-2 py-3 border-y border-[var(--color-border)]">
-              <MiniStat label="TEAMS" value={featuredTeamCount?.value ?? 0} />
-              <MiniStat label="PLAYERS" value={featuredPlayerCount?.value ?? 0} accent />
-              <MiniStat label="STAGE" value={featured.status.toUpperCase()} />
-            </div>
-            <Btn full asChild>
-              <Link href={`/${featured.slug}`} className="w-full">
-                进入赛季 →
-              </Link>
-            </Btn>
-          </div>
-        </Panel>
-      </div>
-
-      {/* Nav tiles */}
-      <div>
-        <Marker num={1} sub="NAVIGATION">
-          入口
-        </Marker>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          {[
-            { href: `/${featured.slug}/register`, label: "报名参赛", mono: "REGISTER", meta: "个人报名" },
-            { href: `/${featured.slug}/captains`, label: "队长投票", mono: "CAPTAINS", meta: "实时票数" },
-            { href: `/${featured.slug}/draft`, label: "选秀直播间", mono: "DRAFT ROOM", meta: "● LIVE" },
-            { href: `/${featured.slug}/teams`, label: "战队阵容", mono: "TEAMS", meta: "8 支战队" },
-            { href: `/${featured.slug}/matches`, label: "赛程", mono: "MATCHES", meta: "Bracket · 赛果" },
-            { href: `/${featured.slug}/stats`, label: "数据排行", mono: "STATS", meta: "Rating · ADR" },
-            { href: "/seasons", label: "历史赛季", mono: "ARCHIVE", meta: "浏览回顾" },
-            { href: "/login", label: "登录后台", mono: "LOGIN", meta: "管理员 · 队长" },
-          ].map((tile) => (
-            <Link key={tile.href} href={tile.href as never} className="group">
-              <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
+        {/* 右侧动态面板 */}
+        {featured.status === "registration" ? (
+          <Panel label="REGISTRATION">
+            <div className="grid gap-3.5">
+              <div>
                 <div
-                  className="flex items-center gap-2 mb-1.5"
+                  className="uppercase"
                   style={{
                     fontFamily: "var(--font-mono)",
                     fontSize: 10,
@@ -183,22 +271,360 @@ export default async function HomePage() {
                     letterSpacing: "var(--tracking-label)",
                   }}
                 >
-                  {tile.mono}
+                  {SEASON_STATUS_LABELS[featured.status]}
                 </div>
                 <div
-                  className="font-semibold"
+                  className="mt-1 font-semibold"
                   style={{
-                    fontFamily: "var(--font-sans)",
-                    fontSize: 14,
+                    fontFamily: "var(--font-display)",
+                    fontSize: 20,
                     color: "var(--color-fg)",
                   }}
                 >
-                  {tile.label}
+                  {featured.name}
+                </div>
+              </div>
+              <div className="grid gap-2">
+                {featured.positions.map((pos) => {
+                  const filled = positionCountMap.get(pos) ?? 0;
+                  const pct = maxPerPosition > 0 ? Math.min(100, Math.round((filled / maxPerPosition) * 100)) : 0;
+                  return (
+                    <div key={pos}>
+                      <div className="flex justify-between mb-1" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--color-fg-dim)", letterSpacing: "var(--tracking-label)" }}>
+                        <span className="uppercase">{pos}</span>
+                        <span style={{ color: "var(--color-fg-mid)" }}>{filled} / {maxPerPosition}</span>
+                      </div>
+                      <div className="h-[3px] rounded-full" style={{ background: "var(--color-border)" }}>
+                        <div
+                          className="h-full rounded-full transition-all"
+                          style={{
+                            width: `${pct}%`,
+                            background: pct >= 90 ? "var(--color-warn)" : "var(--color-accent)",
+                          }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              <Btn full asChild>
+                <Link href={`/${featured.slug}/register`} className="w-full">
+                  立即报名 →
+                </Link>
+              </Btn>
+            </div>
+          </Panel>
+        ) : featured.status === "voting" ? (
+          <Panel label="CAPTAIN VOTING">
+            <div className="grid gap-3.5">
+              <div>
+                <div
+                  className="uppercase"
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--color-fg-dim)",
+                    letterSpacing: "var(--tracking-label)",
+                  }}
+                >
+                  {SEASON_STATUS_LABELS[featured.status]}
+                </div>
+                <div
+                  className="mt-1 font-semibold"
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: 20,
+                    color: "var(--color-fg)",
+                  }}
+                >
+                  {featured.name}
+                </div>
+              </div>
+              <div className="grid gap-2 py-3 border-y border-[var(--color-border)]">
+                {topCandidatesWithNames.length > 0 ? (
+                  topCandidatesWithNames.map((c, i) => (
+                    <div key={i} className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11,
+                            color: i === 0 ? "var(--color-accent)" : "var(--color-fg-dim)",
+                            minWidth: 20,
+                          }}
+                        >
+                          #{i + 1}
+                        </span>
+                        <span style={{ fontFamily: "var(--font-sans)", fontSize: 14, color: "var(--color-fg)" }}>
+                          {c.name}
+                        </span>
+                      </div>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 12,
+                          color: "var(--color-fg-mid)",
+                        }}
+                      >
+                        {c.voteCount} 票
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-dim)" }}>
+                    暂无投票数据
+                  </div>
+                )}
+              </div>
+              <Btn full asChild>
+                <Link href={`/${featured.slug}/captains`} className="w-full">
+                  前往投票 →
+                </Link>
+              </Btn>
+            </div>
+          </Panel>
+        ) : featured.status === "playing" ? (
+          <Panel label="LIVE MATCHES">
+            <div className="grid gap-3.5">
+              <div>
+                <div
+                  className="uppercase"
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--color-fg-dim)",
+                    letterSpacing: "var(--tracking-label)",
+                  }}
+                >
+                  {SEASON_STATUS_LABELS[featured.status]}
+                </div>
+                <div
+                  className="mt-1 font-semibold"
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: 20,
+                    color: "var(--color-fg)",
+                  }}
+                >
+                  {featured.name}
+                </div>
+              </div>
+              <div className="grid gap-2 py-3 border-y border-[var(--color-border)]">
+                {liveAndUpcomingMatches.length > 0 ? (
+                  liveAndUpcomingMatches.map((m) => (
+                    <div key={m.id} className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {m.status === "in_progress" && (
+                          <span
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 10,
+                              color: "var(--color-ok)",
+                              letterSpacing: "var(--tracking-label)",
+                            }}
+                          >
+                            ● LIVE
+                          </span>
+                        )}
+                        {m.status === "scheduled" && (
+                          <span
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              fontSize: 10,
+                              color: "var(--color-fg-dim)",
+                              letterSpacing: "var(--tracking-label)",
+                            }}
+                          >
+                            NEXT
+                          </span>
+                        )}
+                      </div>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 11,
+                          color: "var(--color-fg-mid)",
+                        }}
+                      >
+                        {m.format.toUpperCase()}
+                        {m.scheduledAt
+                          ? ` · ${new Date(m.scheduledAt).toLocaleString("zh-CN", {
+                              timeZone: "Asia/Shanghai",
+                              month: "numeric",
+                              day: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            })}`
+                          : ""}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-dim)" }}>
+                    暂无进行中的比赛
+                  </div>
+                )}
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <MiniStat label="TEAMS" value={featuredTeamCount?.value ?? 0} />
+                <MiniStat label="PLAYERS" value={featuredPlayerCount?.value ?? 0} accent />
+                <MiniStat label="STAGE" value={featured.status.toUpperCase()} />
+              </div>
+              <Btn full asChild>
+                <Link href={`/${featured.slug}/matches`} className="w-full">
+                  查看赛程 →
+                </Link>
+              </Btn>
+            </div>
+          </Panel>
+        ) : (
+          <Panel label="CURRENT SEASON">
+            <div className="grid gap-3.5">
+              <div>
+                <div
+                  className="uppercase"
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--color-fg-dim)",
+                    letterSpacing: "var(--tracking-label)",
+                  }}
+                >
+                  {SEASON_STATUS_LABELS[featured.status]}
+                </div>
+                <div
+                  className="mt-1 font-semibold"
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontSize: 20,
+                    color: "var(--color-fg)",
+                  }}
+                >
+                  {featured.name}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <StatusPill status={featured.status} />
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 11,
+                    color: "var(--color-fg-mid)",
+                  }}
+                >
+                  {featured.kind}
+                </span>
+              </div>
+              <div className="grid grid-cols-3 gap-2 py-3 border-y border-[var(--color-border)]">
+                <MiniStat label="TEAMS" value={featuredTeamCount?.value ?? 0} />
+                <MiniStat label="PLAYERS" value={featuredPlayerCount?.value ?? 0} accent />
+                <MiniStat label="STAGE" value={featured.status.toUpperCase()} />
+              </div>
+              <Btn full asChild>
+                <Link href={`/${featured.slug}`} className="w-full">
+                  进入赛季 →
+                </Link>
+              </Btn>
+            </div>
+          </Panel>
+        )}
+      </div>
+
+      {/* 分层导航 */}
+      <div>
+        <Marker num={1} sub="NAVIGATION">
+          入口
+        </Marker>
+
+        {/* Tier 1：主行动入口 */}
+        {tier1Entry && (
+          <div className="mb-3">
+            <Link href={tier1Entry.href as never} className="group block">
+              <Panel
+                className="transition-colors hover:border-[var(--color-border-hi)] border-l-[3px] border-l-[var(--color-accent)]"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        color: "var(--color-fg-dim)",
+                        letterSpacing: "var(--tracking-label)",
+                        marginBottom: 4,
+                      }}
+                    >
+                      {tier1Entry.mono}
+                    </div>
+                    <div
+                      className="font-semibold"
+                      style={{
+                        fontFamily: "var(--font-sans)",
+                        fontSize: 18,
+                        color: "var(--color-fg)",
+                      }}
+                    >
+                      {tier1Entry.label}
+                    </div>
+                  </div>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 20,
+                      color: "var(--color-accent)",
+                    }}
+                  >
+                    →
+                  </span>
                 </div>
               </Panel>
             </Link>
-          ))}
-        </div>
+          </div>
+        )}
+
+        {/* Tier 2：grid-cols-4 次要入口 */}
+        {tier2Entries.length > 0 && (
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
+            {tier2Entries.map((tile) => (
+              <Link key={tile.href} href={tile.href as never} className="group">
+                <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
+                  <div
+                    className="flex items-center gap-2 mb-1.5"
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 10,
+                      color: "var(--color-fg-dim)",
+                      letterSpacing: "var(--tracking-label)",
+                    }}
+                  >
+                    {tile.mono}
+                  </div>
+                  <div
+                    className="font-semibold"
+                    style={{
+                      fontFamily: "var(--font-sans)",
+                      fontSize: 14,
+                      color: "var(--color-fg)",
+                    }}
+                  >
+                    {tile.label}
+                  </div>
+                </Panel>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* Tier 3：紧凑按钮行 */}
+        {tier3Entries.length > 0 && (
+          <div className="flex gap-2 flex-wrap">
+            {tier3Entries.map((tile) => (
+              <Btn key={tile.href} ghost asChild>
+                <Link href={tile.href as never}>{tile.label}</Link>
+              </Btn>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Other seasons */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,13 @@ export default async function HomePage() {
   const featured = activeSeasons[0];
   const others = activeSeasons.slice(1);
 
+  const archivedSeasons = await db
+    .select()
+    .from(seasons)
+    .where(eq(seasons.status, "archived"))
+    .orderBy(desc(seasons.createdAt))
+    .limit(6);
+
   if (!featured) {
     return (
       <div className="mx-auto px-4 lg:px-9 py-8 max-w-[1240px]">
@@ -635,6 +642,45 @@ export default async function HomePage() {
           </Marker>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {others.map((s) => (
+              <Link key={s.id} href={`/${s.slug}` as never}>
+                <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
+                  <div className="flex items-center gap-2 mb-2">
+                    <StatusPill status={s.status} />
+                    <span
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        color: "var(--color-fg-dim)",
+                      }}
+                    >
+                      {s.kind}
+                    </span>
+                  </div>
+                  <div
+                    className="font-semibold"
+                    style={{
+                      fontFamily: "var(--font-sans)",
+                      fontSize: 16,
+                      color: "var(--color-fg)",
+                    }}
+                  >
+                    {s.name}
+                  </div>
+                </Panel>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Archive */}
+      {archivedSeasons.length > 0 && (
+        <div>
+          <Marker num={3} sub="ARCHIVE">
+            历届赛季
+          </Marker>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {archivedSeasons.map((s) => (
               <Link key={s.id} href={`/${s.slug}` as never}>
                 <Panel className="transition-colors hover:border-[var(--color-border-hi)]">
                   <div className="flex items-center gap-2 mb-2">

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -20,6 +20,7 @@ import {
 import { rankValues, RANK_LABELS } from "@/lib/validators/registration";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Panel } from "@/components/rivalhub";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -245,15 +246,23 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
     });
   }
 
-  return (
-    <Card className="p-6 space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold">{title}</h1>
-        {fieldHelp && <p className="text-sm text-yellow-600 mt-2">{fieldHelp}</p>}
+  const SaveBtn = () => (
+    mode === "edit" ? (
+      <div className="flex justify-end pt-2">
+        <Button type="button" size="sm" disabled={isPending} onClick={handleSubmit}>
+          {isPending ? "保存中…" : "保存"}
+        </Button>
       </div>
+    ) : null
+  );
 
-      {/* Preset selector */}
-      {mode === "create" && (
+  if (mode === "create") {
+    return (
+      <Card className="p-6 space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold">{title}</h1>
+        </div>
+
         <section className="space-y-2">
           <Label>快速预设</Label>
           <Select onValueChange={(v) => v !== "__none__" && applyPreset(v as "major" | "rivals")}>
@@ -265,11 +274,107 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
             </SelectContent>
           </Select>
         </section>
-      )}
 
-      {/* Basic info */}
-      <section className="space-y-4">
-        <h2 className="font-semibold">基础信息</h2>
+        <section className="space-y-4">
+          <h2 className="font-semibold">基础信息</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div><Label htmlFor="season-name">名称</Label><Input id="season-name" value={name} onChange={(e) => setName(e.target.value)} /></div>
+            <div>
+              <Label htmlFor="season-slug">Slug</Label>
+              <Input id="season-slug" value={slug} onChange={(e) => setSlug(e.target.value)} />
+              <p className="text-xs text-muted-foreground mt-1">URL 路径标识，输入名称后自动生成，可手动修改</p>
+            </div>
+            <div><Label htmlFor="season-kind">类型</Label><Input id="season-kind" value={kind} onChange={(e) => setKind(e.target.value)} /></div>
+            <div><Label>主题色</Label><ThemeColorPicker value={themeColor} onChange={setThemeColor} /></div>
+            <div>
+              <Label htmlFor="start-at">报名开始时间</Label>
+              <Input id="start-at" type="datetime-local" value={startAt ?? ""} onChange={(e) => setStartAt(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="registration-deadline">报名截止时间</Label>
+              <Input id="registration-deadline" type="datetime-local" value={registrationDeadline ?? ""} onChange={(e) => setRegistrationDeadline(e.target.value)} />
+            </div>
+            <div><Label htmlFor="end-at">赛季结束时间</Label><Input id="end-at" type="datetime-local" value={endAt ?? ""} onChange={(e) => setEndAt(e.target.value)} /></div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="font-semibold">Capability</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <Label>报名模式</Label>
+              <Select value={registrationMode} onValueChange={(v) => handleRegistrationModeChange(v as "solo" | "team")}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="solo">个人报名</SelectItem>
+                  <SelectItem value="team">队伍报名</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div><Label htmlFor="positions">位置列表</Label><Input id="positions" value={positionsText} onChange={(e) => setPositionsText(e.target.value)} /></div>
+            <div><Label htmlFor="max-team-size">每队人数上限</Label><Input id="max-team-size" type="number" min={1} value={maxTeamSize} onChange={(e) => setMaxTeamSize(Number(e.target.value))} /></div>
+            <div><Label htmlFor="min-team-size">每队人数下限</Label><Input id="min-team-size" type="number" min={1} value={minTeamSize} onChange={(e) => setMinTeamSize(Number(e.target.value))} /></div>
+            <div><Label htmlFor="starter-count">首发人数</Label><Input id="starter-count" type="number" min={1} value={starterCount} onChange={(e) => setStarterCount(Number(e.target.value))} /></div>
+          </div>
+          {registrationMode === "solo" && (
+            <div className="flex flex-wrap gap-4 text-sm">
+              <label className="flex items-center gap-2"><input type="checkbox" checked={hasCaptainVoting} onChange={(e) => setHasCaptainVoting(e.target.checked)} />队长投票</label>
+              <label className="flex items-center gap-2"><input type="checkbox" checked={hasDraft} onChange={(e) => setHasDraft(e.target.checked)} />蛇形选秀</label>
+            </div>
+          )}
+        </section>
+
+        {registrationMode === "solo" && (
+          <section className="space-y-4">
+            <h2 className="font-semibold">报名配置</h2>
+            <div className="flex flex-wrap gap-4 text-sm">
+              {PLAYER_TYPES.map((type) => (
+                <label key={type} className="flex items-center gap-2">
+                  <input type="checkbox" checked={allowedPlayerTypes.includes(type)} onChange={() => togglePlayerType(type)} />
+                  {PLAYER_TYPE_LABELS[type]}
+                </label>
+              ))}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div><Label>当前段位门槛</Label><Select value={currentMin} onValueChange={setCurrentMin}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value={NO_RANK}>无门槛</SelectItem>{rankValues.map((rank) => (<SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>))}</SelectContent></Select></div>
+              <div><Label>历史段位门槛</Label><Select value={peakMin} onValueChange={setPeakMin}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value={NO_RANK}>无门槛</SelectItem>{rankValues.map((rank) => (<SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>))}</SelectContent></Select></div>
+              <div><Label htmlFor="max-position">每位置上限</Label><Input id="max-position" type="number" min={1} max={50} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} /></div>
+              <div><Label htmlFor="screenshot-count">截图链接数量</Label><Input id="screenshot-count" type="number" min={1} max={5} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} /></div>
+              <div className="sm:col-span-2"><Label htmlFor="map-pool">比赛图池</Label><Input id="map-pool" value={mapPoolText} onChange={(e) => setMapPoolText(e.target.value)} placeholder="de_mirage,de_inferno,de_nuke..." /></div>
+            </div>
+          </section>
+        )}
+
+        {registrationMode === "team" && (
+          <section className="space-y-4">
+            <h2 className="font-semibold">队伍报名配置</h2>
+            <TeamConfigForm value={teamConfig} maxTeamSize={maxTeamSize} onChange={setTeamConfig} />
+          </section>
+        )}
+
+        <section className="space-y-4">
+          <h2 className="font-semibold">赛制配置</h2>
+          <StagePlanEditor value={stagePlan} onChange={setStagePlan} />
+        </section>
+
+        <div className="flex justify-end">
+          <Button type="button" disabled={isPending} onClick={handleSubmit}>
+            {isPending ? "创建中…" : "创建赛季"}
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {fieldHelp && <p className="text-sm text-yellow-600">{fieldHelp}</p>}
+      </div>
+
+      {/* Panel 1: 基础信息 */}
+      <Panel label="基础信息" pad={20}>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <Label htmlFor="season-name">名称</Label>
@@ -277,15 +382,8 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
           </div>
           <div>
             <Label htmlFor="season-slug">Slug</Label>
-            <Input
-              id="season-slug"
-              value={slug}
-              disabled={mode === "edit"}
-              onChange={(e) => setSlug(e.target.value)}
-            />
-            <p className="text-xs text-muted-foreground mt-1">
-              URL 路径标识，输入名称后自动生成，可手动修改
-            </p>
+            <Input id="season-slug" value={slug} disabled onChange={(e) => setSlug(e.target.value)} />
+            <p className="text-xs text-muted-foreground mt-1">编辑时不可修改 slug</p>
           </div>
           <div>
             <Label htmlFor="season-kind">类型</Label>
@@ -295,35 +393,33 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
             <Label>主题色</Label>
             <ThemeColorPicker value={themeColor} onChange={setThemeColor} />
           </div>
+        </div>
+        <SaveBtn />
+      </Panel>
+
+      {/* Panel 2: 时间设置 */}
+      <Panel label="时间设置" pad={20}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <Label htmlFor="start-at">报名开始时间</Label>
             <Input id="start-at" type="datetime-local" value={startAt ?? ""} onChange={(e) => setStartAt(e.target.value)} />
-            <p className="text-xs text-muted-foreground mt-1">
-              赛季发布后页面立即可见；到此时间前只能保存草稿。
-            </p>
+            <p className="text-xs text-muted-foreground mt-1">赛季发布后页面立即可见；到此时间前只能保存草稿。</p>
           </div>
           <div>
             <Label htmlFor="registration-deadline">报名截止时间</Label>
-            <Input
-              id="registration-deadline"
-              type="datetime-local"
-              value={registrationDeadline ?? ""}
-              onChange={(e) => setRegistrationDeadline(e.target.value)}
-            />
-            <p className="text-xs text-muted-foreground mt-1">
-              截止后关闭草稿保存和正式提交。
-            </p>
+            <Input id="registration-deadline" type="datetime-local" value={registrationDeadline ?? ""} onChange={(e) => setRegistrationDeadline(e.target.value)} />
+            <p className="text-xs text-muted-foreground mt-1">截止后关闭草稿保存和正式提交。</p>
           </div>
           <div>
             <Label htmlFor="end-at">赛季结束时间</Label>
             <Input id="end-at" type="datetime-local" value={endAt ?? ""} onChange={(e) => setEndAt(e.target.value)} />
           </div>
         </div>
-      </section>
+        <SaveBtn />
+      </Panel>
 
-      {/* Capability */}
-      <section className="space-y-4">
-        <h2 className="font-semibold">Capability</h2>
+      {/* Panel 3: 能力开关 */}
+      <Panel label="能力配置" pad={20}>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <Label>报名模式</Label>
@@ -338,51 +434,27 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
           <div>
             <Label htmlFor="positions">位置列表</Label>
             <Input id="positions" value={positionsText} disabled={coreLocked} onChange={(e) => setPositionsText(e.target.value)} />
-            {registrationMode === "team" && (
-              <p className="text-xs text-muted-foreground mt-1">
-                可选填，不填位置则不参与排行榜和最佳五人组评选
-              </p>
-            )}
           </div>
-          <div>
-            <Label htmlFor="max-team-size">每队人数上限</Label>
-            <Input id="max-team-size" type="number" min={1} value={maxTeamSize} disabled={coreLocked} onChange={(e) => setMaxTeamSize(Number(e.target.value))} />
-          </div>
-          <div>
-            <Label htmlFor="min-team-size">每队人数下限</Label>
-            <Input id="min-team-size" type="number" min={1} value={minTeamSize} disabled={coreLocked} onChange={(e) => setMinTeamSize(Number(e.target.value))} />
-          </div>
-          <div>
-            <Label htmlFor="starter-count">首发人数</Label>
-            <Input id="starter-count" type="number" min={1} value={starterCount} disabled={coreLocked} onChange={(e) => setStarterCount(Number(e.target.value))} />
-          </div>
+          <div><Label htmlFor="max-team-size">每队人数上限</Label><Input id="max-team-size" type="number" min={1} value={maxTeamSize} disabled={coreLocked} onChange={(e) => setMaxTeamSize(Number(e.target.value))} /></div>
+          <div><Label htmlFor="min-team-size">每队人数下限</Label><Input id="min-team-size" type="number" min={1} value={minTeamSize} disabled={coreLocked} onChange={(e) => setMinTeamSize(Number(e.target.value))} /></div>
+          <div><Label htmlFor="starter-count">首发人数</Label><Input id="starter-count" type="number" min={1} value={starterCount} disabled={coreLocked} onChange={(e) => setStarterCount(Number(e.target.value))} /></div>
         </div>
         {registrationMode === "solo" && (
-          <div className="flex flex-wrap gap-4 text-sm">
-            <label className="flex items-center gap-2">
-              <input type="checkbox" checked={hasCaptainVoting} disabled={coreLocked} onChange={(e) => setHasCaptainVoting(e.target.checked)} />
-              队长投票
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="checkbox" checked={hasDraft} disabled={coreLocked} onChange={(e) => setHasDraft(e.target.checked)} />
-              蛇形选秀
-            </label>
+          <div className="flex flex-wrap gap-4 text-sm mt-4">
+            <label className="flex items-center gap-2"><input type="checkbox" checked={hasCaptainVoting} disabled={coreLocked} onChange={(e) => setHasCaptainVoting(e.target.checked)} />队长投票</label>
+            <label className="flex items-center gap-2"><input type="checkbox" checked={hasDraft} disabled={coreLocked} onChange={(e) => setHasDraft(e.target.checked)} />蛇形选秀</label>
           </div>
         )}
-      </section>
+        <SaveBtn />
+      </Panel>
 
-      {/* Registration config — solo mode only */}
+      {/* Panel 4: 报名规则 (solo) / 队伍报名配置 (team) */}
       {registrationMode === "solo" && (
-        <section className="space-y-4">
-          <h2 className="font-semibold">报名配置</h2>
-          <div className="flex flex-wrap gap-4 text-sm">
+        <Panel label="报名规则" pad={20}>
+          <div className="flex flex-wrap gap-4 text-sm mb-4">
             {PLAYER_TYPES.map((type) => (
               <label key={type} className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={allowedPlayerTypes.includes(type)}
-                  onChange={() => togglePlayerType(type)}
-                />
+                <input type="checkbox" checked={allowedPlayerTypes.includes(type)} onChange={() => togglePlayerType(type)} />
                 {PLAYER_TYPE_LABELS[type]}
               </label>
             ))}
@@ -394,9 +466,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NO_RANK}>无门槛</SelectItem>
-                  {rankValues.map((rank) => (
-                    <SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>
-                  ))}
+                  {rankValues.map((rank) => (<SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>))}
                 </SelectContent>
               </Select>
             </div>
@@ -406,70 +476,45 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NO_RANK}>无门槛</SelectItem>
-                  {rankValues.map((rank) => (
-                    <SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>
-                  ))}
+                  {rankValues.map((rank) => (<SelectItem key={rank} value={rank}>{RANK_LABELS[rank]}</SelectItem>))}
                 </SelectContent>
               </Select>
             </div>
-            <div>
-              <Label htmlFor="max-position">每位置上限</Label>
-              <Input id="max-position" type="number" min={1} max={50} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} />
-            </div>
-            <div>
-              <Label htmlFor="screenshot-count">截图链接数量</Label>
-              <Input id="screenshot-count" type="number" min={1} max={5} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} />
-            </div>
+            <div><Label htmlFor="max-position">每位置上限</Label><Input id="max-position" type="number" min={1} max={50} value={maxPerPosition} onChange={(e) => setMaxPerPosition(Number(e.target.value))} /></div>
+            <div><Label htmlFor="screenshot-count">截图链接数量</Label><Input id="screenshot-count" type="number" min={1} max={5} value={screenshotCount} onChange={(e) => setScreenshotCount(Number(e.target.value))} /></div>
             <div className="sm:col-span-2">
               <Label htmlFor="map-pool">比赛图池</Label>
-              <Input
-                id="map-pool"
-                value={mapPoolText}
-                onChange={(e) => setMapPoolText(e.target.value)}
-                placeholder="de_mirage,de_inferno,de_nuke..."
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                逗号分隔，报名地图熟练度和比赛录入会使用同一组地图。
-              </p>
+              <Input id="map-pool" value={mapPoolText} onChange={(e) => setMapPoolText(e.target.value)} placeholder="de_mirage,de_inferno,de_nuke..." />
+              <p className="text-xs text-muted-foreground mt-1">逗号分隔，报名地图熟练度和比赛录入会使用同一组地图。</p>
             </div>
           </div>
-        </section>
+          <SaveBtn />
+        </Panel>
       )}
-
-      {/* Team registration config — team mode only */}
       {registrationMode === "team" && (
-        <section className="space-y-4">
-          <h2 className="font-semibold">队伍报名配置</h2>
+        <Panel label="队伍报名配置" pad={20}>
           <TeamConfigForm value={teamConfig} maxTeamSize={maxTeamSize} onChange={setTeamConfig} />
-        </section>
+          <SaveBtn />
+        </Panel>
       )}
 
-      {/* Stage plan */}
-      <section className="space-y-4">
-        <h2 className="font-semibold">赛制配置</h2>
+      {/* Panel 5: 赛程阶段 */}
+      <Panel label="赛程阶段" pad={20}>
         <StagePlanEditor value={stagePlan} onChange={setStagePlan} />
-      </section>
+        <SaveBtn />
+      </Panel>
 
-      {/* Actions */}
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          {mode === "edit" && initial?.status === "draft" && (
-            <Button type="button" variant="destructive" disabled={isPending} onClick={handleDelete}>
-              删除赛季
-            </Button>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {mode === "edit" && initial?.status === "draft" && (
-            <Button type="button" variant="outline" disabled={isPending} onClick={handlePublish}>
-              发布
-            </Button>
-          )}
-          <Button type="button" disabled={isPending} onClick={handleSubmit}>
-            {isPending ? "保存中…" : mode === "create" ? "创建赛季" : "保存设置"}
+      {/* 底部操作区（发布 / 删除） */}
+      {initial?.status === "draft" && (
+        <div className="flex items-center justify-between gap-3 pt-2">
+          <Button type="button" variant="destructive" disabled={isPending} onClick={handleDelete}>
+            删除赛季
+          </Button>
+          <Button type="button" variant="outline" disabled={isPending} onClick={handlePublish}>
+            发布赛季
           </Button>
         </div>
-      </div>
-    </Card>
+      )}
+    </div>
   );
 }

--- a/src/components/layout/OnlineCounter.tsx
+++ b/src/components/layout/OnlineCounter.tsx
@@ -33,8 +33,9 @@ export function OnlineCounter() {
   if (count === null) return null;
 
   return (
-    <span className="text-xs text-[var(--color-fg-dim)]">
-      {count} 人在线
+    <span className="font-mono text-[11px] text-[var(--color-fg-mid)] select-none">
+      <span style={{ color: "var(--color-accent)" }}>●</span>{" "}
+      {count.toLocaleString()}
     </span>
   );
 }

--- a/src/components/layout/header-client.tsx
+++ b/src/components/layout/header-client.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { Season } from "@/db/schema/seasons";
 import type { UserSession } from "@/lib/auth/session";
+import { OnlineCounter } from "./OnlineCounter";
 
 interface HeaderClientProps {
   seasons: Season[];
@@ -128,8 +129,8 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
               className={cn(
                 "flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors",
                 link.active
-                  ? "bg-[var(--color-panel)] border border-[var(--color-border)] border-b-[var(--color-accent)] text-[var(--color-fg)] font-semibold"
-                  : "text-[var(--color-fg-mid)] border border-transparent hover:text-[var(--color-fg)] font-medium",
+                  ? "bg-[var(--color-panel)] border-b border-[var(--color-accent)] text-[var(--color-fg)] font-semibold"
+                  : "text-[var(--color-fg-mid)] border-b border-transparent hover:text-[var(--color-fg)] font-medium",
                 "rounded-sm"
               )}
               style={{ fontFamily: "var(--font-sans)" }}
@@ -151,8 +152,8 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
             className={cn(
               "px-3 py-1.5 text-xs rounded-sm transition-colors border border-transparent",
               pathname === "/seasons"
-                ? "bg-[var(--color-panel)] border-[var(--color-border)] text-[var(--color-fg)] font-semibold"
-                : "text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] font-medium"
+                ? "bg-[var(--color-panel)] border-b border-[var(--color-accent)] text-[var(--color-fg)] font-semibold"
+                : "text-[var(--color-fg-mid)] border-b border-transparent hover:text-[var(--color-fg)] font-medium"
             )}
             style={{ fontFamily: "var(--font-sans)" }}
           >
@@ -160,8 +161,13 @@ export function HeaderClient({ seasons, session, avatarUrl, steamName, displayNa
           </Link>
         </nav>
 
-        {/* 右侧：用户区域 + mobile hamburger */}
-        <div className="flex items-center gap-2">
+        {/* 右侧：在线人数 + 用户区域 + mobile hamburger */}
+        <div className="flex items-center gap-3">
+          {/* 在线人数 */}
+          <div className="hidden sm:flex items-center">
+            <OnlineCounter />
+          </div>
+
           {/* 用户区域（仅桌面） */}
           <div className="hidden sm:block">
             {session ? (

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,7 +3,6 @@ import { seasons, users } from "@/db/schema";
 import { getUserSession } from "@/lib/auth/session";
 import { resolveAvatarUrl } from "@/lib/steam";
 import { HeaderClient } from "./header-client";
-import { OnlineCounter } from "./OnlineCounter";
 import { eq } from "drizzle-orm";
 
 export async function Header() {
@@ -38,15 +37,12 @@ export async function Header() {
   }
 
   return (
-    <>
-      <HeaderClient
-        seasons={publicSeasons}
-        session={session}
-        avatarUrl={avatarUrl}
-        steamName={currentUser?.steamName ?? null}
-        displayName={currentUser?.displayName ?? null}
-      />
-      <OnlineCounter />
-    </>
+    <HeaderClient
+      seasons={publicSeasons}
+      session={session}
+      avatarUrl={avatarUrl}
+      steamName={currentUser?.steamName ?? null}
+      displayName={currentUser?.displayName ?? null}
+    />
   );
 }

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Card } from "@/components/ui/card";
+import { Panel } from "@/components/rivalhub";
 import { Badge } from "@/components/ui/badge";
 import { MatchStatusBadge } from "./MatchStatusBadge";
 import { MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
@@ -39,8 +39,8 @@ export function MatchCard({
         : null;
 
   return (
-    <Link href={`/${seasonSlug}/matches/${matchId}`}>
-      <Card className="p-4 hover:bg-[var(--color-panel-hi)] transition-colors cursor-pointer">
+    <Link href={`/${seasonSlug}/matches/${matchId}`} className="cursor-pointer">
+      <Panel hoverable pad={16}>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <div className="flex items-center gap-3 flex-1 min-w-0">
             <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
@@ -64,7 +64,7 @@ export function MatchCard({
             <MatchStatusBadge status={status} />
           </div>
         </div>
-      </Card>
+      </Panel>
     </Link>
   );
 }

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -82,6 +82,7 @@ export function MatchMvpVote({
     }
   }
   const mvp = allVotes.reduce((a, b) => (a.count >= b.count ? a : b), allVotes[0]);
+  const maxVoteCount = Math.max(...allVotes.map((v) => v.count));
   const mvpStats = candidates.find((c) => c.perfectName === mvp?.playerName);
 
   // ── 投票截止：展示 MVP 结果 ──
@@ -164,18 +165,22 @@ export function MatchMvpVote({
         </span>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {candidates.map((c) => {
           const v = optimisticVotes.find((x) => x.playerName === c.perfectName);
           const count = v?.count ?? 0;
           const isVoted = votedName === c.perfectName;
+          const isLeading = count === maxVoteCount && count > 0;
 
           return (
             <button
               key={c.perfectName}
               disabled={!!votedName || isPending}
               onClick={() => handleVote(c.userId, c.perfectName)}
-              className={cardStyle(isVoted, !!votedName)}
+              className={[
+                cardStyle(isVoted, !!votedName),
+                isLeading && !isVoted ? "border border-[var(--color-accent)] bg-[var(--color-accent-soft)]" : "",
+              ].join(" ").trim()}
             >
               <div className="flex items-center justify-between mb-2">
                 <span className="font-semibold text-[var(--color-fg)]">

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -42,6 +42,16 @@ const POSITIONS = [
   { key: "anchor", label: "Anchor" },
 ];
 
+// 列 key → 表格列对应关系
+const SORT_COL_MAP: Record<string, string> = {
+  rating: "rating",
+  adr: "adr",
+  kd: "kd",
+  we: "we",
+  kpr: "kpr",
+  maps: "maps",
+};
+
 export function StatsLeaderboard({
   rows,
   sort,
@@ -56,6 +66,9 @@ export function StatsLeaderboard({
     );
   }
 
+  const sortColBg = "rgba(255,107,26,0.04)";
+  const accentText = "var(--color-accent)";
+
   return (
     <div>
       {/* 排序 Tab */}
@@ -64,9 +77,9 @@ export function StatsLeaderboard({
           <a
             key={key}
             href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}
-            className={`inline-block px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+            className={`inline-block font-mono text-[10px] px-2.5 py-1 uppercase tracking-wider rounded transition-colors ${
               sort === key
-                ? "bg-[var(--color-accent)] text-white"
+                ? "bg-[var(--color-accent)] text-[var(--color-accent-fg)]"
                 : "border border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
             }`}
           >
@@ -81,10 +94,10 @@ export function StatsLeaderboard({
           <a
             key={key}
             href={`/${seasonSlug}/stats?sort=${sort}${key ? `&position=${key}` : ""}`}
-            className={`inline-block px-2.5 py-1 rounded text-[11px] transition-colors ${
+            className={`inline-block font-mono text-[10px] px-2.5 py-1 uppercase tracking-wider rounded transition-colors ${
               position === key
-                ? "bg-[var(--color-panel-hi)] text-[var(--color-fg)] font-medium"
-                : "text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+                ? "bg-[var(--color-accent)] text-[var(--color-accent-fg)]"
+                : "border border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
             }`}
           >
             {label}
@@ -102,17 +115,42 @@ export function StatsLeaderboard({
               <th className="px-4 py-3 text-left">选手</th>
               <th className="px-4 py-3 text-left hidden sm:table-cell">位置</th>
               <th className="px-4 py-3 text-left hidden sm:table-cell">队伍</th>
-              <th className="px-4 py-3 text-center hidden sm:table-cell">图数</th>
-              <th className="px-4 py-3 text-center">Rating</th>
-              <th className="px-4 py-3 text-center hidden sm:table-cell">ADR</th>
-              <th className="px-4 py-3 text-center hidden sm:table-cell">K/D</th>
+              <th
+                className="px-4 py-3 text-center hidden sm:table-cell"
+                style={SORT_COL_MAP[sort] === "maps" ? { background: sortColBg, color: accentText } : undefined}
+              >
+                图数
+              </th>
+              <th
+                className="px-4 py-3 text-center"
+                style={SORT_COL_MAP[sort] === "rating" ? { background: sortColBg, color: accentText } : undefined}
+              >
+                Rating
+              </th>
+              <th
+                className="px-4 py-3 text-center hidden sm:table-cell"
+                style={SORT_COL_MAP[sort] === "adr" ? { background: sortColBg, color: accentText } : undefined}
+              >
+                ADR
+              </th>
+              <th
+                className="px-4 py-3 text-center hidden sm:table-cell"
+                style={SORT_COL_MAP[sort] === "kd" ? { background: sortColBg, color: accentText } : undefined}
+              >
+                K/D
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-[var(--color-border)]">
             {rows.map((r, i) => (
               <tr key={r.userId ?? r.perfectName}>
-                <td className="px-4 py-3 text-[var(--color-fg-dim)] text-xs">
-                  {i + 1}
+                <td className="px-4 py-3 text-xs">
+                  <span
+                    className={i < 3 ? "font-bold" : "text-[var(--color-fg-dim)]"}
+                    style={i < 3 ? { color: accentText } : undefined}
+                  >
+                    {i + 1}
+                  </span>
                 </td>
                 <td className="px-4 py-3 font-medium text-[var(--color-fg)]">
                   {r.userId ? (
@@ -143,22 +181,50 @@ export function StatsLeaderboard({
                     r.teamName ?? "—"
                   )}
                 </td>
-                <td className="px-4 py-3 text-center tabular-nums text-[var(--color-fg-mid)] hidden sm:table-cell">
+                <td
+                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
+                    sort === "maps" ? "font-semibold" : "text-[var(--color-fg-mid)]"
+                  }`}
+                  style={
+                    sort === "maps"
+                      ? { background: sortColBg, color: accentText }
+                      : undefined
+                  }
+                >
                   {r.maps}
                 </td>
                 <td
                   className={`px-4 py-3 text-center tabular-nums font-semibold ${
-                    r.avgRating >= 1.2
+                    r.avgRating >= 1.2 || sort === "rating"
                       ? "text-[var(--color-accent)]"
                       : "text-[var(--color-fg)]"
                   }`}
+                  style={sort === "rating" ? { background: sortColBg } : undefined}
                 >
                   {r.avgRating.toFixed(2)}
                 </td>
-                <td className="px-4 py-3 text-center tabular-nums text-[var(--color-fg)] hidden sm:table-cell">
+                <td
+                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
+                    sort === "adr" ? "font-semibold" : "text-[var(--color-fg)]"
+                  }`}
+                  style={
+                    sort === "adr"
+                      ? { background: sortColBg, color: accentText }
+                      : undefined
+                  }
+                >
                   {r.avgAdr.toFixed(1)}
                 </td>
-                <td className="px-4 py-3 text-center tabular-nums text-[var(--color-fg)] hidden sm:table-cell">
+                <td
+                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
+                    sort === "kd" ? "font-semibold" : "text-[var(--color-fg)]"
+                  }`}
+                  style={
+                    sort === "kd"
+                      ? { background: sortColBg, color: accentText }
+                      : undefined
+                  }
+                >
                   {r.avgDeaths > 0
                     ? (r.avgKills / r.avgDeaths).toFixed(2)
                     : "—"}

--- a/src/components/matches/VetoView.tsx
+++ b/src/components/matches/VetoView.tsx
@@ -21,10 +21,10 @@ const ACTION_VERBS: Record<string, string> = {
 };
 
 const ACTION_COLORS: Record<string, string> = {
-  ban: "#ef4444",
-  pick: "#22c55e",
+  ban: "var(--color-danger)",
+  pick: "var(--color-ok)",
   side_pick: "#a78bfa",
-  decider: "#eab308",
+  decider: "var(--color-info)",
 };
 
 export async function VetoView({

--- a/src/components/rivalhub/index.ts
+++ b/src/components/rivalhub/index.ts
@@ -12,3 +12,4 @@ export { TeamBadge } from "./team-badge";
 export { PosChip } from "./pos-chip";
 export { StatusPill } from "./status-pill";
 export { ScrollHint } from "./scroll-hint";
+export { PhaseStep } from "./phase-step";

--- a/src/components/rivalhub/panel.tsx
+++ b/src/components/rivalhub/panel.tsx
@@ -5,7 +5,7 @@ interface PanelProps {
   children: React.ReactNode;
   className?: string;
   hi?: boolean;
-  label?: string;
+  label?: React.ReactNode;
   pad?: number;
   hoverable?: boolean;
   teamColor?: string;
@@ -26,14 +26,18 @@ export function Panel({ children, className, hi, label, pad = 16, hoverable, tea
       {label && (
         <CardHeader
           className="flex flex-row items-center justify-between px-4 py-2.5 border-b border-[var(--color-border)]"
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            fontWeight: 700,
-            letterSpacing: "var(--tracking-label)",
-            color: "var(--color-fg-mid)",
-            textTransform: "uppercase",
-          }}
+          style={
+            typeof label === "string"
+              ? {
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  letterSpacing: "var(--tracking-label)",
+                  color: "var(--color-fg-mid)",
+                  textTransform: "uppercase",
+                }
+              : undefined
+          }
         >
           {label}
         </CardHeader>

--- a/src/components/rivalhub/panel.tsx
+++ b/src/components/rivalhub/panel.tsx
@@ -26,20 +26,16 @@ export function Panel({ children, className, hi, label, pad = 16, hoverable, tea
       {label && (
         <CardHeader
           className="flex flex-row items-center justify-between px-4 py-2.5 border-b border-[var(--color-border)]"
-          style={
-            typeof label === "string"
-              ? {
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: "var(--tracking-label)",
-                  color: "var(--color-fg-mid)",
-                  textTransform: "uppercase",
-                }
-              : undefined
-          }
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "var(--tracking-label)",
+            color: "var(--color-fg-mid)",
+            textTransform: "uppercase",
+          }}
         >
-          {label}
+          {typeof label === "string" ? <span>{label}</span> : label}
         </CardHeader>
       )}
       <div style={{ padding: pad }}>{children}</div>

--- a/src/components/rivalhub/panel.tsx
+++ b/src/components/rivalhub/panel.tsx
@@ -7,13 +7,21 @@ interface PanelProps {
   hi?: boolean;
   label?: string;
   pad?: number;
+  hoverable?: boolean;
+  teamColor?: string;
 }
 
-export function Panel({ children, className, hi, label, pad = 16 }: PanelProps) {
+export function Panel({ children, className, hi, label, pad = 16, hoverable, teamColor }: PanelProps) {
   return (
     <Card
-      className={cn(className)}
-      style={{ background: hi ? "var(--color-panel-hi)" : "var(--color-panel)" }}
+      className={cn(
+        hoverable && "transition-all duration-[180ms] ease-out hover:-translate-y-0.5 hover:border-[var(--color-border-hi)] hover:shadow-[0_4px_20px_rgba(255,107,26,0.03)]",
+        className
+      )}
+      style={{
+        background: hi ? "var(--color-panel-hi)" : "var(--color-panel)",
+        ...(teamColor ? { borderTop: `3px solid ${teamColor}` } : {}),
+      }}
     >
       {label && (
         <CardHeader

--- a/src/components/rivalhub/phase-step.tsx
+++ b/src/components/rivalhub/phase-step.tsx
@@ -7,100 +7,65 @@ interface PhaseStepProps {
 }
 
 export function PhaseStep({ label, stepNumber, isDone, isCurrent, isLast }: PhaseStepProps) {
-  const iconBorderColor = isDone
-    ? "var(--color-ok)"
-    : isCurrent
-      ? "var(--color-accent)"
-      : "var(--color-border)";
-
-  const iconBg = isDone
-    ? "rgba(77,212,122,0.13)"
-    : isCurrent
-      ? "rgba(255,107,26,0.13)"
-      : "transparent";
-
-  const iconColor = isDone
+  const color = isDone
     ? "var(--color-ok)"
     : isCurrent
       ? "var(--color-accent)"
       : "var(--color-fg-dim)";
 
-  const iconShadow = isCurrent ? "0 0 12px rgba(255,107,26,0.2)" : undefined;
-
-  const labelColor = isDone
-    ? "var(--color-fg)"
+  const iconBg = isDone
+    ? "rgba(77,212,122,0.13)"
     : isCurrent
-      ? "var(--color-accent)"
-      : "var(--color-fg-mid)";
+      ? "rgba(255,107,26,0.09)"
+      : "transparent";
 
   return (
     <div
-      className="relative flex-1 min-w-[120px]"
-      style={{
-        padding: "18px 16px",
-        borderRight: !isLast ? "1px solid var(--color-border)" : "none",
-        background: isCurrent ? "var(--color-panel-hi)" : "transparent",
-      }}
+      className="flex items-center gap-0"
+      style={{ flex: isLast ? "0 0 auto" : 1 }}
     >
-      <div className="flex items-center gap-2 mb-1.5">
-        {/* Icon dot */}
+      <div className="flex flex-col items-center gap-1 min-w-[80px]">
         <div
-          className="grid place-items-center font-bold rounded-sm shrink-0"
+          className="grid place-items-center font-bold shrink-0"
           style={{
-            width: 16,
-            height: 16,
-            border: `1px solid ${iconBorderColor}`,
+            width: 24,
+            height: 24,
+            border: `2px solid ${color}`,
             background: iconBg,
+            borderRadius: "var(--radius-sm, 2px)",
             fontFamily: "var(--font-mono)",
-            fontSize: 10,
-            color: iconColor,
-            boxShadow: iconShadow,
+            fontSize: 11,
+            fontWeight: 700,
+            color,
+            boxShadow: isCurrent ? `0 0 12px ${color}33` : "none",
+            transition: "all 300ms ease",
           }}
         >
           {isDone ? "✓" : stepNumber}
         </div>
-
-        {/* Connector line between icon and label */}
         <div
-          className="uppercase"
           style={{
             fontFamily: "var(--font-mono)",
             fontSize: 10,
-            color: "var(--color-fg-dim)",
-            letterSpacing: "var(--tracking-label)",
+            fontWeight: 700,
+            color,
+            letterSpacing: "0.06em",
+            textAlign: "center",
           }}
         >
-          STEP {stepNumber}
+          {label}
         </div>
       </div>
-
-      {/* Step label */}
-      <div
-        className="font-semibold"
-        style={{
-          fontFamily: "var(--font-display)",
-          fontSize: 14,
-          color: labelColor,
-          letterSpacing: "0.04em",
-        }}
-      >
-        {label}
-      </div>
-
-      {/* Connector line to next step (bottom-right area, purely decorative) */}
       {!isLast && (
         <div
           aria-hidden
           style={{
-            position: "absolute",
-            top: "50%",
-            right: -1,
-            transform: "translateY(-50%)",
-            width: 1,
-            height: "40%",
-            background: isDone
-              ? "rgba(77,212,122,0.4)"
-              : "var(--color-border)",
+            flex: 1,
+            height: 2,
+            margin: "0 8px",
+            marginTop: -18,
+            background: isDone ? "rgba(77,212,122,0.35)" : "var(--color-border)",
+            transition: "background 300ms ease",
           }}
         />
       )}

--- a/src/components/rivalhub/phase-step.tsx
+++ b/src/components/rivalhub/phase-step.tsx
@@ -1,0 +1,109 @@
+interface PhaseStepProps {
+  label: string;
+  stepNumber: number;
+  isDone: boolean;
+  isCurrent: boolean;
+  isLast: boolean;
+}
+
+export function PhaseStep({ label, stepNumber, isDone, isCurrent, isLast }: PhaseStepProps) {
+  const iconBorderColor = isDone
+    ? "var(--color-ok)"
+    : isCurrent
+      ? "var(--color-accent)"
+      : "var(--color-border)";
+
+  const iconBg = isDone
+    ? "rgba(77,212,122,0.13)"
+    : isCurrent
+      ? "rgba(255,107,26,0.13)"
+      : "transparent";
+
+  const iconColor = isDone
+    ? "var(--color-ok)"
+    : isCurrent
+      ? "var(--color-accent)"
+      : "var(--color-fg-dim)";
+
+  const iconShadow = isCurrent ? "0 0 12px rgba(255,107,26,0.2)" : undefined;
+
+  const labelColor = isDone
+    ? "var(--color-fg)"
+    : isCurrent
+      ? "var(--color-accent)"
+      : "var(--color-fg-mid)";
+
+  return (
+    <div
+      className="relative flex-1 min-w-[120px]"
+      style={{
+        padding: "18px 16px",
+        borderRight: !isLast ? "1px solid var(--color-border)" : "none",
+        background: isCurrent ? "var(--color-panel-hi)" : "transparent",
+      }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        {/* Icon dot */}
+        <div
+          className="grid place-items-center font-bold rounded-sm shrink-0"
+          style={{
+            width: 16,
+            height: 16,
+            border: `1px solid ${iconBorderColor}`,
+            background: iconBg,
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: iconColor,
+            boxShadow: iconShadow,
+          }}
+        >
+          {isDone ? "✓" : stepNumber}
+        </div>
+
+        {/* Connector line between icon and label */}
+        <div
+          className="uppercase"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: "var(--color-fg-dim)",
+            letterSpacing: "var(--tracking-label)",
+          }}
+        >
+          STEP {stepNumber}
+        </div>
+      </div>
+
+      {/* Step label */}
+      <div
+        className="font-semibold"
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: 14,
+          color: labelColor,
+          letterSpacing: "0.04em",
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Connector line to next step (bottom-right area, purely decorative) */}
+      {!isLast && (
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            top: "50%",
+            right: -1,
+            transform: "translateY(-50%)",
+            width: 1,
+            height: "40%",
+            background: isDone
+              ? "rgba(77,212,122,0.4)"
+              : "var(--color-border)",
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -1,21 +1,20 @@
 import "server-only";
-import { eq, asc } from "drizzle-orm";
+import { and, eq, asc } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matches, teams } from "@/db/schema";
 import { calculateStandings, type TeamStanding } from "@/lib/standings";
 
 export async function getStandings(seasonId: string): Promise<TeamStanding[]> {
-  const [allTeams, allMatches] = await Promise.all([
+  const [allTeams, finished] = await Promise.all([
     db.query.teams.findMany({
       where: eq(teams.seasonId, seasonId),
       orderBy: [asc(teams.draftOrder)],
     }),
     db.query.matches.findMany({
-      where: eq(matches.seasonId, seasonId),
+      where: and(eq(matches.seasonId, seasonId), eq(matches.status, "finished")),
       orderBy: [asc(matches.createdAt)],
     }),
   ]);
 
-  const finished = allMatches.filter((m) => m.status === "finished");
   return calculateStandings(allTeams, finished);
 }

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { eq, asc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matches, teams } from "@/db/schema";
+import { calculateStandings, type TeamStanding } from "@/lib/standings";
+
+export async function getStandings(seasonId: string): Promise<TeamStanding[]> {
+  const [allTeams, allMatches] = await Promise.all([
+    db.query.teams.findMany({
+      where: eq(teams.seasonId, seasonId),
+      orderBy: [asc(teams.draftOrder)],
+    }),
+    db.query.matches.findMany({
+      where: eq(matches.seasonId, seasonId),
+      orderBy: [asc(matches.createdAt)],
+    }),
+  ]);
+
+  const finished = allMatches.filter((m) => m.status === "finished");
+  return calculateStandings(allTeams, finished);
+}


### PR DESCRIPTION
## Summary
- 21 文件，7 commits，基于 Tactical Grid v2 设计方案的增量视觉优化
- 全部通过 `pnpm tsc --noEmit` + `pnpm build`

## 改动清单

### Token & 组件层
- `globals.css` 新增 `--color-info` / `--color-info-soft` / `--color-info-edge`
- `ui-tokens.md` 文档与代码对齐
- `Panel` 新增 `hoverable` (hover 微浮) + `teamColor` (顶部色条) prop，`label` 支持 JSX
- 新建 `PhaseStep` 组件 (连线 + glow + 完成 ✓)
- `MatchCard` 迁移至 Panel + hoverable

### 首页
- 动态 Hero: registration/voting/playing 三态 eyebrow + 右侧面板
- 分层导航: Tier1 accent 大卡片 → Tier2 grid-cols-4 → Tier3 ghost 按钮
- 移除虚构奖金池 → 实际数据 stat 四格
- Archive 历届赛季 grid-cols-3

### 赛季首页
- Phase Tracker 升级为 PhaseStep 连线
- Quick Links: grid-cols-3 + 40×40 图标容器
- Next Matches (1.5fr) + Standings TOP 4 (1fr) 双栏布局

### 赛程 & 比赛详情
- VetoView 语义色: BAN=danger / PICK=ok / DECIDER=info
- MVP 投票 grid-cols-4 + 票数最多 accent 高亮
- Map Tab Pick pill 归属标注

### 队伍 & 数据
- 队伍详情: 阵容 hover + 地图胜率配色 (≥60% ok / ≤40% danger)
- StatsLeaderboard: 排序列高亮 + 前 3 accent + Btn 筛选
- 选手卡片 Panel hoverable

### 管理后台
- 比赛管理 `<details>` 折叠 + 状态排序 + in_progress accent 边框
- SeasonForm edit 拆分为 5 个独立 Panel + 每节 SaveBtn
- Dashboard 赛季卡片直接操作按钮 (比赛管理/报名审核/选秀/设置)

### 数据层 & 其他
- `src/lib/data/standings.ts` 共享积分榜查询
- OnlineCounter 移至 Header 右侧 + 设计风格
- Header Tab 去四边框 → 仅底部 accent 下划线

### 代码审查
- 3 agents 并行审计，7 项修复 (CRITICAL Server Component 事件处理器, HIGH 未定义 token, efficiency × 4, micro × 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)