### PR TITLE
v1.18.0 — 比赛详情页/数据统计/队伍页重构 + design token 清理

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,41 +210,57 @@ src/
 │   ├── auth/callback # Supabase Auth 回调兼容入口（生产不依赖邮件确认）
 │   ├── admin/        # 管理员后台（rivalhub-session / rivalhub-admin 保护）
 │   └── api/cron/     # Cron API Route（当前由 GitHub Actions 触发）
-├── actions/          # Server Actions（所有业务逻辑入口）
-│   ├── account.ts    # 用户账号（修改密码、个人信息 updateProfile）
-│   ├── admin.ts      # 管理员操作（审核/邀请码/撤销权限）
-│   ├── auth.ts       # 邮箱+密码注册/登录/退出
-│   ├── captains.ts   # 队长投票
-│   ├── draft/        # 选秀（state / picks / queries）
-│   ├── matches/      # 赛程（schedule / results / roster）
-│   ├── register.ts   # 报名提交
-│   ├── seasons.ts    # 赛季 CRUD（create/update/delete/publish）
-│   └── teams.ts      # 队伍（修改队名/上传图标）
-├── db/
-│   ├── schema/       # Drizzle 表定义（18 张表）
-│   ├── client.ts     # Drizzle client 单例（pg Pool，错误处理 + 超时配置）
-│   └── seed.ts       # 种子数据（赛季 + 根管理员 RivalHub_root）
-├── lib/
-│   ├── auth/         # session.ts（双 Cookie iron-session）+ supabase.ts
-│   ├── bracket/      # brackets-manager 适配层（禁止绕过）
-│   ├── formats/       # StageExecutor 接口 + 赛制执行器（round-robin/double-elim/single-elim/swiss/gsl-group）+ _shared 工具
-│   ├── config/       # 共享常量配置（报名默认值/上传限制/密码约束/队伍配置）
-│   ├── realtime/     # Supabase Realtime 订阅辅助
-│   ├── validators/   # Zod schema（registration / vote / match）
-│   └── utils/        # date（UTC/CST）+ season（capability 工具）+ password（scrypt）+ cn
-├── components/
-│   ├── layout/       # Header / Footer
-│   ├── ui/           # shadcn 组件（按需 add，已覆盖 button/input/badge/card/skeleton/select）
-│   ├── rivalhub/     # Tactical Grid 组件（15 个：Panel/Btn/Field/Marker/Stat/MiniStat/
-│   │                 #   StatusBanner/InlineConfirm/EmptyState/ErrorState/Skeleton/Spinner/
-│   │                 #   TeamBadge/PosChip/StatusPill/ScrollHint）
-│   ├── settings/     # 用户设置组件（ProfileForm / ChangePasswordForm）
-│   ├── register/     # 报名业务组件
-│   ├── admin/        # 管理后台业务组件（AdminSidebar 侧边栏 + 统一 layout）
-│   ├── draft/        # 选秀业务组件
-│   ├── captains/     # 队长投票业务组件
-│   ├── teams/        # 队伍展示业务组件
-│   └── matches/      # 赛程 / bracket 业务组件
+│   ├── actions/          # Server Actions（所有业务逻辑入口）
+│   │   ├── account.ts    # 用户账号（修改密码、个人信息 updateProfile）
+│   │   ├── admin.ts      # 管理员操作（审核/邀请码/撤销权限）
+│   │   ├── audit.ts      # 审计日志查询（含 actor/target 可读名称解析）
+│   │   ├── auth.ts       # 邮箱+密码注册/登录/退出
+│   │   ├── captains.ts   # 队长投票
+│   │   ├── draft/        # 选秀（state / picks / queries）
+│   │   ├── matches/      # 赛程（schedule / results / roster / veto / scheduling / score）
+│   │   ├── player-stats.ts # 玩家数据（OCR 识别 / 保存 / 查询）
+│   │   ├── register.ts   # 报名提交
+│   │   ├── seasons.ts    # 赛季 CRUD（create/update/delete/publish）
+│   │   ├── transitions.ts # 赛季阶段自动推进
+│   │   └── teams.ts      # 队伍（修改队名/上传图标）
+│   ├── db/
+│   │   ├── schema/       # Drizzle 表定义（19 张表，含 match_veto_steps）
+│   │   ├── client.ts     # Drizzle client 单例（pg Pool，错误处理 + 超时配置）
+│   │   └── seed.ts       # 种子数据（赛季 + 根管理员 RivalHub_root）
+│   ├── lib/
+│   │   ├── auth/         # session.ts（双 Cookie iron-session）+ supabase.ts
+│   │   ├── bracket/      # brackets-manager 适配层（禁止绕过）
+│   │   ├── formats/       # StageExecutor 接口 + 赛制执行器（round-robin/double-elim/single-elim/swiss/gsl-group）+ _shared 工具
+│   │   ├── config/       # 共享常量配置（报名默认值/上传限制/密码约束/队伍配置）
+│   │   ├── realtime/     # Supabase Realtime 订阅辅助
+│   │   ├── validators/   # Zod schema（registration / vote / match）
+│   │   └── utils/        # date（UTC/CST）+ season（capability 工具）+ password（scrypt）+ cn
+│   ├── components/
+│   │   ├── layout/       # Header / Footer / AdminShortcut / HeaderClient / SeasonNav / Breadcrumb / OnlineCounter
+│   │   ├── ui/           # shadcn 组件（按需 add，已覆盖 button/input/badge/card/skeleton/select/dialog/tabs/table/textarea）
+│   │   ├── rivalhub/     # Tactical Grid 组件（16 个：Panel/Btn/Field/Marker/Stat/
+│   │   │                 #   StatusBanner/InlineConfirm/EmptyState/ErrorState/Skeleton/
+│   │   │                 #   TeamBadge/PosChip/StatusPill/ScrollHint/PhaseStep/MapPreferenceChips）
+│   │   ├── auth/         # 登录/邀请组件（2 个：LoginForm / ClaimInviteForm）
+│   │   ├── settings/     # 用户设置组件（ProfileForm / ChangePasswordForm）
+│   │   ├── register/     # 报名组件（RegistrationForm）
+│   │   ├── admin/        # 管理后台组件（14 个：AdminLoginForm / AdminRegisterForm / AdminSidebar /
+│   │   │                 #   AdminUserList / AuditLogTable / ChangePasswordForm / DraftRegistrationTable /
+│   │   │                 #   InviteManager / RegistrationReviewList / SeasonForm / SeasonSubNav /
+│   │   │                 #   StagePlanEditor / TeamConfigForm / ThemeColorPicker）
+│   │   ├── draft/        # 选秀组件（7 个：CaptainDraftPanel / DraftAdminPanel / DraftCountdown /
+│   │   │                 #   DraftLiveRoom / PlayerInfoPopover / PlayerPool / TeamDraftGrid）
+│   │   ├── captains/     # 队长投票组件（2 个：CaptainConfirmPanel / CaptainVotingPanel）
+│   │   ├── teams/        # 队伍组件（5 个：TeamCard / TeamGrid / TeamLogoUpload / TeamNameForm / TeamRosterCard）
+│   │   └── matches/      # 赛程组件（28 个：MatchCard / MatchTeamFilter / CreateMatchForm /
+│   │                     #   AdminMatchFilter / AdminMatchRow / AdminRosterDialog / BatchDeadlineCard / BracketView /
+│   │                     #   DeleteMatchButton / GeneratePlayoffCard / GenerateScheduleCard /
+│   │                     #   MapByMapInput / MatchMvpVote / MatchRosterForm / MatchRosterView /
+│   │                     #   MatchStatusBadge / MatchTabsSection / MatchTimeNegotiation /
+│   │                     #   PlayerStatsTable / ScheduledAtInput / ScoreInput / StandingsTable /
+│   │                     #   StatsLeaderboard / StatsOCRPanel / SwissBracket / TimeProposalHistory /
+│   │                     #   VetoInputDialog / VetoView）
+│   └── types/            # 共享 TypeScript 类型
 └── types/            # 共享 TypeScript 类型
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2026-05-19
+
+### Added
+- **比赛详情页 — 赛季综合对比**：Hero 下方显示双方赛季战绩（胜负/胜率/Rating/ADR/K/D），较高值高亮标记
+- **比赛详情页 — 地图池雷达图**：纯 SVG 七边形雷达图，Win%/Pick%/Ban% 三态切换，同轴对比两队数据
+- **比赛详情页 — 历史交锋**：显示两队赛季内交手记录（近 10 场），含胜负汇总和每场比分链接
+- **比赛详情页 — 阵容对比**：HLTV 风格五人 H2H 比较器，点击切换选手，Rating/ADR/K/D/HS%/FK/WE 条形对比
+- **比赛详情页 — 整场汇总 Tab**：BO3/BO5 系列赛第一个 Tab，所有上场选手跨图聚合数据（K/D/A/HS%/Rating 等）
+- **比赛详情页 — 比赛时间显示**：Hero 下方显示赛前计划时间或赛后完成时间（CST 格式）
+- **管理端 — 完成时间编辑**：`updateMatchCompletedAt` Server Action，已结束比赛可在折叠区修改 `completed_at`（datetime-local 控件 + 清除按钮）
+- **设计 token — Accent B 族**：`--color-accent-b` / `-b-soft` / `-b-edge` / `-b-fg`，统一团队 B / 对比实体 accent 色
+
+### Changed
+- **数据统计排行榜重构**：新增全部 10 种排序（Rating/ADR/K/D/KPR/HS%/WE/RWS/首杀/残局/场次），数据驱动 `ColDef[]` 表格渲染
+- **队伍详情页重构**：综合数据改为 2×4 网格（出场/胜/负/胜率 + Rating/ADR/K/D/WE）；阵容行内嵌选手赛季数据（地图数/Rating/ADR/K/D）；替补显示地图偏好；删除"位置最佳"区块；重排段落顺序
+- **MVP 投票布局**：候选卡片从 `grid-cols-2 sm:grid-cols-4` 改为固定 `grid-cols-2`（2×2 布局）
+- **MatchCard 风格**：从卡片网格改为行列表，增大垂直间距（`space-y-2` → `space-y-3`）
+- **BP 面板显示条件**：VetoView 仅在比赛开始后（非 scheduled）显示，赛前不展示空 BP 面板
+
+### Fixed
+- **数据统计 SQL 口径**：`positionFilter` 改用原始字符串 `sr.primary_position`，修复 Drizzle schema 对象展开为表名与别名冲突
+- **K/D 计算**：从前端 `avg/avg` 改为 SQL 层 `sum(kills)/sum(deaths)`，修复统计口径
+- **`computeRecord` 平局逻辑**：平局不再误计为负（`else` → `else if`）
+
+### Refactored
+- **Pick/Ban 统计合并**：`getTeamPickStats` 和 `getTeamBanStats` 合并共享 `getTeamVetoActionStats` 实现（60 行重复 → 一行委托）
+- **DB 查询精简**：首发选手赛季数据从 `teamRawStats` 内存过滤，省 2 次 `matchPlayerStats` 查询；赛季比赛查询提取 `getSeasonFinishedMatches` 辅助
+- **硬编码颜色清零**：全站 30+ 处裸 hex 值替换为 CSS 变量（`StatusPill`/`StatusBanner`/`EmptyState`/`ErrorState`/`InlineConfirm` + 5 个新赛程组件）
+
 ## [1.17.1] - 2026-05-19
 
 ### Fixed

--- a/docs/ui-tokens.md
+++ b/docs/ui-tokens.md
@@ -30,14 +30,23 @@
 | `--color-fg-mid` | `#8e96a3` | 辅助说明、元信息 |
 | `--color-fg-dim` | `#525a6a` | 占位符、禁用态、标签 |
 
-### 强调色（Accent）
+### 强调色（Accent A / 团队 A）
 
 | Token | 值 | 用途 |
 |---|---|---|
-| `--color-accent` | `#ff6b1a` | 主 CTA、当前状态、高亮 |
+| `--color-accent` | `#ff6b1a` | 主 CTA、当前状态、高亮、团队 A primary |
 | `--color-accent-soft` | `rgba(255,107,26,0.12)` | 浅底色背景 |
 | `--color-accent-edge` | `rgba(255,107,26,0.34)` | 边框高亮 |
 | `--color-accent-fg` | `#0a0c10` | accent 背景上的文字色 |
+
+### 强调色（Accent B / 团队 B）
+
+| Token | 值 | 用途 |
+|---|---|---|
+| `--color-accent-b` | `#3aa1ff` | 团队 B primary、对比实体 |
+| `--color-accent-b-soft` | `rgba(58,161,255,0.12)` | 浅底色背景 |
+| `--color-accent-b-edge` | `rgba(58,161,255,0.34)` | 边框高亮 |
+| `--color-accent-b-fg` | `#0a0c10` | accent-b 背景上的文字色 |
 
 ### 语义色
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,5 +1,5 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
-export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore } from "./results";
+export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, updateMatchCompletedAt } from "./results";
 export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster, updateMatchRoster } from "./roster";
 export { saveVetoSteps } from "./veto";

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -668,3 +668,49 @@ export async function deleteMatch(matchId: string): Promise<ActionResult<void>> 
     return actionError("deleteMatch", e);
   }
 }
+
+// ── 修改完成时间 ──────────────────────────────────────────────────────────
+
+/**
+ * 更新已完成比赛的 completed_at 时间戳。
+ * 仅允许 status === "finished" 的比赛修改。
+ */
+export async function updateMatchCompletedAt(
+  matchId: string,
+  completedAtStr: string | null,
+): Promise<ActionResult<void>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const session = await requireSeasonAdmin(match.seasonId);
+
+    if (match.status !== "finished") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "只有已完成的比赛才能修改完成时间");
+    }
+
+    const { parseCSTInput } = await import("@/lib/utils/date");
+    const completedAt = parseCSTInput(completedAtStr);
+
+    const season = await getSeasonOrThrow(match.seasonId);
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(matches)
+        .set({ completedAt, updatedAt: new Date() })
+        .where(eq(matches.id, matchId));
+
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "update_match_completed_at",
+        actorId: auditActorId(session),
+        targetId: matchId,
+        targetType: "match",
+        meta: { completedAt: completedAt?.toISOString() ?? null },
+      });
+    });
+
+    revalidateMatchPaths(season.slug, matchId);
+    return ok(undefined);
+  } catch (e) {
+    return actionError("updateMatchCompletedAt", e);
+  }
+}

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -31,7 +31,7 @@ import { sumNums, avgNums, weightedAvgNums } from "@/lib/utils/stats";
 import { getUserSession } from "@/lib/auth/session";
 import { formatCSTDateTime } from "@/lib/utils/date";
 import { normalizeRegistrationConfig } from "@/types/season";
-import { getTeamMapWinStats, getTeamPickStats, getTeamBanStats } from "@/lib/teams/data";
+import { getTeamMapWinStats, getTeamPickStats, getTeamBanStats, type MapWinStats } from "@/lib/teams/data";
 
 interface MatchDetailPageProps {
   params: Promise<{ seasonSlug: string; matchId: string }>;
@@ -56,7 +56,7 @@ function computeRecord(
     const myScore = isA ? (m.scoreA ?? 0) : (m.scoreB ?? 0);
     const oppScore = isA ? (m.scoreB ?? 0) : (m.scoreA ?? 0);
     if (myScore > oppScore) wins++;
-    else losses++;
+    else if (myScore < oppScore) losses++;
   }
   return { wins, losses };
 }
@@ -72,7 +72,33 @@ function computeTeamAvgStats(rows: MPS[]) {
   };
 }
 
-const EMPTY_MPS: MPS[] = [];
+function buildRadarData(
+  mapPool: string[],
+  mapWin: Map<string, MapWinStats>,
+  pickStats: { pickCount: Map<string, number>; bpMatchCount: number },
+  banStats: { banCount: Map<string, number>; bpMatchCount: number },
+): Map<string, { winRate: number; pickRate: number; banRate: number }> {
+  const data = new Map<string, { winRate: number; pickRate: number; banRate: number }>();
+  for (const map of mapPool) {
+    const win = mapWin.get(map);
+    data.set(map, {
+      winRate: win && win.played > 0 ? (win.wins / win.played) * 100 : 0,
+      pickRate: pickStats.bpMatchCount > 0 ? ((pickStats.pickCount.get(map) ?? 0) / pickStats.bpMatchCount) * 100 : 0,
+      banRate: banStats.bpMatchCount > 0 ? ((banStats.banCount.get(map) ?? 0) / banStats.bpMatchCount) * 100 : 0,
+    });
+  }
+  return data;
+}
+
+async function getSeasonFinishedMatches(seasonId: string, teamId: string) {
+  return db.query.matches.findMany({
+    where: and(
+      eq(matches.seasonId, seasonId),
+      eq(matches.status, "finished"),
+      or(eq(matches.teamAId, teamId), eq(matches.teamBId, teamId)),
+    ),
+  });
+}
 
 export default async function MatchDetailPage({ params }: MatchDetailPageProps) {
   const { seasonSlug, matchId } = await params;
@@ -118,20 +144,8 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
         .innerJoin(users, eq(seasonRegistrations.userId, users.id))
         .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId])),
-      db.query.matches.findMany({
-        where: and(
-          eq(matches.seasonId, season.id),
-          eq(matches.status, "finished"),
-          or(eq(matches.teamAId, match.teamAId), eq(matches.teamBId, match.teamAId)),
-        ),
-      }),
-      db.query.matches.findMany({
-        where: and(
-          eq(matches.seasonId, season.id),
-          eq(matches.status, "finished"),
-          or(eq(matches.teamAId, match.teamBId), eq(matches.teamBId, match.teamBId)),
-        ),
-      }),
+      getSeasonFinishedMatches(season.id, match.teamAId),
+      getSeasonFinishedMatches(season.id, match.teamBId),
     ]);
 
   // 从赛季对局列表计算战绩、H2H
@@ -197,13 +211,12 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
     .filter((m) => m.teamId === match.teamBId && starterBMemberIds.has(m.id) && m.userId)
     .map((m) => m.userId as string);
 
-  // Phase 4: 地图胜/pick/ban 率 + 队伍赛季数据 + 首发选手数据（全部并行）
+  // Phase 4: 地图胜/pick/ban 率 + 队伍赛季数据（全部并行）
   const [
     mapWinA, mapWinB,
     pickStatsA, pickStatsB,
     banStatsA, banStatsB,
     teamRawStatsA, teamRawStatsB,
-    starterStatsA, starterStatsB,
   ] = await Promise.all([
     getTeamMapWinStats(match.teamAId, seasonMatchesA),
     getTeamMapWinStats(match.teamBId, seasonMatchesB),
@@ -219,7 +232,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
             isNotNull(matchPlayerStats.verifiedByAdmin),
           ),
         )
-      : Promise.resolve(EMPTY_MPS),
+      : ([] as MPS[]),
     teamBUserIds.length > 0 && matchIdsB.length > 0
       ? db.select().from(matchPlayerStats).where(
           and(
@@ -228,48 +241,22 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
             isNotNull(matchPlayerStats.verifiedByAdmin),
           ),
         )
-      : Promise.resolve(EMPTY_MPS),
-    starterAUserIds.length > 0 && matchIdsA.length > 0
-      ? db.select().from(matchPlayerStats).where(
-          and(
-            inArray(matchPlayerStats.matchId, matchIdsA),
-            inArray(matchPlayerStats.userId as never, starterAUserIds),
-            isNotNull(matchPlayerStats.verifiedByAdmin),
-          ),
-        )
-      : Promise.resolve(EMPTY_MPS),
-    starterBUserIds.length > 0 && matchIdsB.length > 0
-      ? db.select().from(matchPlayerStats).where(
-          and(
-            inArray(matchPlayerStats.matchId, matchIdsB),
-            inArray(matchPlayerStats.userId as never, starterBUserIds),
-            isNotNull(matchPlayerStats.verifiedByAdmin),
-          ),
-        )
-      : Promise.resolve(EMPTY_MPS),
+      : ([] as MPS[]),
   ]);
+
+  // 首发选手赛季数据从 teamRawStats 内存过滤（启动者是队伍成员子集）
+  const starterAIdSet = new Set(starterAUserIds);
+  const starterBIdSet = new Set(starterBUserIds);
+  const starterStatsA = teamRawStatsA.filter((r) => r.userId && starterAIdSet.has(r.userId));
+  const starterStatsB = teamRawStatsB.filter((r) => r.userId && starterBIdSet.has(r.userId));
 
   // 队伍赛季平均数据（用于 TeamStatsCompare）
   const teamAvgA = computeTeamAvgStats(teamRawStatsA);
   const teamAvgB = computeTeamAvgStats(teamRawStatsB);
 
   // 雷达图数据
-  const radarDataA = new Map<string, { winRate: number; pickRate: number; banRate: number }>();
-  const radarDataB = new Map<string, { winRate: number; pickRate: number; banRate: number }>();
-  for (const map of mapPool) {
-    const winA = mapWinA.get(map);
-    const winB = mapWinB.get(map);
-    radarDataA.set(map, {
-      winRate: winA && winA.played > 0 ? (winA.wins / winA.played) * 100 : 0,
-      pickRate: pickStatsA.bpMatchCount > 0 ? ((pickStatsA.pickCount.get(map) ?? 0) / pickStatsA.bpMatchCount) * 100 : 0,
-      banRate: banStatsA.bpMatchCount > 0 ? ((banStatsA.banCount.get(map) ?? 0) / banStatsA.bpMatchCount) * 100 : 0,
-    });
-    radarDataB.set(map, {
-      winRate: winB && winB.played > 0 ? (winB.wins / winB.played) * 100 : 0,
-      pickRate: pickStatsB.bpMatchCount > 0 ? ((pickStatsB.pickCount.get(map) ?? 0) / pickStatsB.bpMatchCount) * 100 : 0,
-      banRate: banStatsB.bpMatchCount > 0 ? ((banStatsB.banCount.get(map) ?? 0) / banStatsB.bpMatchCount) * 100 : 0,
-    });
-  }
+  const radarDataA = buildRadarData(mapPool, mapWinA, pickStatsA, banStatsA);
+  const radarDataB = buildRadarData(mapPool, mapWinB, pickStatsB, banStatsB);
 
   // 首发选手赛季数据（用于 MatchLineupsH2H）
   function buildLineupsPlayers(rows: MPS[], starterUserIds: string[]) {

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import { eq, and, or, inArray } from "drizzle-orm";
+import { eq, and, or, inArray, isNotNull } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, teams, matchMaps, users, seasonRegistrations, teamMembers } from "@/db/schema";
 import { matchPlayerStats } from "@/db/schema/player-stats";
@@ -19,21 +19,60 @@ import { MatchTimeNegotiation } from "@/components/matches/MatchTimeNegotiation"
 import { MatchRosterView } from "@/components/matches/MatchRosterView";
 import { MatchRosterForm } from "@/components/matches/MatchRosterForm";
 import { VetoView } from "@/components/matches/VetoView";
+import { MapPoolRadarChart } from "@/components/matches/MapPoolRadarChart";
+import { MatchLineupsH2H } from "@/components/matches/MatchLineupsH2H";
+import { TeamStatsCompare } from "@/components/matches/TeamStatsCompare";
+import { MatchHeadToHead } from "@/components/matches/MatchHeadToHead";
+import { MatchSummaryStats } from "@/components/matches/MatchSummaryStats";
 import { getMatchMvpResults, ensureMvpWinner } from "@/actions/player-stats";
 import { getTimeProposals } from "@/actions/matches/scheduling";
 import { getMatchRoster } from "@/actions/matches/roster";
 import { sumNums, avgNums, weightedAvgNums } from "@/lib/utils/stats";
 import { getUserSession } from "@/lib/auth/session";
+import { formatCSTDateTime } from "@/lib/utils/date";
+import { normalizeRegistrationConfig } from "@/types/season";
+import { getTeamMapWinStats, getTeamPickStats, getTeamBanStats } from "@/lib/teams/data";
 
 interface MatchDetailPageProps {
   params: Promise<{ seasonSlug: string; matchId: string }>;
 }
+
+type MPS = typeof matchPlayerStats.$inferSelect;
 
 const TEAM_COLORS = ["#ff6b1a", "#3aa1ff", "#a8ff3a", "#ff3a7a", "#9b6bff", "#ffd23a", "#3affc7", "#ff8a3a"];
 
 function teamBadgeData(name: string, idx: number): { tag: string; color: string } {
   return { tag: name.slice(0, 3).toUpperCase(), color: TEAM_COLORS[idx % TEAM_COLORS.length] };
 }
+
+function computeRecord(
+  teamId: string,
+  matchList: { teamAId: string; teamBId: string; scoreA: number | null; scoreB: number | null }[],
+): { wins: number; losses: number } {
+  let wins = 0;
+  let losses = 0;
+  for (const m of matchList) {
+    const isA = m.teamAId === teamId;
+    const myScore = isA ? (m.scoreA ?? 0) : (m.scoreB ?? 0);
+    const oppScore = isA ? (m.scoreB ?? 0) : (m.scoreA ?? 0);
+    if (myScore > oppScore) wins++;
+    else losses++;
+  }
+  return { wins, losses };
+}
+
+function computeTeamAvgStats(rows: MPS[]) {
+  if (!rows.length) return { avgRating: null, avgAdr: null, avgKd: null };
+  const totalKills = sumNums(rows.map((r) => r.kills)) ?? 0;
+  const totalDeaths = sumNums(rows.map((r) => r.deaths)) ?? 0;
+  return {
+    avgRating: avgNums(rows.map((r) => r.ratingPro)),
+    avgAdr: avgNums(rows.map((r) => r.adr)),
+    avgKd: totalDeaths > 0 ? totalKills / totalDeaths : null,
+  };
+}
+
+const EMPTY_MPS: MPS[] = [];
 
 export default async function MatchDetailPage({ params }: MatchDetailPageProps) {
   const { seasonSlug, matchId } = await params;
@@ -44,6 +83,8 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   ]);
   if (!season) notFound();
   if (!match || match.seasonId !== season.id) notFound();
+
+  const mapPool = normalizeRegistrationConfig(season.registrationConfig).mapPool;
 
   const [teamA, teamB, maps] = await Promise.all([
     db.query.teams.findFirst({ where: eq(teams.id, match.teamAId) }),
@@ -56,133 +97,219 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
 
   const isFinished = match.status === "finished";
 
-  const [timeProposals, rosterA, rosterB, userSession] = await Promise.all([
-    getTimeProposals(match.id),
-    getMatchRoster(match.id, match.teamAId),
-    getMatchRoster(match.id, match.teamBId),
-    getUserSession(),
+  // Phase 3: 所有独立查询并行
+  const [timeProposals, rosterA, rosterB, userSession, allTeamMembers, seasonMatchesA, seasonMatchesB] =
+    await Promise.all([
+      getTimeProposals(match.id),
+      getMatchRoster(match.id, match.teamAId),
+      getMatchRoster(match.id, match.teamBId),
+      getUserSession(),
+      db
+        .select({
+          id: teamMembers.id,
+          teamId: teamMembers.teamId,
+          steamName: users.steamName,
+          displayName: users.displayName,
+          perfectName: users.perfectName,
+          primaryPosition: seasonRegistrations.primaryPosition,
+          userId: users.id,
+        })
+        .from(teamMembers)
+        .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
+        .innerJoin(users, eq(seasonRegistrations.userId, users.id))
+        .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId])),
+      db.query.matches.findMany({
+        where: and(
+          eq(matches.seasonId, season.id),
+          eq(matches.status, "finished"),
+          or(eq(matches.teamAId, match.teamAId), eq(matches.teamBId, match.teamAId)),
+        ),
+      }),
+      db.query.matches.findMany({
+        where: and(
+          eq(matches.seasonId, season.id),
+          eq(matches.status, "finished"),
+          or(eq(matches.teamAId, match.teamBId), eq(matches.teamBId, match.teamBId)),
+        ),
+      }),
+    ]);
+
+  // 从赛季对局列表计算战绩、H2H
+  const recordA = computeRecord(match.teamAId, seasonMatchesA);
+  const recordB = computeRecord(match.teamBId, seasonMatchesB);
+
+  const matchIdsA = seasonMatchesA.map((m) => m.id);
+  const matchIdsB = seasonMatchesB.map((m) => m.id);
+
+  // H2H：teamA 的赛季对局中与 teamB 的交手记录
+  const h2hRaw = seasonMatchesA
+    .filter((m) => m.teamAId === match.teamBId || m.teamBId === match.teamBId)
+    .sort((a, b) => {
+      const ta = (a.completedAt ?? a.scheduledAt)?.getTime() ?? 0;
+      const tb = (b.completedAt ?? b.scheduledAt)?.getTime() ?? 0;
+      return tb - ta;
+    });
+
+  const h2hMatches = h2hRaw.slice(0, 10).map((m) => {
+    const aIsTeamA = m.teamAId === match.teamAId;
+    const scoreA = aIsTeamA ? (m.scoreA ?? 0) : (m.scoreB ?? 0);
+    const scoreB = aIsTeamA ? (m.scoreB ?? 0) : (m.scoreA ?? 0);
+    return {
+      matchId: m.id,
+      scheduledAt: m.scheduledAt,
+      completedAt: m.completedAt,
+      stage: m.stage,
+      format: m.format,
+      scoreA,
+      scoreB,
+      teamAWon: scoreA > scoreB,
+    };
+  });
+
+  const h2hWinsA = h2hMatches.filter((m) => m.teamAWon).length;
+  const h2hWinsB = h2hMatches.filter((m) => !m.teamAWon).length;
+
+  // 建立 userId 集合
+  const teamAUserIds = allTeamMembers
+    .filter((m) => m.teamId === match.teamAId && m.userId)
+    .map((m) => m.userId as string);
+  const teamBUserIds = allTeamMembers
+    .filter((m) => m.teamId === match.teamBId && m.userId)
+    .map((m) => m.userId as string);
+  const userIdToTeamId = new Map<string, string>(
+    allTeamMembers.filter((m) => m.userId).map((m) => [m.userId as string, m.teamId]),
+  );
+  const userIdToMember = new Map(
+    allTeamMembers.filter((m) => m.userId).map((m) => [m.userId as string, m]),
+  );
+
+  // 首发阵容 userId（来自已提交名单）
+  const starterAMemberIds = new Set(
+    rosterA ? rosterA.players.filter((p) => p.isStarter).map((p) => p.teamMemberId) : [],
+  );
+  const starterBMemberIds = new Set(
+    rosterB ? rosterB.players.filter((p) => p.isStarter).map((p) => p.teamMemberId) : [],
+  );
+  const starterAUserIds = allTeamMembers
+    .filter((m) => m.teamId === match.teamAId && starterAMemberIds.has(m.id) && m.userId)
+    .map((m) => m.userId as string);
+  const starterBUserIds = allTeamMembers
+    .filter((m) => m.teamId === match.teamBId && starterBMemberIds.has(m.id) && m.userId)
+    .map((m) => m.userId as string);
+
+  // Phase 4: 地图胜/pick/ban 率 + 队伍赛季数据 + 首发选手数据（全部并行）
+  const [
+    mapWinA, mapWinB,
+    pickStatsA, pickStatsB,
+    banStatsA, banStatsB,
+    teamRawStatsA, teamRawStatsB,
+    starterStatsA, starterStatsB,
+  ] = await Promise.all([
+    getTeamMapWinStats(match.teamAId, seasonMatchesA),
+    getTeamMapWinStats(match.teamBId, seasonMatchesB),
+    getTeamPickStats(match.teamAId, matchIdsA),
+    getTeamPickStats(match.teamBId, matchIdsB),
+    getTeamBanStats(match.teamAId, matchIdsA),
+    getTeamBanStats(match.teamBId, matchIdsB),
+    teamAUserIds.length > 0 && matchIdsA.length > 0
+      ? db.select().from(matchPlayerStats).where(
+          and(
+            inArray(matchPlayerStats.matchId, matchIdsA),
+            inArray(matchPlayerStats.userId as never, teamAUserIds),
+            isNotNull(matchPlayerStats.verifiedByAdmin),
+          ),
+        )
+      : Promise.resolve(EMPTY_MPS),
+    teamBUserIds.length > 0 && matchIdsB.length > 0
+      ? db.select().from(matchPlayerStats).where(
+          and(
+            inArray(matchPlayerStats.matchId, matchIdsB),
+            inArray(matchPlayerStats.userId as never, teamBUserIds),
+            isNotNull(matchPlayerStats.verifiedByAdmin),
+          ),
+        )
+      : Promise.resolve(EMPTY_MPS),
+    starterAUserIds.length > 0 && matchIdsA.length > 0
+      ? db.select().from(matchPlayerStats).where(
+          and(
+            inArray(matchPlayerStats.matchId, matchIdsA),
+            inArray(matchPlayerStats.userId as never, starterAUserIds),
+            isNotNull(matchPlayerStats.verifiedByAdmin),
+          ),
+        )
+      : Promise.resolve(EMPTY_MPS),
+    starterBUserIds.length > 0 && matchIdsB.length > 0
+      ? db.select().from(matchPlayerStats).where(
+          and(
+            inArray(matchPlayerStats.matchId, matchIdsB),
+            inArray(matchPlayerStats.userId as never, starterBUserIds),
+            isNotNull(matchPlayerStats.verifiedByAdmin),
+          ),
+        )
+      : Promise.resolve(EMPTY_MPS),
   ]);
 
-  let mvpCandidates: {
-    userId: string | null;
-    perfectName: string;
-    kills: number | null;
-    deaths: number | null;
-    assists: number | null;
-    hsPercent: number | null;
-    firstKills: number | null;
-    multiKills: number | null;
-    clutches: number | null;
-    adr: number | null;
-    rws: number | null;
-    ratingPro: number | null;
-    we: number | null;
-  }[] = [];
-  let mvpVoteResults: Awaited<ReturnType<typeof getMatchMvpResults>> = [];
-  let userVoted: string | null = null;
+  // 队伍赛季平均数据（用于 TeamStatsCompare）
+  const teamAvgA = computeTeamAvgStats(teamRawStatsA);
+  const teamAvgB = computeTeamAvgStats(teamRawStatsB);
 
-  if (isFinished) {
-    const allStats = await db.query.matchPlayerStats.findMany({
-      where: eq(matchPlayerStats.matchId, match.id),
+  // 雷达图数据
+  const radarDataA = new Map<string, { winRate: number; pickRate: number; banRate: number }>();
+  const radarDataB = new Map<string, { winRate: number; pickRate: number; banRate: number }>();
+  for (const map of mapPool) {
+    const winA = mapWinA.get(map);
+    const winB = mapWinB.get(map);
+    radarDataA.set(map, {
+      winRate: winA && winA.played > 0 ? (winA.wins / winA.played) * 100 : 0,
+      pickRate: pickStatsA.bpMatchCount > 0 ? ((pickStatsA.pickCount.get(map) ?? 0) / pickStatsA.bpMatchCount) * 100 : 0,
+      banRate: banStatsA.bpMatchCount > 0 ? ((banStatsA.banCount.get(map) ?? 0) / banStatsA.bpMatchCount) * 100 : 0,
     });
-
-    // 按玩家分组，跨地图聚合
-    const groupMap = new Map<string, typeof allStats>();
-    for (const s of allStats) {
-      const key = s.userId ?? `name:${s.perfectName}`;
-      const list = groupMap.get(key) ?? [];
-      list.push(s);
-      groupMap.set(key, list);
-    }
-
-    const aggregated = Array.from(groupMap.values()).map((rows) => ({
-      userId: rows[0].userId,
-      perfectName: rows[0].perfectName,
-      kills: sumNums(rows.map((r) => r.kills)),
-      deaths: sumNums(rows.map((r) => r.deaths)),
-      assists: sumNums(rows.map((r) => r.assists)),
-      hsPercent: weightedAvgNums(rows.map((r) => r.hsPercent), rows.map((r) => r.kills)),
-      firstKills: sumNums(rows.map((r) => r.firstKills)),
-      multiKills: sumNums(rows.map((r) => r.multiKills)),
-      clutches: sumNums(rows.map((r) => r.clutches)),
-      adr: avgNums(rows.map((r) => r.adr)),
-      rws: avgNums(rows.map((r) => r.rws)),
-      ratingPro: avgNums(rows.map((r) => r.ratingPro)),
-      we: avgNums(rows.map((r) => r.we)),
-    }));
-
-    // 按平均 Rating 降序，取前 4
-    mvpCandidates = aggregated
-      .sort((a, b) => (b.ratingPro ?? 0) - (a.ratingPro ?? 0))
-      .slice(0, 4);
-
-    mvpVoteResults = await getMatchMvpResults(match.id);
-    ensureMvpWinner(match.id); // 懒加载持久化 MVP 胜者（不阻塞渲染）
-
-    if (userSession?.userId) {
-      const existingVote = await db.query.matchMvpVotes.findFirst({
-        where: and(
-          eq(matchMvpVotes.matchId, match.id),
-          eq(matchMvpVotes.voterUserId, userSession.userId),
-        ),
-      });
-      if (existingVote) userVoted = existingVote.playerName;
-    }
+    radarDataB.set(map, {
+      winRate: winB && winB.played > 0 ? (winB.wins / winB.played) * 100 : 0,
+      pickRate: pickStatsB.bpMatchCount > 0 ? ((pickStatsB.pickCount.get(map) ?? 0) / pickStatsB.bpMatchCount) * 100 : 0,
+      banRate: banStatsB.bpMatchCount > 0 ? ((banStatsB.banCount.get(map) ?? 0) / banStatsB.bpMatchCount) * 100 : 0,
+    });
   }
 
-  const allTeamMembers = await db
-    .select({
-      id: teamMembers.id,
-      teamId: teamMembers.teamId,
-      steamName: users.steamName,
-      displayName: users.displayName,
-      perfectName: users.perfectName,
-      primaryPosition: seasonRegistrations.primaryPosition,
-      userId: users.id,
-    })
-    .from(teamMembers)
-    .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
-    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
-    .where(
-      inArray(teamMembers.teamId, [match.teamAId, match.teamBId]),
-    );
-
-  let isCaptainA = false;
-  let isCaptainB = false;
-  let isSeasonAdmin = false;
-  let captainTeamMembers: { id: string; steamName: string; displayName: string | null; perfectName: string | null; primaryPosition: string }[] = [];
-
-  if (userSession?.userId) {
-    isSeasonAdmin =
-      userSession.role === "super_admin" ||
-      (userSession.role === "season_admin" &&
-        userSession.adminSeasonIds.includes(season.id));
-
-    const reg = await db.query.seasonRegistrations.findFirst({
-      where: and(
-        eq(seasonRegistrations.userId, userSession.userId),
-        eq(seasonRegistrations.seasonId, season.id),
-      ),
-    });
-    if (reg) {
-      isCaptainA = teamA?.captainRegistrationId === reg.id;
-      isCaptainB = teamB?.captainRegistrationId === reg.id;
-
-      if (isCaptainA || isCaptainB) {
-        const captainTeamId = isCaptainA ? match.teamAId : match.teamBId;
-        captainTeamMembers = allTeamMembers
-          .filter((m) => m.teamId === captainTeamId)
-          .map((r) => ({
-            id: r.id,
-            steamName: r.steamName ?? "未知",
-            displayName: r.displayName ?? null,
-            perfectName: r.perfectName ?? null,
-            primaryPosition: r.primaryPosition,
-          }));
-      }
+  // 首发选手赛季数据（用于 MatchLineupsH2H）
+  function buildLineupsPlayers(rows: MPS[], starterUserIds: string[]) {
+    const grouped = new Map<string, MPS[]>();
+    for (const r of rows) {
+      if (!r.userId) continue;
+      const list = grouped.get(r.userId) ?? [];
+      list.push(r);
+      grouped.set(r.userId, list);
     }
+    return starterUserIds.map((userId) => {
+      const playerRows = grouped.get(userId) ?? [];
+      const member = userIdToMember.get(userId);
+      const perfectName =
+        playerRows[0]?.perfectName ?? member?.perfectName ?? member?.displayName ?? member?.steamName ?? "未知";
+      const totalKills = sumNums(playerRows.map((r) => r.kills)) ?? 0;
+      const totalDeaths = sumNums(playerRows.map((r) => r.deaths)) ?? 0;
+      const firstKills = sumNums(playerRows.map((r) => r.firstKills)) ?? 0;
+      return {
+        userId,
+        perfectName,
+        maps: playerRows.length,
+        avgRating: avgNums(playerRows.map((r) => r.ratingPro)) ?? 0,
+        avgAdr: avgNums(playerRows.map((r) => r.adr)) ?? 0,
+        kdRatio: totalDeaths > 0 ? totalKills / totalDeaths : null,
+        avgHs: avgNums(playerRows.map((r) => r.hsPercent)) ?? 0,
+        avgFk: playerRows.length > 0 ? firstKills / playerRows.length : 0,
+        avgWe: avgNums(playerRows.map((r) => r.we)) ?? 0,
+      };
+    });
   }
 
+  const lineupsPlayersA = buildLineupsPlayers(starterStatsA, starterAUserIds);
+  const lineupsPlayersB = buildLineupsPlayers(starterStatsB, starterBUserIds);
+  const showLineupsH2H =
+    lineupsPlayersA.length > 0 &&
+    lineupsPlayersB.length > 0 &&
+    (lineupsPlayersA.some((p) => p.maps > 0) || lineupsPlayersB.some((p) => p.maps > 0));
+
+  // 队长 / 管理员权限检查
   interface RosterPlayer {
     steamName: string;
     displayName: string | null;
@@ -211,6 +338,40 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       }));
   }
 
+  let isCaptainA = false;
+  let isCaptainB = false;
+  let isSeasonAdmin = false;
+  let captainTeamMembers: { id: string; steamName: string; displayName: string | null; perfectName: string | null; primaryPosition: string }[] = [];
+
+  if (userSession?.userId) {
+    isSeasonAdmin =
+      userSession.role === "super_admin" ||
+      (userSession.role === "season_admin" && userSession.adminSeasonIds.includes(season.id));
+
+    const reg = await db.query.seasonRegistrations.findFirst({
+      where: and(
+        eq(seasonRegistrations.userId, userSession.userId),
+        eq(seasonRegistrations.seasonId, season.id),
+      ),
+    });
+    if (reg) {
+      isCaptainA = teamA?.captainRegistrationId === reg.id;
+      isCaptainB = teamB?.captainRegistrationId === reg.id;
+      if (isCaptainA || isCaptainB) {
+        const captainTeamId = isCaptainA ? match.teamAId : match.teamBId;
+        captainTeamMembers = allTeamMembers
+          .filter((m) => m.teamId === captainTeamId)
+          .map((r) => ({
+            id: r.id,
+            steamName: r.steamName ?? "未知",
+            displayName: r.displayName ?? null,
+            perfectName: r.perfectName ?? null,
+            primaryPosition: r.primaryPosition,
+          }));
+      }
+    }
+  }
+
   const captainRoster = isCaptainA ? rosterA : isCaptainB ? rosterB : null;
   const teamARoster: RosterPlayer[] | null = rosterA
     ? buildRoster(rosterA, allTeamMembers, match.teamAId)
@@ -218,6 +379,107 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   const teamBRoster: RosterPlayer[] | null = rosterB
     ? buildRoster(rosterB, allTeamMembers, match.teamBId)
     : null;
+
+  // MVP 投票 + 整场汇总数据（已结束比赛）
+  let mvpCandidates: {
+    userId: string | null;
+    perfectName: string;
+    kills: number | null;
+    deaths: number | null;
+    assists: number | null;
+    hsPercent: number | null;
+    firstKills: number | null;
+    multiKills: number | null;
+    clutches: number | null;
+    adr: number | null;
+    rws: number | null;
+    ratingPro: number | null;
+    we: number | null;
+  }[] = [];
+  let mvpVoteResults: Awaited<ReturnType<typeof getMatchMvpResults>> = [];
+  let userVoted: string | null = null;
+  let summaryPlayers: {
+    userId: string | null;
+    perfectName: string;
+    teamId: string;
+    kills: number;
+    deaths: number;
+    assists: number;
+    hsPercent: number | null;
+    firstKills: number;
+    multiKills: number;
+    clutches: number;
+    adr: number | null;
+    rws: number | null;
+    ratingPro: number | null;
+    we: number | null;
+    mapsPlayed: number;
+  }[] = [];
+
+  if (isFinished) {
+    const allStats = await db.query.matchPlayerStats.findMany({
+      where: eq(matchPlayerStats.matchId, match.id),
+    });
+
+    const groupMap = new Map<string, typeof allStats>();
+    for (const s of allStats) {
+      const key = s.userId ?? `name:${s.perfectName}`;
+      const list = groupMap.get(key) ?? [];
+      list.push(s);
+      groupMap.set(key, list);
+    }
+
+    const aggregated = Array.from(groupMap.values()).map((rows) => ({
+      userId: rows[0].userId,
+      perfectName: rows[0].perfectName,
+      kills: sumNums(rows.map((r) => r.kills)),
+      deaths: sumNums(rows.map((r) => r.deaths)),
+      assists: sumNums(rows.map((r) => r.assists)),
+      hsPercent: weightedAvgNums(rows.map((r) => r.hsPercent), rows.map((r) => r.kills)),
+      firstKills: sumNums(rows.map((r) => r.firstKills)),
+      multiKills: sumNums(rows.map((r) => r.multiKills)),
+      clutches: sumNums(rows.map((r) => r.clutches)),
+      adr: avgNums(rows.map((r) => r.adr)),
+      rws: avgNums(rows.map((r) => r.rws)),
+      ratingPro: avgNums(rows.map((r) => r.ratingPro)),
+      we: avgNums(rows.map((r) => r.we)),
+    }));
+
+    mvpCandidates = aggregated
+      .sort((a, b) => (b.ratingPro ?? 0) - (a.ratingPro ?? 0))
+      .slice(0, 4);
+
+    // 整场汇总（BO3/BO5 用，带 teamId）
+    summaryPlayers = aggregated
+      .map((p) => ({
+        ...p,
+        teamId: p.userId ? (userIdToTeamId.get(p.userId) ?? "") : "",
+        mapsPlayed: groupMap.get(p.userId ?? `name:${p.perfectName}`)?.length ?? 1,
+        kills: p.kills ?? 0,
+        deaths: p.deaths ?? 0,
+        assists: p.assists ?? 0,
+        firstKills: p.firstKills ?? 0,
+        multiKills: p.multiKills ?? 0,
+        clutches: p.clutches ?? 0,
+      }))
+      .filter((p) => p.teamId === match.teamAId || p.teamId === match.teamBId);
+
+    mvpVoteResults = await getMatchMvpResults(match.id);
+    ensureMvpWinner(match.id);
+
+    if (userSession?.userId) {
+      const existingVote = await db.query.matchMvpVotes.findFirst({
+        where: and(
+          eq(matchMvpVotes.matchId, match.id),
+          eq(matchMvpVotes.voterUserId, userSession.userId),
+        ),
+      });
+      if (existingVote) userVoted = existingVote.playerName;
+    }
+  }
+
+  const showSummaryTab = isFinished && match.format !== "bo1" && summaryPlayers.length > 0;
+  const defaultTab = showSummaryTab ? "summary" : (maps[0]?.id ?? "");
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl space-y-8">
@@ -241,12 +503,12 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
 
       {/* Hero header */}
       <div
-        className="flex flex-col sm:grid sm:grid-cols-[1fr_auto_1fr] items-center gap-6 px-8 py-8 border-b"
+        className="flex flex-col sm:grid sm:grid-cols-[1fr_auto_1fr] items-center gap-6 px-8 py-8"
         style={{
-          background: teamA && teamB
-            ? `linear-gradient(90deg, ${teamBadgeData(teamA.name, 0).color}15 0%, transparent 35%, transparent 65%, ${teamBadgeData(teamB.name, 1).color}15 100%)`
-            : `var(--color-panel-low)`,
-          borderColor: "var(--color-border)",
+          background:
+            teamA && teamB
+              ? `linear-gradient(90deg, ${teamBadgeData(teamA.name, 0).color}15 0%, transparent 35%, transparent 65%, ${teamBadgeData(teamB.name, 1).color}15 100%)`
+              : `var(--color-panel-low)`,
           borderRadius: "var(--radius-lg)",
           border: `1px solid var(--color-border)`,
         }}
@@ -283,7 +545,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
           )}
         </div>
 
-        {/* Score / VS */}
+        {/* 比分 / VS */}
         <div className="text-center px-4">
           {match.status === "in_progress" && (
             <div
@@ -366,21 +628,70 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         </div>
       </div>
 
-      {/* BP 流程 */}
-      <VetoView
-        matchId={match.id}
+      {/* 时间显示 */}
+      <div className="text-center text-xs text-[var(--color-fg-dim)]">
+        {isFinished
+          ? match.completedAt
+            ? `完成于 ${formatCSTDateTime(match.completedAt)}`
+            : "结束时间未记录"
+          : match.scheduledAt
+          ? `计划于 ${formatCSTDateTime(match.scheduledAt)}`
+          : "未排期"}
+      </div>
+
+      {/* 赛季综合对比 */}
+      <TeamStatsCompare
         teamAName={teamA?.name ?? "队伍 A"}
         teamBName={teamB?.name ?? "队伍 B"}
-        teamAId={match.teamAId}
-        teamBId={match.teamBId}
+        statA={{ ...recordA, ...teamAvgA }}
+        statB={{ ...recordB, ...teamAvgB }}
       />
 
-      {/* 地图结果 — 有 maps 时用 Tab 切换，无 maps 时 fallback */}
+      {/* 地图池雷达图 */}
+      {mapPool.length > 0 && (
+        <Panel label="地图池">
+          <MapPoolRadarChart
+            mapPool={mapPool}
+            teamAName={teamA?.name ?? "A"}
+            teamBName={teamB?.name ?? "B"}
+            teamAData={radarDataA}
+            teamBData={radarDataB}
+          />
+        </Panel>
+      )}
+
+      {/* 历史交锋 */}
+      <MatchHeadToHead
+        teamAName={teamA?.name ?? "队伍 A"}
+        teamBName={teamB?.name ?? "队伍 B"}
+        teamAWins={h2hWinsA}
+        teamBWins={h2hWinsB}
+        matches={h2hMatches}
+        seasonSlug={seasonSlug}
+      />
+
+      {/* BP 流程（进行中 / 已结束时显示） */}
+      {match.status !== "scheduled" && (
+        <VetoView
+          matchId={match.id}
+          teamAName={teamA?.name ?? "队伍 A"}
+          teamBName={teamB?.name ?? "队伍 B"}
+          teamAId={match.teamAId}
+          teamBId={match.teamBId}
+        />
+      )}
+
+      {/* 地图结果 */}
       {maps.length > 0 ? (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">地图结果</h2>
-          <Tabs defaultValue={maps[0].id}>
+          <Tabs defaultValue={defaultTab}>
             <TabsList>
+              {showSummaryTab && (
+                <TabsTrigger value="summary" className="text-xs">
+                  整场汇总
+                </TabsTrigger>
+              )}
               {maps.map((map) => (
                 <TabsTrigger key={map.id} value={map.id} className="text-xs">
                   {mapLabel(map.mapName)}
@@ -398,27 +709,32 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                 </TabsTrigger>
               ))}
             </TabsList>
+
+            {/* 整场汇总 Tab */}
+            {showSummaryTab && (
+              <TabsContent value="summary">
+                <MatchSummaryStats
+                  players={summaryPlayers}
+                  teamAId={match.teamAId}
+                  teamBId={match.teamBId}
+                  teamAName={teamA?.name ?? "队伍 A"}
+                  teamBName={teamB?.name ?? "队伍 B"}
+                  seasonSlug={seasonSlug}
+                />
+              </TabsContent>
+            )}
+
+            {/* 单图 Tab */}
             {maps.map((map) => (
               <TabsContent key={map.id} value={map.id}>
                 <Panel pad={16} className="space-y-3">
-                  {/* 地图 info bar */}
                   <div className="flex items-center justify-between gap-4">
                     <div className="flex items-center gap-3">
-                      <span className="text-xs text-[var(--color-fg-mid)] w-5">
-                        #{map.mapOrder}
-                      </span>
-                      <span className="font-medium text-[var(--color-fg)]">
-                        {mapLabel(map.mapName)}
-                      </span>
-                      {map.pickedByTeamId === match.teamAId && (
-                        <PosChip pos={`${teamA?.name} Pick`} />
-                      )}
-                      {map.pickedByTeamId === match.teamBId && (
-                        <PosChip pos={`${teamB?.name} Pick`} />
-                      )}
-                      {map.pickedByTeamId === null && (
-                        <PosChip pos="决胜图" />
-                      )}
+                      <span className="text-xs text-[var(--color-fg-mid)] w-5">#{map.mapOrder}</span>
+                      <span className="font-medium text-[var(--color-fg)]">{mapLabel(map.mapName)}</span>
+                      {map.pickedByTeamId === match.teamAId && <PosChip pos={`${teamA?.name} Pick`} />}
+                      {map.pickedByTeamId === match.teamBId && <PosChip pos={`${teamB?.name} Pick`} />}
+                      {map.pickedByTeamId === null && <PosChip pos="决胜图" />}
                     </div>
                     <div className="flex items-center gap-3 text-sm">
                       {map.teamAStartSide && (
@@ -433,41 +749,45 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                       )}
                     </div>
                   </div>
-                  {/* 玩家数据 / OCR */}
-                  {isFinished && (
-                    <PlayerStatsTable matchId={match.id} mapId={map.id} />
-                  )}
+                  {isFinished && <PlayerStatsTable matchId={match.id} mapId={map.id} />}
                   {!isFinished && map.scoreA == null && (
-                    <p className="text-xs text-[var(--color-fg-dim)] py-2">
-                      比赛未开始
-                    </p>
+                    <p className="text-xs text-[var(--color-fg-dim)] py-2">比赛未开始</p>
                   )}
-                  {isFinished && isSeasonAdmin && (
-                    <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                  )}
+                  {isFinished && isSeasonAdmin && <StatsOCRPanel mapId={map.id} mapName={map.mapName} />}
                 </Panel>
               </TabsContent>
             ))}
           </Tabs>
         </section>
       ) : isFinished && match.scoreA != null && match.scoreB != null ? (
-        // BO1 fallback (from Phase 1)
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">比赛结果</h2>
           <Panel pad={16}>
             <p className="text-sm text-[var(--color-fg-mid)]">
-              {MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：{match.scoreA} : {match.scoreB}
+              {MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：{match.scoreA} :{" "}
+              {match.scoreB}
             </p>
           </Panel>
         </section>
       ) : null}
 
-      {/* 赛前名单 */}
-      {match.status !== "finished" && (
+      {/* 阵容对比（双方名单提交后，有赛季数据时显示） */}
+      {showLineupsH2H && (
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-[var(--color-fg)]">
-            赛前名单
-          </h2>
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">阵容对比</h2>
+          <MatchLineupsH2H
+            teamAName={teamA?.name ?? "队伍 A"}
+            teamBName={teamB?.name ?? "队伍 B"}
+            teamAPlayers={lineupsPlayersA}
+            teamBPlayers={lineupsPlayersB}
+          />
+        </section>
+      )}
+
+      {/* 赛前名单 */}
+      {!isFinished && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">赛前名单</h2>
           <Panel pad={16}>
             <MatchRosterView
               teamAName={teamA?.name ?? "队伍 A"}
@@ -493,9 +813,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       {/* 比赛时间协商 */}
       {match.status === "scheduled" && (
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-[var(--color-fg)]">
-            比赛时间协商
-          </h2>
+          <h2 className="text-lg font-semibold text-[var(--color-fg)]">比赛时间协商</h2>
           <Panel pad={16}>
             <MatchTimeNegotiation
               matchId={match.id}
@@ -516,7 +834,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         </section>
       )}
 
-      {/* MVP 投票 */}
+      {/* MVP 投票（2×2） */}
       {isFinished && mvpCandidates.length > 0 && (
         <MatchMvpVote
           matchId={match.id}

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -2,9 +2,6 @@ import { notFound } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
-import { seasonRegistrations } from "@/db/schema/registrations";
-import { teamMembers } from "@/db/schema/teams";
-import { teams } from "@/db/schema/teams";
 import { sql } from "drizzle-orm";
 import { StatsLeaderboard } from "@/components/matches/StatsLeaderboard";
 import { Marker } from "@/components/rivalhub";
@@ -36,17 +33,22 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
 
   const sortColumn = (() => {
     switch (sort) {
-      case "adr": return sql`avg(mps.adr)`;
-      case "kd": return sql`CASE WHEN sum(mps.deaths) > 0 THEN round((sum(mps.kills) / sum(mps.deaths))::numeric, 2) ELSE 0 END`;
-      case "we": return sql`avg(mps.we)`;
-      case "kpr": return sql`round((sum(mps.kills) / count(*))::numeric, 1)`;
-      case "maps": return sql`count(*)`;
-      default: return sql`avg(mps.rating_pro)`;
+      case "adr":    return sql`avg(mps.adr)`;
+      case "kd":     return sql`CASE WHEN sum(mps.deaths) > 0 THEN sum(mps.kills)::numeric / sum(mps.deaths) ELSE 0 END`;
+      case "kpr":    return sql`sum(mps.kills)::numeric / count(*)`;
+      case "hs":     return sql`avg(mps.hs_percent)`;
+      case "we":     return sql`avg(mps.we)`;
+      case "rws":    return sql`avg(mps.rws)`;
+      case "fk":     return sql`sum(mps.first_kills)::numeric / count(*)`;
+      case "clutch": return sql`sum(mps.clutches)::numeric / count(*)`;
+      case "maps":   return sql`count(*)`;
+      default:       return sql`avg(mps.rating_pro)`;
     }
   })();
 
+  // 修复：使用原始字符串 sr.primary_position 而非 Drizzle schema 对象（展开后为表名，与别名 sr 冲突）
   const positionFilter = position
-    ? sql`AND ${seasonRegistrations.primaryPosition} = ${position}`
+    ? sql`AND sr.primary_position = ${position}`
     : sql``;
 
   const { rows } = await db.execute(sql`
@@ -54,16 +56,20 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
       mps.user_id,
       mps.perfect_name,
       sr.primary_position,
-      t.name as team_name,
-      t.id as team_id,
-      count(*)::int as maps,
-      round(avg(mps.rating_pro)::numeric, 2) as avg_rating,
-      round(avg(mps.adr)::numeric, 1) as avg_adr,
-      round(avg(mps.kills)::numeric, 1) as avg_kills,
-      round(avg(mps.deaths)::numeric, 1) as avg_deaths,
-      round(avg(mps.we)::numeric, 1) as avg_we,
-      sum(mps.kills)::int as total_kills,
-      sum(mps.deaths)::int as total_deaths
+      t.name  AS team_name,
+      t.id    AS team_id,
+      count(*)::int                                                          AS maps,
+      round(avg(mps.rating_pro)::numeric, 2)                                AS avg_rating,
+      round(avg(mps.adr)::numeric, 1)                                       AS avg_adr,
+      round(avg(mps.rws)::numeric, 2)                                       AS avg_rws,
+      round(avg(mps.we)::numeric, 1)                                        AS avg_we,
+      round(avg(mps.hs_percent)::numeric, 1)                                AS avg_hs,
+      CASE WHEN sum(mps.deaths) > 0
+        THEN round(sum(mps.kills)::numeric / sum(mps.deaths), 2)
+        ELSE NULL END                                                        AS kd_ratio,
+      round(sum(mps.kills)::numeric    / count(*), 2)                       AS kpr,
+      round(sum(mps.first_kills)::numeric / count(*), 2)                    AS avg_fk,
+      round(sum(mps.clutches)::numeric    / count(*), 2)                    AS avg_clutch
     FROM match_player_stats mps
     JOIN matches m ON m.id = mps.match_id
     LEFT JOIN season_registrations sr
@@ -79,21 +85,25 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     LIMIT 100
   `);
 
-  // db.execute 原始 SQL 中 numeric 类型由 pg 驱动返回字符串，需显式转换
   const toNum = (v: unknown) => (v == null ? 0 : Number(v));
+  const toNumOrNull = (v: unknown) => (v == null ? null : Number(v));
 
   const leaderboardRows = rows.map((r) => ({
-    userId: r.user_id as string | null,
+    userId:     r.user_id as string | null,
     perfectName: r.perfect_name as string,
-    position: r.primary_position as string | null,
-    teamName: r.team_name as string | null,
-    teamId: r.team_id as string | null,
-    maps: toNum(r.maps),
-    avgRating: toNum(r.avg_rating),
-    avgAdr: toNum(r.avg_adr),
-    avgKills: toNum(r.avg_kills),
-    avgDeaths: toNum(r.avg_deaths),
-    avgWe: toNum(r.avg_we),
+    position:   r.primary_position as string | null,
+    teamName:   r.team_name as string | null,
+    teamId:     r.team_id as string | null,
+    maps:       toNum(r.maps),
+    avgRating:  toNum(r.avg_rating),
+    avgAdr:     toNum(r.avg_adr),
+    avgRws:     toNum(r.avg_rws),
+    avgWe:      toNum(r.avg_we),
+    avgHs:      toNum(r.avg_hs),
+    kdRatio:    toNumOrNull(r.kd_ratio),
+    kpr:        toNum(r.kpr),
+    avgFk:      toNum(r.avg_fk),
+    avgClutch:  toNum(r.avg_clutch),
   }));
 
   return (

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import { eq, or, and, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
-import { matchPlayerStats } from "@/db/schema/player-stats";
 import { Panel, Stat, Marker, PosChip, Btn } from "@/components/rivalhub";
 import { MatchCard } from "@/components/matches/MatchCard";
 import { MapPreferenceChips } from "@/components/rivalhub/MapPreferenceChips";
@@ -99,7 +98,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     });
   const subs = roster.filter((r) => !r.isStarter);
 
-  // 对手队名（包含已完成和即将进行的比赛对手）
+  // 对手队名
   const opponentIds = [
     ...new Set([
       ...teamMatches.map((m) => (m.teamAId === teamId ? m.teamBId : m.teamAId)),
@@ -107,13 +106,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     ]),
   ];
   const opponentTeams = opponentIds.length
-    ? await db.query.teams.findMany({
-        where: inArray(teams.id, opponentIds),
-      })
+    ? await db.query.teams.findMany({ where: inArray(teams.id, opponentIds) })
     : [];
   const teamNameMap = new Map(opponentTeams.map((t) => [t.id, t]));
 
-  // 整体胜负统计
+  // 整体胜负
   let totalWins = 0;
   let totalLosses = 0;
   for (const m of teamMatches) {
@@ -123,17 +120,19 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     if (myScore > oppScore) totalWins++;
     else totalLosses++;
   }
+  const played = totalWins + totalLosses;
+  const winRate = played > 0 ? `${Math.round((totalWins / played) * 100)}%` : "—";
 
   const seasonMapPool = normalizeRegistrationConfig(season.registrationConfig).mapPool;
 
-  // ── 地图表现统计 ──────────────────────────────────────────────────────────
+  // 地图表现统计
   const matchIds = teamMatches.map((m) => m.id);
   const [mapStats, { banCount, bpMatchCount }] = await Promise.all([
     getTeamMapWinStats(teamId, teamMatches),
     getTeamBanStats(teamId, matchIds),
   ]);
 
-  // ── 历史对阵（按对手分组） ─────────────────────────────────────────────
+  // 历史对阵（按对手分组）
   interface HeadToHead { opponentId: string; wins: number; losses: number }
   const h2hMap = new Map<string, HeadToHead>();
   for (const m of teamMatches) {
@@ -150,81 +149,74 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   }
   const h2hList = [...h2hMap.values()].sort((a, b) => b.wins + b.losses - (a.wins + a.losses));
 
-  const played = totalWins + totalLosses;
-
-  // ── 队伍聚合统计 ──────────────────────────────────────────────────
+  // 队伍 + 选手统计（每人聚合，用于阵容内联和队伍均值）
   const teamStatResult = roster.length
     ? await db.execute(sql`
         SELECT
-          round(avg(mps.rating_pro)::numeric, 2) as avg_rating,
-          round(avg(mps.adr)::numeric, 1) as avg_adr,
-          round(avg(mps.kills)::numeric, 1) as avg_kills,
-          round(avg(mps.deaths)::numeric, 1) as avg_deaths,
-          round(avg(mps.we)::numeric, 1) as avg_we,
-          sr.primary_position,
-          mps.perfect_name,
-          mps.rating_pro,
-          mps.user_id
+          mps.user_id,
+          count(*)::int                                                      AS maps,
+          round(avg(mps.rating_pro)::numeric, 2)                            AS avg_rating,
+          round(avg(mps.adr)::numeric, 1)                                   AS avg_adr,
+          round(avg(mps.we)::numeric, 1)                                    AS avg_we,
+          sum(mps.kills)::int                                                AS total_kills,
+          sum(mps.deaths)::int                                               AS total_deaths,
+          CASE WHEN sum(mps.deaths) > 0
+            THEN round(sum(mps.kills)::numeric / sum(mps.deaths), 2)
+            ELSE NULL END                                                    AS kd_ratio
         FROM match_player_stats mps
         JOIN season_registrations sr ON sr.user_id = mps.user_id AND sr.season_id = ${season.id}
         JOIN team_members tm ON tm.registration_id = sr.id
         WHERE tm.team_id = ${teamId}
           AND mps.verified_by_admin IS NOT NULL
-        GROUP BY sr.primary_position, mps.perfect_name, mps.rating_pro, mps.user_id
+        GROUP BY mps.user_id
       `)
     : null;
 
-  const teamStatRows: Record<string, unknown>[] = teamStatResult?.rows ?? [];
-
   interface TeamStatRow {
+    user_id: string | null;
+    maps: number;
     avg_rating: number;
     avg_adr: number;
-    avg_kills: number;
-    avg_deaths: number;
     avg_we: number;
-    primary_position: string;
-    perfect_name: string;
-    rating_pro: number;
-    user_id?: string | null;
+    total_kills: number;
+    total_deaths: number;
+    kd_ratio: number | null;
   }
+  const typedStats = (teamStatResult?.rows ?? []) as unknown as TeamStatRow[];
 
-  const typedStats = teamStatRows as unknown as TeamStatRow[];
-
-  const teamAvgRating =
-    typedStats.length > 0
-      ? (typedStats.reduce((s, r) => s + Number(r.avg_rating), 0) / typedStats.length).toFixed(2)
-      : null;
-  const teamAvgAdr =
-    typedStats.length > 0
-      ? (typedStats.reduce((s, r) => s + Number(r.avg_adr), 0) / typedStats.length).toFixed(1)
-      : null;
-  const teamAvgKd =
-    typedStats.length > 0
-      ? (() => {
-          const k = typedStats.reduce((s, r) => s + Number(r.avg_kills), 0);
-          const d = typedStats.reduce((s, r) => s + Number(r.avg_deaths), 0);
-          return d > 0 ? (k / d).toFixed(2) : null;
-        })()
-      : null;
-  const teamAvgWe =
-    typedStats.length > 0
-      ? (typedStats.reduce((s, r) => s + Number(r.avg_we), 0) / typedStats.length).toFixed(1)
-      : null;
-
-  // 每位置最高 Rating 选手
-  const positionBest = new Map<string, { name: string; rating: number; userId?: string | null }>();
+  // 选手数据 map（用于阵容内联显示）
+  interface PlayerStats { maps: number; avgRating: number; avgAdr: number; kdRatio: number | null }
+  const playerStatsMap = new Map<string, PlayerStats>();
   for (const r of typedStats) {
-    const pos = r.primary_position;
-    const existing = positionBest.get(pos);
-    if (!existing || Number(r.rating_pro) > existing.rating) {
-      positionBest.set(pos, { name: r.perfect_name, rating: Number(r.rating_pro), userId: r.user_id });
+    if (r.user_id) {
+      playerStatsMap.set(r.user_id as string, {
+        maps: Number(r.maps),
+        avgRating: Number(r.avg_rating),
+        avgAdr: Number(r.avg_adr),
+        kdRatio: r.kd_ratio != null ? Number(r.kd_ratio) : null,
+      });
     }
   }
+
+  // 队伍均值（K/D 用总杀/总死，避免平均的平均）
+  const hasStats = typedStats.length > 0;
+  const teamAvgRating = hasStats
+    ? (typedStats.reduce((s, r) => s + Number(r.avg_rating), 0) / typedStats.length).toFixed(2)
+    : null;
+  const teamAvgAdr = hasStats
+    ? (typedStats.reduce((s, r) => s + Number(r.avg_adr), 0) / typedStats.length).toFixed(1)
+    : null;
+  const totalK = typedStats.reduce((s, r) => s + Number(r.total_kills), 0);
+  const totalD = typedStats.reduce((s, r) => s + Number(r.total_deaths), 0);
+  const teamAvgKd = totalD > 0 ? (totalK / totalD).toFixed(2) : null;
+  const teamAvgWe = hasStats
+    ? (typedStats.reduce((s, r) => s + Number(r.avg_we), 0) / typedStats.length).toFixed(1)
+    : null;
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-4xl space-y-10">
 
-      {/* 队伍标题 */}
+      {/* 1. 队伍标题 */}
       <div className="flex items-start gap-5">
         <div className="flex flex-col items-center gap-2">
           <TeamLogoUpload
@@ -235,9 +227,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
           />
           {isAdmin && team.logoUrl && (
             <Btn small ghost asChild>
-              <a href={team.logoUrl} target="_blank" rel="noopener noreferrer">
-                下载头像
-              </a>
+              <a href={team.logoUrl} target="_blank" rel="noopener noreferrer">下载头像</a>
             </Btn>
           )}
         </div>
@@ -256,68 +246,212 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </div>
       </div>
 
-      {/* 整体战绩 */}
-      <div className="grid grid-cols-3 gap-3 sm:gap-4">
+      {/* 2. 综合数据：战绩 + 均值合并为 2×4 grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
         <Stat label="出场" value={played} />
         <Stat label="胜" value={totalWins} />
         <Stat label="负" value={totalLosses} />
+        <Stat label="胜率" value={winRate} />
+        {teamAvgRating && (
+          <>
+            <Stat label="场均 Rating" value={teamAvgRating} accent />
+            <Stat label="场均 ADR" value={teamAvgAdr ?? "—"} accent />
+            <Stat label="场均 K/D" value={teamAvgKd ?? "—"} accent />
+            <Stat label="场均 WE" value={teamAvgWe ?? "—"} accent />
+          </>
+        )}
       </div>
 
-      {/* 阵容 */}
+      {/* 3. 阵容（首发 + 替补，均显示数据和地图偏好） */}
       <section>
         <Panel label="阵容" pad={20}>
-          <div className="space-y-3">
-            {starters.map((p) => (
-              <div key={p.registrationId} className="flex items-center justify-between gap-2 hover:bg-[var(--color-panel-hi)] transition-colors rounded px-2 -mx-2">
-                <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-                  {p.registrationId === team.captainRegistrationId && (
-                    <PosChip pos="C" small />
-                  )}
-                  {p.userId ? (
-                    <Link href={`/players/${p.userId}`} className="font-medium text-[var(--color-fg)] truncate text-sm sm:text-base hover:text-[var(--color-accent)] transition-colors">
-                      {getDisplayName(p)}
-                    </Link>
-                  ) : (
-                    <span className="font-medium text-[var(--color-fg)] truncate text-sm sm:text-base">
-                      {getDisplayName(p)}
-                    </span>
-                  )}
-                </div>
-                <div className="text-right shrink-0">
-                  <span className="text-xs sm:text-sm text-[var(--color-fg-mid)]">
-                    {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
-                  </span>
-                  <div className="mt-1 flex justify-end">
-                    <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
+          <div className="divide-y divide-[var(--color-border)]">
+            {starters.map((p) => {
+              const stats = p.userId ? playerStatsMap.get(p.userId) : undefined;
+              return (
+                <div key={p.registrationId} className="py-2.5 px-2 -mx-2 hover:bg-[var(--color-panel-hi)] transition-colors rounded">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        {p.registrationId === team.captainRegistrationId && <PosChip pos="C" small />}
+                        {p.userId ? (
+                          <Link href={`/players/${p.userId}`} className="font-medium text-sm sm:text-base text-[var(--color-fg)] truncate hover:text-[var(--color-accent)] transition-colors">
+                            {getDisplayName(p)}
+                          </Link>
+                        ) : (
+                          <span className="font-medium text-sm sm:text-base text-[var(--color-fg)] truncate">
+                            {getDisplayName(p)}
+                          </span>
+                        )}
+                      </div>
+                      {stats && (
+                        <div className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
+                          <span>{stats.maps}图</span>
+                          <span className="text-[var(--color-fg-dim)]">·</span>
+                          <span style={stats.avgRating >= 1.2 ? { color: "var(--color-accent)" } : undefined}>
+                            {stats.avgRating.toFixed(2)} RT
+                          </span>
+                          <span className="text-[var(--color-fg-dim)]">·</span>
+                          <span>{stats.avgAdr.toFixed(1)} ADR</span>
+                          <span className="text-[var(--color-fg-dim)]">·</span>
+                          <span>{stats.kdRatio != null ? stats.kdRatio.toFixed(2) : "—"} K/D</span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="text-right shrink-0">
+                      <span className="text-xs text-[var(--color-fg-mid)]">
+                        {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
+                      </span>
+                      <div className="mt-1 flex justify-end">
+                        <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
             {subs.length > 0 && (
-              <div className="border-t border-[var(--color-border)] pt-3 space-y-2">
-                <p className="text-xs text-[var(--color-fg-mid)] font-medium uppercase tracking-wide">替补</p>
-                {subs.map((p) => (
-                  <div key={p.registrationId} className="flex items-center justify-between gap-2 opacity-70 hover:bg-[var(--color-panel-hi)] transition-colors rounded px-2 -mx-2">
-                    {p.userId ? (
-                      <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] truncate hover:text-[var(--color-accent)] transition-colors">
-                        {getDisplayName(p)}
-                      </Link>
-                    ) : (
-                      <span className="text-sm text-[var(--color-fg)] truncate">{getDisplayName(p)}</span>
-                    )}
-                    <span className="text-xs text-[var(--color-fg-mid)] shrink-0">
-                      {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
-                    </span>
-                  </div>
-                ))}
-              </div>
+              <>
+                <div className="pt-3 pb-1">
+                  <p className="text-xs text-[var(--color-fg-mid)] font-medium uppercase tracking-wide">替补</p>
+                </div>
+                {subs.map((p) => {
+                  const stats = p.userId ? playerStatsMap.get(p.userId) : undefined;
+                  return (
+                    <div key={p.registrationId} className="py-2.5 px-2 -mx-2 opacity-70 hover:bg-[var(--color-panel-hi)] transition-colors rounded">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            {p.userId ? (
+                              <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] truncate hover:text-[var(--color-accent)] transition-colors">
+                                {getDisplayName(p)}
+                              </Link>
+                            ) : (
+                              <span className="text-sm text-[var(--color-fg)] truncate">{getDisplayName(p)}</span>
+                            )}
+                          </div>
+                          {stats && (
+                            <div className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
+                              <span>{stats.maps}图</span>
+                              <span className="text-[var(--color-fg-dim)]">·</span>
+                              <span style={stats.avgRating >= 1.2 ? { color: "var(--color-accent)" } : undefined}>
+                                {stats.avgRating.toFixed(2)} RT
+                              </span>
+                              <span className="text-[var(--color-fg-dim)]">·</span>
+                              <span>{stats.avgAdr.toFixed(1)} ADR</span>
+                              <span className="text-[var(--color-fg-dim)]">·</span>
+                              <span>{stats.kdRatio != null ? stats.kdRatio.toFixed(2) : "—"} K/D</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-right shrink-0">
+                          <span className="text-xs text-[var(--color-fg-mid)]">
+                            {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
+                          </span>
+                          <div className="mt-1 flex justify-end">
+                            <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </>
             )}
           </div>
         </Panel>
       </section>
 
-      {/* 即将进行的比赛 */}
+      {/* 4. 地图表现 */}
+      <section>
+        <Panel pad={0} className="overflow-hidden" label="地图表现">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[340px]">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
+                  <th className="px-5 py-3 text-left font-medium">地图</th>
+                  <th className="px-5 py-3 text-center font-medium">胜率</th>
+                  <th className="px-5 py-3 text-center font-medium">ban 率</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--color-border)]">
+                {seasonMapPool.map((mapName) => {
+                  const stat = mapStats.get(mapName);
+                  const bans = banCount.get(mapName) ?? 0;
+                  return (
+                    <tr key={mapName}>
+                      <td className="px-5 py-3 font-medium text-[var(--color-fg)]">{mapLabel(mapName)}</td>
+                      <td className="px-5 py-3 text-center">
+                        {stat !== undefined ? (() => {
+                          const wr = pct(stat.wins, stat.played);
+                          return (
+                            <>
+                              <div className="font-semibold" style={{ color: wr.color }}>{wr.text}</div>
+                              <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
+                            </>
+                          );
+                        })() : <span className="text-[var(--color-fg-dim)]">—</span>}
+                      </td>
+                      <td className="px-5 py-3 text-center">
+                        {bpMatchCount > 0 ? (
+                          <>
+                            <div className="font-semibold text-[var(--color-fg)]">{pct(bans, bpMatchCount).text}</div>
+                            <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
+                          </>
+                        ) : <span className="text-[var(--color-fg-dim)]">—</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Panel>
+      </section>
+
+      {/* 5. 历史对阵 */}
+      {h2hList.length > 0 && (
+        <section>
+          <Panel pad={0} className="overflow-hidden" label="历史对阵">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[320px]">
+                <thead>
+                  <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
+                    <th className="px-5 py-3 text-left font-medium">对手</th>
+                    <th className="px-5 py-3 text-center font-medium">胜</th>
+                    <th className="px-5 py-3 text-center font-medium">负</th>
+                    <th className="px-5 py-3 text-right font-medium">胜率</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--color-border)]">
+                  {h2hList.map((h) => {
+                    const opp = teamNameMap.get(h.opponentId);
+                    return (
+                      <tr key={h.opponentId}>
+                        <td className="px-5 py-3 font-medium text-[var(--color-fg)]">
+                          {opp ? (
+                            <Link href={`/${seasonSlug}/teams/${opp.id}`} className="hover:underline hover:text-[var(--color-accent)]">
+                              {opp.name}
+                            </Link>
+                          ) : "未知队伍"}
+                        </td>
+                        <td className="px-5 py-3 text-center text-[var(--color-ok)]">{h.wins}</td>
+                        <td className="px-5 py-3 text-center text-[var(--color-danger)]">{h.losses}</td>
+                        <td className="px-5 py-3 text-right font-semibold text-[var(--color-fg)]">
+                          {pct(h.wins, h.wins + h.losses).text}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </Panel>
+        </section>
+      )}
+
+      {/* 6. 即将进行的比赛 */}
       {upcomingMatches.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">即将进行的比赛</h2>
@@ -345,7 +479,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 历史战绩 */}
+      {/* 7. 历史战绩 */}
       {teamMatches.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">历史战绩</h2>
@@ -379,7 +513,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 队内联系方式（仅同队成员可见） */}
+      {/* 8. 队内联系方式（仅同队成员可见） */}
       {isTeamMember && (
         <section>
           <Panel label="队内联系方式" pad={20}>
@@ -392,9 +526,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                       {getDisplayName(p)}
                     </Link>
                   ) : (
-                    <span className="text-sm font-medium text-[var(--color-fg)]">
-                      {getDisplayName(p)}
-                    </span>
+                    <span className="text-sm font-medium text-[var(--color-fg)]">{getDisplayName(p)}</span>
                   )}
                   <div className="flex items-center gap-4 text-sm text-[var(--color-fg-mid)]">
                     {p.qq && <span>QQ: {p.qq}</span>}
@@ -407,150 +539,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 队伍数据 */}
-      {teamAvgRating && (
-        <section>
-          <Panel label="队伍数据" pad={20}>
-            <div className="space-y-4">
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
-                <Stat label="场均 Rating" value={teamAvgRating ?? "—"} accent />
-                <Stat label="场均 ADR" value={teamAvgAdr ?? "—"} accent />
-                <Stat label="场均 K/D" value={teamAvgKd ?? "—"} accent />
-                <Stat label="场均 WE" value={teamAvgWe ?? "—"} accent />
-              </div>
-              {positionBest.size > 0 && (
-                <div className="text-[11px] text-[var(--color-fg-dim)] border-t border-[var(--color-border)] pt-3">
-                  {[...positionBest.entries()]
-                    .map(([pos, info], i) => {
-                      const label =
-                        POSITION_LABELS[pos as keyof typeof POSITION_LABELS]?.cn ?? pos;
-                      return (
-                        <span key={pos}>
-                          {i > 0 && " · "}
-                          {label}{" "}
-                          {info.userId ? (
-                            <Link href={`/players/${info.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
-                              {info.name}
-                            </Link>
-                          ) : (
-                            info.name
-                          )}
-                          {" "}({info.rating.toFixed(2)})
-                        </span>
-                      );
-                    })}
-                </div>
-              )}
-            </div>
-          </Panel>
-        </section>
-      )}
-
-      {/* 地图表现 */}
-      <section>
-        <Panel pad={0} className="overflow-hidden" label="地图表现">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm min-w-[340px]">
-              <thead>
-                <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
-                  <th className="px-5 py-3 text-left font-medium">地图</th>
-                  <th className="px-5 py-3 text-center font-medium">胜率</th>
-                  <th className="px-5 py-3 text-center font-medium">ban 率</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--color-border)]">
-                {seasonMapPool.map((mapName) => {
-                  const stat = mapStats.get(mapName);
-                  const bans = banCount.get(mapName) ?? 0;
-                  return (
-                    <tr key={mapName}>
-                      <td className="px-5 py-3 font-medium text-[var(--color-fg)]">
-                        {mapLabel(mapName)}
-                      </td>
-                      <td className="px-5 py-3 text-center">
-                        {stat !== undefined ? (() => {
-                          const wr = pct(stat.wins, stat.played);
-                          return (
-                            <>
-                              <div
-                                className="font-semibold"
-                                style={{ color: wr.color }}
-                              >
-                                {wr.text}
-                              </div>
-                              <div className="text-xs text-[var(--color-fg-mid)]">{stat.played} 场</div>
-                            </>
-                          );
-                        })() : (
-                          <span className="text-[var(--color-fg-dim)]">—</span>
-                        )}
-                      </td>
-                      <td className="px-5 py-3 text-center">
-                        {bpMatchCount > 0 ? (
-                          <>
-                            <div className="font-semibold text-[var(--color-fg)]">
-                              {pct(bans, bpMatchCount).text}
-                            </div>
-                            <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
-                          </>
-                        ) : (
-                          <span className="text-[var(--color-fg-dim)]">—</span>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </Panel>
-      </section>
-
-      {/* 历史对阵 */}
-      {h2hList.length > 0 && (
-        <section>
-          <Panel pad={0} className="overflow-hidden" label="历史对阵">
-            <div className="overflow-x-auto">
-            <table className="w-full text-sm min-w-[320px]">
-              <thead>
-                <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
-                  <th className="px-5 py-3 text-left font-medium">对手</th>
-                  <th className="px-5 py-3 text-center font-medium">胜</th>
-                  <th className="px-5 py-3 text-center font-medium">负</th>
-                  <th className="px-5 py-3 text-right font-medium">胜率</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--color-border)]">
-                {h2hList.map((h) => {
-                  const opp = teamNameMap.get(h.opponentId);
-                  return (
-                    <tr key={h.opponentId}>
-                      <td className="px-5 py-3 font-medium text-[var(--color-fg)]">
-                        {opp ? (
-                          <Link
-                            href={`/${seasonSlug}/teams/${opp.id}`}
-                            className="hover:underline hover:text-[var(--color-accent)]"
-                          >
-                            {opp.name}
-                          </Link>
-                        ) : "未知队伍"}
-                      </td>
-                      <td className="px-5 py-3 text-center text-[var(--color-ok)]">{h.wins}</td>
-                      <td className="px-5 py-3 text-center text-[var(--color-danger)]">{h.losses}</td>
-                      <td className="px-5 py-3 text-right font-semibold text-[var(--color-fg)]">
-                        {pct(h.wins, h.wins + h.losses).text}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-            </div>
-          </Panel>
-        </section>
-      )}
-
-      {/* 无赛果时的空态 */}
+      {/* 无赛果空态 */}
       {played === 0 && (
         <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
           暂无比赛记录

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,11 +34,17 @@
   --color-fg-mid: #8e96a3;
   --color-fg-dim: #525a6a;
 
-  /* Accent */
+  /* Accent (team A) */
   --color-accent: #ff6b1a;
   --color-accent-soft: rgba(255, 107, 26, 0.12);
   --color-accent-edge: rgba(255, 107, 26, 0.34);
   --color-accent-fg: #0a0c10;
+
+  /* Accent B (team B / contrasting entity) */
+  --color-accent-b: #3aa1ff;
+  --color-accent-b-soft: rgba(58, 161, 255, 0.12);
+  --color-accent-b-edge: rgba(58, 161, 255, 0.34);
+  --color-accent-b-fg: #0a0c10;
 
   /* Status */
   --color-ok: #4dd47a;

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -10,6 +10,8 @@ import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
 import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
 import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
 import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
+import { CompletedAtInput } from "@/components/matches/CompletedAtInput";
+import { toCSTDateTimeInput } from "@/lib/utils/date";
 import { MATCH_FORMAT_LABELS } from "@/types/match";
 
 export interface TeamMemberData {
@@ -39,6 +41,7 @@ interface AdminMatchRowProps {
     teamAId: string;
     teamBId: string;
     bracketNodeId: string | null;
+    completedAt: Date | null;
   };
   teamAName: string;
   teamBName: string;
@@ -172,6 +175,10 @@ export function AdminMatchRow({
                   format={match.format}
                   currentScoreA={match.scoreA}
                   currentScoreB={match.scoreB}
+                />
+                <CompletedAtInput
+                  matchId={match.id}
+                  initialValue={toCSTDateTimeInput(match.completedAt)}
                 />
                 {finishedMaps.map((map) => (
                   <div key={map.id}>

--- a/src/components/matches/CompletedAtInput.tsx
+++ b/src/components/matches/CompletedAtInput.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { updateMatchCompletedAt } from "@/actions/matches";
+
+interface CompletedAtInputProps {
+  matchId: string;
+  initialValue: string | null;
+}
+
+export function CompletedAtInput({ matchId, initialValue }: CompletedAtInputProps) {
+  const [value, setValue] = useState(initialValue ?? "");
+  const [isPending, startTransition] = useTransition();
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await updateMatchCompletedAt(matchId, value || null);
+      if (result.success) {
+        toast.success(value ? "完成时间已更新" : "完成时间已清除");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handleClear() {
+    setValue("");
+    startTransition(async () => {
+      const result = await updateMatchCompletedAt(matchId, null);
+      if (result.success) {
+        toast.success("完成时间已清除");
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-[var(--color-fg-mid)] shrink-0">完成时间（CST）</span>
+      <Input
+        type="datetime-local"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="w-48 text-xs h-8"
+        disabled={isPending}
+      />
+      <Button size="sm" variant="outline" className="h-8 text-xs" onClick={handleSave} disabled={isPending}>
+        保存
+      </Button>
+      {initialValue && (
+        <Button size="sm" variant="ghost" className="h-8 text-xs text-[var(--color-fg-mid)]" onClick={handleClear} disabled={isPending}>
+          清除
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/matches/MapPoolRadarChart.tsx
+++ b/src/components/matches/MapPoolRadarChart.tsx
@@ -17,9 +17,10 @@ interface MapPoolRadarChartProps {
   teamBData: Map<string, MapData>;
 }
 
-const A_COLOR = "rgba(255,107,26,0.25)";
+// 对应 --color-accent / --color-accent-b；SVG 表现属性不支持 CSS var，用匹配常量
+const A_FILL = "rgba(255,107,26,0.25)";
 const A_STROKE = "#ff6b1a";
-const B_COLOR = "rgba(58,161,255,0.25)";
+const B_FILL = "rgba(58,161,255,0.25)";
 const B_STROKE = "#3aa1ff";
 
 const METRICS = [
@@ -151,7 +152,7 @@ export function MapPoolRadarChart({
         {/* Team B polygon */}
         <polygon
           points={dataPolygon(teamBData)}
-          fill={B_COLOR}
+          fill={B_FILL}
           stroke={B_STROKE}
           strokeWidth={1.5}
         />
@@ -159,7 +160,7 @@ export function MapPoolRadarChart({
         {/* Team A polygon */}
         <polygon
           points={dataPolygon(teamAData)}
-          fill={A_COLOR}
+          fill={A_FILL}
           stroke={A_STROKE}
           strokeWidth={1.5}
         />
@@ -184,11 +185,11 @@ export function MapPoolRadarChart({
 
         {/* Legend */}
         <g transform="translate(272, 340)">
-          <rect x={0} y={0} width={10} height={10} fill={A_COLOR} stroke={A_STROKE} strokeWidth={1} />
+          <rect x={0} y={0} width={10} height={10} fill={A_FILL} stroke={A_STROKE} strokeWidth={1} />
           <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamAName}</text>
         </g>
         <g transform="translate(272, 356)">
-          <rect x={0} y={0} width={10} height={10} fill={B_COLOR} stroke={B_STROKE} strokeWidth={1} />
+          <rect x={0} y={0} width={10} height={10} fill={B_FILL} stroke={B_STROKE} strokeWidth={1} />
           <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamBName}</text>
         </g>
       </svg>

--- a/src/components/matches/MapPoolRadarChart.tsx
+++ b/src/components/matches/MapPoolRadarChart.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState } from "react";
+import { mapLabel } from "@/lib/maps";
+
+interface MapData {
+  winRate: number;
+  pickRate: number;
+  banRate: number;
+}
+
+interface MapPoolRadarChartProps {
+  mapPool: string[];
+  teamAName: string;
+  teamBName: string;
+  teamAData: Map<string, MapData>;
+  teamBData: Map<string, MapData>;
+}
+
+const A_COLOR = "rgba(255,107,26,0.25)";
+const A_STROKE = "#ff6b1a";
+const B_COLOR = "rgba(58,161,255,0.25)";
+const B_STROKE = "#3aa1ff";
+
+const METRICS = [
+  { key: "win" as const, label: "Win%" },
+  { key: "pick" as const, label: "Pick%" },
+  { key: "ban" as const, label: "Ban%" },
+];
+
+function getMetricValue(data: MapData | undefined, metric: "win" | "pick" | "ban"): number {
+  if (!data) return 0;
+  if (metric === "win") return data.winRate;
+  if (metric === "pick") return data.pickRate;
+  return data.banRate;
+}
+
+export function MapPoolRadarChart({
+  mapPool,
+  teamAName,
+  teamBName,
+  teamAData,
+  teamBData,
+}: MapPoolRadarChartProps) {
+  const [metric, setMetric] = useState<"win" | "pick" | "ban">("win");
+
+  const n = mapPool.length;
+  const cx = 200;
+  const cy = 200;
+  const r = 140;
+
+  const angle = (i: number) => ((i / n) * 2 * Math.PI) - Math.PI / 2;
+  const vertex = (i: number) => ({
+    x: cx + r * Math.cos(angle(i)),
+    y: cy + r * Math.sin(angle(i)),
+  });
+  const dataPoint = (i: number, value: number) => {
+    const a = angle(i);
+    const d = (value / 100) * r;
+    return { x: cx + d * Math.cos(a), y: cy + d * Math.sin(a) };
+  };
+
+  const gridLevels = [0.25, 0.5, 0.75, 1.0];
+
+  const gridPolygon = (scale: number) => {
+    const points = Array.from({ length: n }, (_, i) => {
+      const a = angle(i);
+      return `${cx + r * scale * Math.cos(a)},${cy + r * scale * Math.sin(a)}`;
+    });
+    return points.join(" ");
+  };
+
+  const dataPolygon = (teamData: Map<string, MapData>) => {
+    const points = mapPool.map((map, i) => {
+      const val = getMetricValue(teamData.get(map), metric);
+      const pt = dataPoint(i, val);
+      return `${pt.x},${pt.y}`;
+    });
+    return points.join(" ");
+  };
+
+  const labelPos = (i: number) => {
+    const a = angle(i);
+    const dist = r + 22;
+    return {
+      x: cx + dist * Math.cos(a),
+      y: cy + dist * Math.sin(a),
+    };
+  };
+
+  if (n === 0) return null;
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {/* Metric toggle */}
+      <div className="flex gap-1">
+        {METRICS.map((m) => (
+          <button
+            key={m.key}
+            onClick={() => setMetric(m.key)}
+            className="px-3 py-1 text-xs rounded transition-colors"
+            style={{
+              background:
+                metric === m.key
+                  ? "var(--color-accent)"
+                  : "var(--color-panel-hi)",
+              color:
+                metric === m.key
+                  ? "#fff"
+                  : "var(--color-fg-mid)",
+              border: "1px solid var(--color-border)",
+            }}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {/* SVG radar */}
+      <svg viewBox="0 0 400 380" className="w-full max-w-[400px]">
+        {/* Grid rings */}
+        {gridLevels.map((scale) => (
+          <polygon
+            key={scale}
+            points={gridPolygon(scale)}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            strokeDasharray="4 3"
+            opacity={0.6}
+          />
+        ))}
+
+        {/* Axis lines */}
+        {Array.from({ length: n }, (_, i) => {
+          const v = vertex(i);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={v.x}
+              y2={v.y}
+              stroke="var(--color-border)"
+              strokeWidth={1}
+              opacity={0.4}
+            />
+          );
+        })}
+
+        {/* Team B polygon */}
+        <polygon
+          points={dataPolygon(teamBData)}
+          fill={B_COLOR}
+          stroke={B_STROKE}
+          strokeWidth={1.5}
+        />
+
+        {/* Team A polygon */}
+        <polygon
+          points={dataPolygon(teamAData)}
+          fill={A_COLOR}
+          stroke={A_STROKE}
+          strokeWidth={1.5}
+        />
+
+        {/* Map labels */}
+        {mapPool.map((map, i) => {
+          const pos = labelPos(i);
+          return (
+            <text
+              key={map}
+              x={pos.x}
+              y={pos.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={10}
+              fill="var(--color-fg-mid)"
+            >
+              {mapLabel(map)}
+            </text>
+          );
+        })}
+
+        {/* Legend */}
+        <g transform="translate(272, 340)">
+          <rect x={0} y={0} width={10} height={10} fill={A_COLOR} stroke={A_STROKE} strokeWidth={1} />
+          <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamAName}</text>
+        </g>
+        <g transform="translate(272, 356)">
+          <rect x={0} y={0} width={10} height={10} fill={B_COLOR} stroke={B_STROKE} strokeWidth={1} />
+          <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamBName}</text>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/matches/MatchHeadToHead.tsx
+++ b/src/components/matches/MatchHeadToHead.tsx
@@ -46,10 +46,10 @@ export function MatchHeadToHead({
           {teamAWins} 胜
         </span>
         <span className="text-sm" style={{ color: "var(--color-fg-dim)" }}>vs</span>
-        <span className="font-mono font-bold text-base" style={{ color: "#3aa1ff" }}>
+        <span className="font-mono font-bold text-base" style={{ color: "var(--color-accent-b)" }}>
           {teamBWins} 胜
         </span>
-        <span className="font-bold text-sm" style={{ color: "#3aa1ff" }}>
+        <span className="font-bold text-sm" style={{ color: "var(--color-accent-b)" }}>
           {teamBName}
         </span>
       </div>

--- a/src/components/matches/MatchHeadToHead.tsx
+++ b/src/components/matches/MatchHeadToHead.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+import { Panel } from "@/components/rivalhub";
+import { formatCSTDateTime } from "@/lib/utils/date";
+import { MATCH_STAGE_LABELS, MATCH_FORMAT_LABELS } from "@/types/match";
+
+interface H2HMatch {
+  matchId: string;
+  scheduledAt: Date | null;
+  completedAt: Date | null;
+  stage: string;
+  format: string;
+  scoreA: number;
+  scoreB: number;
+  teamAWon: boolean;
+}
+
+interface MatchHeadToHeadProps {
+  teamAName: string;
+  teamBName: string;
+  teamAWins: number;
+  teamBWins: number;
+  matches: H2HMatch[];
+  seasonSlug: string;
+}
+
+export function MatchHeadToHead({
+  teamAName,
+  teamBName,
+  teamAWins,
+  teamBWins,
+  matches,
+  seasonSlug,
+}: MatchHeadToHeadProps) {
+  if (matches.length === 0) return null;
+
+  const displayed = matches.slice(0, 10);
+
+  return (
+    <Panel label="历史交锋">
+      {/* 汇总标题行 */}
+      <div className="flex items-center justify-center gap-3 pb-4 mb-2 border-b border-[var(--color-border)]">
+        <span className="font-bold text-sm" style={{ color: "var(--color-accent)" }}>
+          {teamAName}
+        </span>
+        <span className="font-mono font-bold text-base" style={{ color: "var(--color-accent)" }}>
+          {teamAWins} 胜
+        </span>
+        <span className="text-sm" style={{ color: "var(--color-fg-dim)" }}>vs</span>
+        <span className="font-mono font-bold text-base" style={{ color: "#3aa1ff" }}>
+          {teamBWins} 胜
+        </span>
+        <span className="font-bold text-sm" style={{ color: "#3aa1ff" }}>
+          {teamBName}
+        </span>
+      </div>
+
+      {/* 比赛列表 */}
+      <div className="space-y-1">
+        {displayed.map((m) => {
+          const displayTime = m.completedAt ?? m.scheduledAt;
+          const stageLabel = MATCH_STAGE_LABELS[m.stage] ?? m.stage;
+          const formatLabel = MATCH_FORMAT_LABELS[m.format as keyof typeof MATCH_FORMAT_LABELS] ?? m.format.toUpperCase();
+
+          return (
+            <div
+              key={m.matchId}
+              className="grid grid-cols-[1fr_auto_auto_auto] gap-3 items-center py-2 border-b border-[var(--color-border)] last:border-0 text-sm"
+            >
+              {/* 日期 */}
+              <div style={{ color: "var(--color-fg-dim)", fontSize: 12 }}>
+                {displayTime ? formatCSTDateTime(displayTime) : "—"}
+              </div>
+
+              {/* 阶段 + 赛制 */}
+              <div style={{ color: "var(--color-fg-mid)", fontSize: 12, whiteSpace: "nowrap" }}>
+                {stageLabel} · {formatLabel}
+              </div>
+
+              {/* 比分链接 */}
+              <Link
+                href={`/${seasonSlug}/matches/${m.matchId}`}
+                className="font-mono font-semibold text-sm hover:underline"
+                style={{ color: "var(--color-fg)", whiteSpace: "nowrap" }}
+              >
+                {m.scoreA} : {m.scoreB}
+              </Link>
+
+              {/* 胜负（相对 A 队） */}
+              <div
+                className="font-mono text-xs font-bold w-4 text-center"
+                style={{ color: m.teamAWon ? "var(--color-ok)" : "var(--color-danger)" }}
+              >
+                {m.teamAWon ? "✓" : "✗"}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/matches/MatchLineupsH2H.tsx
+++ b/src/components/matches/MatchLineupsH2H.tsx
@@ -23,7 +23,7 @@ interface MatchLineupsH2HProps {
 }
 
 const A_COLOR = "var(--color-accent)";
-const B_COLOR = "#3aa1ff";
+const B_COLOR = "var(--color-accent-b)";
 
 function CompareBar({
   aVal,

--- a/src/components/matches/MatchLineupsH2H.tsx
+++ b/src/components/matches/MatchLineupsH2H.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+interface PlayerStats {
+  userId: string | null;
+  perfectName: string;
+  maps: number;
+  avgRating: number;
+  avgAdr: number;
+  kdRatio: number | null;
+  avgHs: number;
+  avgFk: number;
+  avgWe: number;
+}
+
+interface MatchLineupsH2HProps {
+  teamAName: string;
+  teamBName: string;
+  teamAPlayers: PlayerStats[];
+  teamBPlayers: PlayerStats[];
+}
+
+const A_COLOR = "var(--color-accent)";
+const B_COLOR = "#3aa1ff";
+
+function CompareBar({
+  aVal,
+  bVal,
+}: {
+  aVal: number;
+  bVal: number;
+}) {
+  const total = aVal + bVal;
+  const aPct = total > 0 ? (aVal / total) * 100 : 50;
+  return (
+    <div className="flex h-1.5 rounded overflow-hidden w-full">
+      <div style={{ width: `${aPct}%`, background: A_COLOR }} />
+      <div style={{ width: `${100 - aPct}%`, background: B_COLOR }} />
+    </div>
+  );
+}
+
+interface StatRowProps {
+  label: string;
+  aVal: number;
+  bVal: number;
+  format?: (v: number) => string;
+  showBar?: boolean;
+}
+
+function StatRow({ label, aVal, bVal, format, showBar = true }: StatRowProps) {
+  const fmt = format ?? ((v: number) => v.toString());
+  const aWins = aVal >= bVal;
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="w-20 text-[11px] text-[var(--color-fg-dim)] shrink-0">
+        {label}
+      </span>
+      <span
+        className="w-16 text-right text-xs tabular-nums shrink-0 font-medium"
+        style={{ color: aWins ? A_COLOR : "var(--color-fg-mid)" }}
+      >
+        {fmt(aVal)}
+      </span>
+      {showBar ? (
+        <div className="flex-1 min-w-0">
+          <CompareBar aVal={aVal} bVal={bVal} />
+        </div>
+      ) : (
+        <div className="flex-1" />
+      )}
+      <span
+        className="w-16 text-left text-xs tabular-nums shrink-0 font-medium"
+        style={{ color: !aWins ? B_COLOR : "var(--color-fg-mid)" }}
+      >
+        {fmt(bVal)}
+      </span>
+    </div>
+  );
+}
+
+function PlayerButton({
+  player,
+  selected,
+  side,
+  onClick,
+}: {
+  player: PlayerStats;
+  selected: boolean;
+  side: "a" | "b";
+  onClick: () => void;
+}) {
+  const color = side === "a" ? A_COLOR : B_COLOR;
+  return (
+    <button
+      onClick={onClick}
+      className="px-2 py-1 text-xs rounded transition-all"
+      style={{
+        background: selected ? `${color}22` : "var(--color-panel-hi)",
+        color: selected ? color : "var(--color-fg-mid)",
+        border: `1px solid ${selected ? color : "var(--color-border)"}`,
+        outline: selected ? `1px solid ${color}` : "none",
+        outlineOffset: "1px",
+      }}
+    >
+      {player.perfectName}
+    </button>
+  );
+}
+
+export function MatchLineupsH2H({
+  teamAName,
+  teamBName,
+  teamAPlayers,
+  teamBPlayers,
+}: MatchLineupsH2HProps) {
+  const [aIdx, setAIdx] = useState(0);
+  const [bIdx, setBIdx] = useState(0);
+
+  const pa = teamAPlayers[aIdx];
+  const pb = teamBPlayers[bIdx];
+
+  if (!pa || !pb) {
+    return (
+      <p className="text-xs text-[var(--color-fg-dim)] py-2">暂无阵容数据</p>
+    );
+  }
+
+  const kdA = pa.kdRatio ?? 0;
+  const kdB = pb.kdRatio ?? 0;
+
+  return (
+    <div
+      className="rounded-md overflow-hidden"
+      style={{ border: "1px solid var(--color-border)" }}
+    >
+      {/* Team A player selector */}
+      <div
+        className="flex flex-wrap gap-1.5 px-3 py-2"
+        style={{ borderBottom: "1px solid var(--color-border)", background: "var(--color-panel-hi)" }}
+      >
+        <span className="text-[10px] text-[var(--color-fg-dim)] self-center mr-1 shrink-0">
+          {teamAName}
+        </span>
+        {teamAPlayers.map((p, i) => (
+          <PlayerButton
+            key={p.perfectName}
+            player={p}
+            selected={i === aIdx}
+            side="a"
+            onClick={() => setAIdx(i)}
+          />
+        ))}
+      </div>
+
+      {/* H2H content */}
+      <div className="px-3 py-3">
+        {/* Player names header */}
+        <div className="flex items-center gap-2 mb-3">
+          <div className="w-20 shrink-0" />
+          <div className="w-16 text-right shrink-0">
+            {pa.userId ? (
+              <Link
+                href={`/players/${pa.userId}`}
+                className="text-sm font-semibold hover:opacity-80 transition-opacity truncate block"
+                style={{ color: A_COLOR }}
+              >
+                {pa.perfectName}
+              </Link>
+            ) : (
+              <span className="text-sm font-semibold truncate block" style={{ color: A_COLOR }}>
+                {pa.perfectName}
+              </span>
+            )}
+          </div>
+          <div className="flex-1 text-center text-xs text-[var(--color-fg-dim)] shrink-0">vs</div>
+          <div className="w-16 text-left shrink-0">
+            {pb.userId ? (
+              <Link
+                href={`/players/${pb.userId}`}
+                className="text-sm font-semibold hover:opacity-80 transition-opacity truncate block"
+                style={{ color: B_COLOR }}
+              >
+                {pb.perfectName}
+              </Link>
+            ) : (
+              <span className="text-sm font-semibold truncate block" style={{ color: B_COLOR }}>
+                {pb.perfectName}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Maps row — no bar */}
+        <div className="flex items-center gap-2 py-1">
+          <span className="w-20 text-[11px] text-[var(--color-fg-dim)] shrink-0">图数</span>
+          <span className="w-16 text-right text-xs tabular-nums shrink-0 text-[var(--color-fg-mid)]">
+            {pa.maps}
+          </span>
+          <div className="flex-1 text-center text-[10px] text-[var(--color-fg-dim)]">—</div>
+          <span className="w-16 text-left text-xs tabular-nums shrink-0 text-[var(--color-fg-mid)]">
+            {pb.maps}
+          </span>
+        </div>
+
+        <StatRow
+          label="Rating"
+          aVal={pa.avgRating}
+          bVal={pb.avgRating}
+          format={(v) => v.toFixed(2)}
+        />
+        <StatRow
+          label="ADR"
+          aVal={pa.avgAdr}
+          bVal={pb.avgAdr}
+          format={(v) => v.toFixed(1)}
+        />
+        <StatRow
+          label="K/D"
+          aVal={kdA}
+          bVal={kdB}
+          format={(v) => v.toFixed(2)}
+        />
+        <StatRow
+          label="HS%"
+          aVal={pa.avgHs}
+          bVal={pb.avgHs}
+          format={(v) => `${v.toFixed(0)}%`}
+        />
+        <StatRow
+          label="首杀/图"
+          aVal={pa.avgFk}
+          bVal={pb.avgFk}
+          format={(v) => v.toFixed(1)}
+        />
+        <StatRow
+          label="WE"
+          aVal={pa.avgWe}
+          bVal={pb.avgWe}
+          format={(v) => v.toFixed(1)}
+        />
+      </div>
+
+      {/* Team B player selector */}
+      <div
+        className="flex flex-wrap gap-1.5 px-3 py-2"
+        style={{ borderTop: "1px solid var(--color-border)", background: "var(--color-panel-hi)" }}
+      >
+        <span className="text-[10px] text-[var(--color-fg-dim)] self-center mr-1 shrink-0">
+          {teamBName}
+        </span>
+        {teamBPlayers.map((p, i) => (
+          <PlayerButton
+            key={p.perfectName}
+            player={p}
+            selected={i === bIdx}
+            side="b"
+            onClick={() => setBIdx(i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -180,7 +180,7 @@ export function MatchMvpVote({
         </span>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 gap-3">
         {candidates.map((c) => {
           const v = optimisticVotes.find((x) => x.playerName === c.perfectName);
           const count = v?.count ?? 0;

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Panel } from "@/components/rivalhub";
 
-interface SummaryPlayer {
+export interface SummaryPlayer {
   userId: string | null;
   perfectName: string;
   teamId: string;
@@ -198,7 +198,7 @@ export function MatchSummaryStats({
             {teamBPlayers.length > 0 && (
               <TeamSection
                 teamName={teamBName}
-                teamColor="#3aa1ff"
+                teamColor="var(--color-accent-b)"
                 players={teamBPlayers}
                 seasonSlug={seasonSlug}
               />

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -1,0 +1,211 @@
+import Link from "next/link";
+import { Panel } from "@/components/rivalhub";
+
+interface SummaryPlayer {
+  userId: string | null;
+  perfectName: string;
+  teamId: string;
+  kills: number;
+  deaths: number;
+  assists: number;
+  hsPercent: number | null;
+  firstKills: number;
+  multiKills: number;
+  clutches: number;
+  adr: number | null;
+  rws: number | null;
+  ratingPro: number | null;
+  we: number | null;
+  mapsPlayed: number;
+}
+
+interface MatchSummaryStatsProps {
+  players: SummaryPlayer[];
+  teamAId: string;
+  teamBId: string;
+  teamAName: string;
+  teamBName: string;
+  seasonSlug: string;
+}
+
+const COL_HEADER_STYLE: React.CSSProperties = {
+  color: "var(--color-fg-dim)",
+  fontSize: 11,
+  fontWeight: 700,
+  letterSpacing: "0.05em",
+  textTransform: "uppercase" as const,
+  textAlign: "right" as const,
+  padding: "4px 8px",
+  whiteSpace: "nowrap",
+};
+
+const CELL_STYLE: React.CSSProperties = {
+  color: "var(--color-fg)",
+  fontSize: 13,
+  textAlign: "right" as const,
+  padding: "6px 8px",
+  fontFamily: "var(--font-mono)",
+  whiteSpace: "nowrap",
+};
+
+function fmt1(v: number | null): string {
+  return v != null ? v.toFixed(1) : "—";
+}
+
+function fmt2(v: number | null): string {
+  return v != null ? v.toFixed(2) : "—";
+}
+
+function fmtPct(v: number | null): string {
+  return v != null ? `${v.toFixed(0)}%` : "—";
+}
+
+interface PlayerRowProps {
+  player: SummaryPlayer;
+  seasonSlug: string;
+}
+
+function PlayerRow({ player, seasonSlug }: PlayerRowProps) {
+  const ratingHigh = player.ratingPro != null && player.ratingPro >= 1.2;
+
+  return (
+    <tr className="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-panel-hi)] transition-colors">
+      {/* 选手名 */}
+      <td style={{ padding: "6px 8px", whiteSpace: "nowrap" }}>
+        {player.userId ? (
+          <Link
+            href={`/players/${player.userId}`}
+            className="text-sm font-medium hover:underline"
+            style={{ color: "var(--color-fg)" }}
+          >
+            {player.perfectName}
+          </Link>
+        ) : (
+          <span className="text-sm" style={{ color: "var(--color-fg)" }}>
+            {player.perfectName}
+          </span>
+        )}
+      </td>
+
+      {/* 图数 */}
+      <td style={CELL_STYLE}>{player.mapsPlayed}</td>
+
+      {/* Rating */}
+      <td
+        style={{
+          ...CELL_STYLE,
+          color: ratingHigh ? "var(--color-accent)" : "var(--color-fg)",
+          fontWeight: ratingHigh ? 700 : 400,
+        }}
+      >
+        {fmt2(player.ratingPro)}
+      </td>
+
+      {/* ADR */}
+      <td style={CELL_STYLE}>{fmt1(player.adr)}</td>
+
+      {/* K */}
+      <td style={CELL_STYLE}>{player.kills}</td>
+
+      {/* D */}
+      <td style={{ ...CELL_STYLE, color: "var(--color-fg-mid)" }}>{player.deaths}</td>
+
+      {/* A */}
+      <td style={CELL_STYLE}>{player.assists}</td>
+
+      {/* HS% */}
+      <td style={CELL_STYLE}>{fmtPct(player.hsPercent)}</td>
+
+      {/* FK */}
+      <td style={CELL_STYLE}>{player.firstKills}</td>
+
+      {/* 残局 */}
+      <td style={CELL_STYLE}>{player.clutches}</td>
+    </tr>
+  );
+}
+
+interface TeamSectionProps {
+  teamName: string;
+  teamColor: string;
+  players: SummaryPlayer[];
+  seasonSlug: string;
+}
+
+function TeamSection({ teamName, teamColor, players, seasonSlug }: TeamSectionProps) {
+  return (
+    <>
+      <tr>
+        <td
+          colSpan={10}
+          style={{
+            padding: "10px 8px 4px",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: teamColor,
+          }}
+        >
+          {teamName}
+        </td>
+      </tr>
+      {players.map((p) => (
+        <PlayerRow key={p.userId ?? p.perfectName} player={p} seasonSlug={seasonSlug} />
+      ))}
+    </>
+  );
+}
+
+export function MatchSummaryStats({
+  players,
+  teamAId,
+  teamBId,
+  teamAName,
+  teamBName,
+  seasonSlug,
+}: MatchSummaryStatsProps) {
+  const teamAPlayers = players.filter((p) => p.teamId === teamAId);
+  const teamBPlayers = players.filter((p) => p.teamId === teamBId);
+
+  return (
+    <Panel pad={0}>
+      <div className="overflow-x-auto">
+        <table className="w-full" style={{ minWidth: 600 }}>
+          <thead>
+            <tr className="border-b border-[var(--color-border)]">
+              <th style={{ ...COL_HEADER_STYLE, textAlign: "left" }}>选手</th>
+              <th style={COL_HEADER_STYLE}>图数</th>
+              <th style={COL_HEADER_STYLE}>Rating</th>
+              <th style={COL_HEADER_STYLE}>ADR</th>
+              <th style={COL_HEADER_STYLE}>K</th>
+              <th style={COL_HEADER_STYLE}>D</th>
+              <th style={COL_HEADER_STYLE}>A</th>
+              <th style={COL_HEADER_STYLE}>HS%</th>
+              <th style={COL_HEADER_STYLE}>FK</th>
+              <th style={COL_HEADER_STYLE}>残局</th>
+            </tr>
+          </thead>
+          <tbody>
+            {teamAPlayers.length > 0 && (
+              <TeamSection
+                teamName={teamAName}
+                teamColor="var(--color-accent)"
+                players={teamAPlayers}
+                seasonSlug={seasonSlug}
+              />
+            )}
+            {teamBPlayers.length > 0 && (
+              <TeamSection
+                teamName={teamBName}
+                teamColor="#3aa1ff"
+                players={teamBPlayers}
+                seasonSlug={seasonSlug}
+              />
+            )}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -12,9 +12,13 @@ interface LeaderboardRow {
   maps: number;
   avgRating: number;
   avgAdr: number;
-  avgKills: number;
-  avgDeaths: number;
+  avgRws: number;
   avgWe: number;
+  avgHs: number;
+  kdRatio: number | null;
+  kpr: number;
+  avgFk: number;
+  avgClutch: number;
 }
 
 interface StatsLeaderboardProps {
@@ -25,39 +29,98 @@ interface StatsLeaderboardProps {
 }
 
 const SORT_OPTIONS = [
-  { key: "rating", label: "Rating" },
-  { key: "adr", label: "ADR" },
-  { key: "kd", label: "K/D" },
-  { key: "we", label: "WE" },
-  { key: "kpr", label: "KPR" },
-  { key: "maps", label: "场次" },
+  { key: "rating",  label: "Rating" },
+  { key: "adr",     label: "ADR" },
+  { key: "kd",      label: "K/D" },
+  { key: "kpr",     label: "KPR" },
+  { key: "hs",      label: "HS%" },
+  { key: "we",      label: "WE" },
+  { key: "rws",     label: "RWS" },
+  { key: "fk",      label: "首杀" },
+  { key: "clutch",  label: "残局" },
+  { key: "maps",    label: "场次" },
 ];
 
 const POSITIONS = [
-  { key: "", label: "全部位置" },
-  { key: "igl", label: "IGL" },
-  { key: "awper", label: "AWPer" },
+  { key: "",        label: "全部" },
+  { key: "igl",    label: "IGL" },
+  { key: "awper",  label: "AWPer" },
   { key: "opener", label: "Opener" },
   { key: "closer", label: "Closer" },
   { key: "anchor", label: "Anchor" },
 ];
 
-// 列 key → 表格列对应关系
-const SORT_COL_MAP: Record<string, string> = {
-  rating: "rating",
-  adr: "adr",
-  kd: "kd",
-  we: "we",
-  kpr: "kpr",
-  maps: "maps",
-};
+interface ColDef {
+  key: string;
+  label: string;
+  getValue: (r: LeaderboardRow) => number | null;
+  format: (v: number | null) => string;
+}
 
-export function StatsLeaderboard({
-  rows,
-  sort,
-  position,
-  seasonSlug,
-}: StatsLeaderboardProps) {
+const COLS: ColDef[] = [
+  {
+    key: "maps",
+    label: "图数",
+    getValue: (r) => r.maps,
+    format: (v) => String(v ?? 0),
+  },
+  {
+    key: "rating",
+    label: "Rating",
+    getValue: (r) => r.avgRating,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "adr",
+    label: "ADR",
+    getValue: (r) => r.avgAdr,
+    format: (v) => (v ?? 0).toFixed(1),
+  },
+  {
+    key: "kd",
+    label: "K/D",
+    getValue: (r) => r.kdRatio,
+    format: (v) => (v != null ? v.toFixed(2) : "—"),
+  },
+  {
+    key: "kpr",
+    label: "KPR",
+    getValue: (r) => r.kpr,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "hs",
+    label: "HS%",
+    getValue: (r) => r.avgHs,
+    format: (v) => (v ?? 0).toFixed(1) + "%",
+  },
+  {
+    key: "we",
+    label: "WE",
+    getValue: (r) => r.avgWe,
+    format: (v) => (v ?? 0).toFixed(1),
+  },
+  {
+    key: "rws",
+    label: "RWS",
+    getValue: (r) => r.avgRws,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "fk",
+    label: "首杀/图",
+    getValue: (r) => r.avgFk,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "clutch",
+    label: "残局/图",
+    getValue: (r) => r.avgClutch,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+];
+
+export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLeaderboardProps) {
   if (rows.length === 0) {
     return (
       <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
@@ -93,134 +156,93 @@ export function StatsLeaderboard({
         ))}
       </div>
 
-      {/* 表格 */}
+      {/* 表格：min-w 确保桌面端不压缩，移动端横向滚动 */}
       <Panel pad={0} className="overflow-hidden">
         <div className="overflow-x-auto">
-        <table className="w-full text-sm min-w-[480px]">
-          <thead>
-            <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
-              <th className="px-4 py-3 text-left w-8">#</th>
-              <th className="px-4 py-3 text-left">选手</th>
-              <th className="px-4 py-3 text-left hidden sm:table-cell">位置</th>
-              <th className="px-4 py-3 text-left hidden sm:table-cell">队伍</th>
-              <th
-                className="px-4 py-3 text-center hidden sm:table-cell"
-                style={SORT_COL_MAP[sort] === "maps" ? { background: sortColBg, color: accentText } : undefined}
-              >
-                图数
-              </th>
-              <th
-                className="px-4 py-3 text-center"
-                style={SORT_COL_MAP[sort] === "rating" ? { background: sortColBg, color: accentText } : undefined}
-              >
-                Rating
-              </th>
-              <th
-                className="px-4 py-3 text-center hidden sm:table-cell"
-                style={SORT_COL_MAP[sort] === "adr" ? { background: sortColBg, color: accentText } : undefined}
-              >
-                ADR
-              </th>
-              <th
-                className="px-4 py-3 text-center hidden sm:table-cell"
-                style={SORT_COL_MAP[sort] === "kd" ? { background: sortColBg, color: accentText } : undefined}
-              >
-                K/D
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-[var(--color-border)]">
-            {rows.map((r, i) => (
-              <tr key={r.userId ?? r.perfectName}>
-                <td className="px-4 py-3 text-xs">
-                  <span
-                    className={i < 3 ? "font-bold" : "text-[var(--color-fg-dim)]"}
-                    style={i < 3 ? { color: accentText } : undefined}
+          <table className="w-full text-sm min-w-[900px]">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
+                <th className="px-3 py-3 text-left w-8">#</th>
+                <th className="px-3 py-3 text-left">选手</th>
+                <th className="px-3 py-3 text-left">位置</th>
+                <th className="px-3 py-3 text-left">队伍</th>
+                {COLS.map((col) => (
+                  <th
+                    key={col.key}
+                    className="px-3 py-3 text-center whitespace-nowrap"
+                    style={sort === col.key ? { background: sortColBg, color: accentText } : undefined}
                   >
-                    {i + 1}
-                  </span>
-                </td>
-                <td className="px-4 py-3 font-medium text-[var(--color-fg)]">
-                  {r.userId ? (
-                    <Link
-                      href={`/players/${r.userId}`}
-                      className="hover:text-[var(--color-accent)] transition-colors"
-                    >
-                      {r.perfectName}
-                    </Link>
-                  ) : (
-                    r.perfectName
-                  )}
-                </td>
-                <td className="px-4 py-3 text-xs text-[var(--color-fg-mid)] hidden sm:table-cell">
-                  {r.position
-                    ? POSITION_LABELS[r.position as keyof typeof POSITION_LABELS]?.cn ?? r.position
-                    : "—"}
-                </td>
-                <td className="px-4 py-3 text-xs text-[var(--color-fg-mid)] hidden sm:table-cell">
-                  {r.teamId ? (
-                    <Link
-                      href={`/${seasonSlug}/teams/${r.teamId}`}
-                      className="hover:text-[var(--color-accent)] transition-colors"
-                    >
-                      {r.teamName ?? "—"}
-                    </Link>
-                  ) : (
-                    r.teamName ?? "—"
-                  )}
-                </td>
-                <td
-                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
-                    sort === "maps" ? "font-semibold" : "text-[var(--color-fg-mid)]"
-                  }`}
-                  style={
-                    sort === "maps"
-                      ? { background: sortColBg, color: accentText }
-                      : undefined
-                  }
-                >
-                  {r.maps}
-                </td>
-                <td
-                  className={`px-4 py-3 text-center tabular-nums font-semibold ${
-                    r.avgRating >= 1.2 || sort === "rating"
-                      ? "text-[var(--color-accent)]"
-                      : "text-[var(--color-fg)]"
-                  }`}
-                  style={sort === "rating" ? { background: sortColBg } : undefined}
-                >
-                  {r.avgRating.toFixed(2)}
-                </td>
-                <td
-                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
-                    sort === "adr" ? "font-semibold" : "text-[var(--color-fg)]"
-                  }`}
-                  style={
-                    sort === "adr"
-                      ? { background: sortColBg, color: accentText }
-                      : undefined
-                  }
-                >
-                  {r.avgAdr.toFixed(1)}
-                </td>
-                <td
-                  className={`px-4 py-3 text-center tabular-nums hidden sm:table-cell ${
-                    sort === "kd" ? "font-semibold" : "text-[var(--color-fg)]"
-                  }`}
-                  style={
-                    sort === "kd"
-                      ? { background: sortColBg, color: accentText }
-                      : undefined
-                  }
-                >
-                  {r.avgDeaths > 0
-                    ? (r.avgKills / r.avgDeaths).toFixed(2)
-                    : "—"}
-                </td>
+                    {col.label}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-[var(--color-border)]">
+              {rows.map((r, i) => (
+                <tr key={r.userId ?? r.perfectName} className="hover:bg-[var(--color-surface-raised)] transition-colors">
+                  <td className="px-3 py-2.5 text-xs">
+                    <span
+                      className={i < 3 ? "font-bold" : "text-[var(--color-fg-dim)]"}
+                      style={i < 3 ? { color: accentText } : undefined}
+                    >
+                      {i + 1}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5 font-medium text-[var(--color-fg)]">
+                    {r.userId ? (
+                      <Link
+                        href={`/players/${r.userId}`}
+                        className="hover:text-[var(--color-accent)] transition-colors"
+                      >
+                        {r.perfectName}
+                      </Link>
+                    ) : (
+                      r.perfectName
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-[var(--color-fg-mid)]">
+                    {r.position
+                      ? (POSITION_LABELS[r.position as keyof typeof POSITION_LABELS]?.cn ?? r.position)
+                      : "—"}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-[var(--color-fg-mid)]">
+                    {r.teamId ? (
+                      <Link
+                        href={`/${seasonSlug}/teams/${r.teamId}`}
+                        className="hover:text-[var(--color-accent)] transition-colors"
+                      >
+                        {r.teamName ?? "—"}
+                      </Link>
+                    ) : (
+                      r.teamName ?? "—"
+                    )}
+                  </td>
+                  {COLS.map((col) => {
+                    const val = col.getValue(r);
+                    const isSort = sort === col.key;
+                    const isHighRating = col.key === "rating" && (val ?? 0) >= 1.2;
+                    return (
+                      <td
+                        key={col.key}
+                        className={`px-3 py-2.5 text-center tabular-nums ${
+                          isSort || isHighRating ? "font-semibold" : "text-[var(--color-fg)]"
+                        }`}
+                        style={
+                          isSort
+                            ? { background: sortColBg, color: accentText }
+                            : isHighRating
+                            ? { color: accentText }
+                            : undefined
+                        }
+                      >
+                        {col.format(val)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </Panel>
     </div>

--- a/src/components/matches/TeamStatsCompare.tsx
+++ b/src/components/matches/TeamStatsCompare.tsx
@@ -27,7 +27,7 @@ function compare(a: number | null, b: number | null): Comparison {
 function numColor(side: "a" | "b", winner: Comparison): string {
   if (winner === "equal") return "var(--color-fg)";
   if (side === "a" && winner === "a") return "var(--color-accent)";
-  if (side === "b" && winner === "b") return "#3aa1ff";
+  if (side === "b" && winner === "b") return "var(--color-accent-b)";
   return "var(--color-fg)";
 }
 
@@ -93,7 +93,7 @@ export function TeamStatsCompare({
         <div className="text-center" />
         <div
           className="text-left text-sm font-bold pl-4 truncate"
-          style={{ color: "#3aa1ff" }}
+          style={{ color: "var(--color-accent-b)" }}
         >
           {teamBName}
         </div>

--- a/src/components/matches/TeamStatsCompare.tsx
+++ b/src/components/matches/TeamStatsCompare.tsx
@@ -1,0 +1,134 @@
+import { Panel } from "@/components/rivalhub";
+
+interface TeamStat {
+  wins: number;
+  losses: number;
+  avgRating: number | null;
+  avgAdr: number | null;
+  avgKd: number | null;
+}
+
+interface TeamStatsCompareProps {
+  teamAName: string;
+  teamBName: string;
+  statA: TeamStat;
+  statB: TeamStat;
+}
+
+type Comparison = "a" | "b" | "equal";
+
+function compare(a: number | null, b: number | null): Comparison {
+  if (a == null || b == null) return "equal";
+  if (a > b) return "a";
+  if (b > a) return "b";
+  return "equal";
+}
+
+function numColor(side: "a" | "b", winner: Comparison): string {
+  if (winner === "equal") return "var(--color-fg)";
+  if (side === "a" && winner === "a") return "var(--color-accent)";
+  if (side === "b" && winner === "b") return "#3aa1ff";
+  return "var(--color-fg)";
+}
+
+interface StatRowProps {
+  label: string;
+  valA: string;
+  valB: string;
+  winner: Comparison;
+}
+
+function StatRow({ label, valA, valB, winner }: StatRowProps) {
+  return (
+    <div className="grid grid-cols-3 items-center py-2 border-b border-[var(--color-border)] last:border-0">
+      <div
+        className="text-right font-mono text-sm font-semibold pr-4"
+        style={{ color: numColor("a", winner) }}
+      >
+        {valA}
+      </div>
+      <div
+        className="text-center text-xs"
+        style={{ color: "var(--color-fg-mid)" }}
+      >
+        {label}
+      </div>
+      <div
+        className="text-left font-mono text-sm font-semibold pl-4"
+        style={{ color: numColor("b", winner) }}
+      >
+        {valB}
+      </div>
+    </div>
+  );
+}
+
+export function TeamStatsCompare({
+  teamAName,
+  teamBName,
+  statA,
+  statB,
+}: TeamStatsCompareProps) {
+  const totalA = statA.wins + statA.losses;
+  const totalB = statB.wins + statB.losses;
+  const wrA = totalA > 0 ? (statA.wins / totalA) * 100 : 0;
+  const wrB = totalB > 0 ? (statB.wins / totalB) * 100 : 0;
+
+  const recordWinner: Comparison = (() => {
+    if (wrA > wrB) return "a";
+    if (wrB > wrA) return "b";
+    return "equal";
+  })();
+
+  return (
+    <Panel label="赛季对比">
+      {/* 队名行 */}
+      <div className="grid grid-cols-3 items-center pb-3 mb-1">
+        <div
+          className="text-right text-sm font-bold pr-4 truncate"
+          style={{ color: "var(--color-accent)" }}
+        >
+          {teamAName}
+        </div>
+        <div className="text-center" />
+        <div
+          className="text-left text-sm font-bold pl-4 truncate"
+          style={{ color: "#3aa1ff" }}
+        >
+          {teamBName}
+        </div>
+      </div>
+
+      <StatRow
+        label="赛季战绩"
+        valA={`${statA.wins}-${statA.losses}`}
+        valB={`${statB.wins}-${statB.losses}`}
+        winner={recordWinner}
+      />
+      <StatRow
+        label="胜率"
+        valA={`${wrA.toFixed(1)}%`}
+        valB={`${wrB.toFixed(1)}%`}
+        winner={compare(wrA, wrB)}
+      />
+      <StatRow
+        label="Rating"
+        valA={statA.avgRating != null ? statA.avgRating.toFixed(2) : "—"}
+        valB={statB.avgRating != null ? statB.avgRating.toFixed(2) : "—"}
+        winner={compare(statA.avgRating, statB.avgRating)}
+      />
+      <StatRow
+        label="ADR"
+        valA={statA.avgAdr != null ? statA.avgAdr.toFixed(1) : "—"}
+        valB={statB.avgAdr != null ? statB.avgAdr.toFixed(1) : "—"}
+        winner={compare(statA.avgAdr, statB.avgAdr)}
+      />
+      <StatRow
+        label="K/D"
+        valA={statA.avgKd != null ? statA.avgKd.toFixed(2) : "—"}
+        valB={statB.avgKd != null ? statB.avgKd.toFixed(2) : "—"}
+        winner={compare(statA.avgKd, statB.avgKd)}
+      />
+    </Panel>
+  );
+}

--- a/src/components/rivalhub/EmptyState.tsx
+++ b/src/components/rivalhub/EmptyState.tsx
@@ -21,11 +21,11 @@ export function EmptyState({
           width: 56,
           height: 56,
           borderColor: accent
-            ? "#ff6b1a55"
+            ? "color-mix(in srgb, var(--color-accent) 33%, transparent)"
             : "var(--color-border)",
-          border: `1px solid ${accent ? "#ff6b1a55" : "var(--color-border)"}`,
+          border: `1px solid ${accent ? "color-mix(in srgb, var(--color-accent) 33%, transparent)" : "var(--color-border)"}`,
           background: accent
-            ? "#ff6b1a10"
+            ? "color-mix(in srgb, var(--color-accent) 6%, transparent)"
             : "var(--color-panel-low)",
           color: accent ? "var(--color-accent)" : "var(--color-fg-dim)",
           borderRadius: "var(--radius-md)",

--- a/src/components/rivalhub/ErrorState.tsx
+++ b/src/components/rivalhub/ErrorState.tsx
@@ -18,9 +18,9 @@ export function ErrorState({
       <div
         className="inline-flex items-center gap-2 px-2.5 py-1 mb-3.5 rounded-sm border"
         style={{
-          borderColor: "#ff547055",
-          background: "#ff547010",
-          color: "#ff5470",
+          borderColor: "color-mix(in srgb, var(--color-danger) 33%, transparent)",
+          background: "color-mix(in srgb, var(--color-danger) 6%, transparent)",
+          color: "var(--color-danger)",
           fontFamily: "var(--font-mono)",
           fontSize: 11,
           letterSpacing: "var(--tracking-label)",

--- a/src/components/rivalhub/InlineConfirm.tsx
+++ b/src/components/rivalhub/InlineConfirm.tsx
@@ -15,14 +15,14 @@ export function InlineConfirm({
   onConfirm,
   onCancel,
 }: InlineConfirmProps) {
-  const c = danger ? "#ff5470" : "#ffc44d";
+  const c = danger ? "var(--color-danger)" : "var(--color-warn)";
   return (
     <div
       className="grid gap-3 items-center rounded-sm border px-4 py-3"
       style={{
         gridTemplateColumns: "1fr auto",
-        background: c + "0d",
-        borderColor: c + "55",
+        background: `color-mix(in srgb, ${c} 5%, transparent)`,
+        borderColor: `color-mix(in srgb, ${c} 33%, transparent)`,
         borderLeft: `3px solid ${c}`,
       }}
     >

--- a/src/components/rivalhub/StatusBanner.tsx
+++ b/src/components/rivalhub/StatusBanner.tsx
@@ -1,11 +1,11 @@
 type Tone = "info" | "success" | "warn" | "error" | "live";
 
 const TONE_CONFIG: Record<Tone, { color: string; glyph: string }> = {
-  info:    { color: "#ff6b1a", glyph: "●" },
-  success: { color: "#4dd47a", glyph: "✓" },
-  warn:    { color: "#ffc44d", glyph: "▲" },
-  error:   { color: "#ff5470", glyph: "✕" },
-  live:    { color: "#ff5470", glyph: "●" },
+  info:    { color: "var(--color-accent)", glyph: "●" },
+  success: { color: "var(--color-ok)", glyph: "✓" },
+  warn:    { color: "var(--color-warn)", glyph: "▲" },
+  error:   { color: "var(--color-danger)", glyph: "✕" },
+  live:    { color: "var(--color-danger)", glyph: "●" },
 };
 
 interface StatusBannerProps {
@@ -23,15 +23,15 @@ export function StatusBanner({
   action,
   onDismiss,
 }: StatusBannerProps) {
-  const config = TONE_CONFIG[tone];
+  const c = TONE_CONFIG[tone].color;
   return (
     <div
       className="grid gap-3.5 items-center rounded-sm border px-4 py-2.5"
       style={{
         gridTemplateColumns: "auto 1fr auto auto",
-        background: config.color + "10",
-        borderColor: config.color + "55",
-        borderLeft: `3px solid ${config.color}`,
+        background: `color-mix(in srgb, ${c} 6%, transparent)`,
+        borderColor: `color-mix(in srgb, ${c} 33%, transparent)`,
+        borderLeft: `3px solid ${c}`,
       }}
     >
       <div
@@ -39,15 +39,15 @@ export function StatusBanner({
         style={{
           width: 22,
           height: 22,
-          color: config.color,
-          borderColor: config.color + "55",
-          border: `1px solid ${config.color}55`,
-          background: config.color + "1f",
+          color: c,
+          borderColor: `color-mix(in srgb, ${c} 33%, transparent)`,
+          border: `1px solid color-mix(in srgb, ${c} 33%, transparent)`,
+          background: `color-mix(in srgb, ${c} 12%, transparent)`,
           fontFamily: "var(--font-mono)",
           fontSize: 11,
         }}
       >
-        {config.glyph}
+        {TONE_CONFIG[tone].glyph}
       </div>
       <div className="min-w-0">
         <div

--- a/src/components/rivalhub/StatusPill.tsx
+++ b/src/components/rivalhub/StatusPill.tsx
@@ -1,16 +1,16 @@
 import type { SeasonStatus } from "@/types/season";
 
 const STATUS_CONFIG: Record<SeasonStatus | string, { color: string; label: string }> = {
-  draft:        { color: "#525a6a", label: "DRAFT" },
-  archived:     { color: "#525a6a", label: "ARCHIVED" },
-  live:         { color: "#ff5470", label: "● LIVE" },
-  finished:     { color: "#525a6a", label: "FT" },
-  scheduled:    { color: "#8e96a3", label: "UPCOMING" },
-  open:         { color: "#4dd47a", label: "● OPEN" },
-  registration: { color: "#4dd47a", label: "● OPEN" },
-  voting:       { color: "#ffc44d", label: "● VOTING" },
-  drafting:     { color: "#ff6b1a", label: "● DRAFTING" },
-  playing:      { color: "#4dd47a", label: "● PLAYING" },
+  draft:        { color: "var(--color-fg-dim)", label: "DRAFT" },
+  archived:     { color: "var(--color-fg-dim)", label: "ARCHIVED" },
+  live:         { color: "var(--color-danger)", label: "● LIVE" },
+  finished:     { color: "var(--color-fg-dim)", label: "FT" },
+  scheduled:    { color: "var(--color-fg-mid)", label: "UPCOMING" },
+  open:         { color: "var(--color-ok)", label: "● OPEN" },
+  registration: { color: "var(--color-ok)", label: "● OPEN" },
+  voting:       { color: "var(--color-warn)", label: "● VOTING" },
+  drafting:     { color: "var(--color-accent)", label: "● DRAFTING" },
+  playing:      { color: "var(--color-ok)", label: "● PLAYING" },
 };
 
 interface StatusPillProps {

--- a/src/lib/teams/data.ts
+++ b/src/lib/teams/data.ts
@@ -73,14 +73,14 @@ export async function getTeamMapWinStats(
   return mapStats;
 }
 
-/** Ban 统计：返回每图 ban 次数 + 参与 BP 的对局总数（ban 率分母） */
-export async function getTeamBanStats(
+async function getTeamVetoActionStats(
   teamId: string,
   matchIds: string[],
-): Promise<{ banCount: Map<string, number>; bpMatchCount: number }> {
-  if (!matchIds.length) return { banCount: new Map(), bpMatchCount: 0 };
+  actionType: "ban" | "pick",
+): Promise<{ count: Map<string, number>; bpMatchCount: number }> {
+  if (!matchIds.length) return { count: new Map(), bpMatchCount: 0 };
 
-  const [bpMatches, bans] = await Promise.all([
+  const [bpMatches, actions] = await Promise.all([
     db
       .selectDistinct({ matchId: matchVetoSteps.matchId })
       .from(matchVetoSteps)
@@ -91,18 +91,27 @@ export async function getTeamBanStats(
       .where(
         and(
           inArray(matchVetoSteps.matchId, matchIds),
-          eq(matchVetoSteps.actionType, "ban"),
+          eq(matchVetoSteps.actionType, actionType),
           eq(matchVetoSteps.teamId, teamId),
         ),
       ),
   ]);
 
-  const banCount = new Map<string, number>();
-  for (const b of bans) {
-    banCount.set(b.mapName, (banCount.get(b.mapName) ?? 0) + 1);
+  const count = new Map<string, number>();
+  for (const a of actions) {
+    count.set(a.mapName, (count.get(a.mapName) ?? 0) + 1);
   }
 
-  return { banCount, bpMatchCount: bpMatches.length };
+  return { count, bpMatchCount: bpMatches.length };
+}
+
+/** Ban 统计：返回每图 ban 次数 + 参与 BP 的对局总数（ban 率分母） */
+export async function getTeamBanStats(
+  teamId: string,
+  matchIds: string[],
+): Promise<{ banCount: Map<string, number>; bpMatchCount: number }> {
+  const { count, bpMatchCount } = await getTeamVetoActionStats(teamId, matchIds, "ban");
+  return { banCount: count, bpMatchCount };
 }
 
 /** Pick 统计：返回每图 pick 次数 + 参与 BP 的对局总数（pick 率分母） */
@@ -110,29 +119,6 @@ export async function getTeamPickStats(
   teamId: string,
   matchIds: string[],
 ): Promise<{ pickCount: Map<string, number>; bpMatchCount: number }> {
-  if (!matchIds.length) return { pickCount: new Map(), bpMatchCount: 0 };
-
-  const [bpMatches, picks] = await Promise.all([
-    db
-      .selectDistinct({ matchId: matchVetoSteps.matchId })
-      .from(matchVetoSteps)
-      .where(inArray(matchVetoSteps.matchId, matchIds)),
-    db
-      .select({ mapName: matchVetoSteps.mapName })
-      .from(matchVetoSteps)
-      .where(
-        and(
-          inArray(matchVetoSteps.matchId, matchIds),
-          eq(matchVetoSteps.actionType, "pick"),
-          eq(matchVetoSteps.teamId, teamId),
-        ),
-      ),
-  ]);
-
-  const pickCount = new Map<string, number>();
-  for (const p of picks) {
-    pickCount.set(p.mapName, (pickCount.get(p.mapName) ?? 0) + 1);
-  }
-
-  return { pickCount, bpMatchCount: bpMatches.length };
+  const { count, bpMatchCount } = await getTeamVetoActionStats(teamId, matchIds, "pick");
+  return { pickCount: count, bpMatchCount };
 }

--- a/src/lib/teams/data.ts
+++ b/src/lib/teams/data.ts
@@ -104,3 +104,35 @@ export async function getTeamBanStats(
 
   return { banCount, bpMatchCount: bpMatches.length };
 }
+
+/** Pick 统计：返回每图 pick 次数 + 参与 BP 的对局总数（pick 率分母） */
+export async function getTeamPickStats(
+  teamId: string,
+  matchIds: string[],
+): Promise<{ pickCount: Map<string, number>; bpMatchCount: number }> {
+  if (!matchIds.length) return { pickCount: new Map(), bpMatchCount: 0 };
+
+  const [bpMatches, picks] = await Promise.all([
+    db
+      .selectDistinct({ matchId: matchVetoSteps.matchId })
+      .from(matchVetoSteps)
+      .where(inArray(matchVetoSteps.matchId, matchIds)),
+    db
+      .select({ mapName: matchVetoSteps.mapName })
+      .from(matchVetoSteps)
+      .where(
+        and(
+          inArray(matchVetoSteps.matchId, matchIds),
+          eq(matchVetoSteps.actionType, "pick"),
+          eq(matchVetoSteps.teamId, teamId),
+        ),
+      ),
+  ]);
+
+  const pickCount = new Map<string, number>();
+  for (const p of picks) {
+    pickCount.set(p.mapName, (pickCount.get(p.mapName) ?? 0) + 1);
+  }
+
+  return { pickCount, bpMatchCount: bpMatches.length };
+}

--- a/tests/unit/components/matches/StatsLeaderboard.test.tsx
+++ b/tests/unit/components/matches/StatsLeaderboard.test.tsx
@@ -33,7 +33,8 @@ describe("StatsLeaderboard", () => {
             userId: "u1", perfectName: "张三", position: "awper",
             teamName: "Alpha", teamId: "t1",
             maps: 10, avgRating: 1.25, avgAdr: 92.3,
-            avgKills: 20.5, avgDeaths: 10.1, avgWe: 10.5,
+            avgRws: 12.5, avgWe: 10.5, avgHs: 45.0,
+            kdRatio: 2.03, kpr: 20.5, avgFk: 2.1, avgClutch: 0.3,
           },
         ]}
       />
@@ -54,7 +55,8 @@ describe("StatsLeaderboard", () => {
             userId: "u1", perfectName: "李四", position: "opener",
             teamName: "Beta", teamId: "t2",
             maps: 5, avgRating: 1.1, avgAdr: 88.0,
-            avgKills: 18.0, avgDeaths: 12.0, avgWe: 8.5,
+            avgRws: 10.0, avgWe: 8.5, avgHs: 38.0,
+            kdRatio: 1.50, kpr: 18.0, avgFk: 1.8, avgClutch: 0.2,
           },
         ]}
       />
@@ -73,7 +75,8 @@ describe("StatsLeaderboard", () => {
             userId: "u1", perfectName: "王五", position: "awper",
             teamName: "Gamma", teamId: "t3",
             maps: 8, avgRating: 1.3, avgAdr: 90.0,
-            avgKills: 22.0, avgDeaths: 9.0, avgWe: 11.0,
+            avgRws: 13.0, avgWe: 11.0, avgHs: 42.0,
+            kdRatio: 2.44, kpr: 22.0, avgFk: 2.3, avgClutch: 0.4,
           },
         ]}
       />


### PR DESCRIPTION
## 摘要
- 比赛详情页完整重构：赛季对比、地图池雷达图、历史交锋、HLTV 风格阵容对比、整场汇总 Tab（BO3/BO5）、MVP 2×2 布局
- 数据统计排行榜重构：补全全部字段、10 种排序、数据驱动表格
- 队伍详情页重构：2×4 数据网格、阵容内嵌选手数据、替补地图偏好
- 管理端比赛完成时间编辑
- 新增 `--color-accent-b` design token 族
- 代码审查清理：消除冗余 DB 查询、合并重复函数、全站硬编码颜色替换为 CSS 变量
- MatchCard 网格改行列表风格

## 测试
- TypeScript: 0 errors
- 测试: 390 passed
- 构建: 成功

## 版本
v1.17.1 → v1.18.0（MINOR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)