### PR TITLE
v1.17.1: 赛程时间显示、排序修正与地图池修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.13.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。v2 赛制引擎代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.17.1，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2026-05-19
+
+### Fixed
+- **已结束比赛时间显示**：赛程页"已结束"标签页现在显示比赛完成时间（`completed_at`，无则回退到 `scheduled_at`）
+- **已结束比赛排序**：已结束比赛改为按完成时间从近到远降序排列
+- **队伍页地图池**：地图胜率/ban 率表格改用赛季 `registrationConfig.mapPool`，不再硬编码 `DEFAULT_CS2_MAP_POOL`
+- **默认地图池**：`DEFAULT_CS2_MAP_POOL` 将 `de_train` 更新为 `de_overpass`（当前赛季活跃图池）
+
 ## [1.17.0] - 2026-05-19
 
 ### Added
@@ -528,6 +536,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
+[1.17.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.16.1...v1.17.0
 [1.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.1...v1.3.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.16.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.17.1，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -62,8 +62,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   const qualifierMatches = qualifierMatchesAll.filter(matchFilter);
   const playoffMatches = playoffMatchesAll.filter(matchFilter);
 
-  // 排序：已排期（由近及远）→ 未排期
-  const sortMatchList = (list: typeof allMatches) =>
+  // 待进行：已排期（由近及远）→ 未排期
+  const sortActiveMatches = (list: typeof allMatches) =>
     [...list].sort((a, b) => {
       const aTime = a.scheduledAt?.getTime() ?? Infinity;
       const bTime = b.scheduledAt?.getTime() ?? Infinity;
@@ -71,9 +71,18 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
       return a.createdAt.getTime() - b.createdAt.getTime();
     });
 
+  // 已结束：按结束时间从近到远
+  const sortDoneMatches = (list: typeof allMatches) =>
+    [...list].sort((a, b) => {
+      const aTime = (a.completedAt ?? a.scheduledAt)?.getTime() ?? 0;
+      const bTime = (b.completedAt ?? b.scheduledAt)?.getTime() ?? 0;
+      if (aTime !== bTime) return bTime - aTime;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    });
+
   const splitMatches = (list: typeof allMatches) => ({
-    active: sortMatchList(list.filter((m) => m.status !== "finished" && m.status !== "cancelled")),
-    done: sortMatchList(list.filter((m) => m.status === "finished" || m.status === "cancelled")),
+    active: sortActiveMatches(list.filter((m) => m.status !== "finished" && m.status !== "cancelled")),
+    done: sortDoneMatches(list.filter((m) => m.status === "finished" || m.status === "cancelled")),
   });
 
   const { active: qualifierActive, done: qualifierDone } = splitMatches(qualifierMatches);

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -10,7 +10,7 @@ import { TeamNameForm } from "@/components/teams/TeamNameForm";
 import { TeamLogoUpload } from "@/components/teams/TeamLogoUpload";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
-import { CS2_POSITIONS, DEFAULT_CS2_MAP_POOL } from "@/types/season";
+import { CS2_POSITIONS, normalizeRegistrationConfig } from "@/types/season";
 import { getUserSession, checkAdminSession } from "@/lib/auth/session";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { getTeamMapWinStats, getTeamBanStats } from "@/lib/teams/data";
@@ -123,6 +123,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     if (myScore > oppScore) totalWins++;
     else totalLosses++;
   }
+
+  const seasonMapPool = normalizeRegistrationConfig(season.registrationConfig).mapPool;
 
   // ── 地图表现统计 ──────────────────────────────────────────────────────────
   const matchIds = teamMatches.map((m) => m.id);
@@ -457,7 +459,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--color-border)]">
-                {DEFAULT_CS2_MAP_POOL.map((mapName) => {
+                {seasonMapPool.map((mapName) => {
                   const stat = mapStats.get(mapName);
                   const bans = banCount.get(mapName) ?? 0;
                   return (

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -17,6 +17,7 @@ interface MatchCardProps {
   format: MatchFormat;
   status: "scheduled" | "in_progress" | "finished" | "cancelled";
   scheduledAt?: Date | string | null;
+  completedAt?: Date | string | null;
 }
 
 export function MatchCard({
@@ -30,13 +31,17 @@ export function MatchCard({
   format,
   status,
   scheduledAt,
+  completedAt,
 }: MatchCardProps) {
+  const finishedTime = completedAt ?? scheduledAt ?? null;
   const timeText =
-    status === "scheduled" && scheduledAt
-      ? formatCSTDateTime(scheduledAt)
-      : status === "scheduled" && !scheduledAt
-        ? "未排期"
-        : null;
+    status === "finished"
+      ? finishedTime ? formatCSTDateTime(finishedTime) : null
+      : status === "scheduled" && scheduledAt
+        ? formatCSTDateTime(scheduledAt)
+        : status === "scheduled" && !scheduledAt
+          ? "未排期"
+          : null;
 
   return (
     <Link href={`/${seasonSlug}/matches/${matchId}`} className="cursor-pointer">

--- a/src/components/matches/MatchTabsSection.tsx
+++ b/src/components/matches/MatchTabsSection.tsx
@@ -11,6 +11,7 @@ interface MatchRow {
   format: string;
   status: string;
   scheduledAt: Date | null;
+  completedAt: Date | null;
 }
 
 interface MatchTabsSectionProps {
@@ -70,6 +71,7 @@ export function MatchTabsSection({
             format={isMatchFormat(m.format) ? m.format : "bo1"}
             status={isMatchStatus(m.status) ? m.status : "scheduled"}
             scheduledAt={m.scheduledAt}
+            completedAt={m.completedAt}
           />
         )) : (
           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>

--- a/src/lib/validators/registration.test.ts
+++ b/src/lib/validators/registration.test.ts
@@ -46,7 +46,7 @@ function validData(overrides?: Record<string, any>) {
       { map: "de_ancient", level: "basic" },
       { map: "de_dust2", level: "basic" },
       { map: "de_anubis", level: "basic" },
-      { map: "de_train", level: "none" },
+      { map: "de_overpass", level: "none" },
     ],
     gameplayStyle: "激进突破",
     antiCheatPledge: true,
@@ -134,7 +134,7 @@ describe("buildRegistrationSchema", () => {
           { map: "de_ancient", level: "basic" },
           { map: "de_dust2", level: "basic" },
           { map: "de_anubis", level: "basic" },
-          { map: "de_train", level: "none" },
+          { map: "de_overpass", level: "none" },
         ],
       }),
     );

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -158,7 +158,7 @@ export const DEFAULT_CS2_MAP_POOL = [
   "de_ancient",
   "de_dust2",
   "de_anubis",
-  "de_train",
+  "de_overpass",
 ] as const;
 
 export const MAP_LABELS: Record<string, string> = {

--- a/tests/unit/validators/registration.test.ts
+++ b/tests/unit/validators/registration.test.ts
@@ -32,7 +32,7 @@ function validInput() {
       { map: "de_ancient", level: "basic" },
       { map: "de_dust2", level: "basic" },
       { map: "de_anubis", level: "basic" },
-      { map: "de_train", level: "none" },
+      { map: "de_overpass", level: "none" },
     ],
     gameplayStyle: "进攻型步枪手",
     competitionHistory: "参加过校级比赛",
@@ -131,7 +131,7 @@ describe("buildRegistrationSchema", () => {
         { map: "de_ancient", level: "basic" },
         { map: "de_dust2", level: "basic" },
         { map: "de_anubis", level: "basic" },
-        { map: "de_train", level: "none" },
+        { map: "de_overpass", level: "none" },
       ],
     });
     expect(r.success).toBe(false);
@@ -147,7 +147,7 @@ describe("buildRegistrationSchema", () => {
         { map: "de_ancient", level: "strong" },
         { map: "de_dust2", level: "playable" },
         { map: "de_anubis", level: "basic" },
-        { map: "de_train", level: "none" },
+        { map: "de_overpass", level: "none" },
       ],
     });
     expect(r.success).toBe(false);


### PR DESCRIPTION
## Summary

### Fixed
- 已结束比赛在赛程页面现在显示完成时间（`completed_at`，无则回退 `scheduled_at`）
- 已结束比赛改为按完成时间从近到远降序排列
- 队伍页地图胜率/ban 率表格改用赛季 `registrationConfig.mapPool`，不再硬编码
- `DEFAULT_CS2_MAP_POOL` 将 `de_train` 更新为 `de_overpass`

## Test plan
- [ ] pnpm test
- [ ] pnpm tsc --noEmit
- [ ] 赛程页"已结束"标签页确认显示比赛时间且按完成时间降序
- [ ] 队伍页地图池与赛季配置一致（无 Train）