### PR TITLE
v1.16.1 — layout consistency, token cleanup, player name links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2026-05-18
+
+### Added
+- **选手名全站可点击**：队伍列表（TeamCard 首发/替补名）、队伍详情（阵容首发/替补/队内联系方式、每位置最佳）、比赛赛前名单（MatchRosterView 两队首发/替补）、比赛赛后数据表（PlayerStatsTable）、MVP 投票结果页，选手名均链接到 `/players/[userId]`
+- **比赛详情页队伍名可点击**：Hero 区双方队伍名链接到队伍详情页
+- **管理员下载队伍头像**：队伍详情页 Logo 下方显示「下载头像」按钮，仅 admin 可见且有 logo 时出现
+- `formatCSTDateTime()` 格式化函数（CST 月日+时间，如 "5月18日 19:30"）
+
+### Changed
+- **比赛时间显示日期+具体时间**：MatchCard 和赛季首页 NEXT MATCHES 从仅日期（"5月18日"）改为日期+时间（"5月18日 19:30"）
+- **赛季子页面统一垂直间距**：4 个页面（赛季首页 / draft / captains / register）父容器改为 `space-y-*` 统一间距，消除各区块 ad-hoc `mb-*`/`mt-*`
+- **赛季首页 STANDINGS 视觉对齐**：右侧积分榜从裸 div 改为 `<Panel label="STANDINGS · TOP 4">` 包裹，与左侧 NEXT MATCHES 视觉对称
+- **StatsLeaderboard 筛选改用 `Btn` 组件**：排序 Tab 和位置筛选从手动 `<a>` 改为 `<Btn small ghost asChild>`，全站按钮风格统一
+- **3 组件 shadcn Card → rivalhub Panel**：MatchMvpVote / CaptainVotingPanel / StatsLeaderboard 统一使用 Panel 组件
+- **admin matches 页提取 `AdminMatchRow` 组件**：消除排位赛/正赛 ~200 行重复 JSX，净减 153 行；统一 VetoInputDialog 可见性（scheduled + in_progress 均显示）；清理 10+ 不再使用的 import
+
+### Fixed
+- `tailwind.config.ts` 删除 6 个无效 token 映射（`bg-base` / `bg-elevated` / `bg-overlay` / `text-primary` / `text-secondary` / `text-muted`），均无代码引用
+- `TeamCard` 未定义 token `--color-bg-subtle` → `--color-panel-low`
+- 3 处 `var(--primary)` → `var(--color-accent)`（StandingsTable / MapByMapInput / StatsLeaderboard），token 一致性
+- `MatchMvpVote` 圆角 `rounded-lg` → `rounded-sm`，与全站 `--radius: 3px` 一致
+- `Btn` / `Panel` 补显式 `import React`，修复 vitest 环境 `React is not defined`
+- 队伍详情页 `checkAdminSession()` 重复解密 iron-session cookie，改为复用 `getUserSession()` 结果
+- `TeamMemberData` / `RosterData` 类型三处重复定义 → 统一从 `AdminMatchRow` 导出
+- `AdminMatchRow` match.status/format 从 `string` 改为联合类型，移除 6 处类型断言
+- `completedMaps`/`finishedMaps` 映射逻辑在 admin matches 页两处复制粘贴 → 提取 `mapCompletedMaps()`/`mapFinishedMaps()` 辅助函数
+
 ## [1.16.0] - 2026-05-18
 
 ### Added
@@ -459,6 +486,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.16.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.15.1...v1.16.0
 [1.15.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.14.3...v1.15.0

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，覆盖报名、审核、队长投票、蛇形选秀、队伍展示、赛程管理、Bracket、比分录入、数据统计与上线部署。
 
-当前 `1.11.0` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
+当前 `1.16.1` 版本服务于 **2026 NJU Rivals 春季赛**：8 支队伍、队长投票、蛇形选秀、排位赛 + 双败淘汰，生产站点部署在 [match.starfie1d.top](https://match.starfie1d.top)。
 
 ## 功能状态
 
-| 模块 | 1.7.0 能力 |
+| 模块 | 1.16.1 能力 |
 |---|----|
 | 赛季管理 | capability 驱动的多赛事模型，`/[seasonSlug]` 路由，动态 PhaseTracker 阶段追踪，NEXT MATCHES 面板 + Stat 四格（playing 阶段）；SeasonNav / PhaseTracker 应用 ScrollHint 横滚提示 |
 | 报名 | 邮箱密码账号、自动草稿恢复、Zod 校验、位置/人数上限（仅统计 approved）、NJUBox 截图链接 |
 | 审核 | 管理员审核、候补名单、邀请码提权、审批通过自动推进赛季状态、操作审计 |
-| 选手 | `/[seasonSlug]/players` 选手名单页，按主/副位置 OR 筛选，卡片展示段位/Rating/副位置/所属队伍 |
+| 选手 | `/[seasonSlug]/players` 选手名单页，按主/副位置 OR 筛选，卡片展示段位/Rating/副位置/所属队伍；全站选手名可点击跳转个人主页 |
 | 队长投票 | 每人最多 3 票，Realtime 刷新票数；移动端切换卡片列表（`CaptainVotingPanel` 双模式） |
 | 选秀 | 队长面板按段位+Rt 排序统一列表、满员位置灰显禁用、可折叠阵容摘要；围观直播间 pick 通知 Banner 3 秒淡出；事务行锁、幂等 pick、超时自动递补 |
-| 队伍 | 阵容展示、首发/替补、队长标识、队伍图标上传；同队成员可见 QQ/邮箱联系方式 |
-| 比赛 | 赛程、Bracket（Tactical Grid 暗色主题）、地图结果、比分录入 |
+| 队伍 | 阵容展示、首发/替补、队长标识、队伍图标上传、管理员下载头像；同队成员可见 QQ/邮箱联系方式；队伍名可点击跳转详情 |
+| 比赛 | 赛程、Bracket（Tactical Grid 暗色主题）、地图结果、比分录入；赛前名单/MVP 结果/赛后数据表选手名可点击跳转个人主页 |
 | 协商 | 比赛时间提议/接受/拒绝（双方队长均可随时提议）、24h 未回应自动采纳、管理员强制设定、协商截止自动裁定、管理员批量设置截止时间（按阶段/轮次） |
 | 账号 | 邮箱+密码注册/登录、个人信息自助修改（perfectName/steamName/steam64/steamProfileUrl/QQ/学号）、修改密码、`getDisplayName()` 统一展示名派生 |
 | 数据 | 完美平台截图 OCR、比赛数据表、MVP 投票、选手/队伍统计、后台操作日志 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/captains/page.tsx
+++ b/src/app/[seasonSlug]/captains/page.tsx
@@ -57,7 +57,7 @@ export default async function CaptainsPage({ params }: CaptainsPageProps) {
   }
 
   return (
-    <main className="container mx-auto max-w-6xl px-4 py-10">
+    <main className="container mx-auto max-w-6xl px-4 py-10 space-y-8">
       <div className="mb-8">
         <p className="font-mono text-[11px] tracking-[0.18em] text-[var(--color-accent)] uppercase mb-1">
           {season.name} · CAPTAINS
@@ -69,7 +69,7 @@ export default async function CaptainsPage({ params }: CaptainsPageProps) {
       </div>
 
       {season.status === "voting" && (
-        <div className="mb-6 rounded-sm border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5 p-4 text-sm text-[var(--color-fg-mid)]">
+        <div className="rounded-sm border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/5 p-4 text-sm text-[var(--color-fg-mid)]">
           <p className="font-medium text-[var(--color-fg)] mb-1">关于选秀顺序</p>
           <p>
             第一轮选秀将<strong className="text-[var(--color-fg)]">逆向进行</strong>

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -31,7 +31,7 @@ export default async function DraftPage({ params }: DraftPageProps) {
 
   if (!season.hasDraft) {
     return (
-      <main className="container mx-auto max-w-5xl px-4 py-10">
+      <main className="container mx-auto max-w-5xl px-4 py-10 space-y-8">
         <Panel pad={32}>
           <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
           <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
@@ -46,7 +46,7 @@ export default async function DraftPage({ params }: DraftPageProps) {
     const stageLabel = SEASON_STATUS_LABELS[season.status] ?? season.status;
     const draftFinished = season.status === "playing" || season.status === "finished";
     return (
-      <main className="container mx-auto max-w-5xl px-4 py-10">
+      <main className="container mx-auto max-w-5xl px-4 py-10 space-y-8">
         <Panel pad={32}>
           <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
           <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
@@ -63,7 +63,7 @@ export default async function DraftPage({ params }: DraftPageProps) {
 
   if (!data.state) {
     return (
-      <main className="container mx-auto max-w-7xl px-4 py-10">
+      <main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">
         <Marker sub="队伍已组建，选秀尚未启动。队长可提前查看选手池研究阵容。">
           选秀预览 · {season.name}
         </Marker>
@@ -97,7 +97,7 @@ export default async function DraftPage({ params }: DraftPageProps) {
   }
 
   return (
-    <main className="container mx-auto max-w-7xl px-4 py-10">
+    <main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">
       <div className="flex items-center justify-between">
         <Marker sub="实时更新选秀进度，队伍阵容与选手池自动刷新。">
           选秀直播间 · {season.name}
@@ -108,7 +108,7 @@ export default async function DraftPage({ params }: DraftPageProps) {
       </div>
 
       {data.state.isActive && (
-        <div className="mt-4">
+        <div>
           <a
             href={`/${seasonSlug}/draft/captain`}
             className="inline-flex items-center gap-2 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-4 py-2 text-sm font-medium text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20 transition-colors"

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -138,6 +138,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       displayName: users.displayName,
       perfectName: users.perfectName,
       primaryPosition: seasonRegistrations.primaryPosition,
+      userId: users.id,
     })
     .from(teamMembers)
     .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
@@ -188,6 +189,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
     perfectName: string | null;
     primaryPosition: string;
     isStarter: boolean;
+    userId?: string | null;
   }
 
   function buildRoster(
@@ -205,6 +207,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         perfectName: m.perfectName ?? null,
         primaryPosition: m.primaryPosition,
         isStarter: playerMap.get(m.id) ?? false,
+        userId: m.userId ?? null,
       }));
   }
 
@@ -251,8 +254,9 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         {/* Team A */}
         <div className="flex items-center gap-4 justify-end">
           <div className="text-right min-w-0">
-            <div
-              className="font-bold text-lg sm:text-[28px]"
+            <Link
+              href={`/${seasonSlug}/teams/${match.teamAId}`}
+              className="font-bold text-lg sm:text-[28px] hover:text-[var(--color-accent)] transition-colors"
               style={{
                 fontFamily: "var(--font-display)",
                 color: "var(--color-fg)",
@@ -260,7 +264,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
               }}
             >
               {teamA?.name ?? "未知队伍"}
-            </div>
+            </Link>
           </div>
           {teamA && (
             <div className="w-12 h-12 sm:w-16 sm:h-16 shrink-0">
@@ -347,8 +351,9 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
             </div>
           )}
           <div className="min-w-0">
-            <div
-              className="font-bold text-lg sm:text-[28px]"
+            <Link
+              href={`/${seasonSlug}/teams/${match.teamBId}`}
+              className="font-bold text-lg sm:text-[28px] hover:text-[var(--color-accent)] transition-colors"
               style={{
                 fontFamily: "var(--font-display)",
                 color: "var(--color-fg)",
@@ -356,7 +361,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
               }}
             >
               {teamB?.name ?? "未知队伍"}
-            </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -5,7 +5,7 @@ import { alias } from "drizzle-orm/pg-core";
 import { UserPlus, Vote, Users, Swords, Shuffle, BarChart3, UserRoundSearch } from "lucide-react";
 import { db } from "@/db/client";
 import { seasons, matches, teams, seasonRegistrations } from "@/db/schema";
-import { formatCSTShortDate } from "@/lib/utils/date";
+import { formatCSTDateTime } from "@/lib/utils/date";
 import { normalizeStagePlan } from "@/types/season";
 import type { SeasonStatus } from "@/types/season";
 import { showStats } from "@/lib/utils/season";
@@ -204,7 +204,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
   ].filter((l) => l.show);
 
   return (
-    <div className="container mx-auto px-4 py-10">
+    <div className="container mx-auto px-4 py-10 space-y-8">
       <div className="relative mb-12 pt-6">
         <div className="flex items-center gap-3 mb-4 text-xs uppercase tracking-wider">
           <StatusPill status={season.status} />
@@ -280,7 +280,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
                             <span className="font-mono text-[11px] text-[var(--color-ok)]">● LIVE</span>
                           ) : match.scheduledAt ? (
                             <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">
-                              {formatCSTShortDate(match.scheduledAt)}
+                              {formatCSTDateTime(match.scheduledAt)}
                             </span>
                           ) : (
                             <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">待定</span>
@@ -299,18 +299,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
 
           {/* Right: 积分榜 TOP 4 */}
           {standings.length > 0 && (
-            <div>
-              <div className="flex items-center justify-between mb-3">
-                <h3
-                  className="font-semibold text-sm"
-                  style={{
-                    fontFamily: "var(--font-sans)",
-                    color: "var(--color-fg)",
-                  }}
-                >
-                  STANDINGS · TOP 4
-                </h3>
-              </div>
+            <Panel label="STANDINGS · TOP 4">
               <StandingsTable
                 standings={standings.slice(0, 4)}
                 seasonSlug={seasonSlug}
@@ -323,7 +312,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
                   </Link>
                 </Btn>
               </div>
-            </div>
+            </Panel>
           )}
         </div>
       )}
@@ -353,7 +342,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
       </div>
 
       {/* Stat 四格 */}
-      <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <Stat label="TEAMS" value={teamCountRow?.value ?? 0} />
         <Stat label="PLAYERS" value={approvedCountRow?.value ?? 0} />
         <Stat

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -122,7 +122,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   });
 
   return (
-    <div className="container mx-auto px-4 py-10 max-w-2xl">
+    <div className="container mx-auto px-4 py-10 max-w-2xl space-y-6">
       <div className="mb-8">
         <p className="font-mono text-[11px] tracking-[0.18em] text-[var(--color-accent)] uppercase mb-1">
           {season.name} · REGISTER
@@ -131,7 +131,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
       </div>
 
       {/* 位置实时容量 */}
-      <div className="mb-6">
+      <div>
         <StatusBanner
           tone={getWindowTone(registrationWindow.phase, registrationWindow.canSubmit)}
           title={registrationWindow.message}
@@ -142,7 +142,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
         />
       </div>
 
-      <div className="mb-6">
+      <div>
         <Panel label="实时容量">
           <div className="grid gap-2.5">
             {capacityEntries.map(({ pos, label, cur, max }) => {
@@ -188,7 +188,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
       </div>
 
       {currentRegistration && (
-        <div className="mb-6">
+        <div>
           <StatusBanner
             tone={currentRegistration.status === "approved" ? "success" : currentRegistration.status === "rejected" ? "warn" : "info"}
             title={`你的报名状态：${existingStatusLabel}`}

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -3,7 +3,7 @@ import { eq, or, and, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
 import { matchPlayerStats } from "@/db/schema/player-stats";
-import { Panel, Stat, Marker, PosChip } from "@/components/rivalhub";
+import { Panel, Stat, Marker, PosChip, Btn } from "@/components/rivalhub";
 import { MatchCard } from "@/components/matches/MatchCard";
 import { MapPreferenceChips } from "@/components/rivalhub/map-preference-chips";
 import { TeamNameForm } from "@/components/teams/TeamNameForm";
@@ -11,7 +11,7 @@ import { TeamLogoUpload } from "@/components/teams/TeamLogoUpload";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { CS2_POSITIONS, DEFAULT_CS2_MAP_POOL } from "@/types/season";
-import { getUserSession } from "@/lib/auth/session";
+import { getUserSession, checkAdminSession } from "@/lib/auth/session";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { getTeamMapWinStats, getTeamBanStats } from "@/lib/teams/data";
 import { mapLabel } from "@/lib/maps";
@@ -41,6 +41,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   if (!team) notFound();
 
   const session = await getUserSession();
+  const isAdmin = session ? session.role !== "user" : !!(await checkAdminSession());
   const currentUserRegistration = session
     ? await db.query.seasonRegistrations.findFirst({
         where: and(
@@ -63,6 +64,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         perfectName: users.perfectName,
         email: users.email,
         qq: users.qq,
+        userId: users.id,
       })
       .from(teamMembers)
       .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
@@ -159,13 +161,14 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           round(avg(mps.we)::numeric, 1) as avg_we,
           sr.primary_position,
           mps.perfect_name,
-          mps.rating_pro
+          mps.rating_pro,
+          mps.user_id
         FROM match_player_stats mps
         JOIN season_registrations sr ON sr.user_id = mps.user_id AND sr.season_id = ${season.id}
         JOIN team_members tm ON tm.registration_id = sr.id
         WHERE tm.team_id = ${teamId}
           AND mps.verified_by_admin IS NOT NULL
-        GROUP BY sr.primary_position, mps.perfect_name, mps.rating_pro
+        GROUP BY sr.primary_position, mps.perfect_name, mps.rating_pro, mps.user_id
       `)
     : null;
 
@@ -180,6 +183,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     primary_position: string;
     perfect_name: string;
     rating_pro: number;
+    user_id?: string | null;
   }
 
   const typedStats = teamStatRows as unknown as TeamStatRow[];
@@ -206,12 +210,12 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
       : null;
 
   // 每位置最高 Rating 选手
-  const positionBest = new Map<string, { name: string; rating: number }>();
+  const positionBest = new Map<string, { name: string; rating: number; userId?: string | null }>();
   for (const r of typedStats) {
     const pos = r.primary_position;
     const existing = positionBest.get(pos);
     if (!existing || Number(r.rating_pro) > existing.rating) {
-      positionBest.set(pos, { name: r.perfect_name, rating: Number(r.rating_pro) });
+      positionBest.set(pos, { name: r.perfect_name, rating: Number(r.rating_pro), userId: r.user_id });
     }
   }
 
@@ -220,12 +224,21 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 
       {/* 队伍标题 */}
       <div className="flex items-start gap-5">
-        <TeamLogoUpload
-          teamId={team.id}
-          currentLogoUrl={team.logoUrl ?? null}
-          teamName={team.name}
-          canEdit={canEditTeamName}
-        />
+        <div className="flex flex-col items-center gap-2">
+          <TeamLogoUpload
+            teamId={team.id}
+            currentLogoUrl={team.logoUrl ?? null}
+            teamName={team.name}
+            canEdit={canEditTeamName}
+          />
+          {isAdmin && team.logoUrl && (
+            <Btn small ghost asChild>
+              <a href={team.logoUrl} target="_blank" rel="noopener noreferrer">
+                下载头像
+              </a>
+            </Btn>
+          )}
+        </div>
         <div className="space-y-1 min-w-0">
           <p className="text-xs text-[var(--color-fg-mid)]">
             <Link href={`/${seasonSlug}/teams`} className="hover:underline">参赛队伍</Link>
@@ -258,9 +271,15 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                   {p.registrationId === team.captainRegistrationId && (
                     <PosChip pos="C" small />
                   )}
-                  <span className="font-medium text-[var(--color-fg)] truncate text-sm sm:text-base">
-                    {getDisplayName(p)}
-                  </span>
+                  {p.userId ? (
+                    <Link href={`/players/${p.userId}`} className="font-medium text-[var(--color-fg)] truncate text-sm sm:text-base hover:text-[var(--color-accent)] transition-colors">
+                      {getDisplayName(p)}
+                    </Link>
+                  ) : (
+                    <span className="font-medium text-[var(--color-fg)] truncate text-sm sm:text-base">
+                      {getDisplayName(p)}
+                    </span>
+                  )}
                 </div>
                 <div className="text-right shrink-0">
                   <span className="text-xs sm:text-sm text-[var(--color-fg-mid)]">
@@ -278,7 +297,13 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                 <p className="text-xs text-[var(--color-fg-mid)] font-medium uppercase tracking-wide">替补</p>
                 {subs.map((p) => (
                   <div key={p.registrationId} className="flex items-center justify-between gap-2 opacity-70 hover:bg-[var(--color-panel-hi)] transition-colors rounded px-2 -mx-2">
-                    <span className="text-sm text-[var(--color-fg)] truncate">{getDisplayName(p)}</span>
+                    {p.userId ? (
+                      <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] truncate hover:text-[var(--color-accent)] transition-colors">
+                        {getDisplayName(p)}
+                      </Link>
+                    ) : (
+                      <span className="text-sm text-[var(--color-fg)] truncate">{getDisplayName(p)}</span>
+                    )}
                     <span className="text-xs text-[var(--color-fg-mid)] shrink-0">
                       {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
                     </span>
@@ -360,9 +385,15 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
             <div className="space-y-3">
               {roster.map((p) => (
                 <div key={p.registrationId} className="flex items-center justify-between gap-2">
-                  <span className="text-sm font-medium text-[var(--color-fg)]">
-                    {getDisplayName(p)}
-                  </span>
+                  {p.userId ? (
+                    <Link href={`/players/${p.userId}`} className="text-sm font-medium text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors">
+                      {getDisplayName(p)}
+                    </Link>
+                  ) : (
+                    <span className="text-sm font-medium text-[var(--color-fg)]">
+                      {getDisplayName(p)}
+                    </span>
+                  )}
                   <div className="flex items-center gap-4 text-sm text-[var(--color-fg-mid)]">
                     {p.qq && <span>QQ: {p.qq}</span>}
                     {p.email && <span>邮箱: {p.email}</span>}
@@ -388,12 +419,24 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
               {positionBest.size > 0 && (
                 <div className="text-[11px] text-[var(--color-fg-dim)] border-t border-[var(--color-border)] pt-3">
                   {[...positionBest.entries()]
-                    .map(([pos, info]) => {
+                    .map(([pos, info], i) => {
                       const label =
                         POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.cn ?? pos;
-                      return `${label} ${info.name} (${info.rating.toFixed(2)})`;
-                    })
-                    .join(" · ")}
+                      return (
+                        <span key={pos}>
+                          {i > 0 && " · "}
+                          {label}{" "}
+                          {info.userId ? (
+                            <Link href={`/players/${info.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
+                              {info.name}
+                            </Link>
+                          ) : (
+                            info.name
+                          )}
+                          {" "}({info.rating.toFixed(2)})
+                        </span>
+                      );
+                    })}
                 </div>
               )}
             </div>

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -45,6 +45,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       steamName: users.steamName,
       perfectName: users.perfectName,
       email: users.email,
+      userId: users.id,
     })
     .from(teamMembers)
     .innerJoin(teams, eq(teamMembers.teamId, teams.id))
@@ -76,6 +77,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
               primaryPosition: m.primaryPosition,
               isStarter: m.isStarter,
               isCaptain: m.registrationId === m.captainRegId,
+              userId: m.userId,
             }))
             .sort((a, b) => {
               if (a.isStarter !== b.isStarter) return a.isStarter ? -1 : 1;

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { eq, count, asc, and, inArray } from "drizzle-orm";
+import { eq, asc, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, teams, matchMaps, teamMembers, matchRosters, matchRosterPlayers } from "@/db/schema";
 import { users, seasonRegistrations } from "@/db/schema";
@@ -10,21 +10,12 @@ import { GeneratePlayoffCard } from "@/components/matches/GeneratePlayoffCard";
 import { CreateMatchForm } from "@/components/matches/CreateMatchForm";
 import { AdminMatchFilter } from "@/components/matches/AdminMatchFilter";
 import { StandingsTable } from "@/components/matches/StandingsTable";
-import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
-import { ScoreInput } from "@/components/matches/ScoreInput";
-import { MapByMapInput } from "@/components/matches/MapByMapInput";
-import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
-import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
-import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
-import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
-import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
+import { AdminMatchRow } from "@/components/matches/AdminMatchRow";
+import type { TeamMemberData, RosterData } from "@/components/matches/AdminMatchRow";
 import { BatchDeadlineCard } from "@/components/matches/BatchDeadlineCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Panel, StatusPill } from "@/components/rivalhub";
-import { cn } from "@/lib/utils/cn";
-import { Separator } from "@/components/ui/separator";
+import { Panel } from "@/components/rivalhub";
 import { getFirstStageOfType, normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
-import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
 export const dynamic = "force-dynamic";
@@ -35,6 +26,21 @@ const STATUS_SORT_ORDER: Record<string, number> = {
   finished: 2,
   cancelled: 3,
 };
+
+function mapCompletedMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; scoreB: number | null; pickedByTeamId: string | null; teamAStartSide: string | null }[]) {
+  return records.map((r) => ({
+    mapOrder: r.mapOrder,
+    mapName: r.mapName,
+    scoreA: r.scoreA ?? 0,
+    scoreB: r.scoreB ?? 0,
+    pickedByTeamId: r.pickedByTeamId,
+    teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+  }));
+}
+
+function mapFinishedMaps(records: { id: string; mapName: string }[]) {
+  return records.map((r) => ({ id: r.id, mapName: r.mapName }));
+}
 
 function sortMatches<T extends { status: string; scheduledAt: Date | null }>(list: T[]): T[] {
   return [...list].sort((a, b) => {
@@ -190,19 +196,6 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   }
 
   // ── 人员名单查询（供 AdminRosterDialog 用）───────────────────
-  interface TeamMemberData {
-    id: string;
-    teamId: string;
-    steamName: string;
-    displayName: string | null;
-    perfectName: string | null;
-    primaryPosition: string;
-  }
-  interface RosterData {
-    starters: string[];
-    substitutes: string[];
-    status: string | null;
-  }
   let allTeamMembers: TeamMemberData[] = [];
   const rosterByMatch = new Map<string, Map<string, RosterData>>();
   const teamMembersByTeam = new Map<string, TeamMemberData[]>();
@@ -391,92 +384,20 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "未知队伍";
                     const teamBName = teamMap.get(m.teamBId) ?? "未知队伍";
                     return (
-                      <Panel key={m.id} pad={16} className={cn("space-y-3", m.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]")}>
-                        <div className="flex items-center justify-between gap-4 flex-wrap">
-                          <div className="flex items-center gap-3">
-                            <span className="font-semibold">{teamAName}</span>
-                            <span className="text-[var(--color-fg-mid)]">
-                              {m.status === "finished"
-                                ? `${m.scoreA ?? 0} : ${m.scoreB ?? 0}`
-                                : "vs"}
-                            </span>
-                            <span className="font-semibold">{teamBName}</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <StatusPill status={MATCH_FORMAT_LABELS[m.format as keyof typeof MATCH_FORMAT_LABELS]} />
-                            <MatchStatusBadge
-                              status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                            />
-                          </div>
-                        </div>
-                        {m.status !== "cancelled" && (
-                          <details open={m.status === "in_progress" ? true : undefined}>
-                            <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
-                              {m.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
-                            </summary>
-                            <div className="space-y-3 pt-2">
-                              <Separator />
-                              {m.status !== "finished" && (
-                                <>
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <AdminRosterDialog
-                                      matchId={m.id}
-                                      teamAName={teamAName}
-                                      teamBName={teamBName}
-                                      teamAId={m.teamAId}
-                                      teamBId={m.teamBId}
-                                      teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
-                                      teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
-                                      teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                                      teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                                    />
-                                    {m.status === "in_progress" && (
-                                      <VetoInputDialog
-                                        matchId={m.id}
-                                        format={m.format as "bo1" | "bo3" | "bo5"}
-                                        teamAName={teamAName}
-                                        teamBName={teamBName}
-                                        teamAId={m.teamAId}
-                                        teamBId={m.teamBId}
-                                        mapPool={mapPool}
-                                      />
-                                    )}
-                                  </div>
-                                  <ScheduledAtInput
-                                    matchId={m.id}
-                                    currentScheduledAt={m.scheduledAt}
-                                    currentCompletionDeadline={m.completionDeadline}
-                                  />
-                                  <ScoreInput
-                                    matchId={m.id}
-                                    teamAName={teamAName}
-                                    teamBName={teamBName}
-                                    currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                                    format={m.format as "bo1" | "bo3" | "bo5"}
-                                  />
-                                </>
-                              )}
-                              {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
-                                <div key={map.id}>
-                                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                                </div>
-                              ))}
-                            </div>
-                          </details>
-                        )}
-                        <div className="flex items-center justify-between gap-2">
-                          <Link
-                            href={`/${seasonSlug}/matches/${m.id}`}
-                            className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
-                            target="_blank"
-                          >
-                            查看公开页 ↗
-                          </Link>
-                          {m.bracketNodeId == null && (
-                            <DeleteMatchButton matchId={m.id} />
-                          )}
-                        </div>
-                      </Panel>
+                      <AdminMatchRow
+                        key={m.id}
+                        match={m}
+                        teamAName={teamAName}
+                        teamBName={teamBName}
+                        seasonSlug={seasonSlug}
+                        mapPool={mapPool}
+                        teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                        teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+                        teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                        teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                        completedMaps={mapCompletedMaps(mapsByMatchId.get(m.id) ?? [])}
+                        finishedMaps={mapFinishedMaps(mapsByMatch.get(m.id) ?? [])}
+                      />
                     );
                   })}
                 </div>
@@ -498,112 +419,21 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     const teamAName = teamMap.get(m.teamAId) ?? "TBD";
                     const teamBName = teamMap.get(m.teamBId) ?? "TBD";
                     return (
-                      <Panel key={m.id} pad={16} className={cn("space-y-3", m.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]")}>
-                        <div className="flex items-center justify-between gap-4 flex-wrap">
-                          <div className="flex items-center gap-3">
-                            <span className="font-semibold">{teamAName}</span>
-                            <span className="text-[var(--color-fg-mid)]">
-                              {m.status === "finished"
-                                ? `${m.scoreA ?? 0} : ${m.scoreB ?? 0}`
-                                : "vs"}
-                            </span>
-                            <span className="font-semibold">{teamBName}</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <StatusPill status={MATCH_FORMAT_LABELS[m.format as keyof typeof MATCH_FORMAT_LABELS]} />
-                            <MatchStatusBadge
-                              status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                            />
-                          </div>
-                        </div>
-                        {m.status !== "cancelled" && (
-                          <details open={m.status === "in_progress" ? true : undefined}>
-                            <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
-                              {m.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
-                            </summary>
-                            <div className="space-y-3 pt-2">
-                              <Separator />
-                              {m.status !== "finished" && (
-                                <>
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <AdminRosterDialog
-                                      matchId={m.id}
-                                      teamAName={teamAName}
-                                      teamBName={teamBName}
-                                      teamAId={m.teamAId}
-                                      teamBId={m.teamBId}
-                                      teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
-                                      teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
-                                      teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                                      teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                                    />
-                                    {(m.status === "scheduled" || m.status === "in_progress") && (
-                                      <VetoInputDialog
-                                        matchId={m.id}
-                                        format={m.format as "bo1" | "bo3" | "bo5"}
-                                        teamAName={teamAName}
-                                        teamBName={teamBName}
-                                        teamAId={m.teamAId}
-                                        teamBId={m.teamBId}
-                                        mapPool={mapPool}
-                                      />
-                                    )}
-                                  </div>
-                                  <ScheduledAtInput
-                                    matchId={m.id}
-                                    currentScheduledAt={m.scheduledAt}
-                                    currentCompletionDeadline={m.completionDeadline}
-                                  />
-                                  {m.status === "in_progress" ? (
-                                    <MapByMapInput
-                                      matchId={m.id}
-                                      format={m.format as "bo1" | "bo3" | "bo5"}
-                                      teamAName={teamAName}
-                                      teamBName={teamBName}
-                                      teamAId={m.teamAId}
-                                      teamBId={m.teamBId}
-                                      completedMaps={(mapsByMatchId.get(m.id) ?? []).map((r) => ({
-                                        mapOrder: r.mapOrder,
-                                        mapName: r.mapName,
-                                        scoreA: r.scoreA ?? 0,
-                                        scoreB: r.scoreB ?? 0,
-                                        pickedByTeamId: r.pickedByTeamId,
-                                        teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
-                                      }))}
-                                      mapPool={mapPool}
-                                    />
-                                  ) : (
-                                    <ScoreInput
-                                      matchId={m.id}
-                                      teamAName={teamAName}
-                                      teamBName={teamBName}
-                                      currentStatus={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
-                                      format={m.format as "bo1" | "bo3" | "bo5"}
-                                    />
-                                  )}
-                                </>
-                              )}
-                              {m.status === "finished" && (mapsByMatch.get(m.id) ?? []).map((map) => (
-                                <div key={map.id}>
-                                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                                </div>
-                              ))}
-                            </div>
-                          </details>
-                        )}
-                        <div className="flex items-center justify-between gap-2">
-                          <Link
-                            href={`/${seasonSlug}/matches/${m.id}`}
-                            className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
-                            target="_blank"
-                          >
-                            查看公开页 ↗
-                          </Link>
-                          {m.bracketNodeId == null && (
-                            <DeleteMatchButton matchId={m.id} />
-                          )}
-                        </div>
-                      </Panel>
+                      <AdminMatchRow
+                        key={m.id}
+                        match={m}
+                        teamAName={teamAName}
+                        teamBName={teamBName}
+                        seasonSlug={seasonSlug}
+                        mapPool={mapPool}
+                        isPlayoff
+                        teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+                        teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+                        teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+                        teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+                        completedMaps={mapCompletedMaps(mapsByMatchId.get(m.id) ?? [])}
+                        finishedMaps={mapFinishedMaps(mapsByMatch.get(m.id) ?? [])}
+                      />
                     );
                   })}
                 </div>

--- a/src/components/captains/CaptainVotingPanel.tsx
+++ b/src/components/captains/CaptainVotingPanel.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { castVote, retractVote } from "@/actions/captains";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Panel } from "@/components/rivalhub";
 import { createBrowserClient } from "@/lib/auth/supabase";
 import { MAX_CAPTAIN_VOTES } from "@/lib/captains/rules";
 import { positionLabel } from "@/lib/validators/registration";
@@ -214,7 +214,7 @@ export function CaptainVotingPanel({
       {/* ── 桌面端布局（≥ md）──────────────────────────── */}
       <div className="hidden md:grid gap-6 lg:grid-cols-[280px_1fr]">
         <aside className="space-y-4">
-          <Card className="p-4">
+          <Panel pad={16}>
             <div className="space-y-3">
               <div>
                 <h2 className="text-base font-semibold">我的投票</h2>
@@ -263,7 +263,7 @@ export function CaptainVotingPanel({
                 刷新票数
               </Button>
             </div>
-          </Card>
+          </Panel>
         </aside>
 
         <section className="space-y-3">
@@ -280,9 +280,9 @@ export function CaptainVotingPanel({
           </div>
 
           {candidates.length === 0 ? (
-            <Card className="p-8 text-center text-sm text-[var(--color-fg-mid)]">
+            <Panel pad={32} className="text-center text-sm text-[var(--color-fg-mid)]">
               暂无符合条件的队长候选人
-            </Card>
+            </Panel>
           ) : (
             <div className="space-y-3">
               {candidates.map((candidate, index) => {
@@ -295,7 +295,7 @@ export function CaptainVotingPanel({
                   (!hasVoted && votes.length >= MAX_CAPTAIN_VOTES);
 
                 return (
-                  <Card key={candidate.id} className="p-4">
+                  <Panel key={candidate.id} pad={16}>
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2">
@@ -348,7 +348,7 @@ export function CaptainVotingPanel({
                         )}
                       </div>
                     </div>
-                  </Card>
+                  </Panel>
                 );
               })}
             </div>

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -1,0 +1,188 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { Separator } from "@/components/ui/separator";
+import { Panel, StatusPill } from "@/components/rivalhub";
+import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
+import { ScoreInput } from "@/components/matches/ScoreInput";
+import { MapByMapInput } from "@/components/matches/MapByMapInput";
+import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
+import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
+import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
+import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
+import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
+import { MATCH_FORMAT_LABELS } from "@/types/match";
+
+export interface TeamMemberData {
+  id: string;
+  teamId: string;
+  steamName: string;
+  displayName: string | null;
+  perfectName: string | null;
+  primaryPosition: string;
+}
+
+export interface RosterData {
+  starters: string[];
+  substitutes: string[];
+  status: string | null;
+}
+
+interface AdminMatchRowProps {
+  match: {
+    id: string;
+    status: "scheduled" | "in_progress" | "finished" | "cancelled";
+    format: "bo1" | "bo3" | "bo5";
+    scoreA: number | null;
+    scoreB: number | null;
+    scheduledAt: Date | null;
+    completionDeadline: Date | null;
+    teamAId: string;
+    teamBId: string;
+    bracketNodeId: string | null;
+  };
+  teamAName: string;
+  teamBName: string;
+  seasonSlug: string;
+  mapPool: string[];
+  isPlayoff?: boolean;
+  teamAMembers: TeamMemberData[];
+  teamBMembers: TeamMemberData[];
+  teamARoster: RosterData | null;
+  teamBRoster: RosterData | null;
+  completedMaps: {
+    mapOrder: number;
+    mapName: string;
+    scoreA: number;
+    scoreB: number;
+    pickedByTeamId: string | null;
+    teamAStartSide: "t" | "ct" | null;
+  }[];
+  finishedMaps: { id: string; mapName: string }[];
+}
+
+export function AdminMatchRow({
+  match,
+  teamAName,
+  teamBName,
+  seasonSlug,
+  mapPool,
+  isPlayoff = false,
+  teamAMembers,
+  teamBMembers,
+  teamARoster,
+  teamBRoster,
+  completedMaps,
+  finishedMaps,
+}: AdminMatchRowProps) {
+  return (
+    <Panel
+      pad={16}
+      className={cn(
+        "space-y-3",
+        match.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]"
+      )}
+    >
+      {/* Header: team names + score + badges */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <span className="font-semibold">{teamAName}</span>
+          <span className="text-[var(--color-fg-mid)]">
+            {match.status === "finished"
+              ? `${match.scoreA ?? 0} : ${match.scoreB ?? 0}`
+              : "vs"}
+          </span>
+          <span className="font-semibold">{teamBName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusPill status={MATCH_FORMAT_LABELS[match.format]} />
+          <MatchStatusBadge
+            status={match.status}
+          />
+        </div>
+      </div>
+
+      {/* Operations */}
+      {match.status !== "cancelled" && (
+        <details open={match.status === "in_progress" ? true : undefined}>
+          <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
+            {match.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
+          </summary>
+          <div className="space-y-3 pt-2">
+            <Separator />
+            {match.status !== "finished" && (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <AdminRosterDialog
+                    matchId={match.id}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    teamAId={match.teamAId}
+                    teamBId={match.teamBId}
+                    teamAMembers={teamAMembers}
+                    teamBMembers={teamBMembers}
+                    teamARoster={teamARoster}
+                    teamBRoster={teamBRoster}
+                  />
+                  {(match.status === "scheduled" || match.status === "in_progress") && (
+                    <VetoInputDialog
+                      matchId={match.id}
+                      format={match.format}
+                      teamAName={teamAName}
+                      teamBName={teamBName}
+                      teamAId={match.teamAId}
+                      teamBId={match.teamBId}
+                      mapPool={mapPool}
+                    />
+                  )}
+                </div>
+                <ScheduledAtInput
+                  matchId={match.id}
+                  currentScheduledAt={match.scheduledAt}
+                  currentCompletionDeadline={match.completionDeadline}
+                />
+                {isPlayoff && match.status === "in_progress" ? (
+                  <MapByMapInput
+                    matchId={match.id}
+                    format={match.format}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    teamAId={match.teamAId}
+                    teamBId={match.teamBId}
+                    completedMaps={completedMaps}
+                    mapPool={mapPool}
+                  />
+                ) : (
+                  <ScoreInput
+                    matchId={match.id}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    currentStatus={match.status}
+                    format={match.format}
+                  />
+                )}
+              </>
+            )}
+            {match.status === "finished" &&
+              finishedMaps.map((map) => (
+                <div key={map.id}>
+                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                </div>
+              ))}
+          </div>
+        </details>
+      )}
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          href={`/${seasonSlug}/matches/${match.id}`}
+          className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
+          target="_blank"
+        >
+          查看公开页 ↗
+        </Link>
+        {match.bracketNodeId == null && <DeleteMatchButton matchId={match.id} />}
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/matches/AdminRosterDialog.tsx
+++ b/src/components/matches/AdminRosterDialog.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { updateMatchRoster } from "@/actions/matches/roster";
+import type { RosterData } from "@/components/matches/AdminMatchRow";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -24,12 +25,6 @@ interface TeamMember {
   displayName: string | null;
   perfectName: string | null;
   primaryPosition: string;
-}
-
-interface RosterData {
-  starters: string[];
-  substitutes: string[];
-  status: string | null;
 }
 
 interface AdminRosterDialogProps {

--- a/src/components/matches/MapByMapInput.tsx
+++ b/src/components/matches/MapByMapInput.tsx
@@ -86,7 +86,7 @@ export function MapByMapInput({
     <div className="space-y-3">
       <div className="flex items-center gap-3">
         <span className="text-xs text-[var(--color-fg-mid)]">{format.toUpperCase()} 进度</span>
-        <span className="font-mono font-bold text-[var(--primary)]">{mapWinsA} : {mapWinsB}</span>
+        <span className="font-mono font-bold text-[var(--color-accent)]">{mapWinsA} : {mapWinsB}</span>
         <span className="text-xs text-[var(--color-fg-mid)]">（先赢 {maxWins} 图胜）</span>
       </div>
 

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -3,7 +3,7 @@ import { Panel } from "@/components/rivalhub";
 import { Badge } from "@/components/ui/badge";
 import { MatchStatusBadge } from "./MatchStatusBadge";
 import { MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
-import { formatCSTShortDate } from "@/lib/utils/date";
+import { formatCSTDateTime } from "@/lib/utils/date";
 import type { MatchFormat } from "@/types/match";
 
 interface MatchCardProps {
@@ -33,7 +33,7 @@ export function MatchCard({
 }: MatchCardProps) {
   const timeText =
     status === "scheduled" && scheduledAt
-      ? formatCSTShortDate(scheduledAt)
+      ? formatCSTDateTime(scheduledAt)
       : status === "scheduled" && !scheduledAt
         ? "未排期"
         : null;

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useTransition } from "react";
-import { Card } from "@/components/ui/card";
+import Link from "next/link";
+import { Panel } from "@/components/rivalhub";
 import { castMatchMvpVote } from "@/actions/player-stats";
 import { isDeadlinePassed, MVP_DEADLINE_MS } from "@/lib/utils/date";
 
@@ -88,11 +89,17 @@ export function MatchMvpVote({
   // ── 投票截止：展示 MVP 结果 ──
   if (votingClosed) {
     return (
-      <Card className="p-6 space-y-5 border-[var(--color-border)]">
+      <Panel pad={24} className="space-y-5">
         <div className="text-center space-y-1">
           <p className="text-sm text-[var(--color-fg-mid)]">本场 MVP</p>
           <p className="text-2xl font-bold text-[var(--color-accent)]">
-            {mvp?.playerName ?? "—"}
+            {mvp?.playerUserId ? (
+              <Link href={`/players/${mvp.playerUserId}`} className="hover:underline">
+                {mvp?.playerName ?? "—"}
+              </Link>
+            ) : (
+              mvp?.playerName ?? "—"
+            )}
           </p>
           <p className="text-sm text-[var(--color-fg-mid)]">
             {mvp?.count ?? 0} 票
@@ -136,26 +143,34 @@ export function MatchMvpVote({
               .sort((a, b) => b.count - a.count)
               .map((v) => (
                 <div key={v.playerName} className="flex justify-between text-[var(--color-fg-mid)]">
-                  <span>{v.playerName}</span>
+                  <span>
+                    {v.playerUserId ? (
+                      <Link href={`/players/${v.playerUserId}`} className="hover:text-[var(--color-accent)] transition-colors">
+                        {v.playerName}
+                      </Link>
+                    ) : (
+                      v.playerName
+                    )}
+                  </span>
                   <span className="tabular-nums">{v.count} 票</span>
                 </div>
               ))}
           </div>
         )}
-      </Card>
+      </Panel>
     );
   }
 
   // ── 投票中 ──
   function cardStyle(isVoted: boolean, hasVoted: boolean): string {
-    const base = "rounded-lg p-4 text-left transition-colors";
+    const base = "rounded-sm p-4 text-left transition-colors";
     if (isVoted) return `${base} bg-[rgba(255,107,26,0.12)] ring-1 ring-inset ring-[var(--color-accent)]`;
     if (hasVoted) return `${base} bg-[var(--color-panel-hi)] cursor-not-allowed opacity-60`;
     return `${base} bg-[var(--color-panel-hi)] hover:bg-[var(--color-panel)] cursor-pointer`;
   }
 
   return (
-    <Card className="p-5 space-y-4 border-[var(--color-border)]">
+    <Panel pad={20} className="space-y-4">
       <div className="flex items-center justify-between flex-wrap gap-2">
         <h3 className="text-base font-semibold text-[var(--color-fg)]">
           本场 MVP 投票
@@ -223,7 +238,7 @@ export function MatchMvpVote({
           );
         })}
       </div>
-    </Card>
+    </Panel>
   );
 }
 

--- a/src/components/matches/MatchRosterView.tsx
+++ b/src/components/matches/MatchRosterView.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getDisplayName } from "@/lib/utils/display-name";
 
 interface RosterPlayer {
@@ -6,6 +7,7 @@ interface RosterPlayer {
   perfectName: string | null;
   primaryPosition: string;
   isStarter: boolean;
+  userId?: string | null;
 }
 
 interface MatchRosterViewProps {
@@ -35,7 +37,13 @@ function RosterColumn({ teamName, roster }: { teamName: string; roster: RosterPl
               className="flex items-center justify-between text-sm"
               style={{ color: "var(--color-fg)" }}
             >
-              <span>{getDisplayName(p)}</span>
+              {p.userId ? (
+                <Link href={`/players/${p.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
+                  {getDisplayName(p)}
+                </Link>
+              ) : (
+                <span>{getDisplayName(p)}</span>
+              )}
               <span
                 className="text-xs"
                 style={{ fontFamily: "var(--font-mono)", color: "var(--color-fg-dim)", letterSpacing: "0.06em" }}
@@ -49,7 +57,18 @@ function RosterColumn({ teamName, roster }: { teamName: string; roster: RosterPl
               className="pt-1 mt-1 text-xs"
               style={{ borderTop: "1px solid var(--color-border)", color: "var(--color-fg-mid)" }}
             >
-              替补：{subs.map((p) => getDisplayName(p)).join("、")}
+              替补：{subs.map((p, i) => (
+                <span key={i}>
+                  {i > 0 && "、"}
+                  {p.userId ? (
+                    <Link href={`/players/${p.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
+                      {getDisplayName(p)}
+                    </Link>
+                  ) : (
+                    <>{getDisplayName(p)}</>
+                  )}
+                </span>
+              ))}
             </div>
           )}
         </div>

--- a/src/components/matches/PlayerStatsTable.tsx
+++ b/src/components/matches/PlayerStatsTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchPlayerStats } from "@/db/schema/player-stats";
@@ -120,7 +121,13 @@ function PlayerStatRow({ stat }: { stat: StatRow }) {
   return (
     <>
       <span className="text-[var(--color-fg)] truncate">
-        {stat.perfectName}
+        {stat.userId ? (
+          <Link href={`/players/${stat.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
+            {stat.perfectName}
+          </Link>
+        ) : (
+          stat.perfectName
+        )}
       </span>
       <span className="tabular-nums text-[var(--color-fg)]">
         {stat.kills ?? "—"}

--- a/src/components/matches/StandingsTable.tsx
+++ b/src/components/matches/StandingsTable.tsx
@@ -30,7 +30,7 @@ export function StandingsTable({ standings, seasonSlug, isFinal }: StandingsTabl
             >
               <td className="py-3 px-3 text-[var(--color-fg-mid)] tabular-nums">
                 {isFinal ? (
-                  <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-[var(--primary)]/10 text-[var(--primary)] font-bold text-xs">
+                  <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-bold text-xs">
                     {s.seed}
                   </span>
                 ) : (
@@ -40,7 +40,7 @@ export function StandingsTable({ standings, seasonSlug, isFinal }: StandingsTabl
               <td className="py-3 px-3">
                 <Link
                   href={`/${seasonSlug}/teams/${s.teamId}`}
-                  className="font-semibold text-[var(--color-fg)] hover:text-[var(--primary)] transition-colors"
+                  className="font-semibold text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors"
                 >
                   {s.teamName}
                 </Link>

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { Card } from "@/components/ui/card";
+import { Panel, Btn } from "@/components/rivalhub";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 
 interface LeaderboardRow {
@@ -60,9 +60,9 @@ export function StatsLeaderboard({
 }: StatsLeaderboardProps) {
   if (rows.length === 0) {
     return (
-      <Card className="p-8 text-center text-[var(--color-fg-mid)]">
+      <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
         该赛季暂无已确认的玩家数据
-      </Card>
+      </Panel>
     );
   }
 
@@ -74,39 +74,27 @@ export function StatsLeaderboard({
       {/* 排序 Tab */}
       <div className="flex gap-1 flex-wrap mb-2">
         {SORT_OPTIONS.map(({ key, label }) => (
-          <a
-            key={key}
-            href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}
-            className={`inline-block font-mono text-[10px] px-2.5 py-1 uppercase tracking-wider rounded transition-colors ${
-              sort === key
-                ? "bg-[var(--color-accent)] text-[var(--color-accent-fg)]"
-                : "border border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
-            }`}
-          >
-            {label}
-          </a>
+          <Btn key={key} small ghost={sort !== key} asChild>
+            <a href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}>
+              {label}
+            </a>
+          </Btn>
         ))}
       </div>
 
       {/* 位置筛选 */}
       <div className="flex gap-1 flex-wrap mb-4">
         {POSITIONS.map(({ key, label }) => (
-          <a
-            key={key}
-            href={`/${seasonSlug}/stats?sort=${sort}${key ? `&position=${key}` : ""}`}
-            className={`inline-block font-mono text-[10px] px-2.5 py-1 uppercase tracking-wider rounded transition-colors ${
-              position === key
-                ? "bg-[var(--color-accent)] text-[var(--color-accent-fg)]"
-                : "border border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
-            }`}
-          >
-            {label}
-          </a>
+          <Btn key={key} small ghost={position !== key} asChild>
+            <a href={`/${seasonSlug}/stats?sort=${sort}${key ? `&position=${key}` : ""}`}>
+              {label}
+            </a>
+          </Btn>
         ))}
       </div>
 
       {/* 表格 */}
-      <Card className="p-0 overflow-hidden">
+      <Panel pad={0} className="overflow-hidden">
         <div className="overflow-x-auto">
         <table className="w-full text-sm min-w-[480px]">
           <thead>
@@ -156,7 +144,7 @@ export function StatsLeaderboard({
                   {r.userId ? (
                     <Link
                       href={`/players/${r.userId}`}
-                      className="hover:text-[var(--primary)] transition-colors"
+                      className="hover:text-[var(--color-accent)] transition-colors"
                     >
                       {r.perfectName}
                     </Link>
@@ -173,7 +161,7 @@ export function StatsLeaderboard({
                   {r.teamId ? (
                     <Link
                       href={`/${seasonSlug}/teams/${r.teamId}`}
-                      className="hover:text-[var(--primary)] transition-colors"
+                      className="hover:text-[var(--color-accent)] transition-colors"
                     >
                       {r.teamName ?? "—"}
                     </Link>
@@ -234,7 +222,7 @@ export function StatsLeaderboard({
           </tbody>
         </table>
         </div>
-      </Card>
+      </Panel>
     </div>
   );
 }

--- a/src/components/rivalhub/btn.tsx
+++ b/src/components/rivalhub/btn.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils/cn";
 

--- a/src/components/rivalhub/panel.tsx
+++ b/src/components/rivalhub/panel.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Card, CardHeader } from "@/components/ui/card";
 import { cn } from "@/lib/utils/cn";
 

--- a/src/components/teams/TeamCard.tsx
+++ b/src/components/teams/TeamCard.tsx
@@ -8,6 +8,7 @@ interface PlayerPreview {
   primaryPosition: string;
   isStarter: boolean;
   isCaptain: boolean;
+  userId?: string | null;
 }
 
 interface TeamCardProps {
@@ -31,7 +32,7 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
           {/* 队名 + logo */}
           <div className="flex items-center gap-3">
             {/* 小 logo：40×40 */}
-            <div className="relative w-10 h-10 rounded-md overflow-hidden shrink-0 border border-[var(--color-border)] bg-[var(--color-bg-subtle)] flex items-center justify-center">
+            <div className="relative w-10 h-10 rounded-md overflow-hidden shrink-0 border border-[var(--color-border)] bg-[var(--color-panel-low)] flex items-center justify-center">
               {logoUrl ? (
                 <Image src={logoUrl} alt={`${teamName} logo`} fill className="object-cover" />
               ) : (
@@ -50,7 +51,13 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
               <div key={p.name} className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2">
                   {p.isCaptain && <PosChip pos="C" small />}
-                  <span className="text-sm text-[var(--color-fg)]">{p.name}</span>
+                  {p.userId ? (
+                    <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors">
+                      {p.name}
+                    </Link>
+                  ) : (
+                    <span className="text-sm text-[var(--color-fg)]">{p.name}</span>
+                  )}
                 </div>
                 <span className="text-xs text-[var(--color-fg-mid)]">
                   {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
@@ -64,7 +71,13 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
             <div className="border-t border-[var(--color-border)] pt-2 space-y-1">
               {subs.map((p) => (
                 <div key={p.name} className="flex items-center justify-between gap-2 opacity-60">
-                  <span className="text-xs text-[var(--color-fg-mid)]">{p.name}</span>
+                  {p.userId ? (
+                    <Link href={`/players/${p.userId}`} className="text-xs text-[var(--color-fg-mid)] hover:text-[var(--color-accent)] transition-colors">
+                      {p.name}
+                    </Link>
+                  ) : (
+                    <span className="text-xs text-[var(--color-fg-mid)]">{p.name}</span>
+                  )}
                   <span className="text-[10px] text-[var(--color-fg-mid)]">替补</span>
                 </div>
               ))}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -49,3 +49,15 @@ export function formatCSTShortDate(date: Date | string): string {
   const d = typeof date === "string" ? new Date(date) : date;
   return d.toLocaleDateString(CST_LOCALE, { timeZone: CST_TZ, month: "short", day: "numeric" });
 }
+
+/** CST 月日+时间，例如 "5月18日 19:30" */
+export function formatCSTDateTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString(CST_LOCALE, {
+    timeZone: CST_TZ,
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,17 +12,7 @@ const config: Config = {
       fontFamily: {
         sans: ["var(--font-geist)", "var(--font-noto-sans-sc)", "sans-serif"],
       },
-      colors: {
-        // Design tokens — see docs/ui-tokens.md for full specification
-        // Background layers
-        "bg-base": "var(--bg-base)",
-        "bg-elevated": "var(--bg-elevated)",
-        "bg-overlay": "var(--bg-overlay)",
-        // Text layers
-        "text-primary": "var(--text-primary)",
-        "text-secondary": "var(--text-secondary)",
-        "text-muted": "var(--text-muted)",
-      },
+      // Design tokens are defined in globals.css via @theme block — no additional color mappings needed.
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",

--- a/tests/unit/lib/date.test.ts
+++ b/tests/unit/lib/date.test.ts
@@ -4,6 +4,10 @@ import {
   parseCST,
   getCountdownSeconds,
   isDeadlinePassed,
+  formatCSTDateTime,
+  formatCSTShortDate,
+  parseCSTInput,
+  toCSTDateTimeInput,
 } from "@/lib/utils/date";
 
 describe("formatCST", () => {
@@ -62,5 +66,53 @@ describe("isDeadlinePassed", () => {
     expect(isDeadlinePassed(new Date(Date.now() - 10_000).toISOString())).toBe(
       true
     );
+  });
+});
+
+describe("formatCSTDateTime", () => {
+  it("返回 CST 月日+时间格式", () => {
+    // 2026-06-01T06:00:00.000Z = 北京时间 14:00
+    const d = new Date("2026-06-01T06:00:00.000Z");
+    const result = formatCSTDateTime(d);
+    expect(result).toContain("14:00");
+    expect(result).toMatch(/6月1日/);
+  });
+
+  it("字符串输入也可处理", () => {
+    const result = formatCSTDateTime("2026-12-15T10:30:00.000Z");
+    expect(result).toContain("18:30");
+    expect(result).toMatch(/12月15日/);
+  });
+});
+
+describe("formatCSTShortDate", () => {
+  it("返回 CST 月日格式", () => {
+    const d = new Date("2026-06-01T06:00:00.000Z");
+    const result = formatCSTShortDate(d);
+    expect(result).toMatch(/6月1日/);
+  });
+});
+
+describe("parseCSTInput", () => {
+  it("含 +08:00 偏移的 datetime-local 值解析为 Date", () => {
+    const d = parseCSTInput("2026-06-01T14:00");
+    expect(d instanceof Date).toBe(true);
+    expect(d?.toISOString()).toBe("2026-06-01T06:00:00.000Z");
+  });
+
+  it("null 返回 null", () => {
+    expect(parseCSTInput(null)).toBeNull();
+  });
+});
+
+describe("toCSTDateTimeInput", () => {
+  it("UTC Date 转为 CST datetime-local 字符串", () => {
+    const d = new Date("2026-06-01T06:00:00.000Z");
+    const result = toCSTDateTimeInput(d);
+    expect(result).toMatch(/2026-06-01T14:00/);
+  });
+
+  it("null 返回 null", () => {
+    expect(toCSTDateTimeInput(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

V2 Design Audit v2 全量修复 + 选手名全站可点击 + 代码卫生清理，共 24 files, +290/-352。

### Layout
- 赛季首页 + draft/captains/register 统一 `space-y-*` 垂直间距体系
- 赛季首页 STANDINGS 用 `<Panel>` 包裹与左侧 NEXT MATCHES 视觉对齐

### Token & Style
- `tailwind.config.ts` 删除 6 个无效 token 映射
- TeamCard `--color-bg-subtle` → `--color-panel-low`
- 3 文件 `var(--primary)` → `var(--color-accent)`
- MatchMvpVote `rounded-lg` → `rounded-sm`
- Btn/Panel 补显式 `React` import（vitest 兼容）

### Card→Panel 统一
- MatchMvpVote / CaptainVotingPanel / StatsLeaderboard 一致使用 Panel

### Feature
- **全站选手名可点击**跳转 `/players/[userId]`（队伍列表/详情、赛前名单、赛后数据表、MVP 结果）
- 比赛详情页队伍名可点击跳转队伍详情
- 管理员下载队伍头像按钮
- `formatCSTDateTime()` + 赛程卡片/首页比赛时间精确到时分

### Refactor
- admin matches 提取 `AdminMatchRow` 组件（净减 153 行）
- `TeamMemberData`/`RosterData` 类型去重
- `mapCompletedMaps`/`mapFinishedMaps` 映射函数提取
- iron-session 重复解密修复

## Test plan
- [x] `pnpm type-check` ✅
- [x] `pnpm test` 49/49 pass ✅
- [x] `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)