### PR TITLE
refactor: 赛程列表改为平铺行样式

### DIFF
--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Panel } from "@/components/rivalhub";
 import { Badge } from "@/components/ui/badge";
 import { MatchStatusBadge } from "./MatchStatusBadge";
 import { MATCH_FORMAT_LABELS, MATCH_STAGE_LABELS } from "@/types/match";
@@ -44,32 +43,31 @@ export function MatchCard({
           : null;
 
   return (
-    <Link href={`/${seasonSlug}/matches/${matchId}`} className="cursor-pointer">
-      <Panel hoverable pad={16}>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
-            <span className="text-[var(--color-fg-mid)] text-sm shrink-0">
-              {status === "finished"
-                ? `${scoreA ?? 0} : ${scoreB ?? 0}`
-                : "vs"}
-            </span>
-            <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            {timeText && (
-              <span className="text-xs text-[var(--color-fg-mid)]">{timeText}</span>
-            )}
-            <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
-              {MATCH_STAGE_LABELS[stage] ?? stage}
-            </Badge>
-            <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
-              {MATCH_FORMAT_LABELS[format]}
-            </Badge>
-            <MatchStatusBadge status={status} />
-          </div>
-        </div>
-      </Panel>
+    <Link
+      href={`/${seasonSlug}/matches/${matchId}`}
+      className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-panel-hi)] transition-colors duration-150"
+    >
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
+        <span className="text-[var(--color-fg-mid)] text-sm shrink-0">
+          {status === "finished"
+            ? `${scoreA ?? 0} : ${scoreB ?? 0}`
+            : "vs"}
+        </span>
+        <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {timeText && (
+          <span className="text-xs text-[var(--color-fg-mid)]">{timeText}</span>
+        )}
+        <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
+          {MATCH_STAGE_LABELS[stage] ?? stage}
+        </Badge>
+        <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
+          {MATCH_FORMAT_LABELS[format]}
+        </Badge>
+        <MatchStatusBadge status={status} />
+      </div>
     </Link>
   );
 }

--- a/src/components/matches/MatchTabsSection.tsx
+++ b/src/components/matches/MatchTabsSection.tsx
@@ -38,42 +38,50 @@ export function MatchTabsSection({
         <TabsTrigger value="active" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">待进行</TabsTrigger>
         <TabsTrigger value="done" className="text-xs data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">已结束</TabsTrigger>
       </TabsList>
-      <TabsContent value="active" className="mt-4 space-y-3">
-        {activeMatches.length > 0 ? activeMatches.map((m) => (
-          <MatchCard
-            key={m.id}
-            matchId={m.id}
-            seasonSlug={seasonSlug}
-            teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
-            teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
-            scoreA={m.scoreA}
-            scoreB={m.scoreB}
-            stage={stage}
-            format={isMatchFormat(m.format) ? m.format : "bo1"}
-            status={isMatchStatus(m.status) ? m.status : "scheduled"}
-            scheduledAt={m.scheduledAt}
-          />
-        )) : (
+      <TabsContent value="active" className="mt-4">
+        {activeMatches.length > 0 ? (
+          <div className="border border-[var(--color-border)] rounded overflow-hidden">
+            {activeMatches.map((m) => (
+              <MatchCard
+                key={m.id}
+                matchId={m.id}
+                seasonSlug={seasonSlug}
+                teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
+                teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
+                scoreA={m.scoreA}
+                scoreB={m.scoreB}
+                stage={stage}
+                format={isMatchFormat(m.format) ? m.format : "bo1"}
+                status={isMatchStatus(m.status) ? m.status : "scheduled"}
+                scheduledAt={m.scheduledAt}
+              />
+            ))}
+          </div>
+        ) : (
           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无待进行比赛</div>
         )}
       </TabsContent>
-      <TabsContent value="done" className="mt-4 space-y-3">
-        {doneMatches.length > 0 ? doneMatches.map((m) => (
-          <MatchCard
-            key={m.id}
-            matchId={m.id}
-            seasonSlug={seasonSlug}
-            teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
-            teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
-            scoreA={m.scoreA}
-            scoreB={m.scoreB}
-            stage={stage}
-            format={isMatchFormat(m.format) ? m.format : "bo1"}
-            status={isMatchStatus(m.status) ? m.status : "scheduled"}
-            scheduledAt={m.scheduledAt}
-            completedAt={m.completedAt}
-          />
-        )) : (
+      <TabsContent value="done" className="mt-4">
+        {doneMatches.length > 0 ? (
+          <div className="border border-[var(--color-border)] rounded overflow-hidden">
+            {doneMatches.map((m) => (
+              <MatchCard
+                key={m.id}
+                matchId={m.id}
+                seasonSlug={seasonSlug}
+                teamAName={teamMap.get(m.teamAId) ?? unknownTeamName}
+                teamBName={teamMap.get(m.teamBId) ?? unknownTeamName}
+                scoreA={m.scoreA}
+                scoreB={m.scoreB}
+                stage={stage}
+                format={isMatchFormat(m.format) ? m.format : "bo1"}
+                status={isMatchStatus(m.status) ? m.status : "scheduled"}
+                scheduledAt={m.scheduledAt}
+                completedAt={m.completedAt}
+              />
+            ))}
+          </div>
+        ) : (
           <div className="text-center py-8 text-[var(--color-fg-mid)] text-sm">暂无已结束比赛</div>
         )}
       </TabsContent>


### PR DESCRIPTION
## Summary

- 将赛程卡片列表从 Card 堆叠改为平铺行 + 分割线样式
- 去掉 hover 上移动效，改为背景色变化反馈
- 行列表用统一边框容器包裹，视觉更整洁