### PR TITLE
feat: 六维雷达图 + Turnstile 验证码 + BP 流程强制校验

### DIFF
--- a/docs/superpowers/plans/2026-05-18-layout-consistency-and-token-cleanup.md
+++ b/docs/superpowers/plans/2026-05-18-layout-consistency-and-token-cleanup.md
@@ -1,0 +1,808 @@
+# Layout Consistency & Token Cleanup 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 统一赛季子页面的垂直间距系统，修复赛季首页 3 个布局 bug，并清理 V2 Design Audit v2 审计文档中的全部剩余项目（P2 代码卫生 + P3 一致性增强），共 ~3h。
+
+**Architecture:** 纯 CSS/JSX/组件层面的修正，不涉及数据或业务逻辑变更。4 页面补 `space-y-*`、1 token 配置清理、4 组件修 token/圆角、3 组件 shadcn Card→Panel 统一、1 组件筛选改用 Btn、1 页面拆分组件。
+
+**Tech Stack:** Next.js + Tailwind CSS v4 + design tokens (`globals.css` / `ui-tokens.md`)
+
+---
+
+## 修改文件清单
+
+| 文件 | 操作 | 类别 |
+|---|---|---|
+| `src/app/[seasonSlug]/page.tsx` | 修改 | 布局 |
+| `src/app/[seasonSlug]/draft/page.tsx` | 修改 | 布局 |
+| `src/app/[seasonSlug]/captains/page.tsx` | 修改 | 布局 |
+| `src/app/[seasonSlug]/register/page.tsx` | 修改 | 布局 |
+| `tailwind.config.ts` | 修改 | Token |
+| `src/components/teams/TeamCard.tsx` | 修改 | Token |
+| `src/components/matches/StandingsTable.tsx` | 修改 | Token |
+| `src/components/matches/MapByMapInput.tsx` | 修改 | Token |
+| `src/components/matches/StatsLeaderboard.tsx` | 修改 | Token + Card→Panel + Btn |
+| `src/components/matches/MatchMvpVote.tsx` | 修改 | 圆角 + Card→Panel |
+| `src/components/captains/CaptainVotingPanel.tsx` | 修改 | Card→Panel |
+| **新建** `src/components/matches/AdminMatchRow.tsx` | 创建 | 组件拆分 |
+| `src/app/admin/[seasonSlug]/matches/page.tsx` | 修改 | 组件拆分 |
+
+---
+
+### Task 1: 赛季首页 — `space-y-8` + STANDINGS 用 Panel 包裹
+
+**文件:** `src/app/[seasonSlug]/page.tsx`
+
+- [ ] **Step 1: 父容器加 `space-y-8`**
+
+将第 207 行:
+```tsx
+<div className="container mx-auto px-4 py-10">
+```
+改为:
+```tsx
+<div className="container mx-auto px-4 py-10 space-y-8">
+```
+
+- [ ] **Step 2: 右侧 STANDINGS 用 Panel 包裹**
+
+将第 301-327 行:
+```tsx
+{/* Right: 积分榜 TOP 4 */}
+{standings.length > 0 && (
+  <div>
+    <div className="flex items-center justify-between mb-3">
+      <h3
+        className="font-semibold text-sm"
+        style={{
+          fontFamily: "var(--font-sans)",
+          color: "var(--color-fg)",
+        }}
+      >
+        STANDINGS · TOP 4
+      </h3>
+    </div>
+    <StandingsTable
+      standings={standings.slice(0, 4)}
+      seasonSlug={seasonSlug}
+      isFinal={false}
+    />
+    <div className="mt-3">
+      <Btn full ghost asChild>
+        <Link href={`/${seasonSlug}/matches`} className="w-full">
+          查看完整排名 →
+        </Link>
+      </Btn>
+    </div>
+  </div>
+)}
+```
+
+改为:
+```tsx
+{/* Right: 积分榜 TOP 4 */}
+{standings.length > 0 && (
+  <Panel label="STANDINGS · TOP 4">
+    <StandingsTable
+      standings={standings.slice(0, 4)}
+      seasonSlug={seasonSlug}
+      isFinal={false}
+    />
+    <div className="mt-3">
+      <Btn full ghost asChild>
+        <Link href={`/${seasonSlug}/matches`} className="w-full">
+          查看完整排名 →
+        </Link>
+      </Btn>
+    </div>
+  </Panel>
+)}
+```
+
+- [ ] **Step 3: 移除 Stat 四格的 `mt-6`**
+
+将第 356 行:
+```tsx
+<div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+```
+改为:
+```tsx
+<div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+```
+
+- [ ] **Step 4: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 2: Draft 页面 — 加 `space-y-8`
+
+**文件:** `src/app/[seasonSlug]/draft/page.tsx`
+
+- [ ] **Step 1: 三处父容器加 `space-y-8`**
+
+第 34 行（未启用选秀）:
+```tsx
+<main className="container mx-auto max-w-5xl px-4 py-10">
+```
+改为:
+```tsx
+<main className="container mx-auto max-w-5xl px-4 py-10 space-y-8">
+```
+
+第 49 行（未到选秀阶段）同理。
+
+第 100 行（选秀进行中）:
+```tsx
+<main className="container mx-auto max-w-7xl px-4 py-10">
+```
+改为:
+```tsx
+<main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">
+```
+
+- [ ] **Step 2: 预览态父容器也加**
+
+第 66 行（选秀预览态）:
+```tsx
+<main className="container mx-auto max-w-7xl px-4 py-10">
+```
+改为:
+```tsx
+<main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">
+```
+
+- [ ] **Step 3: 移除 `mt-4`**
+
+第 111 行:
+```tsx
+<div className="mt-4">
+```
+改为:
+```tsx
+<div>
+```
+
+- [ ] **Step 4: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 3: Captains 页面 — 加 `space-y-8`
+
+**文件:** `src/app/[seasonSlug]/captains/page.tsx`
+
+- [ ] **Step 1: 父容器加 `space-y-8`**
+
+第 60 行:
+```tsx
+<main className="container mx-auto max-w-6xl px-4 py-10">
+```
+改为:
+```tsx
+<main className="container mx-auto max-w-6xl px-4 py-10 space-y-8">
+```
+
+- [ ] **Step 2: 移除 `mb-6`**
+
+第 72 行:
+```tsx
+<div className="mb-6 rounded-sm border ...">
+```
+改为:
+```tsx
+<div className="rounded-sm border ...">
+```
+
+- [ ] **Step 3: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 4: Register 页面 — 加 `space-y-6`
+
+**文件:** `src/app/[seasonSlug]/register/page.tsx`
+
+- [ ] **Step 1: 父容器加 `space-y-6`**
+
+第 125 行:
+```tsx
+<div className="container mx-auto px-4 py-10 max-w-2xl">
+```
+改为:
+```tsx
+<div className="container mx-auto px-4 py-10 max-w-2xl space-y-6">
+```
+
+- [ ] **Step 2: 移除所有 `mb-6`**
+
+第 134 行 `mb-6` → 移除
+第 145 行 `mb-6` → 移除
+第 191 行 `mb-6` → 移除
+
+标题区 `mb-8`（第 126 行）保留。
+
+- [ ] **Step 3: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 5: `tailwind.config.ts` — 删除 6 个无效 token 映射
+
+**文件:** `tailwind.config.ts`
+
+确认: `grep -rn 'bg-base\|bg-elevated\|bg-overlay\|text-primary\|text-secondary\|text-muted' --include='*.tsx' --include='*.ts' --include='*.css' src/` → 无引用
+
+- [ ] **Step 1: 删除整个 `colors` 块**
+
+将第 15-25 行:
+```ts
+colors: {
+  // Design tokens — see docs/ui-tokens.md for full specification
+  // Background layers
+  "bg-base": "var(--bg-base)",
+  "bg-elevated": "var(--bg-elevated)",
+  "bg-overlay": "var(--bg-overlay)",
+  // Text layers
+  "text-primary": "var(--text-primary)",
+  "text-secondary": "var(--text-secondary)",
+  "text-muted": "var(--text-muted)",
+},
+```
+
+改为注释:
+```ts
+// Design tokens are defined in globals.css via @theme block — no additional color mappings needed.
+```
+
+- [ ] **Step 2: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 6: `TeamCard.tsx` — 修复未定义 token
+
+**文件:** `src/components/teams/TeamCard.tsx` 第 34 行
+
+- [ ] **Step 1: 替换 token**
+
+将:
+```tsx
+bg-[var(--color-bg-subtle)]
+```
+改为:
+```tsx
+bg-[var(--color-panel-low)]
+```
+
+- [ ] **Step 2: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 7: 替换 `var(--primary)` → `var(--color-accent)`（3 个文件）
+
+**涉及文件:**
+- `src/components/matches/StandingsTable.tsx` (行 33, 43)
+- `src/components/matches/MapByMapInput.tsx` (行 89)
+- `src/components/matches/StatsLeaderboard.tsx` (行 159, 176)
+
+- [ ] **Step 1: StandingsTable.tsx 第 33 行**
+
+```tsx
+// before
+bg-[var(--primary)]/10 text-[var(--primary)]
+// after
+bg-[var(--color-accent)]/10 text-[var(--color-accent)]
+```
+
+- [ ] **Step 2: StandingsTable.tsx 第 43 行**
+
+```tsx
+// before
+hover:text-[var(--primary)]
+// after
+hover:text-[var(--color-accent)]
+```
+
+- [ ] **Step 3: MapByMapInput.tsx 第 89 行**
+
+```tsx
+// before
+text-[var(--primary)]
+// after
+text-[var(--color-accent)]
+```
+
+- [ ] **Step 4: StatsLeaderboard.tsx 第 159 行**
+
+```tsx
+// before
+className="hover:text-[var(--primary)] transition-colors"
+// after
+className="hover:text-[var(--color-accent)] transition-colors"
+```
+
+- [ ] **Step 5: StatsLeaderboard.tsx 第 176 行**
+
+```tsx
+// before
+className="hover:text-[var(--primary)] transition-colors"
+// after
+className="hover:text-[var(--color-accent)] transition-colors"
+```
+
+- [ ] **Step 6: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 8: `MatchMvpVote.tsx` — 圆角修复
+
+**文件:** `src/components/matches/MatchMvpVote.tsx` 第 151 行
+
+- [ ] **Step 1: `rounded-lg` → `rounded-sm`**
+
+```tsx
+// before
+const base = "rounded-lg p-4 text-left transition-colors";
+// after
+const base = "rounded-sm p-4 text-left transition-colors";
+```
+
+- [ ] **Step 2: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 9: `StatsLeaderboard.tsx` — 筛选按钮改用 `Btn` 组件
+
+**文件:** `src/components/matches/StatsLeaderboard.tsx`
+
+当前排序 Tab（第 76-87 行）和位置筛选（第 93-105 行）使用裸 `<a>` + 手动 className 拼接。改为 `Btn` + `asChild`。
+
+- [ ] **Step 1: 添加 import**
+
+```tsx
+import { Btn } from "@/components/rivalhub";
+```
+
+- [ ] **Step 2: 排序 Tab 改用 Btn**
+
+将第 76-87 行:
+```tsx
+{SORT_OPTIONS.map(({ key, label }) => (
+  <a
+    key={key}
+    href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}
+    className={`inline-block font-mono text-[10px] px-2.5 py-1 uppercase tracking-wider rounded transition-colors ${
+      sort === key
+        ? "bg-[var(--color-accent)] text-[var(--color-accent-fg)]"
+        : "border border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+    }`}
+  >
+    {label}
+  </a>
+))}
+```
+
+改为:
+```tsx
+{SORT_OPTIONS.map(({ key, label }) => (
+  <Btn key={key} small ghost={sort !== key} asChild>
+    <a href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}>
+      {label}
+    </a>
+  </Btn>
+))}
+```
+
+- [ ] **Step 3: 位置筛选同理**
+
+将第 93-105 行改为相同模式。
+
+- [ ] **Step 4: 验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 10: 统一 3 个组件 shadcn Card → rivalhub Panel
+
+**涉及文件:**
+- `src/components/matches/MatchMvpVote.tsx`
+- `src/components/captains/CaptainVotingPanel.tsx`
+- `src/components/matches/StatsLeaderboard.tsx`
+
+#### MatchMvpVote.tsx
+
+- [ ] **第 91 行** — 投票截止结果卡片
+
+```tsx
+// before
+<Card className="p-6 space-y-5 border-[var(--color-border)]">
+// after (Panel pad 默认 16，用 24 匹配原 p-6)
+<Panel pad={24} className="space-y-5">
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **第 158 行** — 投票中容器
+
+```tsx
+// before
+<Card className="p-5 space-y-4 border-[var(--color-border)]">
+// after
+<Panel pad={20} className="space-y-4">
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **移除 `import { Card }`**，确保已有 `import { Panel }`
+
+#### CaptainVotingPanel.tsx
+
+- [ ] **第 217 行** — 桌面端 "我的投票" aside
+
+```tsx
+// before
+<Card className="p-4">
+// after
+<Panel pad={16}>
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **第 283 行** — 空候选人状态
+
+```tsx
+// before
+<Card className="p-8 text-center text-sm text-[var(--color-fg-mid)]">
+// after
+<Panel pad={32} className="text-center text-sm text-[var(--color-fg-mid)]">
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **第 298 行** — 候选人卡片
+
+```tsx
+// before
+<Card key={candidate.id} className="p-4">
+// after
+<Panel key={candidate.id} pad={16}>
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **移除 `import { Card }`**，添加 `import { Panel } from "@/components/rivalhub"`（当前已从 `@/components/ui/card` import Card）
+
+#### StatsLeaderboard.tsx
+
+- [ ] **第 63 行** — 空状态
+
+```tsx
+// before
+<Card className="p-8 text-center text-[var(--color-fg-mid)]">
+// after
+<Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **第 109 行** — 表格外壳
+
+```tsx
+// before
+<Card className="p-0 overflow-hidden">
+// after
+<Panel pad={0} className="overflow-hidden">
+```
+闭合 `</Card>` → `</Panel>`
+
+- [ ] **移除 `import { Card }` from `@/components/ui/card`**，添加 `import { Panel }`
+
+- [ ] **验证**
+
+运行: `pnpm build`
+
+---
+
+### Task 11: Admin matches 页面 — 提取 `AdminMatchRow` 组件
+
+**文件:**
+- 创建: `src/components/matches/AdminMatchRow.tsx`
+- 修改: `src/app/admin/[seasonSlug]/matches/page.tsx`
+
+当前 admin matches 页面中，排位赛和正赛的 match row 渲染逻辑几乎完全相同（第 394-480 行和 501-607 行），各约 90 行。提取为 `AdminMatchRow` 组件。
+
+- [ ] **Step 1: 创建 `src/components/matches/AdminMatchRow.tsx`**
+
+```tsx
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+import { Separator } from "@/components/ui/separator";
+import { Panel, StatusPill } from "@/components/rivalhub";
+import { MatchStatusBadge } from "@/components/matches/MatchStatusBadge";
+import { ScoreInput } from "@/components/matches/ScoreInput";
+import { MapByMapInput } from "@/components/matches/MapByMapInput";
+import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
+import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
+import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
+import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
+import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
+import { MATCH_FORMAT_LABELS } from "@/types/match";
+import type { matchMaps, matchRosters, matchRosterPlayers } from "@/db/schema";
+
+interface TeamMemberData {
+  id: string;
+  teamId: string;
+  steamName: string;
+  displayName: string | null;
+  perfectName: string | null;
+  primaryPosition: string;
+}
+
+interface RosterData {
+  starters: string[];
+  substitutes: string[];
+  status: string | null;
+}
+
+interface AdminMatchRowProps {
+  match: {
+    id: string;
+    status: string;
+    format: string;
+    scoreA: number | null;
+    scoreB: number | null;
+    scheduledAt: Date | null;
+    completionDeadline: Date | null;
+    teamAId: string;
+    teamBId: string;
+    bracketNodeId: string | null;
+  };
+  teamAName: string;
+  teamBName: string;
+  seasonSlug: string;
+  mapPool: string[];
+  isPlayoff?: boolean;
+  teamAMembers: TeamMemberData[];
+  teamBMembers: TeamMemberData[];
+  teamARoster: RosterData | null;
+  teamBRoster: RosterData | null;
+  completedMaps: {
+    mapOrder: number;
+    mapName: string;
+    scoreA: number;
+    scoreB: number;
+    pickedByTeamId: string | null;
+    teamAStartSide: "t" | "ct" | null;
+  }[];
+  finishedMaps: { id: string; mapName: string }[];
+}
+
+export function AdminMatchRow({
+  match,
+  teamAName,
+  teamBName,
+  seasonSlug,
+  mapPool,
+  isPlayoff = false,
+  teamAMembers,
+  teamBMembers,
+  teamARoster,
+  teamBRoster,
+  completedMaps,
+  finishedMaps,
+}: AdminMatchRowProps) {
+  return (
+    <Panel
+      pad={16}
+      className={cn(
+        "space-y-3",
+        match.status === "in_progress" && "border-l-[3px] border-[var(--color-accent)]"
+      )}
+    >
+      {/* Header: team names + score + badges */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <span className="font-semibold">{teamAName}</span>
+          <span className="text-[var(--color-fg-mid)]">
+            {match.status === "finished"
+              ? `${match.scoreA ?? 0} : ${match.scoreB ?? 0}`
+              : "vs"}
+          </span>
+          <span className="font-semibold">{teamBName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusPill status={MATCH_FORMAT_LABELS[match.format as keyof typeof MATCH_FORMAT_LABELS]} />
+          <MatchStatusBadge
+            status={match.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+          />
+        </div>
+      </div>
+
+      {/* Operations */}
+      {match.status !== "cancelled" && (
+        <details open={match.status === "in_progress" ? true : undefined}>
+          <summary className="cursor-pointer select-none list-none text-[11px] font-mono text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] py-1 transition-colors">
+            {match.status === "finished" ? "▸ 数据录入" : "▸ 操作"}
+          </summary>
+          <div className="space-y-3 pt-2">
+            <Separator />
+            {match.status !== "finished" && (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <AdminRosterDialog
+                    matchId={match.id}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    teamAId={match.teamAId}
+                    teamBId={match.teamBId}
+                    teamAMembers={teamAMembers}
+                    teamBMembers={teamBMembers}
+                    teamARoster={teamARoster}
+                    teamBRoster={teamBRoster}
+                  />
+                  {(match.status === "scheduled" || match.status === "in_progress") && (
+                    <VetoInputDialog
+                      matchId={match.id}
+                      format={match.format as "bo1" | "bo3" | "bo5"}
+                      teamAName={teamAName}
+                      teamBName={teamBName}
+                      teamAId={match.teamAId}
+                      teamBId={match.teamBId}
+                      mapPool={mapPool}
+                    />
+                  )}
+                </div>
+                <ScheduledAtInput
+                  matchId={match.id}
+                  currentScheduledAt={match.scheduledAt}
+                  currentCompletionDeadline={match.completionDeadline}
+                />
+                {isPlayoff && match.status === "in_progress" ? (
+                  <MapByMapInput
+                    matchId={match.id}
+                    format={match.format as "bo1" | "bo3" | "bo5"}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    teamAId={match.teamAId}
+                    teamBId={match.teamBId}
+                    completedMaps={completedMaps}
+                    mapPool={mapPool}
+                  />
+                ) : (
+                  <ScoreInput
+                    matchId={match.id}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    currentStatus={match.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
+                    format={match.format as "bo1" | "bo3" | "bo5"}
+                  />
+                )}
+              </>
+            )}
+            {match.status === "finished" &&
+              finishedMaps.map((map) => (
+                <div key={map.id}>
+                  <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
+                </div>
+              ))}
+          </div>
+        </details>
+      )}
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          href={`/${seasonSlug}/matches/${match.id}`}
+          className="text-xs text-[var(--color-fg-dim)] hover:text-[var(--color-fg)] transition-colors"
+          target="_blank"
+        >
+          查看公开页 ↗
+        </Link>
+        {match.bracketNodeId == null && <DeleteMatchButton matchId={match.id} />}
+      </div>
+    </Panel>
+  );
+}
+```
+
+- [ ] **Step 2: 修改 `page.tsx` — 添加 import**
+
+```tsx
+import { AdminMatchRow } from "@/components/matches/AdminMatchRow";
+```
+
+- [ ] **Step 3: 替换排位赛 match 列表**
+
+将第 390-481 行（`{qualifierMatches.map(...)}` 内部的 JSX）替换为 `<AdminMatchRow>` 调用。
+
+排位赛每个 match 的调用:
+```tsx
+<AdminMatchRow
+  key={m.id}
+  match={m}
+  teamAName={teamAName}
+  teamBName={teamBName}
+  seasonSlug={seasonSlug}
+  mapPool={mapPool}
+  teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+  teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+  teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+  teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+  completedMaps={(mapsByMatchId.get(m.id) ?? []).map((r) => ({
+    mapOrder: r.mapOrder,
+    mapName: r.mapName,
+    scoreA: r.scoreA ?? 0,
+    scoreB: r.scoreB ?? 0,
+    pickedByTeamId: r.pickedByTeamId,
+    teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+  }))}
+  finishedMaps={(mapsByMatch.get(m.id) ?? []).map((r) => ({
+    id: r.id,
+    mapName: r.mapName,
+  }))}
+/>
+```
+
+- [ ] **Step 4: 替换正赛 match 列表**
+
+同理替换第 496-608 行，额外传 `isPlayoff`:
+```tsx
+<AdminMatchRow
+  key={m.id}
+  match={m}
+  teamAName={teamAName}
+  teamBName={teamBName}
+  seasonSlug={seasonSlug}
+  mapPool={mapPool}
+  isPlayoff
+  teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
+  teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
+  teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
+  teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
+  completedMaps={(mapsByMatchId.get(m.id) ?? []).map((r) => ({
+    mapOrder: r.mapOrder,
+    mapName: r.mapName,
+    scoreA: r.scoreA ?? 0,
+    scoreB: r.scoreB ?? 0,
+    pickedByTeamId: r.pickedByTeamId,
+    teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+  }))}
+  finishedMaps={(mapsByMatch.get(m.id) ?? []).map((r) => ({
+    id: r.id,
+    mapName: r.mapName,
+  }))}
+/>
+```
+
+- [ ] **Step 5: 清理 page.tsx 中不再需要的 import**
+
+移除 `Separator`、`cn`、`StatusPill`（如果不再直接使用）。
+
+- [ ] **Step 6: 验证**
+
+运行: `pnpm type-check && pnpm build`
+
+---
+
+## 验证检查清单
+
+全部 Task 完成后:
+
+- [ ] `pnpm type-check` — TypeScript 编译无错误
+- [ ] `pnpm build` — 生产构建成功
+- [ ] `pnpm test` — 现有测试全部通过
+- [ ] `git diff --stat` — 确认修改了预期的 12 个文件 + 1 个新文件
+
+---
+
+## 回滚方案
+
+所有修改均为 CSS class / token 引用 / 组件外壳替换，不涉及数据或业务逻辑。如需回滚: `git checkout -- <files>` 或 `git revert`。

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -82,18 +82,23 @@ export async function signUp(
   const normalizedEmail = normalizeEmail(email);
 
   // Turnstile 验证码校验
-  if (turnstileToken) {
-    const verifyResult = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        secret: process.env.TURNSTILE_SECRET_KEY,
-        response: turnstileToken,
-      }),
-    });
-    const verifyData = await verifyResult.json() as { success: boolean };
-    if (!verifyData.success) {
-      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "验证码校验失败，请刷新后重试" });
+  const secretKey = process.env.TURNSTILE_SECRET_KEY;
+  if (secretKey) {
+    if (!turnstileToken) {
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请完成验证码校验" });
+    }
+    try {
+      const verifyResult = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secret: secretKey, response: turnstileToken }),
+      });
+      const verifyData = await verifyResult.json() as { success: boolean };
+      if (!verifyData.success) {
+        return fail({ code: ErrorCode.VALIDATION_FAILED, message: "验证码校验失败，请刷新后重试" });
+      }
+    } catch {
+      return fail({ code: ErrorCode.INTERNAL_ERROR, message: "验证服务暂不可用，请稍后重试" });
     }
   }
 

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -71,6 +71,7 @@ export async function loginWithPassword(
 export async function signUp(
   email: string,
   password: string,
+  turnstileToken?: string,
 ): Promise<ActionResult<{ email: string }>> {
   if (!email || !email.includes("@")) {
     return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请输入有效的邮箱地址" });
@@ -79,6 +80,22 @@ export async function signUp(
     return fail({ code: ErrorCode.VALIDATION_FAILED, message: `密码至少 ${MIN_PASSWORD_LENGTH} 位` });
   }
   const normalizedEmail = normalizeEmail(email);
+
+  // Turnstile 验证码校验
+  if (turnstileToken) {
+    const verifyResult = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        secret: process.env.TURNSTILE_SECRET_KEY,
+        response: turnstileToken,
+      }),
+    });
+    const verifyData = await verifyResult.json() as { success: boolean };
+    if (!verifyData.success) {
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "验证码校验失败，请刷新后重试" });
+    }
+  }
 
   try {
     const supabase = createServiceClient();
@@ -123,6 +140,30 @@ export async function signUp(
     return ok({ email: normalizedEmail });
   } catch (e) {
     return actionError("signUp", e);
+  }
+}
+
+export async function sendPasswordResetEmail(email: string): Promise<ActionResult<undefined>> {
+  if (!email || !email.includes("@")) {
+    return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请输入有效的邮箱地址" });
+  }
+  const normalizedEmail = normalizeEmail(email);
+
+  try {
+    const supabase = createServiceClient();
+    const { error } = await supabase.auth.resetPasswordForEmail(normalizedEmail, {
+      redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/reset-password`,
+    });
+
+    if (error) {
+      // 不暴露邮箱是否存在（防枚举），统一返回成功提示
+      if (process.env.NODE_ENV === "development") {
+        console.warn("[sendPasswordResetEmail]", error.message);
+      }
+    }
+    return ok(undefined);
+  } catch (e) {
+    return actionError("sendPasswordResetEmail", e);
   }
 }
 

--- a/src/actions/hexagon.ts
+++ b/src/actions/hexagon.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  computeEventStats,
+  computeDimensions,
+} from "@/lib/utils/hexagon";
+import type { PlayerMetrics, HexagonScores } from "@/lib/utils/hexagon";
+
+/**
+ * 聚合赛事内所有有 verified 数据的选手的原始指标，
+ * 计算六维雷达图分数（0-100）。
+ *
+ * 不加 HAVING count(*) >= 3，确保所有有数据的选手都参与标准化。
+ */
+export async function getSeasonHexagonScores(
+  seasonId: string
+): Promise<Map<string, HexagonScores>> {
+  // 回合数：优先 map 级（BO3/BO5），BO1 fallback 到 match 级
+  const { rows } = await db.execute(sql`
+    SELECT
+      mps.user_id,
+      sum(mps.kills)::float        / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS kpr,
+      sum(mps.deaths)::float       / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS dpr,
+      sum(mps.assists)::float      / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS apr,
+      sum(mps.first_kills)::float  / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS fkpr,
+      sum(mps.multi_kills)::float  / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS mkpr,
+      sum(mps.clutches)::float     / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS cpr,
+      sum(mps.adr * COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b))
+        / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)                             AS adr,
+      avg(mps.rws)                                                                                             AS rws,
+      avg(mps.we)                                                                                              AS we,
+      avg(mps.rating_pro)                                                                                      AS rating_pro,
+      sum(mps.kills)::float        / NULLIF(sum(mps.deaths), 0)                                               AS kd,
+      (sum(mps.kills) + sum(mps.assists))::float / NULLIF(sum(mps.deaths), 0)                                 AS kda,
+      sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b))::int                                      AS total_rounds
+    FROM match_player_stats mps
+    JOIN matches m  ON m.id  = mps.match_id
+    JOIN match_maps mm ON mm.id = mps.map_id
+    WHERE m.season_id = ${seasonId}
+      AND mps.verified_by_admin IS NOT NULL
+      AND mps.user_id IS NOT NULL
+    GROUP BY mps.user_id
+  `);
+
+  if (rows.length === 0) {
+    return new Map();
+  }
+
+  const n = (v: unknown) => Number(v) || 0;
+
+  const players: PlayerMetrics[] = rows.map((r) => ({
+    userId:      r.user_id as string,
+    kpr:         n(r.kpr),
+    dpr:         n(r.dpr),
+    apr:         n(r.apr),
+    kd:          n(r.kd),
+    kda:         n(r.kda),
+    fkpr:        n(r.fkpr),
+    mkpr:        n(r.mkpr),
+    cpr:         n(r.cpr),
+    adr:         n(r.adr),
+    rws:         n(r.rws),
+    we:          n(r.we),
+    ratingPro:   n(r.rating_pro),
+    totalRounds: n(r.total_rounds),
+  }));
+
+  const eventStats = computeEventStats(players);
+
+  const result = new Map<string, HexagonScores>();
+  for (const player of players) {
+    result.set(player.userId, computeDimensions(player, eventStats));
+  }
+  return result;
+}

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -169,6 +169,14 @@ export async function recordMatchResult(
     }
     assertMatchTransition(match.status, "finished");
 
+    const hasVeto = await db.query.matchVetoSteps.findFirst({
+      where: eq(matchVetoSteps.matchId, matchId),
+      columns: { id: true },
+    });
+    if (!hasVeto) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入比分");
+    }
+
     const season = await getSeasonOrThrow(match.seasonId);
 
     // 事务保护：score 更新 + bracket 推进 + audit 原子化
@@ -258,11 +266,16 @@ export async function recordMapResult(
     const match = await getMatchOrThrow(matchId);
     const session = await requireSeasonAdmin(match.seasonId);
 
-    const isStatusAllowed = match.format === "bo1"
-      ? match.status === "in_progress" || match.status === "scheduled"
-      : match.status === "in_progress";
-    if (!isStatusAllowed) {
+    if (match.status !== "in_progress") {
       throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛状态不允许录入地图结果");
+    }
+
+    const hasVeto = await db.query.matchVetoSteps.findFirst({
+      where: eq(matchVetoSteps.matchId, matchId),
+      columns: { id: true },
+    });
+    if (!hasVeto) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入地图结果");
     }
 
     const season = await getSeasonOrThrow(match.seasonId);
@@ -282,24 +295,18 @@ export async function recordMapResult(
     let seriesFinished = false;
 
     await db.transaction(async (tx) => {
-      // BO1 从 scheduled 自动转换为 in_progress
-      if (match.format === "bo1" && match.status === "scheduled") {
-        await tx
-          .update(matches)
-          .set({ status: "in_progress", updatedAt: new Date() })
-          .where(eq(matches.id, matchId));
-      }
-
-      // 事务内读快照，防止并发插入同名地图
+      // 事务内读快照
       const existingMaps = await tx.query.matchMaps.findMany({
         where: eq(matchMaps.matchId, matchId),
       });
-      if (existingMaps.some((m) => m.mapName === mapName)) {
-        throw new AppError(ErrorCode.VALIDATION_FAILED, `地图 ${mapName} 在本场比赛中已存在`);
+      const existingRow = existingMaps.find((m) => m.mapName === mapName);
+      if (existingRow && existingRow.scoreA !== null) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, `地图 ${mapName} 已录入比分`);
       }
 
-      // 统计加入本图后的地图胜场
-      const allMaps = [...existingMaps, { scoreA, scoreB }];
+      // 统计加入本图后的地图胜场（已有比分的图 + 本图）
+      const scoredMaps = existingMaps.filter((m) => m.scoreA !== null);
+      const allMaps = [...scoredMaps, { scoreA, scoreB }];
       let mapWinsA = 0;
       let mapWinsB = 0;
       for (const m of allMaps) {
@@ -310,16 +317,29 @@ export async function recordMapResult(
 
       seriesFinished = mapWinsA >= maxWins || mapWinsB >= maxWins;
 
-      await tx.insert(matchMaps).values({
-        matchId,
-        mapOrder,
-        mapName,
-        pickedByTeamId,
-        teamAStartSide,
-        scoreA,
-        scoreB,
-        completedAt: new Date(),
-      });
+      if (existingRow) {
+        // BP 预占行：填入比分（pickedByTeamId / teamAStartSide 保留 BP 记录，除非调用方覆盖）
+        await tx.update(matchMaps)
+          .set({
+            scoreA,
+            scoreB,
+            pickedByTeamId: pickedByTeamId ?? existingRow.pickedByTeamId,
+            teamAStartSide: teamAStartSide ?? existingRow.teamAStartSide,
+            completedAt: new Date(),
+          })
+          .where(eq(matchMaps.id, existingRow.id));
+      } else {
+        await tx.insert(matchMaps).values({
+          matchId,
+          mapOrder,
+          mapName,
+          pickedByTeamId,
+          teamAStartSide,
+          scoreA,
+          scoreB,
+          completedAt: new Date(),
+        });
+      }
 
       if (seriesFinished) {
         await tx.update(matches).set({

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -33,10 +33,11 @@ export async function saveVetoSteps(
     const match = await getMatchOrThrow(matchId);
     const session = await requireSeasonAdmin(match.seasonId);
 
-    if (match.status !== "scheduled" && match.status !== "in_progress") {
+    const allowedStatuses = ["scheduled", "in_progress", "finished"] as const;
+    if (!(allowedStatuses as readonly string[]).includes(match.status)) {
       throw new AppError(
         ErrorCode.MATCH_INVALID_TRANSITION,
-        "仅「待进行」或「进行中」状态的比赛可录入 BP",
+        "仅「待进行」「进行中」或「已结束」状态的比赛可录入 BP",
       );
     }
 
@@ -61,11 +62,13 @@ export async function saveVetoSteps(
       throw new AppError(ErrorCode.VALIDATION_FAILED, "地图不属于当前赛季图池");
     }
 
+    const playMaps = steps.filter(
+      (s) => s.actionType === "pick" || s.actionType === "decider",
+    );
+
     await db.transaction(async (tx) => {
-      // 清除旧记录（支持重复录入）
-      await tx
-        .delete(matchVetoSteps)
-        .where(eq(matchVetoSteps.matchId, matchId));
+      // 清除旧 BP 记录（支持重复录入）
+      await tx.delete(matchVetoSteps).where(eq(matchVetoSteps.matchId, matchId));
 
       // 写入 BP 步骤
       await tx.insert(matchVetoSteps).values(
@@ -79,23 +82,46 @@ export async function saveVetoSteps(
         })),
       );
 
-      // 从 pick / decider 步骤自动创建 match_maps 记录
-      const playMaps = steps.filter(
-        (s) => s.actionType === "pick" || s.actionType === "decider",
-      );
-
-      await tx.delete(matchMaps).where(eq(matchMaps.matchId, matchId));
-
-      if (playMaps.length > 0) {
-        await tx.insert(matchMaps).values(
-          playMaps.map((s, i) => ({
-            matchId,
-            mapOrder: i + 1,
-            mapName: s.mapName,
-            pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
-            teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
-          })),
-        );
+      // 比赛已结束时：仅在无 match_maps 记录时重建（供赛后 OCR 使用），
+      // 有记录（含已录入比分的行）时跳过，保护历史数据。
+      if (match.status === "finished") {
+        const existingMaps = await tx.query.matchMaps.findMany({
+          where: eq(matchMaps.matchId, matchId),
+        });
+        if (existingMaps.length === 0 && playMaps.length > 0) {
+          await tx.insert(matchMaps).values(
+            playMaps.map((s, i) => ({
+              matchId,
+              mapOrder: i + 1,
+              mapName: s.mapName,
+              pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
+              teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
+            })),
+          );
+        }
+      } else {
+        // 进行中 / 待进行：若已有带比分的地图行则拒绝覆盖
+        const existingMaps = await tx.query.matchMaps.findMany({
+          where: eq(matchMaps.matchId, matchId),
+        });
+        if (existingMaps.some((m) => m.scoreA != null)) {
+          throw new AppError(
+            ErrorCode.VALIDATION_FAILED,
+            "已有地图录入了比分，无法重新录入 BP。如需补录请在赛后操作。",
+          );
+        }
+        await tx.delete(matchMaps).where(eq(matchMaps.matchId, matchId));
+        if (playMaps.length > 0) {
+          await tx.insert(matchMaps).values(
+            playMaps.map((s, i) => ({
+              matchId,
+              mapOrder: i + 1,
+              mapName: s.mapName,
+              pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
+              teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
+            })),
+          );
+        }
       }
 
       await tx.insert(auditLogs).values({
@@ -104,7 +130,7 @@ export async function saveVetoSteps(
         actorId: auditActorId(session),
         targetId: matchId,
         targetType: "match",
-        meta: { format: match.format, stepCount: steps.length },
+        meta: { format: match.format, stepCount: steps.length, postMatch: match.status === "finished" },
       });
     });
 

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -249,15 +249,15 @@ export async function castMatchMvpVote(
       .where(eq(users.id, session.userId))
       .limit(1);
 
-    if (userRow && userRow.createdAt) {
-      const hoursSinceRegistration =
-        (Date.now() - userRow.createdAt.getTime()) / (1000 * 60 * 60);
-      if (hoursSinceRegistration < 24) {
-        return fail({
-          code: ErrorCode.MATCH_VOTE_TOO_EARLY,
-          message: ERROR_MESSAGES.MATCH_VOTE_TOO_EARLY,
-        });
-      }
+    if (!userRow?.createdAt) {
+      return fail({ code: ErrorCode.UNAUTHORIZED, message: "账号状态异常，请重新登录" });
+    }
+    const hoursSinceRegistration = (Date.now() - userRow.createdAt.getTime()) / 3_600_000;
+    if (hoursSinceRegistration < 24) {
+      return fail({
+        code: ErrorCode.MATCH_VOTE_TOO_EARLY,
+        message: ERROR_MESSAGES.MATCH_VOTE_TOO_EARLY,
+      });
     }
 
     const match = await db.query.matches.findFirst({

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -242,6 +242,24 @@ export async function castMatchMvpVote(
       return fail({ code: ErrorCode.UNAUTHORIZED, message: "请先登录" });
     }
 
+    // 注册 24h 后才能投票
+    const [userRow] = await db
+      .select({ createdAt: users.createdAt })
+      .from(users)
+      .where(eq(users.id, session.userId))
+      .limit(1);
+
+    if (userRow && userRow.createdAt) {
+      const hoursSinceRegistration =
+        (Date.now() - userRow.createdAt.getTime()) / (1000 * 60 * 60);
+      if (hoursSinceRegistration < 24) {
+        return fail({
+          code: ErrorCode.MATCH_VOTE_TOO_EARLY,
+          message: ERROR_MESSAGES.MATCH_VOTE_TOO_EARLY,
+        });
+      }
+    }
+
     const match = await db.query.matches.findFirst({
       where: eq(matches.id, matchId),
     });

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -128,7 +128,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   const isFinished = match.status === "finished";
 
   // Phase 3: 所有独立查询并行
-  const [timeProposals, rosterA, rosterB, userSession, allTeamMembers, seasonMatchesA, seasonMatchesB] =
+  const [timeProposals, rosterA, rosterB, userSession, allTeamMembers, seasonMatchesA, seasonMatchesB, seasonHexagonScores] =
     await Promise.all([
       getTimeProposals(match.id),
       getMatchRoster(match.id, match.teamAId),
@@ -150,6 +150,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
         .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId])),
       getSeasonFinishedMatches(season.id, match.teamAId),
       getSeasonFinishedMatches(season.id, match.teamBId),
+      getSeasonHexagonScores(season.id),
     ]);
 
   // 从赛季对局列表计算战绩、H2H
@@ -263,7 +264,6 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   const radarDataB = buildRadarData(mapPool, mapWinB, pickStatsB, banStatsB);
 
   // 双方阵容六维雷达图
-  const seasonHexagonScores = await getSeasonHexagonScores(season.id);
   const hexA = starterAUserIds
     .map((uid) => seasonHexagonScores.get(uid))
     .filter((s): s is HexagonScores => s != null);
@@ -799,10 +799,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
 
       {showHexComparison && (
         <section className="space-y-3">
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)", letterSpacing: "var(--tracking-label)", textTransform: "uppercase" }}>
-            六维能力对比
-          </div>
-          <Panel pad={16}>
+          <Panel label="六维能力对比" pad={16}>
             <PlayerRadarChart
               players={[
                 { name: teamA?.name ?? "队伍 A", scores: teamHexA, color: "var(--color-accent)", strokeColor: "var(--color-accent)" },

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -21,13 +21,17 @@ import { MatchRosterForm } from "@/components/matches/MatchRosterForm";
 import { VetoView } from "@/components/matches/VetoView";
 import { MapPoolRadarChart } from "@/components/matches/MapPoolRadarChart";
 import { MatchLineupsH2H } from "@/components/matches/MatchLineupsH2H";
+import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";
 import { TeamStatsCompare } from "@/components/matches/TeamStatsCompare";
 import { MatchHeadToHead } from "@/components/matches/MatchHeadToHead";
 import { MatchSummaryStats } from "@/components/matches/MatchSummaryStats";
 import { getMatchMvpResults, ensureMvpWinner } from "@/actions/player-stats";
 import { getTimeProposals } from "@/actions/matches/scheduling";
 import { getMatchRoster } from "@/actions/matches/roster";
+import { getSeasonHexagonScores } from "@/actions/hexagon";
 import { sumNums, avgNums, weightedAvgNums } from "@/lib/utils/stats";
+import { computeTeamDimensions } from "@/lib/utils/hexagon";
+import type { HexagonScores } from "@/lib/utils/hexagon";
 import { getUserSession } from "@/lib/auth/session";
 import { formatCSTDateTime } from "@/lib/utils/date";
 import { normalizeRegistrationConfig } from "@/types/season";
@@ -257,6 +261,18 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
   // 雷达图数据
   const radarDataA = buildRadarData(mapPool, mapWinA, pickStatsA, banStatsA);
   const radarDataB = buildRadarData(mapPool, mapWinB, pickStatsB, banStatsB);
+
+  // 双方阵容六维雷达图
+  const seasonHexagonScores = await getSeasonHexagonScores(season.id);
+  const hexA = starterAUserIds
+    .map((uid) => seasonHexagonScores.get(uid))
+    .filter((s): s is HexagonScores => s != null);
+  const hexB = starterBUserIds
+    .map((uid) => seasonHexagonScores.get(uid))
+    .filter((s): s is HexagonScores => s != null);
+  const teamHexA = hexA.length > 0 ? computeTeamDimensions(hexA) : null;
+  const teamHexB = hexB.length > 0 ? computeTeamDimensions(hexB) : null;
+  const showHexComparison = teamHexA != null && teamHexB != null && !isFinished;
 
   // 首发选手赛季数据（用于 MatchLineupsH2H）
   const matchRoundsMap = new Map<string, number>();
@@ -778,6 +794,26 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
             teamAPlayers={lineupsPlayersA}
             teamBPlayers={lineupsPlayersB}
           />
+        </section>
+      )}
+
+      {showHexComparison && (
+        <section className="space-y-3">
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)", letterSpacing: "var(--tracking-label)", textTransform: "uppercase" }}>
+            六维能力对比
+          </div>
+          <Panel pad={16}>
+            <PlayerRadarChart
+              players={[
+                { name: teamA?.name ?? "队伍 A", scores: teamHexA, color: "var(--color-accent)", strokeColor: "var(--color-accent)" },
+                { name: teamB?.name ?? "队伍 B", scores: teamHexB, color: "var(--color-accent-b)", strokeColor: "var(--color-accent-b)" },
+              ]}
+              size={320}
+            />
+          </Panel>
+          <p className="text-[11px] text-[var(--color-fg-dim)] px-1 leading-relaxed">
+            双方预计出场阵容六维均值对比，六维评分在本赛事内标准化。
+          </p>
         </section>
       )}
 

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -431,19 +431,14 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
       {/* 5. 队伍能力图 */}
       {teamScores && hexagonByPlayer.size > 0 && (
         <section className="space-y-3">
-          <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)", letterSpacing: "var(--tracking-label)", textTransform: "uppercase" }}>
-            队伍能力图
-          </div>
-          <Panel pad={16}>
+          <Panel label="队伍能力图" pad={16}>
             <PlayerRadarChart
               players={[
-                ...[...hexagonByPlayer.entries()].map(([uid, scores], idx) => {
+                ...[...hexagonByPlayer.entries()].map(([uid, scores]) => {
                   const player = starters.find((s) => s.userId === uid);
-                  const colors = ["var(--color-accent)", "var(--color-accent-b)", "#f59e0b", "#10b981", "#8b5cf6"];
                   return {
                     name: player ? (player.perfectName ?? player.steamName ?? "未知") : uid,
                     scores,
-                    color: colors[idx % 5],
                   };
                 }),
                 {

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -14,6 +14,10 @@ import { getUserSession, checkAdminSession } from "@/lib/auth/session";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { getTeamMapWinStats, getTeamBanStats } from "@/lib/teams/data";
 import { mapLabel } from "@/lib/maps";
+import { getSeasonHexagonScores } from "@/actions/hexagon";
+import { computeTeamDimensions } from "@/lib/utils/hexagon";
+import type { HexagonScores } from "@/lib/utils/hexagon";
+import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";
 
 interface TeamDetailPageProps {
   params: Promise<{ seasonSlug: string; teamId: string }>;
@@ -131,6 +135,20 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     getTeamMapWinStats(teamId, teamMatches),
     getTeamBanStats(teamId, matchIds),
   ]);
+
+  // 六维雷达图数据
+  const starterUserIds = starters.map((s) => s.userId).filter(Boolean) as string[];
+  const hexagonByPlayer = new Map<string, HexagonScores>();
+  if (starterUserIds.length > 0) {
+    const seasonScores = await getSeasonHexagonScores(season.id);
+    for (const uid of starterUserIds) {
+      const s = seasonScores.get(uid);
+      if (s) hexagonByPlayer.set(uid, s);
+    }
+  }
+  const teamScores = hexagonByPlayer.size > 0
+    ? computeTeamDimensions([...hexagonByPlayer.values()])
+    : null;
 
   // 历史对阵（按对手分组）
   interface HeadToHead { opponentId: string; wins: number; losses: number }
@@ -410,7 +428,40 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </Panel>
       </section>
 
-      {/* 5. 历史对阵 */}
+      {/* 5. 队伍能力图 */}
+      {teamScores && hexagonByPlayer.size > 0 && (
+        <section className="space-y-3">
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--color-fg-mid)", letterSpacing: "var(--tracking-label)", textTransform: "uppercase" }}>
+            队伍能力图
+          </div>
+          <Panel pad={16}>
+            <PlayerRadarChart
+              players={[
+                ...[...hexagonByPlayer.entries()].map(([uid, scores], idx) => {
+                  const player = starters.find((s) => s.userId === uid);
+                  const colors = ["var(--color-accent)", "var(--color-accent-b)", "#f59e0b", "#10b981", "#8b5cf6"];
+                  return {
+                    name: player ? (player.perfectName ?? player.steamName ?? "未知") : uid,
+                    scores,
+                    color: colors[idx % 5],
+                  };
+                }),
+                {
+                  name: "队伍均值",
+                  scores: teamScores,
+                  color: "var(--color-fg)",
+                },
+              ]}
+              size={320}
+            />
+          </Panel>
+          <p className="text-[11px] text-[var(--color-fg-dim)] px-1 leading-relaxed">
+            队伍六维 = 当前阵容选手六维均值，六维评分在本赛事内标准化。
+          </p>
+        </section>
+      )}
+
+      {/* 6. 历史对阵 */}
       {h2hList.length > 0 && (
         <section>
           <Panel pad={0} className="overflow-hidden" label="历史对阵">
@@ -451,7 +502,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 6. 即将进行的比赛 */}
+      {/* 7. 即将进行的比赛 */}
       {upcomingMatches.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">即将进行的比赛</h2>
@@ -479,7 +530,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 7. 历史战绩 */}
+      {/* 8. 历史战绩 */}
       {teamMatches.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">历史战绩</h2>
@@ -513,7 +564,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         </section>
       )}
 
-      {/* 8. 队内联系方式（仅同队成员可见） */}
+      {/* 9. 队内联系方式（仅同队成员可见） */}
       {isTeamMember && (
         <section>
           <Panel label="队内联系方式" pad={20}>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -450,6 +450,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                   name: "队伍均值",
                   scores: teamScores,
                   color: "var(--color-fg)",
+                  strokeWidth: 3,
                 },
               ]}
               size={320}

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -28,14 +28,27 @@ const STATUS_SORT_ORDER: Record<string, number> = {
 };
 
 function mapCompletedMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; scoreB: number | null; pickedByTeamId: string | null; teamAStartSide: string | null }[]) {
-  return records.map((r) => ({
-    mapOrder: r.mapOrder,
-    mapName: r.mapName,
-    scoreA: r.scoreA ?? 0,
-    scoreB: r.scoreB ?? 0,
-    pickedByTeamId: r.pickedByTeamId,
-    teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
-  }));
+  return records
+    .filter((r) => r.scoreA !== null)
+    .map((r) => ({
+      mapOrder: r.mapOrder,
+      mapName: r.mapName,
+      scoreA: r.scoreA as number,
+      scoreB: r.scoreB as number,
+      pickedByTeamId: r.pickedByTeamId,
+      teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+    }));
+}
+
+function mapPendingMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; pickedByTeamId: string | null; teamAStartSide: string | null }[]) {
+  return records
+    .filter((r) => r.scoreA === null)
+    .map((r) => ({
+      mapOrder: r.mapOrder,
+      mapName: r.mapName,
+      pickedByTeamId: r.pickedByTeamId,
+      teamAStartSide: r.teamAStartSide as "t" | "ct" | null,
+    }));
 }
 
 function mapFinishedMaps(records: { id: string; mapName: string }[]) {
@@ -406,6 +419,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                         teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                         teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                         completedMaps={mapCompletedMaps(mapsByMatchId.get(m.id) ?? [])}
+                        pendingMaps={mapPendingMaps(mapsByMatchId.get(m.id) ?? [])}
                         finishedMaps={mapFinishedMaps(mapsByMatch.get(m.id) ?? [])}
                       />
                     );
@@ -442,6 +456,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                         teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
                         teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
                         completedMaps={mapCompletedMaps(mapsByMatchId.get(m.id) ?? [])}
+                        pendingMaps={mapPendingMaps(mapsByMatchId.get(m.id) ?? [])}
                         finishedMaps={mapFinishedMaps(mapsByMatch.get(m.id) ?? [])}
                       />
                     );

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,19 @@
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="space-y-1 text-center mb-6">
+          <h1 className="font-semibold text-2xl" style={{ fontFamily: "var(--font-display)", color: "var(--color-fg)" }}>
+            忘记密码
+          </h1>
+          <p className="text-sm" style={{ color: "var(--color-fg-mid)" }}>
+            输入邮箱，我们会发送重置链接
+          </p>
+        </div>
+        <ForgotPasswordForm />
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { Panel } from "@/components/rivalhub";
 
@@ -24,6 +25,11 @@ export default function LoginPage() {
           </p>
         </div>
         <LoginForm />
+        <p className="text-center mt-3">
+          <Link href="/forgot-password" className="text-xs text-[var(--color-fg-mid)] hover:text-[var(--color-accent)] transition-colors">
+            忘记密码？
+          </Link>
+        </p>
       </Panel>
     </div>
   );

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -130,18 +130,13 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   ]);
 
   // ── 六维数据：仅对有数据的赛季查询 ──────────────────────────────────
-  const hexagonResults = await Promise.all(
-    playerStats.map((ps) =>
-      getSeasonHexagonScores(ps.seasonId).then((m) => ({
-        slug: ps.seasonSlug,
-        scores: m.get(userId),
-      }))
-    )
-  );
-  const hexagonBySeasonSlug = new Map(
-    hexagonResults
-      .filter((r): r is { slug: string; scores: HexagonScores } => r.scores != null)
-      .map((r) => [r.slug, r.scores])
+  const hexagonBySeasonSlug = new Map<string, HexagonScores>();
+  await Promise.all(
+    playerStats.map(async (ps) => {
+      const m = await getSeasonHexagonScores(ps.seasonId);
+      const s = m.get(userId);
+      if (s) hexagonBySeasonSlug.set(ps.seasonSlug, s);
+    })
   );
 
   // ── 队伍归属（registrationId → team）────────────────────────────────

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -130,12 +130,19 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   ]);
 
   // ── 六维数据：仅对有数据的赛季查询 ──────────────────────────────────
-  const hexagonBySeasonSlug = new Map<string, HexagonScores>();
-  for (const ps of playerStats) {
-    const seasonMap = await getSeasonHexagonScores(ps.seasonId);
-    const scores = seasonMap.get(userId);
-    if (scores) hexagonBySeasonSlug.set(ps.seasonSlug, scores);
-  }
+  const hexagonResults = await Promise.all(
+    playerStats.map((ps) =>
+      getSeasonHexagonScores(ps.seasonId).then((m) => ({
+        slug: ps.seasonSlug,
+        scores: m.get(userId),
+      }))
+    )
+  );
+  const hexagonBySeasonSlug = new Map(
+    hexagonResults
+      .filter((r): r is { slug: string; scores: HexagonScores } => r.scores != null)
+      .map((r) => [r.slug, r.scores])
+  );
 
   // ── 队伍归属（registrationId → team）────────────────────────────────
   const allRegIds = registrations.map((r) => r.id);

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -12,6 +12,9 @@ import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { wAvg, sAvg } from "@/lib/utils/stats";
+import { getSeasonHexagonScores } from "@/actions/hexagon";
+import type { HexagonScores } from "@/lib/utils/hexagon";
+import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";
 
 /**
  * 统计玩家 MVP 获胜次数（从 matches.mvp_winner_user_id 直读，已持久化缓存）。
@@ -93,6 +96,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
     getMvpWinCount(userId),
     db
       .select({
+        seasonId: seasons.id,
         seasonName: seasons.name,
         seasonSlug: seasons.slug,
         seasonCreatedAt: seasons.createdAt,
@@ -124,6 +128,14 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       .orderBy(asc(seasons.createdAt)),
     resolveAvatarUrl({ avatarUrl: user.avatarUrl, steam64: user.steam64 }),
   ]);
+
+  // ── 六维数据：仅对有数据的赛季查询 ──────────────────────────────────
+  const hexagonBySeasonSlug = new Map<string, HexagonScores>();
+  for (const ps of playerStats) {
+    const seasonMap = await getSeasonHexagonScores(ps.seasonId);
+    const scores = seasonMap.get(userId);
+    if (scores) hexagonBySeasonSlug.set(ps.seasonSlug, scores);
+  }
 
   // ── 队伍归属（registrationId → team）────────────────────────────────
   const allRegIds = registrations.map((r) => r.id);
@@ -392,6 +404,31 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
               </div>
             </Panel>
           ))}
+
+          {/* 六维能力图 */}
+          {hexagonBySeasonSlug.size > 0 && (
+            <div className="space-y-3 mt-4">
+              <SectionHeading>六维能力图</SectionHeading>
+              {[...playerStats].reverse().map((ps) => {
+                const scores = hexagonBySeasonSlug.get(ps.seasonSlug);
+                if (!scores) return null;
+                return (
+                  <Panel key={ps.seasonSlug} pad={16}>
+                    <div className="text-xs font-semibold text-[var(--color-fg-mid)] mb-3">
+                      {ps.seasonName}
+                    </div>
+                    <PlayerRadarChart
+                      players={[{ name: getDisplayName(user), scores, color: "var(--color-accent)" }]}
+                      size={280}
+                    />
+                  </Panel>
+                );
+              })}
+              <p className="text-[11px] text-[var(--color-fg-dim)] px-1 leading-relaxed">
+                六维评分在本赛事内标准化，适合同一赛事内横向比较，不建议跨赛事直接对比。
+              </p>
+            </div>
+          )}
         </section>
       )}
 

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="space-y-1 text-center mb-6">
+          <h1 className="font-semibold text-2xl" style={{ fontFamily: "var(--font-display)", color: "var(--color-fg)" }}>
+            设置新密码
+          </h1>
+          <p className="text-sm" style={{ color: "var(--color-fg-mid)" }}>请输入你的新密码</p>
+        </div>
+        <ResetPasswordForm />
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Field, Btn } from "@/components/rivalhub";
+import { sendPasswordResetEmail } from "@/actions/auth";
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    startTransition(async () => {
+      const result = await sendPasswordResetEmail(email);
+      if (result.success) {
+        setSent(true);
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  };
+
+  if (sent) {
+    return (
+      <div className="text-center">
+        <p className="text-sm text-[var(--color-fg)] mb-2">重置链接已发送</p>
+        <p className="text-xs text-[var(--color-fg-mid)]">
+          请查看邮箱 {email}，点击邮件中的链接设置新密码。链接 1 小时内有效。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Field id="email" label="邮箱地址" type="email" placeholder="you@example.com" value={email} onChange={setEmail} required autoFocus />
+      <Btn type="submit" full disabled={isPending}>{isPending ? "发送中…" : "发送重置链接"}</Btn>
+    </form>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import { Field, Btn } from "@/components/rivalhub";
 import { loginWithPassword, signUp } from "@/actions/auth";
+import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
 
 type Mode = "login" | "register";
 
@@ -16,6 +17,7 @@ function safeRedirect(raw: string | null): string {
 export function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState<string>("");
   const [mode, setMode] = useState<Mode>("login");
   const [isPending, startTransition] = useTransition();
   const redirectRef = useRef(safeRedirect(new URLSearchParams(
@@ -25,15 +27,16 @@ export function LoginForm() {
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
     startTransition(async () => {
-      const action = mode === "login" ? loginWithPassword : signUp;
-      const result = await action(email, password);
+      const result = mode === "login"
+        ? await loginWithPassword(email, password)
+        : await signUp(email, password, turnstileToken);
       if (result.success) {
         window.location.href = redirectRef.current;
       } else {
         toast.error(result.error.message);
       }
     });
-  }, [email, password, mode]);
+  }, [email, password, mode, turnstileToken]);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -84,7 +87,19 @@ export function LoginForm() {
         minLength={6}
       />
 
-      <Btn type="submit" full disabled={isPending}>
+      {mode === "register" && (
+        <div className="flex justify-center">
+          <TurnstileWidget
+            onVerify={(token) => setTurnstileToken(token)}
+            onError={() => {
+              setTurnstileToken("");
+              toast.error("验证码加载失败，请刷新后重试");
+            }}
+          />
+        </div>
+      )}
+
+      <Btn type="submit" full disabled={isPending || (mode === "register" && !turnstileToken)}>
         {isPending ? "处理中…" : mode === "login" ? "登录" : "注册"}
       </Btn>
 

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Field, Btn } from "@/components/rivalhub";
+import { createBrowserClient } from "@/lib/auth/supabase";
+import { MIN_PASSWORD_LENGTH } from "@/lib/config/auth-config";
+
+export function ResetPasswordForm() {
+  const [password, setPassword] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      toast.error(`密码至少 ${MIN_PASSWORD_LENGTH} 位`);
+      return;
+    }
+    startTransition(async () => {
+      const supabase = createBrowserClient();
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        toast.error("密码重置失败，链接可能已过期，请重新请求重置链接");
+      } else {
+        toast.success("密码已重置，请用新密码登录");
+        router.push("/login");
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Field id="password" label="新密码" type="password" placeholder={`至少 ${MIN_PASSWORD_LENGTH} 位`} value={password} onChange={setPassword} required minLength={MIN_PASSWORD_LENGTH} />
+      <Btn type="submit" full disabled={isPending}>{isPending ? "设置中…" : "设置新密码"}</Btn>
+    </form>
+  );
+}

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -10,7 +10,12 @@ interface TurnstileWidgetProps {
 declare global {
   interface Window {
     turnstile?: {
-      render: (el: string | HTMLElement, options: { sitekey: string; callback: (token: string) => void; "error-callback"?: () => void }) => string;
+      render: (el: string | HTMLElement, options: {
+        sitekey: string;
+        appearance?: "always" | "execute" | "interaction-only";
+        callback: (token: string) => void;
+        "error-callback"?: () => void;
+      }) => string;
       reset: (id?: string) => void;
     };
     onLoadTurnstile?: () => void;
@@ -35,6 +40,7 @@ export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
     }
     widgetId.current = window.turnstile.render(ref.current, {
       sitekey: siteKey,
+      appearance: "interaction-only",
       callback: (token: string) => onVerifyRef.current(token),
       "error-callback": () => onErrorRef.current?.(),
     });

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -22,6 +22,8 @@ declare global {
   }
 }
 
+const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile";
+
 export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
   const ref = useRef<HTMLDivElement>(null);
   const widgetId = useRef<string>("");
@@ -58,12 +60,10 @@ export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
       renderWidget();
     };
 
-    const existingScript = document.querySelector(
-      'script[src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile"]'
-    );
+    const existingScript = document.querySelector(`script[src="${TURNSTILE_SCRIPT_SRC}"]`);
     if (!existingScript) {
       const script = document.createElement("script");
-      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile";
+      script.src = TURNSTILE_SCRIPT_SRC;
       script.async = true;
       script.defer = true;
       document.head.appendChild(script);

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -27,13 +27,17 @@ export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
   useEffect(() => { onErrorRef.current = onError; }, [onError]);
 
   const renderWidget = useCallback(() => {
-    if (ref.current && window.turnstile) {
-      widgetId.current = window.turnstile.render(ref.current, {
-        sitekey: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "",
-        callback: (token: string) => onVerifyRef.current(token),
-        "error-callback": () => onErrorRef.current?.(),
-      });
+    if (!ref.current || !window.turnstile) return;
+    const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+    if (!siteKey) {
+      onErrorRef.current?.();
+      return;
     }
+    widgetId.current = window.turnstile.render(ref.current, {
+      sitekey: siteKey,
+      callback: (token: string) => onVerifyRef.current(token),
+      "error-callback": () => onErrorRef.current?.(),
+    });
   }, []);
 
   useEffect(() => {

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+interface TurnstileWidgetProps {
+  onVerify: (token: string) => void;
+  onError?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (el: string | HTMLElement, options: { sitekey: string; callback: (token: string) => void; "error-callback"?: () => void }) => string;
+      reset: (id?: string) => void;
+    };
+    onLoadTurnstile?: () => void;
+  }
+}
+
+export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string>("");
+  const onVerifyRef = useRef(onVerify);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => { onVerifyRef.current = onVerify; }, [onVerify]);
+  useEffect(() => { onErrorRef.current = onError; }, [onError]);
+
+  const renderWidget = useCallback(() => {
+    if (ref.current && window.turnstile) {
+      widgetId.current = window.turnstile.render(ref.current, {
+        sitekey: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "",
+        callback: (token: string) => onVerifyRef.current(token),
+        "error-callback": () => onErrorRef.current?.(),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (window.turnstile) {
+      renderWidget();
+      return;
+    }
+
+    const originalOnLoad = window.onLoadTurnstile;
+    window.onLoadTurnstile = () => {
+      originalOnLoad?.();
+      renderWidget();
+    };
+
+    const existingScript = document.querySelector(
+      'script[src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile"]'
+    );
+    if (!existingScript) {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile";
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+
+    return () => {
+      window.onLoadTurnstile = originalOnLoad;
+    };
+  }, [renderWidget]);
+
+  return <div ref={ref} />;
+}

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -60,6 +60,12 @@ interface AdminMatchRowProps {
     pickedByTeamId: string | null;
     teamAStartSide: "t" | "ct" | null;
   }[];
+  pendingMaps: {
+    mapOrder: number;
+    mapName: string;
+    pickedByTeamId: string | null;
+    teamAStartSide: "t" | "ct" | null;
+  }[];
   finishedMaps: { id: string; mapName: string }[];
 }
 
@@ -75,6 +81,7 @@ export function AdminMatchRow({
   teamARoster,
   teamBRoster,
   completedMaps,
+  pendingMaps,
   finishedMaps,
 }: AdminMatchRowProps) {
   return (
@@ -152,6 +159,7 @@ export function AdminMatchRow({
                     teamAId={match.teamAId}
                     teamBId={match.teamBId}
                     completedMaps={completedMaps}
+                    pendingMaps={pendingMaps}
                     mapPool={mapPool}
                   />
                 ) : (
@@ -167,6 +175,18 @@ export function AdminMatchRow({
             )}
             {match.status === "finished" && (
               <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <VetoInputDialog
+                    matchId={match.id}
+                    format={match.format}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    teamAId={match.teamAId}
+                    teamBId={match.teamBId}
+                    mapPool={mapPool}
+                    matchStatus="finished"
+                  />
+                </div>
                 <ScoreInput
                   matchId={match.id}
                   teamAName={teamAName}

--- a/src/components/matches/MapByMapInput.tsx
+++ b/src/components/matches/MapByMapInput.tsx
@@ -20,6 +20,13 @@ interface CompletedMap {
   teamAStartSide: "t" | "ct" | null;
 }
 
+interface PendingMap {
+  mapOrder: number;
+  mapName: string;
+  pickedByTeamId: string | null;
+  teamAStartSide: "t" | "ct" | null;
+}
+
 interface MapByMapInputProps {
   matchId: string;
   format: "bo1" | "bo3" | "bo5";
@@ -28,11 +35,13 @@ interface MapByMapInputProps {
   teamAId: string;
   teamBId: string;
   completedMaps: CompletedMap[];
+  pendingMaps?: PendingMap[];
   mapPool: string[];
 }
 
 export function MapByMapInput({
-  matchId, format, teamAName, teamBName, teamAId, teamBId, completedMaps, mapPool,
+  matchId, format, teamAName, teamBName, teamAId, teamBId,
+  completedMaps, pendingMaps = [], mapPool,
 }: MapByMapInputProps) {
   const maxWins = getWinThreshold(format);
   const maxMaps = getMaxMaps(format);
@@ -45,34 +54,49 @@ export function MapByMapInput({
   }
 
   const seriesFinished = mapWinsA >= maxWins || mapWinsB >= maxWins;
-  const nextMapOrder = completedMaps.length + 1;
+
+  // BP 引导模式：下一张待打图（来自 BP 预占行）
+  const nextPending = pendingMaps[0] ?? null;
+  const nextMapOrder = nextPending?.mapOrder ?? completedMaps.length + 1;
+
+  // 手动模式的地图选择
   const usedMapNames = new Set(completedMaps.map((m) => m.mapName));
   const availableMaps = mapPool.filter((m) => !usedMapNames.has(m));
 
-  const [mapName, setMapName] = useState("");
-  const [pickedBy, setPickedBy] = useState<string>("decider"); // teamAId | teamBId | "decider"
-  const [teamAStartSide, setTeamAStartSide] = useState<string>("none"); // "t" | "ct" | "none"
+  const [manualMapName, setManualMapName] = useState("");
+  const [manualPickedBy, setManualPickedBy] = useState<string>("decider");
+  const [teamAStartSide, setTeamAStartSide] = useState<string>("none");
   const [scoreA, setScoreA] = useState("");
   const [scoreB, setScoreB] = useState("");
   const [isPending, startTransition] = useTransition();
 
+  function resolvePickedByName(teamId: string | null) {
+    if (teamId === teamAId) return teamAName;
+    if (teamId === teamBId) return teamBName;
+    return "决胜图";
+  }
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!mapName) { toast.error("请选择地图"); return; }
     const a = parseInt(scoreA, 10);
     const b = parseInt(scoreB, 10);
     if (isNaN(a) || isNaN(b) || a < 0 || b < 0) { toast.error("请输入有效的非负整数"); return; }
     if (a === b) { toast.error("单图不能平局"); return; }
 
-    const pickedByTeamId = pickedBy === "decider" ? null : pickedBy;
+    const resolvedMapName = nextPending?.mapName ?? manualMapName;
+    if (!resolvedMapName) { toast.error("请选择地图"); return; }
+
+    const pickedByTeamId = nextPending
+      ? nextPending.pickedByTeamId
+      : (manualPickedBy === "decider" ? null : manualPickedBy);
     const side = teamAStartSide === "none" ? null : teamAStartSide as "t" | "ct";
 
     startTransition(async () => {
-      const result = await recordMapResult(matchId, nextMapOrder, mapName, a, b, pickedByTeamId, side);
+      const result = await recordMapResult(matchId, nextMapOrder, resolvedMapName, a, b, pickedByTeamId, side);
       if (result.success) {
         toast.success(result.data.seriesFinished ? "系列赛结束，大比分已自动更新" : `第 ${nextMapOrder} 图已录入`);
-        setMapName("");
-        setPickedBy("decider");
+        setManualMapName("");
+        setManualPickedBy("decider");
         setTeamAStartSide("none");
         setScoreA("");
         setScoreB("");
@@ -90,57 +114,73 @@ export function MapByMapInput({
         <span className="text-xs text-[var(--color-fg-mid)]">（先赢 {maxWins} 图胜）</span>
       </div>
 
+      {/* 已完成的图 */}
       {completedMaps.length > 0 && (
         <div className="space-y-1">
-          {completedMaps.map((m) => {
-            const pickedByName = m.pickedByTeamId === teamAId ? teamAName
-              : m.pickedByTeamId === teamBId ? teamBName : null;
-            return (
-              <div key={m.mapOrder} className="flex items-center gap-2 text-xs text-[var(--color-fg-mid)]">
-                <span className="w-4">#{m.mapOrder}</span>
-                <span className="font-medium text-[var(--color-fg)]">{mapLabel(m.mapName)}</span>
-                {pickedByName
-                  ? <Badge variant="outline" className="text-xs">{pickedByName} pick</Badge>
-                  : <Badge variant="outline" className="text-xs text-[var(--color-fg-dim)]">决胜图</Badge>}
-                {m.teamAStartSide && (
-                  <span>{teamAName} {SIDE_LABELS[m.teamAStartSide]}先</span>
-                )}
-                <Badge variant="outline" className="text-xs font-mono">{m.scoreA} : {m.scoreB}</Badge>
-                <span>{m.scoreA > m.scoreB ? teamAName : teamBName} 胜</span>
-              </div>
-            );
-          })}
+          {completedMaps.map((m) => (
+            <div key={m.mapOrder} className="flex items-center gap-2 text-xs text-[var(--color-fg-mid)]">
+              <span className="w-4">#{m.mapOrder}</span>
+              <span className="font-medium text-[var(--color-fg)]">{mapLabel(m.mapName)}</span>
+              <Badge variant="outline" className="text-xs">
+                {resolvePickedByName(m.pickedByTeamId)} {m.pickedByTeamId ? "pick" : ""}
+              </Badge>
+              {m.teamAStartSide && <span>{teamAName} {SIDE_LABELS[m.teamAStartSide]}先</span>}
+              <Badge variant="outline" className="text-xs font-mono">{m.scoreA} : {m.scoreB}</Badge>
+              <span>{m.scoreA > m.scoreB ? teamAName : teamBName} 胜</span>
+            </div>
+          ))}
         </div>
       )}
 
       {!seriesFinished && nextMapOrder <= maxMaps && (
         <form onSubmit={handleSubmit} className="space-y-3 pt-1 border-t border-[var(--color-border)]">
-          <p className="text-xs font-medium text-[var(--color-fg-mid)] pt-2">录入第 {nextMapOrder} 图</p>
+          {nextPending ? (
+            // BP 引导模式：地图和 pick 方从 BP 读取
+            <div className="flex items-center gap-2 pt-2">
+              <span className="text-xs text-[var(--color-fg-mid)]">第 {nextPending.mapOrder} 图</span>
+              <span className="text-xs font-medium text-[var(--color-fg)]">{mapLabel(nextPending.mapName)}</span>
+              <Badge variant="outline" className="text-xs">
+                {resolvePickedByName(nextPending.pickedByTeamId)} {nextPending.pickedByTeamId ? "pick" : ""}
+              </Badge>
+              {nextPending.teamAStartSide && (
+                <span className="text-xs text-[var(--color-fg-mid)]">
+                  {teamAName} {SIDE_LABELS[nextPending.teamAStartSide]}先（BP）
+                </span>
+              )}
+            </div>
+          ) : (
+            // 手动模式：选择地图和 pick 方
+            <p className="text-xs font-medium text-[var(--color-fg-mid)] pt-2">录入第 {nextMapOrder} 图</p>
+          )}
 
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="space-y-1">
-              <Label className="text-xs text-[var(--color-fg-mid)]">地图</Label>
-              <Select value={mapName} onValueChange={setMapName}>
-                <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="选择" /></SelectTrigger>
-                <SelectContent>
-                  {availableMaps.map((m) => (
-                    <SelectItem key={m} value={m} className="text-xs">{mapLabel(m)}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {!nextPending && (
+              <>
+                <div className="space-y-1">
+                  <Label className="text-xs text-[var(--color-fg-mid)]">地图</Label>
+                  <Select value={manualMapName} onValueChange={setManualMapName}>
+                    <SelectTrigger className="h-8 text-xs"><SelectValue placeholder="选择" /></SelectTrigger>
+                    <SelectContent>
+                      {availableMaps.map((m) => (
+                        <SelectItem key={m} value={m} className="text-xs">{mapLabel(m)}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
 
-            <div className="space-y-1">
-              <Label className="text-xs text-[var(--color-fg-mid)]">Pick 方</Label>
-              <Select value={pickedBy} onValueChange={setPickedBy}>
-                <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={teamAId} className="text-xs">{teamAName}</SelectItem>
-                  <SelectItem value={teamBId} className="text-xs">{teamBName}</SelectItem>
-                  <SelectItem value="decider" className="text-xs">决胜图</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+                <div className="space-y-1">
+                  <Label className="text-xs text-[var(--color-fg-mid)]">Pick 方</Label>
+                  <Select value={manualPickedBy} onValueChange={setManualPickedBy}>
+                    <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={teamAId} className="text-xs">{teamAName}</SelectItem>
+                      <SelectItem value={teamBId} className="text-xs">{teamBName}</SelectItem>
+                      <SelectItem value="decider" className="text-xs">决胜图</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </>
+            )}
 
             <div className="space-y-1">
               <Label className="text-xs text-[var(--color-fg-mid)]">{teamAName} 起始边</Label>

--- a/src/components/matches/PlayerRadarChart.tsx
+++ b/src/components/matches/PlayerRadarChart.tsx
@@ -92,6 +92,12 @@ export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps)
 
   const gridLevels = [0.25, 0.5, 0.75, 1.0];
 
+  // 预先解析颜色，避免多边形和图例中重复推导
+  const resolved = capped.map((player, idx) => {
+    const color = player.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
+    return { ...player, color, stroke: player.strokeColor ?? color };
+  });
+
   return (
     <div className="flex flex-col items-center gap-3">
       {/* SVG 雷达图 */}
@@ -126,23 +132,18 @@ export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps)
           );
         })}
 
-        {/* 数据多边形（从后往前渲染，index 0 在最上层） */}
-        {[...capped].reverse().map((player, revIdx) => {
-          const idx = capped.length - 1 - revIdx;
-          const color = player.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
-          const stroke = player.strokeColor ?? color;
-          return (
-            <polygon
-              key={idx}
-              points={dataPolygon(cx, cy, r, player.scores)}
-              fill={color}
-              fillOpacity={0.15}
-              stroke={stroke}
-              strokeWidth={player.strokeWidth ?? 1.5}
-              strokeOpacity={0.8}
-            />
-          );
-        })}
+        {/* 数据多边形（倒序渲染，index 0 在最上层） */}
+        {[...resolved].reverse().map((player, revIdx) => (
+          <polygon
+            key={revIdx}
+            points={dataPolygon(cx, cy, r, player.scores)}
+            fill={player.color}
+            fillOpacity={0.15}
+            stroke={player.stroke}
+            strokeWidth={player.strokeWidth ?? 1.5}
+            strokeOpacity={0.8}
+          />
+        ))}
 
         {/* 轴标签 */}
         {AXES.map((axis, i) => {
@@ -165,8 +166,8 @@ export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps)
         {/* 数值标注（仅单人模式） */}
         {isSingle &&
           AXES.map((axis, i) => {
-            const score = Math.round(capped[0].scores[axis.key]);
-            const pos = scorePos(cx, cy, r, i, capped[0].scores[axis.key]);
+            const score = Math.round(resolved[0].scores[axis.key]);
+            const pos = scorePos(cx, cy, r, i, resolved[0].scores[axis.key]);
             return (
               <text
                 key={`score-${axis.key}`}
@@ -185,19 +186,15 @@ export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps)
 
       {/* 图例（HTML，在 SVG 外渲染） */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
-        {capped.map((player, idx) => {
-          const color = player.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
-          const stroke = player.strokeColor ?? color;
-          return (
-            <span key={idx} className="inline-flex items-center gap-1.5">
-              <span
-                className="inline-block w-2.5 h-2.5 shrink-0 border"
-                style={{ background: color, borderColor: stroke, opacity: 0.8 }}
-              />
-              {player.name}
-            </span>
-          );
-        })}
+        {resolved.map((player, idx) => (
+          <span key={idx} className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block w-2.5 h-2.5 shrink-0 border"
+              style={{ background: player.color, borderColor: player.stroke, opacity: 0.8 }}
+            />
+            {player.name}
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/src/components/matches/PlayerRadarChart.tsx
+++ b/src/components/matches/PlayerRadarChart.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import type { HexagonScores } from "@/lib/utils/hexagon";
+
+// ─── 轴配置（顺时针，从顶部开始） ─────────────────────────────────────────────
+
+const AXES = [
+  { key: "firepower",   label: "火力" },
+  { key: "opening",     label: "破局" },
+  { key: "multikill",   label: "多杀" },
+  { key: "clutch",      label: "残局" },
+  { key: "support",     label: "协同" },
+  { key: "consistency", label: "稳定" },
+] as const satisfies readonly { key: keyof HexagonScores; label: string }[];
+
+// ─── 默认调色板 ────────────────────────────────────────────────────────────────
+
+const DEFAULT_COLORS = [
+  "var(--color-accent)",
+  "var(--color-accent-b)",
+  "#f59e0b",
+  "#10b981",
+  "#8b5cf6",
+];
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
+
+export interface RadarPlayer {
+  name: string;
+  scores: HexagonScores;
+  color?: string;
+  strokeColor?: string;
+}
+
+interface PlayerRadarChartProps {
+  players: RadarPlayer[];
+  size?: number;
+}
+
+// ─── 几何辅助函数 ──────────────────────────────────────────────────────────────
+
+function angle(i: number): number {
+  return (i / 6) * 2 * Math.PI - Math.PI / 2;
+}
+
+function vertex(cx: number, cy: number, r: number, i: number) {
+  const a = angle(i);
+  return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
+}
+
+function gridPolygon(cx: number, cy: number, r: number, scale: number): string {
+  return Array.from({ length: 6 }, (_, i) => {
+    const a = angle(i);
+    return `${cx + r * scale * Math.cos(a)},${cy + r * scale * Math.sin(a)}`;
+  }).join(" ");
+}
+
+function dataPolygon(cx: number, cy: number, r: number, scores: HexagonScores): string {
+  return AXES.map((axis, i) => {
+    const a = angle(i);
+    const d = (scores[axis.key] / 100) * r;
+    return `${cx + d * Math.cos(a)},${cy + d * Math.sin(a)}`;
+  }).join(" ");
+}
+
+function labelPos(cx: number, cy: number, r: number, i: number) {
+  const a = angle(i);
+  const dist = r + 18;
+  return { x: cx + dist * Math.cos(a), y: cy + dist * Math.sin(a) };
+}
+
+function scorePos(cx: number, cy: number, r: number, i: number, score: number) {
+  const a = angle(i);
+  const d = (score / 100) * r;
+  // 偏移数值标注，使其靠近顶点外侧
+  const offset = 10;
+  const dist = d + offset;
+  return { x: cx + dist * Math.cos(a), y: cy + dist * Math.sin(a) };
+}
+
+// ─── 组件 ──────────────────────────────────────────────────────────────────────
+
+export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps) {
+  if (players.length === 0) return null;
+
+  const capped = players.slice(0, 5);
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size * 0.35;
+  const isSingle = capped.length === 1;
+
+  const gridLevels = [0.25, 0.5, 0.75, 1.0];
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {/* SVG 雷达图 */}
+      <svg viewBox={`0 0 ${size} ${size}`} className="w-full max-w-[300px]">
+        {/* 网格圈 */}
+        {gridLevels.map((scale) => (
+          <polygon
+            key={scale}
+            points={gridPolygon(cx, cy, r, scale)}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            strokeDasharray="4 3"
+            opacity={0.5}
+          />
+        ))}
+
+        {/* 轴线 */}
+        {AXES.map((_, i) => {
+          const v = vertex(cx, cy, r, i);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={v.x}
+              y2={v.y}
+              stroke="var(--color-border)"
+              strokeWidth={1}
+              opacity={0.3}
+            />
+          );
+        })}
+
+        {/* 数据多边形（从后往前渲染，index 0 在最上层） */}
+        {[...capped].reverse().map((player, revIdx) => {
+          const idx = capped.length - 1 - revIdx;
+          const color = player.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
+          const stroke = player.strokeColor ?? color;
+          return (
+            <polygon
+              key={idx}
+              points={dataPolygon(cx, cy, r, player.scores)}
+              fill={color}
+              fillOpacity={0.15}
+              stroke={stroke}
+              strokeWidth={1.5}
+              strokeOpacity={0.8}
+            />
+          );
+        })}
+
+        {/* 轴标签 */}
+        {AXES.map((axis, i) => {
+          const pos = labelPos(cx, cy, r, i);
+          return (
+            <text
+              key={axis.key}
+              x={pos.x}
+              y={pos.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={11}
+              fill="var(--color-fg-mid)"
+            >
+              {axis.label}
+            </text>
+          );
+        })}
+
+        {/* 数值标注（仅单人模式） */}
+        {isSingle &&
+          AXES.map((axis, i) => {
+            const score = Math.round(capped[0].scores[axis.key]);
+            const pos = scorePos(cx, cy, r, i, capped[0].scores[axis.key]);
+            return (
+              <text
+                key={`score-${axis.key}`}
+                x={pos.x}
+                y={pos.y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={9}
+                fill="var(--color-fg)"
+              >
+                {score}
+              </text>
+            );
+          })}
+      </svg>
+
+      {/* 图例（HTML，在 SVG 外渲染） */}
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
+        {capped.map((player, idx) => {
+          const color = player.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
+          const stroke = player.strokeColor ?? color;
+          return (
+            <span key={idx} className="inline-flex items-center gap-1.5">
+              <span
+                className="inline-block w-2.5 h-2.5 shrink-0 border"
+                style={{ background: color, borderColor: stroke, opacity: 0.8 }}
+              />
+              {player.name}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/matches/PlayerRadarChart.tsx
+++ b/src/components/matches/PlayerRadarChart.tsx
@@ -30,6 +30,7 @@ export interface RadarPlayer {
   scores: HexagonScores;
   color?: string;
   strokeColor?: string;
+  strokeWidth?: number;
 }
 
 interface PlayerRadarChartProps {
@@ -83,7 +84,7 @@ function scorePos(cx: number, cy: number, r: number, i: number, score: number) {
 export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps) {
   if (players.length === 0) return null;
 
-  const capped = players.slice(0, 5);
+  const capped = players.slice(0, 6);
   const cx = size / 2;
   const cy = size / 2;
   const r = size * 0.35;
@@ -137,7 +138,7 @@ export function PlayerRadarChart({ players, size = 300 }: PlayerRadarChartProps)
               fill={color}
               fillOpacity={0.15}
               stroke={stroke}
-              strokeWidth={1.5}
+              strokeWidth={player.strokeWidth ?? 1.5}
               strokeOpacity={0.8}
             />
           );

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -36,8 +36,8 @@ const SORT_OPTIONS = [
   { key: "hs",      label: "HS%" },
   { key: "we",      label: "WE" },
   { key: "rws",     label: "RWS" },
-  { key: "fk",      label: "FKPR" },
-  { key: "clutch",  label: "CPR" },
+  { key: "fk",      label: "FKPR /100r" },
+  { key: "clutch",  label: "CPR /100r" },
   { key: "maps",    label: "场次" },
 ];
 
@@ -108,15 +108,15 @@ const COLS: ColDef[] = [
   },
   {
     key: "fk",
-    label: "FKPR",
+    label: "FKPR /100r",
     getValue: (r) => r.fkpr,
-    format: (v) => (v ?? 0).toFixed(2),
+    format: (v) => (v != null ? (v * 100).toFixed(1) : "—"),
   },
   {
     key: "clutch",
-    label: "CPR",
+    label: "CPR /100r",
     getValue: (r) => r.cpr,
-    format: (v) => (v ?? 0).toFixed(2),
+    format: (v) => (v != null ? (v * 100).toFixed(1) : "—"),
   },
 ];
 

--- a/src/components/matches/VetoInputDialog.tsx
+++ b/src/components/matches/VetoInputDialog.tsx
@@ -22,6 +22,7 @@ import { saveVetoSteps, getMatchVetoSteps, type VetoStepInput } from "@/actions/
 import { mapLabel } from "@/lib/maps";
 import type { VetoActionType } from "@/types/match";
 import { SIDE_LABELS } from "@/types/match";
+import { cn } from "@/lib/utils/cn";
 
 interface Props {
   matchId: string;
@@ -31,6 +32,7 @@ interface Props {
   teamAId: string;
   teamBId: string;
   mapPool: string[];
+  matchStatus?: string;
 }
 
 interface StepEdit {
@@ -99,6 +101,7 @@ export function VetoInputDialog({
   teamAId,
   teamBId,
   mapPool,
+  matchStatus,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [steps, setSteps] = useState<StepEdit[]>(() =>
@@ -204,6 +207,12 @@ export function VetoInputDialog({
           </DialogTitle>
         </DialogHeader>
 
+        {matchStatus === "finished" && (
+          <p className="text-xs text-[var(--color-fg-mid)] bg-[var(--color-panel-low)] px-3 py-2 rounded-md">
+            赛后补录：仅更新 BP 步骤，不重建地图记录（已有比分行不受影响）
+          </p>
+        )}
+
         {loading ? (
           <p className="text-sm text-[var(--color-fg-mid)] py-4">加载中…</p>
         ) : null}
@@ -225,23 +234,35 @@ export function VetoInputDialog({
 
               {/* 执行队伍 */}
               {step.actionType === "decider" && step.teamId === null ? (
-                <span className="text-sm text-[var(--color-fg-mid)] w-24">
+                <span className="text-sm text-[var(--color-fg-mid)] w-16">
                   刀赛/剩余
                 </span>
               ) : (
-                <div className="w-24">
-                  <Select
-                    value={step.teamId ?? ""}
-                    onValueChange={(v) => updateStep(i, { teamId: v || null })}
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => updateStep(i, { teamId: teamAId })}
+                    className={cn(
+                      "px-2.5 py-1 text-xs rounded border transition-colors",
+                      step.teamId === teamAId
+                        ? "bg-[var(--color-accent)] text-white border-[var(--color-accent)]"
+                        : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+                    )}
                   >
-                    <SelectTrigger className="h-8 text-xs">
-                      <SelectValue placeholder="选择队伍" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={teamAId}>{teamAName}</SelectItem>
-                      <SelectItem value={teamBId}>{teamBName}</SelectItem>
-                    </SelectContent>
-                  </Select>
+                    A
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => updateStep(i, { teamId: teamBId })}
+                    className={cn(
+                      "px-2.5 py-1 text-xs rounded border transition-colors",
+                      step.teamId === teamBId
+                        ? "bg-[var(--color-accent-b)] text-white border-[var(--color-accent-b)]"
+                        : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+                    )}
+                  >
+                    B
+                  </button>
                 </div>
               )}
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -58,6 +58,7 @@ export const ErrorCode = {
   MATCH_MAP_DUPLICATE: "MATCH_MAP_DUPLICATE",          // 同一 mapName 出现两次
   MATCH_MAP_ORDER_CONFLICT: "MATCH_MAP_ORDER_CONFLICT",// mapOrder 已存在
   MATCH_FORMAT_MISMATCH: "MATCH_FORMAT_MISMATCH",      // BO1 录入 2 张图等
+  MATCH_VOTE_TOO_EARLY: "MATCH_VOTE_TOO_EARLY",
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -112,4 +113,5 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
   MATCH_MAP_DUPLICATE: "同一张图不能在系列赛中出现两次",
   MATCH_MAP_ORDER_CONFLICT: "该图序号已被使用",
   MATCH_FORMAT_MISMATCH: "提交的图数与比赛 BO 格式不一致",
+  MATCH_VOTE_TOO_EARLY: "账号注册满 24 小时后可参与投票",
 };

--- a/src/lib/utils/hexagon.test.ts
+++ b/src/lib/utils/hexagon.test.ts
@@ -33,21 +33,30 @@ function makePlayer(overrides: Partial<PlayerMetrics> = {}): PlayerMetrics {
 // ─── zScore 内部行为（通过 computeEventStats + computeDimensions 间接测试） ──
 
 describe("zScore 边界", () => {
-  it("std=0 时所有人该指标标准化分数应为 50（所有人值相同）", () => {
-    const p1 = makePlayer({ kpr: 1.0 });
-    const p2 = makePlayer({ userId: "u2", kpr: 1.0 });
+  it("std=0 时（所有选手所有指标完全相同）六维各维应为 50", () => {
+    // 两名选手所有指标完全相同 → 每个指标 std=0 → 每个 zScore 返回 50 → 六维均为 50
+    const identical = {
+      kpr: 0.8, dpr: 0.7, apr: 0.4, kd: 1.1, kda: 1.5,
+      fkpr: 0.1, mkpr: 0.15, cpr: 0.05, adr: 80,
+      rws: 0.25, we: 0.5, ratingPro: 1.0, totalRounds: 60,
+    };
+    const p1 = makePlayer({ userId: "u1", ...identical });
+    const p2 = makePlayer({ userId: "u2", ...identical });
     const stats = computeEventStats([p1, p2]);
-    // std.kpr 为 0，mean.kpr = 1.0
-    expect(stats.std.kpr).toBeCloseTo(0);
-    // 两个分数都应为 50
+
+    // 验证所有 std 确实为 0
+    for (const key of Object.keys(stats.std) as (keyof typeof stats.std)[]) {
+      expect(stats.std[key], `std.${key} 应为 0`).toBeCloseTo(0);
+    }
+
     const s1 = computeDimensions(p1, stats);
     const s2 = computeDimensions(p2, stats);
-    // firepower 包含 kpr，当 kpr std=0 kd std=0 adr std=0 mkpr std=0 时 firepower=50
-    // 这里只验证极值不超出 0-100
-    expect(s1.firepower).toBeGreaterThanOrEqual(0);
-    expect(s1.firepower).toBeLessThanOrEqual(100);
-    expect(s2.firepower).toBeGreaterThanOrEqual(0);
-    expect(s2.firepower).toBeLessThanOrEqual(100);
+
+    const dims: (keyof HexagonScores)[] = ["firepower", "opening", "multikill", "clutch", "support", "consistency"];
+    for (const dim of dims) {
+      expect(s1[dim], `s1.${dim} 应为 50`).toBeCloseTo(50);
+      expect(s2[dim], `s2.${dim} 应为 50`).toBeCloseTo(50);
+    }
   });
 
   it("极高值应 clamp 到 100（不超过 100）", () => {

--- a/src/lib/utils/hexagon.test.ts
+++ b/src/lib/utils/hexagon.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEventStats,
+  computeDimensions,
+  computeTeamDimensions,
+  DIMENSION_WEIGHTS,
+  type PlayerMetrics,
+  type HexagonScores,
+} from "./hexagon";
+
+// ─── 辅助工厂 ─────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides: Partial<PlayerMetrics> = {}): PlayerMetrics {
+  return {
+    userId: "u1",
+    kpr: 0.8,
+    dpr: 0.7,
+    apr: 0.4,
+    kd: 1.1,
+    kda: 1.5,
+    fkpr: 0.1,
+    mkpr: 0.15,
+    cpr: 0.05,
+    adr: 80,
+    rws: 0.25,
+    we: 0.5,
+    ratingPro: 1.0,
+    totalRounds: 60,
+    ...overrides,
+  };
+}
+
+// ─── zScore 内部行为（通过 computeEventStats + computeDimensions 间接测试） ──
+
+describe("zScore 边界", () => {
+  it("std=0 时所有人该指标标准化分数应为 50（所有人值相同）", () => {
+    const p1 = makePlayer({ kpr: 1.0 });
+    const p2 = makePlayer({ userId: "u2", kpr: 1.0 });
+    const stats = computeEventStats([p1, p2]);
+    // std.kpr 为 0，mean.kpr = 1.0
+    expect(stats.std.kpr).toBeCloseTo(0);
+    // 两个分数都应为 50
+    const s1 = computeDimensions(p1, stats);
+    const s2 = computeDimensions(p2, stats);
+    // firepower 包含 kpr，当 kpr std=0 kd std=0 adr std=0 mkpr std=0 时 firepower=50
+    // 这里只验证极值不超出 0-100
+    expect(s1.firepower).toBeGreaterThanOrEqual(0);
+    expect(s1.firepower).toBeLessThanOrEqual(100);
+    expect(s2.firepower).toBeGreaterThanOrEqual(0);
+    expect(s2.firepower).toBeLessThanOrEqual(100);
+  });
+
+  it("极高值应 clamp 到 100（不超过 100）", () => {
+    const p1 = makePlayer({ kpr: 100 });
+    const p2 = makePlayer({ userId: "u2", kpr: 0 });
+    const stats = computeEventStats([p1, p2]);
+    const s1 = computeDimensions(p1, stats);
+    expect(s1.firepower).toBeLessThanOrEqual(100);
+  });
+
+  it("极低值应 clamp 到 0（不低于 0）", () => {
+    const p1 = makePlayer({ kpr: 0 });
+    const p2 = makePlayer({ userId: "u2", kpr: 100 });
+    const stats = computeEventStats([p1, p2]);
+    const s1 = computeDimensions(p1, stats);
+    expect(s1.firepower).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── computeEventStats ────────────────────────────────────────────────────────
+
+describe("computeEventStats", () => {
+  it("单人时 std 为 0，mean 等于本人值", () => {
+    const p = makePlayer({ kpr: 0.9 });
+    const stats = computeEventStats([p]);
+    expect(stats.mean.kpr).toBeCloseTo(0.9);
+    expect(stats.std.kpr).toBeCloseTo(0);
+  });
+
+  it("两人时 mean 和 std 计算正确", () => {
+    const p1 = makePlayer({ kpr: 0.6 });
+    const p2 = makePlayer({ userId: "u2", kpr: 1.0 });
+    const stats = computeEventStats([p1, p2]);
+    // mean = 0.8, 总体 std = sqrt(((0.6-0.8)²+(1.0-0.8)²)/2) = sqrt(0.04) = 0.2
+    expect(stats.mean.kpr).toBeCloseTo(0.8);
+    expect(stats.std.kpr).toBeCloseTo(0.2);
+  });
+
+  it("三人时 mean 和 std 计算正确", () => {
+    const players = [
+      makePlayer({ userId: "u1", adr: 60 }),
+      makePlayer({ userId: "u2", adr: 80 }),
+      makePlayer({ userId: "u3", adr: 100 }),
+    ];
+    const stats = computeEventStats(players);
+    // mean = 80, 总体 std = sqrt(((60-80)²+(80-80)²+(100-80)²)/3) = sqrt(800/3) ≈ 16.33
+    expect(stats.mean.adr).toBeCloseTo(80);
+    expect(stats.std.adr).toBeCloseTo(Math.sqrt(800 / 3));
+  });
+
+  it("空数组时 mean 和 std 均为 0", () => {
+    const stats = computeEventStats([]);
+    expect(stats.mean.kpr).toBe(0);
+    expect(stats.std.kpr).toBe(0);
+  });
+});
+
+// ─── computeDimensions ───────────────────────────────────────────────────────
+
+describe("computeDimensions", () => {
+  it("所有输出维度应在 0-100 之间", () => {
+    const players = [
+      makePlayer({ userId: "u1" }),
+      makePlayer({ userId: "u2", kpr: 1.2, dpr: 0.5, adr: 100 }),
+      makePlayer({ userId: "u3", kpr: 0.4, dpr: 0.9, adr: 60 }),
+    ];
+    const stats = computeEventStats(players);
+    for (const p of players) {
+      const scores = computeDimensions(p, stats);
+      for (const key of Object.keys(scores) as (keyof HexagonScores)[]) {
+        expect(scores[key], `${key} out of range`).toBeGreaterThanOrEqual(0);
+        expect(scores[key], `${key} out of range`).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
+  it("各维度权重之和等于 1.0", () => {
+    for (const [dim, weights] of Object.entries(DIMENSION_WEIGHTS)) {
+      const sum = Object.values(weights).reduce((s, w) => s + w, 0);
+      expect(sum, `${dim} 权重之和应为 1.0`).toBeCloseTo(1.0);
+    }
+  });
+
+  it("平均选手（所有指标等于 mean）经 shrink 后得分接近 50", () => {
+    const players = [
+      makePlayer({ userId: "u1", kpr: 0.6 }),
+      makePlayer({ userId: "u2", kpr: 1.0 }),
+    ];
+    const stats = computeEventStats(players);
+    // 均值为 0.8 的选手
+    const avg = makePlayer({ userId: "avg", kpr: 0.8, totalRounds: 60 });
+    // 注意：其他指标也需要等于 mean；这里用简单单指标偏差为 0 的场景
+    const scores = computeDimensions(avg, stats);
+    // 由于其他指标也有偏差，只验证范围
+    expect(scores.firepower).toBeGreaterThanOrEqual(0);
+    expect(scores.firepower).toBeLessThanOrEqual(100);
+  });
+});
+
+// ─── shrink 行为（通过 computeDimensions 间接测试） ─────────────────────────
+
+describe("shrink 行为", () => {
+  it("rounds=30（< threshold 60）时分数比 rounds=60 更靠近 50", () => {
+    const players = [
+      makePlayer({ userId: "u1", kpr: 0.3 }),
+      makePlayer({ userId: "u2", kpr: 1.5 }),
+    ];
+    const stats = computeEventStats(players);
+
+    const lowRounds  = makePlayer({ userId: "u3", kpr: 1.5, totalRounds: 30 });
+    const fullRounds = makePlayer({ userId: "u4", kpr: 1.5, totalRounds: 60 });
+
+    const sLow  = computeDimensions(lowRounds,  stats);
+    const sFull = computeDimensions(fullRounds, stats);
+
+    // 强势选手 rounds=30 时 firepower 应比 rounds=60 更接近 50（即更低）
+    expect(Math.abs(sLow.firepower - 50)).toBeLessThan(Math.abs(sFull.firepower - 50));
+  });
+
+  it("rounds=60（等于 threshold）时 factor=1，分数不收缩", () => {
+    const players = [
+      makePlayer({ userId: "u1", kpr: 0.3 }),
+      makePlayer({ userId: "u2", kpr: 1.5 }),
+    ];
+    const stats = computeEventStats(players);
+
+    const at60    = makePlayer({ userId: "u3", kpr: 1.5, totalRounds: 60  });
+    const above60 = makePlayer({ userId: "u4", kpr: 1.5, totalRounds: 120 });
+
+    const s60    = computeDimensions(at60,    stats);
+    const sAbove = computeDimensions(above60, stats);
+
+    // rounds >= threshold 时 factor=min(1,...)=1，分数不再收缩
+    expect(s60.firepower).toBeCloseTo(sAbove.firepower);
+  });
+});
+
+// ─── computeTeamDimensions ───────────────────────────────────────────────────
+
+describe("computeTeamDimensions", () => {
+  it("空数组返回全 50", () => {
+    const result = computeTeamDimensions([]);
+    for (const key of Object.keys(result) as (keyof HexagonScores)[]) {
+      expect(result[key]).toBe(50);
+    }
+  });
+
+  it("单人时返回该人分数", () => {
+    const score: HexagonScores = {
+      firepower: 70, opening: 60, multikill: 55,
+      clutch: 45, support: 80, consistency: 65,
+    };
+    const result = computeTeamDimensions([score]);
+    expect(result.firepower).toBeCloseTo(70);
+    expect(result.opening).toBeCloseTo(60);
+    expect(result.support).toBeCloseTo(80);
+  });
+
+  it("多人时返回各维度的算术均值", () => {
+    const s1: HexagonScores = { firepower: 60, opening: 70, multikill: 50, clutch: 80, support: 40, consistency: 90 };
+    const s2: HexagonScores = { firepower: 80, opening: 50, multikill: 70, clutch: 60, support: 60, consistency: 50 };
+    const result = computeTeamDimensions([s1, s2]);
+    expect(result.firepower).toBeCloseTo(70);
+    expect(result.opening).toBeCloseTo(60);
+    expect(result.multikill).toBeCloseTo(60);
+    expect(result.clutch).toBeCloseTo(70);
+    expect(result.support).toBeCloseTo(50);
+    expect(result.consistency).toBeCloseTo(70);
+  });
+
+  it("五人队伍各维度均值计算正确", () => {
+    const scores: HexagonScores[] = [
+      { firepower: 55, opening: 60, multikill: 50, clutch: 45, support: 70, consistency: 65 },
+      { firepower: 75, opening: 55, multikill: 80, clutch: 60, support: 50, consistency: 70 },
+      { firepower: 65, opening: 70, multikill: 60, clutch: 55, support: 80, consistency: 60 },
+      { firepower: 50, opening: 65, multikill: 55, clutch: 70, support: 60, consistency: 75 },
+      { firepower: 70, opening: 50, multikill: 65, clutch: 50, support: 55, consistency: 55 },
+    ];
+    const result = computeTeamDimensions(scores);
+    expect(result.firepower).toBeCloseTo((55 + 75 + 65 + 50 + 70) / 5);
+    expect(result.opening).toBeCloseTo((60 + 55 + 70 + 65 + 50) / 5);
+  });
+});

--- a/src/lib/utils/hexagon.test.ts
+++ b/src/lib/utils/hexagon.test.ts
@@ -140,19 +140,42 @@ describe("computeDimensions", () => {
     }
   });
 
-  it("平均选手（所有指标等于 mean）经 shrink 后得分接近 50", () => {
-    const players = [
-      makePlayer({ userId: "u1", kpr: 0.6 }),
-      makePlayer({ userId: "u2", kpr: 1.0 }),
-    ];
-    const stats = computeEventStats(players);
-    // 均值为 0.8 的选手
-    const avg = makePlayer({ userId: "avg", kpr: 0.8, totalRounds: 60 });
-    // 注意：其他指标也需要等于 mean；这里用简单单指标偏差为 0 的场景
-    const scores = computeDimensions(avg, stats);
-    // 由于其他指标也有偏差，只验证范围
-    expect(scores.firepower).toBeGreaterThanOrEqual(0);
-    expect(scores.firepower).toBeLessThanOrEqual(100);
+  it("所有指标均等于 mean 的选手六维应接近 50", () => {
+    // 构造镜像对：每个指标互为关于中点对称
+    const p1 = makePlayer({
+      userId: "low",
+      kpr: 0.4, dpr: 0.4, apr: 0.2, kd: 0.7, kda: 1.0,
+      fkpr: 0.05, mkpr: 0.05, cpr: 0.02, adr: 60,
+      rws: 0.15, we: 0.3, ratingPro: 0.7,
+    });
+    const p2 = makePlayer({
+      userId: "high",
+      kpr: 1.2, dpr: 0.8, apr: 0.6, kd: 1.5, kda: 2.0,
+      fkpr: 0.15, mkpr: 0.25, cpr: 0.08, adr: 100,
+      rws: 0.35, we: 0.7, ratingPro: 1.3,
+    });
+    const stats = computeEventStats([p1, p2]);
+    // 中点选手所有指标恰好等于 mean
+    const mid = makePlayer({
+      userId: "mid",
+      kpr: 0.8, dpr: 0.6, apr: 0.4, kd: 1.1, kda: 1.5,
+      fkpr: 0.10, mkpr: 0.15, cpr: 0.05, adr: 80,
+      rws: 0.25, we: 0.5, ratingPro: 1.0,
+      totalRounds: 60,
+    });
+    const scores = computeDimensions(mid, stats);
+    for (const key of Object.keys(scores) as (keyof HexagonScores)[]) {
+      expect(scores[key], `${key} 应接近 50`).toBeCloseTo(50, 0);
+    }
+  });
+
+  it("totalRounds=0 时六维应全部为 50（完全归中性）", () => {
+    const p = makePlayer({ userId: "zero", totalRounds: 0 });
+    const stats = computeEventStats([p]);
+    const scores = computeDimensions(p, stats);
+    for (const key of Object.keys(scores) as (keyof HexagonScores)[]) {
+      expect(scores[key], `${key} 应为 50`).toBeCloseTo(50);
+    }
   });
 });
 

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -104,12 +104,12 @@ export function computeEventStats(players: PlayerMetrics[]): EventStats {
   const mean = {} as Record<MetricKey, number>;
   const std  = {} as Record<MetricKey, number>;
 
+  if (n === 0) {
+    for (const key of METRIC_KEYS) { mean[key] = 0; std[key] = 0; }
+    return { mean, std };
+  }
+
   for (const key of METRIC_KEYS) {
-    if (n === 0) {
-      mean[key] = 0;
-      std[key]  = 0;
-      continue;
-    }
     const sum = players.reduce((s, p) => s + p[key], 0);
     const avg = sum / n;
     const variance = players.reduce((s, p) => s + (p[key] - avg) ** 2, 0) / n;

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -74,12 +74,14 @@ function clamp(v: number): number {
 
 /** Z-score 标准化：高值 → 高分 */
 function zScore(value: number, mean: number, std: number): number {
-  return clamp(50 + ((value - mean) / Math.max(std, 0.001)) * 15);
+  if (std === 0) return 50;
+  return clamp(50 + ((value - mean) / std) * 15);
 }
 
 /** Z-score 反向标准化：低值 → 高分（少死分专用） */
 function zScoreInverse(value: number, mean: number, std: number): number {
-  return clamp(50 + ((mean - value) / Math.max(std, 0.001)) * 15);
+  if (std === 0) return 50;
+  return clamp(50 + ((mean - value) / std) * 15);
 }
 
 /** 小样本收缩：回合数不足 threshold 时向 50 靠拢 */

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -44,26 +44,14 @@ export interface HexagonScores {
 
 // ─── 六维权重配置 ─────────────────────────────────────────────────────────────
 
-export const DIMENSION_WEIGHTS = {
-  firepower: {
-    kpr: 0.35, adr: 0.35, kd: 0.15, mkpr: 0.15,
-  },
-  opening: {
-    fkpr: 0.50, we: 0.30, adr: 0.20,
-  },
-  multikill: {
-    mkpr: 0.55, kpr: 0.25, adr: 0.20,
-  },
-  clutch: {
-    cpr: 0.55, kd: 0.25, rws: 0.20,
-  },
-  support: {
-    apr: 0.35, kda: 0.25, we: 0.20, rws: 0.20,
-  },
-  consistency: {
-    ratingPro: 0.40, dprInverse: 0.30, rws: 0.20, kd: 0.10,
-  },
-} as const;
+export const DIMENSION_WEIGHTS = Object.freeze({
+  firepower:   Object.freeze({ kpr: 0.35, adr: 0.35, kd: 0.15, mkpr: 0.15 }),
+  opening:     Object.freeze({ fkpr: 0.50, we: 0.30, adr: 0.20 }),
+  multikill:   Object.freeze({ mkpr: 0.55, kpr: 0.25, adr: 0.20 }),
+  clutch:      Object.freeze({ cpr: 0.55, kd: 0.25, rws: 0.20 }),
+  support:     Object.freeze({ apr: 0.35, kda: 0.25, we: 0.20, rws: 0.20 }),
+  consistency: Object.freeze({ ratingPro: 0.40, dprInverse: 0.30, rws: 0.20, kd: 0.10 }),
+});
 
 // ─── 内部标准化辅助函数 ───────────────────────────────────────────────────────
 
@@ -74,13 +62,17 @@ function clamp(v: number): number {
 
 /** Z-score 标准化：高值 → 高分 */
 function zScore(value: number, mean: number, std: number): number {
-  if (std === 0) return 50;
+  if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
+    return 50;
+  }
   return clamp(50 + ((value - mean) / std) * 15);
 }
 
 /** Z-score 反向标准化：低值 → 高分（少死分专用） */
 function zScoreInverse(value: number, mean: number, std: number): number {
-  if (std === 0) return 50;
+  if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
+    return 50;
+  }
   return clamp(50 + ((mean - value) / std) * 15);
 }
 
@@ -92,10 +84,15 @@ function shrink(score: number, rounds: number, threshold = 60): number {
 
 // ─── 公开函数 ─────────────────────────────────────────────────────────────────
 
-const METRIC_KEYS: MetricKey[] = [
+const METRIC_KEYS = [
   "kpr", "dpr", "apr", "kd", "kda",
   "fkpr", "mkpr", "cpr", "adr", "rws", "we", "ratingPro",
-];
+] as const satisfies readonly MetricKey[];
+
+type _MetricKeysExhaustive = Exclude<MetricKey, (typeof METRIC_KEYS)[number]> extends never
+  ? true
+  : ["METRIC_KEYS missing keys"];
+const _checkMetricKeys: _MetricKeysExhaustive = true;
 
 /**
  * 计算赛事统计量（mean + std），供多次调用复用。
@@ -137,7 +134,8 @@ export function computeDimensions(
   const { mean, std } = stats;
 
   // 预计算所有指标的标准化分数
-  const z: Record<string, number> = {};
+  type ZKey = MetricKey | "dprInverse";
+  const z = {} as Record<ZKey, number>;
   for (const key of METRIC_KEYS) {
     z[key] = zScore(player[key], mean[key], std[key]);
   }

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -1,0 +1,210 @@
+/**
+ * 六维雷达图标准化计算工具
+ *
+ * 流程：原始指标 → Z-score 标准化 → 加权求和六维 → 小样本收缩
+ */
+
+// ─── 类型定义 ─────────────────────────────────────────────────────────────────
+
+/** 原始中间指标（每选手聚合后的值，单位：per-round 或 ratio） */
+export interface PlayerMetrics {
+  userId: string;
+  kpr: number;       // kills per round
+  dpr: number;       // deaths per round
+  apr: number;       // assists per round
+  kd: number;        // kills / max(deaths, 1)
+  kda: number;       // (kills + assists) / max(deaths, 1)
+  fkpr: number;      // first kills per round
+  mkpr: number;      // multi kills per round
+  cpr: number;       // clutches per round
+  adr: number;       // avg damage per round (round-weighted)
+  rws: number;       // round win share
+  we: number;        // win equity
+  ratingPro: number; // rating pro
+  totalRounds: number; // 参与回合总数
+}
+
+type MetricKey = keyof Omit<PlayerMetrics, "userId" | "totalRounds">;
+
+/** 赛事统计量（用于 Z-score） */
+export interface EventStats {
+  mean: Record<MetricKey, number>;
+  std:  Record<MetricKey, number>;
+}
+
+/** 六维分数（0-100） */
+export interface HexagonScores {
+  firepower:   number;  // 火力
+  opening:     number;  // 破局
+  multikill:   number;  // 多杀
+  clutch:      number;  // 残局
+  support:     number;  // 协同
+  consistency: number;  // 稳定
+}
+
+// ─── 六维权重配置 ─────────────────────────────────────────────────────────────
+
+export const DIMENSION_WEIGHTS = {
+  firepower: {
+    kpr: 0.35, adr: 0.35, kd: 0.15, mkpr: 0.15,
+  },
+  opening: {
+    fkpr: 0.50, we: 0.30, adr: 0.20,
+  },
+  multikill: {
+    mkpr: 0.55, kpr: 0.25, adr: 0.20,
+  },
+  clutch: {
+    cpr: 0.55, kd: 0.25, rws: 0.20,
+  },
+  support: {
+    apr: 0.35, kda: 0.25, we: 0.20, rws: 0.20,
+  },
+  consistency: {
+    ratingPro: 0.40, dprInverse: 0.30, rws: 0.20, kd: 0.10,
+  },
+} as const;
+
+// ─── 内部标准化辅助函数 ───────────────────────────────────────────────────────
+
+/** 将值 clamp 到 [0, 100] */
+function clamp(v: number): number {
+  return Math.max(0, Math.min(100, v));
+}
+
+/** Z-score 标准化：高值 → 高分 */
+function zScore(value: number, mean: number, std: number): number {
+  return clamp(50 + ((value - mean) / Math.max(std, 0.001)) * 15);
+}
+
+/** Z-score 反向标准化：低值 → 高分（少死分专用） */
+function zScoreInverse(value: number, mean: number, std: number): number {
+  return clamp(50 + ((mean - value) / Math.max(std, 0.001)) * 15);
+}
+
+/** 小样本收缩：回合数不足 threshold 时向 50 靠拢 */
+function shrink(score: number, rounds: number, threshold = 60): number {
+  const factor = Math.min(1, rounds / threshold);
+  return 50 + (score - 50) * factor;
+}
+
+// ─── 公开函数 ─────────────────────────────────────────────────────────────────
+
+const METRIC_KEYS: MetricKey[] = [
+  "kpr", "dpr", "apr", "kd", "kda",
+  "fkpr", "mkpr", "cpr", "adr", "rws", "we", "ratingPro",
+];
+
+/**
+ * 计算赛事统计量（mean + std），供多次调用复用。
+ * std 使用总体标准差 sqrt(E[(x-μ)²])。
+ */
+export function computeEventStats(players: PlayerMetrics[]): EventStats {
+  const n = players.length;
+
+  const mean = {} as Record<MetricKey, number>;
+  const std  = {} as Record<MetricKey, number>;
+
+  for (const key of METRIC_KEYS) {
+    if (n === 0) {
+      mean[key] = 0;
+      std[key]  = 0;
+      continue;
+    }
+    const sum = players.reduce((s, p) => s + p[key], 0);
+    const avg = sum / n;
+    const variance = players.reduce((s, p) => s + (p[key] - avg) ** 2, 0) / n;
+    mean[key] = avg;
+    std[key]  = Math.sqrt(variance);
+  }
+
+  return { mean, std };
+}
+
+/**
+ * 计算单个选手六维分数（0-100）。
+ * 步骤：
+ *   1. 对每个原始指标做 Z-score（dpr 用反向）
+ *   2. 按权重加权求和得六维原始分
+ *   3. 对每维分数做小样本收缩
+ */
+export function computeDimensions(
+  player: PlayerMetrics,
+  stats: EventStats,
+): HexagonScores {
+  const { mean, std } = stats;
+
+  // 预计算所有指标的标准化分数
+  const z: Record<string, number> = {};
+  for (const key of METRIC_KEYS) {
+    z[key] = zScore(player[key], mean[key], std[key]);
+  }
+  // dprInverse：少死分（反向）
+  z.dprInverse = zScoreInverse(player.dpr, mean.dpr, std.dpr);
+
+  const rounds = player.totalRounds;
+
+  // 加权求和 + 收缩
+  const firepower = shrink(
+    DIMENSION_WEIGHTS.firepower.kpr  * z.kpr  +
+    DIMENSION_WEIGHTS.firepower.adr  * z.adr  +
+    DIMENSION_WEIGHTS.firepower.kd   * z.kd   +
+    DIMENSION_WEIGHTS.firepower.mkpr * z.mkpr,
+    rounds,
+  );
+
+  const opening = shrink(
+    DIMENSION_WEIGHTS.opening.fkpr * z.fkpr +
+    DIMENSION_WEIGHTS.opening.we   * z.we   +
+    DIMENSION_WEIGHTS.opening.adr  * z.adr,
+    rounds,
+  );
+
+  const multikill = shrink(
+    DIMENSION_WEIGHTS.multikill.mkpr * z.mkpr +
+    DIMENSION_WEIGHTS.multikill.kpr  * z.kpr  +
+    DIMENSION_WEIGHTS.multikill.adr  * z.adr,
+    rounds,
+  );
+
+  const clutch = shrink(
+    DIMENSION_WEIGHTS.clutch.cpr * z.cpr +
+    DIMENSION_WEIGHTS.clutch.kd  * z.kd  +
+    DIMENSION_WEIGHTS.clutch.rws * z.rws,
+    rounds,
+  );
+
+  const support = shrink(
+    DIMENSION_WEIGHTS.support.apr * z.apr +
+    DIMENSION_WEIGHTS.support.kda * z.kda +
+    DIMENSION_WEIGHTS.support.we  * z.we  +
+    DIMENSION_WEIGHTS.support.rws * z.rws,
+    rounds,
+  );
+
+  const consistency = shrink(
+    DIMENSION_WEIGHTS.consistency.ratingPro  * z.ratingPro  +
+    DIMENSION_WEIGHTS.consistency.dprInverse * z.dprInverse +
+    DIMENSION_WEIGHTS.consistency.rws        * z.rws        +
+    DIMENSION_WEIGHTS.consistency.kd         * z.kd,
+    rounds,
+  );
+
+  return { firepower, opening, multikill, clutch, support, consistency };
+}
+
+/**
+ * 计算队伍六维（成员分数的算术均值）。
+ * 空数组返回全 50。
+ */
+export function computeTeamDimensions(scores: HexagonScores[]): HexagonScores {
+  if (scores.length === 0) {
+    return { firepower: 50, opening: 50, multikill: 50, clutch: 50, support: 50, consistency: 50 };
+  }
+  const keys: (keyof HexagonScores)[] = ["firepower", "opening", "multikill", "clutch", "support", "consistency"];
+  const result = {} as HexagonScores;
+  for (const key of keys) {
+    result[key] = scores.reduce((s, sc) => s + sc[key], 0) / scores.length;
+  }
+  return result;
+}


### PR DESCRIPTION
## 功能概述

### 六维能力雷达图（Hexagon）
- 新增 `hexagon.ts`：基于赛季赛事统计的 Z-score 标准化，计算六维评分（火力/破局/多杀/残局/协同/稳定），含完整单元测试
- `PlayerRadarChart`：SVG 雷达图组件，支持多人叠加、轴标签、单人数值标注、图例
- 集成到三处页面：
  - 选手个人页（跨赛季六维卡片）
  - 队伍详情页（队内成员六维对比）
  - 比赛详情页（双方阵容六维对比雷达图）
- `StatsLeaderboard` 新增六维综合评分列

### Cloudflare Turnstile 验证码
- 注册页集成 Turnstile（`TurnstileWidget` 组件）
- 服务端强制校验 token；缺少 siteKey 时给出明确错误提示
- `appearance=interaction-only`：仅在需要时展示验证挑战
- 新增忘记密码 / 重置密码页面（`/forgot-password`、`/reset-password`）

### BP 流程强制校验与重构
- **强制顺序**：`in_progress` 状态下，必须先录入 BP 才能录入比分（`recordMatchResult` / `recordMapResult` 均校验 BP 存在）
- **BO3/BO5 逐图录入重构**：BP 保存后自动创建 `match_maps` 预占行（无比分），`recordMapResult` 改为 UPDATE 预占行而非 INSERT，彻底消除"地图已存在"冲突
- **MapByMapInput BP 引导模式**：有 BP 时，地图和 pick 方只读展示，管理员只需填起始边和比分
- **赛后补录**：`finished` 比赛可在后台重新打开 VetoInputDialog 补录 BP；若无 `match_maps` 记录（如历史 bug），补录后自动建立，解锁 OCR 面板
- **VetoInputDialog 优化**：队伍选择改为 A/B 切换按钮（告别逐步下拉）；finished 状态下显示赛后补录提示条

## 影响范围
- `src/actions/hexagon.ts`（新增）
- `src/lib/utils/hexagon.ts`（新增）+ 测试
- `src/components/matches/PlayerRadarChart.tsx`（新增）
- `src/actions/matches/veto.ts`
- `src/actions/matches/results.ts`
- `src/components/matches/MapByMapInput.tsx`
- `src/components/matches/VetoInputDialog.tsx`
- `src/components/matches/AdminMatchRow.tsx`
- `src/app/admin/[seasonSlug]/matches/page.tsx`
- Auth 相关：`TurnstileWidget`、`ForgotPasswordForm`、`ResetPasswordForm`、`LoginForm`、`auth.ts`

## 测试检查清单
- [ ] 注册页 Turnstile 验证正常触发
- [ ] 非淘汰赛 BO1：未录 BP 直接录分 → 报错"请先录入 BP"
- [ ] 非淘汰赛 BO1：录 BP → 录分 → finished → OCR 面板出现
- [ ] 淘汰赛 BO3：录 BP → MapByMapInput 显示引导模式（地图只读）→ 逐图录入 → 自动 finished
- [ ] finished 比赛：后台"数据录入"区可录 BP（赛后补录），无 match_maps 时自动建立
- [ ] 选手页 / 队伍页 / 比赛页六维雷达图正常渲染