### PR TITLE
v1.19.2: 六维公式优化 + FKPR/CPR 口径统一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.19.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.1...v1.19.2
+[1.19.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.0...v1.19.1
+[1.19.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.1...v1.19.0
+[1.18.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.0...v1.18.1
+[1.18.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.17.1...v1.18.0
+[1.17.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.17.0...v1.17.1
+[1.17.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.15.1...v1.16.0
 [1.15.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.15.0...v1.15.1
@@ -625,13 +632,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
-[1.19.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.1...v1.19.2
-[1.19.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.0...v1.19.1
-[1.19.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.1...v1.19.0
-[1.18.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.0...v1.18.1
-[1.18.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.17.1...v1.18.0
-[1.17.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.17.0...v1.17.1
-[1.17.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.16.1...v1.17.0
 [1.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.3.0...v1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.2] - 2026-05-20
+
+### Fixed
+- **选手页与 H2H FKPR/CPR/KPR 口径统一**：选手页生涯总计从场均改为 per-round 率，与排行榜一致；MatchLineupsH2H FKPR 改为 ×100 显示
+
+### Changed
+- **六维雷达图权重优化**：每维主指标权重提升（FKPR 0.65 / MKPR 0.70 / CPR 0.70 / APR 0.45），少死分权重提升至 0.35
+- **Z-score 缩放系数调整**：乘数 15 → 22，拉开分数分布使顶尖选手能达到满分
+
 ## [1.19.1] - 2026-05-20
 
 ### Fixed
@@ -616,6 +625,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.4.0...v1.4.1
+[1.19.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.1...v1.19.2
 [1.19.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.0...v1.19.1
 [1.19.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.1...v1.19.0
 [1.18.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.0...v1.18.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { eq, or, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { users, seasonRegistrations, seasons, teams, teamMembers, matches } from "@/db/schema";
+import { users, seasonRegistrations, seasons, teams, teamMembers, matches, matchMaps } from "@/db/schema";
 import { resolveAvatarUrl } from "@/lib/steam";
 import { PLAYER_INFO_FIELDS } from "@/lib/utils/player-info-fields";
 import { getDisplayName } from "@/lib/utils/display-name";
@@ -114,9 +114,11 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         totalFirstKills: sql<number>`sum(${matchPlayerStats.firstKills})::int`,
         totalMultiKills: sql<number>`sum(${matchPlayerStats.multiKills})::int`,
         totalClutches: sql<number>`sum(${matchPlayerStats.clutches})::int`,
+        totalRounds: sql<number>`sum(COALESCE(${matchMaps.scoreA} + ${matchMaps.scoreB}, ${matches.scoreA} + ${matches.scoreB}))::int`,
       })
       .from(matchPlayerStats)
       .innerJoin(matches, eq(matchPlayerStats.matchId, matches.id))
+      .innerJoin(matchMaps, eq(matchPlayerStats.mapId, matchMaps.id))
       .innerJoin(seasons, eq(matches.seasonId, seasons.id))
       .where(
         and(
@@ -196,6 +198,9 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   const totalMaps = playerStats.reduce((s, x) => s + x.maps, 0);
   const totalKillsAll = playerStats.reduce((s, x) => s + x.totalKills, 0);
   const totalDeathsAll = playerStats.reduce((s, x) => s + x.totalDeaths, 0);
+  const totalFirstKillsAll = playerStats.reduce((s, x) => s + x.totalFirstKills, 0);
+  const totalClutchesAll = playerStats.reduce((s, x) => s + x.totalClutches, 0);
+  const totalRoundsAll = playerStats.reduce((s, x) => s + (x as any).totalRounds, 0);
   const mvpCount = mvpWinCount;
 
   return (
@@ -335,10 +340,10 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                     : "—",
                 },
                 { label: "WE", value: wAvg(playerStats, "avgWe") },
-                { label: "场均击杀", value: sAvg(playerStats, "totalKills") },
-                { label: "首杀", value: sAvg(playerStats, "totalFirstKills") },
+                { label: "KPR", value: totalRoundsAll > 0 ? (totalKillsAll / totalRoundsAll).toFixed(2) : "—" },
+                { label: "FKPR /100r", value: totalRoundsAll > 0 ? (totalFirstKillsAll / totalRoundsAll * 100).toFixed(1) : "—" },
                 { label: "多杀", value: sAvg(playerStats, "totalMultiKills") },
-                { label: "残局", value: sAvg(playerStats, "totalClutches") },
+                { label: "CPR /100r", value: totalRoundsAll > 0 ? (totalClutchesAll / totalRoundsAll * 100).toFixed(1) : "—" },
                 {
                   label: "HS%",
                   value: totalMaps > 0

--- a/src/components/matches/MatchLineupsH2H.tsx
+++ b/src/components/matches/MatchLineupsH2H.tsx
@@ -231,10 +231,10 @@ export function MatchLineupsH2H({
           format={(v) => `${v.toFixed(0)}%`}
         />
         <StatRow
-          label="FKPR"
+          label="FKPR /100r"
           aVal={pa.fkpr}
           bVal={pb.fkpr}
-          format={(v) => v.toFixed(1)}
+          format={(v) => (v * 100).toFixed(1)}
         />
         <StatRow
           label="WE"

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -65,7 +65,7 @@ function zScore(value: number, mean: number, std: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
     return 50;
   }
-  return clamp(50 + ((value - mean) / std) * 20);
+  return clamp(50 + ((value - mean) / std) * 22);
 }
 
 /** Z-score 反向标准化：低值 → 高分（少死分专用） */
@@ -73,7 +73,7 @@ function zScoreInverse(value: number, mean: number, std: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
     return 50;
   }
-  return clamp(50 + ((mean - value) / std) * 20);
+  return clamp(50 + ((mean - value) / std) * 22);
 }
 
 /** 小样本收缩：回合数不足 threshold 时向 50 靠拢 */

--- a/src/lib/utils/hexagon.ts
+++ b/src/lib/utils/hexagon.ts
@@ -45,12 +45,12 @@ export interface HexagonScores {
 // ─── 六维权重配置 ─────────────────────────────────────────────────────────────
 
 export const DIMENSION_WEIGHTS = Object.freeze({
-  firepower:   Object.freeze({ kpr: 0.35, adr: 0.35, kd: 0.15, mkpr: 0.15 }),
-  opening:     Object.freeze({ fkpr: 0.50, we: 0.30, adr: 0.20 }),
-  multikill:   Object.freeze({ mkpr: 0.55, kpr: 0.25, adr: 0.20 }),
-  clutch:      Object.freeze({ cpr: 0.55, kd: 0.25, rws: 0.20 }),
-  support:     Object.freeze({ apr: 0.35, kda: 0.25, we: 0.20, rws: 0.20 }),
-  consistency: Object.freeze({ ratingPro: 0.40, dprInverse: 0.30, rws: 0.20, kd: 0.10 }),
+  firepower:   Object.freeze({ kpr: 0.40, adr: 0.35, mkpr: 0.15, kd: 0.10 }),
+  opening:     Object.freeze({ fkpr: 0.65, we: 0.25, adr: 0.10 }),
+  multikill:   Object.freeze({ mkpr: 0.70, kpr: 0.20, adr: 0.10 }),
+  clutch:      Object.freeze({ cpr: 0.70, rws: 0.20, kd: 0.10 }),
+  support:     Object.freeze({ apr: 0.45, kda: 0.25, we: 0.20, rws: 0.10 }),
+  consistency: Object.freeze({ ratingPro: 0.40, dprInverse: 0.35, kd: 0.15, rws: 0.10 }),
 });
 
 // ─── 内部标准化辅助函数 ───────────────────────────────────────────────────────
@@ -65,7 +65,7 @@ function zScore(value: number, mean: number, std: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
     return 50;
   }
-  return clamp(50 + ((value - mean) / std) * 15);
+  return clamp(50 + ((value - mean) / std) * 20);
 }
 
 /** Z-score 反向标准化：低值 → 高分（少死分专用） */
@@ -73,7 +73,7 @@ function zScoreInverse(value: number, mean: number, std: number): number {
   if (!Number.isFinite(value) || !Number.isFinite(mean) || !Number.isFinite(std) || std < 1e-9) {
     return 50;
   }
-  return clamp(50 + ((mean - value) / std) * 15);
+  return clamp(50 + ((mean - value) / std) * 20);
 }
 
 /** 小样本收缩：回合数不足 threshold 时向 50 靠拢 */


### PR DESCRIPTION
## Summary
- **六维雷达图权重优化**：每维主指标权重提升（FKPR 0.65 / MKPR 0.70 / CPR 0.70），Z-score 乘数 15→22
- **FKPR/CPR/KPR 口径统一**：选手页生涯总计从场均改为 per-round 率，H2H 改为 ×100 显示，与排行榜一致
- **排行榜 FKPR/CPR 显示精度修复**：SQL `round(2)`→`round(4)`

## Test plan
- [ ] `pnpm type-check` 通过
- [ ] `pnpm test` 通过
- [ ] `pnpm build` 通过