### PR TITLE
赛前赛后显示优化 & 雷达图图例修正

### DIFF
--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -626,16 +626,18 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
           : "未排期"}
       </div>
 
-      {/* 赛季综合对比 */}
-      <TeamStatsCompare
-        teamAName={teamA?.name ?? "队伍 A"}
-        teamBName={teamB?.name ?? "队伍 B"}
-        statA={{ ...recordA, ...teamAvgA }}
-        statB={{ ...recordB, ...teamAvgB }}
-      />
+      {/* 赛季综合对比（赛前） */}
+      {!isFinished && (
+        <TeamStatsCompare
+          teamAName={teamA?.name ?? "队伍 A"}
+          teamBName={teamB?.name ?? "队伍 B"}
+          statA={{ ...recordA, ...teamAvgA }}
+          statB={{ ...recordB, ...teamAvgB }}
+        />
+      )}
 
-      {/* 地图池雷达图 */}
-      {mapPool.length > 0 && (
+      {/* 地图池雷达图（赛前） */}
+      {!isFinished && mapPool.length > 0 && (
         <Panel label="地图池">
           <MapPoolRadarChart
             mapPool={mapPool}
@@ -647,15 +649,17 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         </Panel>
       )}
 
-      {/* 历史交锋 */}
-      <MatchHeadToHead
-        teamAName={teamA?.name ?? "队伍 A"}
-        teamBName={teamB?.name ?? "队伍 B"}
-        teamAWins={h2hWinsA}
-        teamBWins={h2hWinsB}
-        matches={h2hMatches}
-        seasonSlug={seasonSlug}
-      />
+      {/* 历史交锋（赛前） */}
+      {!isFinished && (
+        <MatchHeadToHead
+          teamAName={teamA?.name ?? "队伍 A"}
+          teamBName={teamB?.name ?? "队伍 B"}
+          teamAWins={h2hWinsA}
+          teamBWins={h2hWinsB}
+          matches={h2hMatches}
+          seasonSlug={seasonSlug}
+        />
+      )}
 
       {/* BP 流程（进行中 / 已结束时显示） */}
       {match.status !== "scheduled" && (
@@ -758,8 +762,8 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         </section>
       ) : null}
 
-      {/* 阵容对比（双方名单提交后，有赛季数据时显示） */}
-      {showLineupsH2H && (
+      {/* 阵容对比（赛前，双方名单提交后且有赛季数据时显示） */}
+      {!isFinished && showLineupsH2H && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">阵容对比</h2>
           <MatchLineupsH2H

--- a/src/components/matches/MapPoolRadarChart.tsx
+++ b/src/components/matches/MapPoolRadarChart.tsx
@@ -183,14 +183,12 @@ export function MapPoolRadarChart({
           );
         })}
 
-        {/* Legend */}
-        <g transform="translate(272, 340)">
+        {/* Legend — 左下角横向排列，避免与雷达图重合 */}
+        <g transform="translate(14, 362)">
           <rect x={0} y={0} width={10} height={10} fill={A_FILL} stroke={A_STROKE} strokeWidth={1} />
           <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamAName}</text>
-        </g>
-        <g transform="translate(272, 356)">
-          <rect x={0} y={0} width={10} height={10} fill={B_FILL} stroke={B_STROKE} strokeWidth={1} />
-          <text x={14} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamBName}</text>
+          <rect x={76} y={0} width={10} height={10} fill={B_FILL} stroke={B_STROKE} strokeWidth={1} />
+          <text x={90} y={9} fontSize={10} fill="var(--color-fg-mid)">{teamBName}</text>
         </g>
       </svg>
     </div>


### PR DESCRIPTION
- 赛季综合对比/地图池雷达图/历史交锋/阵容对比 赛后自动隐藏（赛前分析工具，比完了直接看结果）
- 雷达图图例从右下角移到左下角横向排列，避免与七边形图形重合

🤖 Generated with [Claude Code](https://claude.com/claude-code)