### PR TITLE
v1.17.1: 赛程时间显示、地图池修复及卡片间距优化

### DIFF
--- a/src/components/matches/MatchTabsSection.tsx
+++ b/src/components/matches/MatchTabsSection.tsx
@@ -38,7 +38,7 @@ export function MatchTabsSection({
         <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
         <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
       </TabsList>
-      <TabsContent value="active" className="mt-4 space-y-2">
+      <TabsContent value="active" className="mt-4 space-y-3">
         {activeMatches.length > 0 ? activeMatches.map((m) => (
           <MatchCard
             key={m.id}
@@ -57,7 +57,7 @@ export function MatchTabsSection({
           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
         )}
       </TabsContent>
-      <TabsContent value="done" className="mt-4 space-y-2">
+      <TabsContent value="done" className="mt-4 space-y-3">
         {doneMatches.length > 0 ? doneMatches.map((m) => (
           <MatchCard
             key={m.id}


### PR DESCRIPTION
## Summary

- 赛程卡片间距从 `space-y-2` 调整为 `space-y-3`，改善可点击卡片的视觉分隔感

## Test plan
- [ ] 赛程页"待进行"和"已结束"标签页卡片间距正常，视觉清晰