### PR TITLE
v1.20.0: MKPR指标 / 选秀回顾 / 用户管理 / v1遗留修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-05-20
+
+### Added
+- **MKPR /100r 指标**：数据排行榜新增多杀率列与排序 Tab，选手个人页同步改为 per-round 口径，与 FKPR/CPR 保持一致
+- **选秀回顾**：选秀结束后 `/[seasonSlug]/draft` 保留完整选人记录，以只读模式展示队伍阵容与逐回合 pick 历史
+- **用户管理——所有用户 Tab**：管理后台新增普通用户列表，含 4 项统计卡片（总注册/参赛/仅注册/近 30 天）、名字/邮箱搜索、全部/参赛/仅注册筛选；优化管理员列表为表格布局
+
+### Fixed
+- **积分榜平局判定顺序**：调整为 胜场 → 净胜回合差 → H2H → 总胜回合数 → 选秀顺位
+- **队名溢出截断**：赛程卡片（MatchCard）与首页 Next Match 区块队名长时正确显示省略号
+
 ## [1.19.2] - 2026-05-20
 
 ### Fixed
@@ -600,6 +611,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.20.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.2...v1.20.0
 [1.19.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.1...v1.19.2
 [1.19.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.19.0...v1.19.1
 [1.19.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.18.1...v1.19.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.17.1，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.20.0，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 
@@ -243,25 +243,27 @@ src/
 │   ├── rivalhub/     # Tactical Grid 组件（16 个：Panel/Btn/Field/Marker/Stat/
 │   │                 #   StatusBanner/InlineConfirm/EmptyState/ErrorState/Skeleton/
 │   │                 #   TeamBadge/PosChip/StatusPill/ScrollHint/PhaseStep/MapPreferenceChips）
-│   ├── auth/         # 登录/邀请组件（2 个：LoginForm / ClaimInviteForm）
+│   ├── auth/         # 登录/邀请组件（5 个：LoginForm / ClaimInviteForm / TurnstileWidget /
+│   │                 #   ForgotPasswordForm / ResetPasswordForm）
 │   ├── settings/     # 用户设置组件（ProfileForm / ChangePasswordForm）
 │   ├── register/     # 报名组件（RegistrationForm）
-│   ├── admin/        # 管理后台组件（14 个：AdminLoginForm / AdminRegisterForm / AdminSidebar /
+│   ├── admin/        # 管理后台组件（15 个：AdminLoginForm / AdminRegisterForm / AdminSidebar /
 │   │                 #   AdminUserList / AuditLogTable / ChangePasswordForm / DraftRegistrationTable /
 │   │                 #   InviteManager / RegistrationReviewList / SeasonForm / SeasonSubNav /
-│   │                 #   StagePlanEditor / TeamConfigForm / ThemeColorPicker）
+│   │                 #   StagePlanEditor / TeamConfigForm / ThemeColorPicker / UserSearchBar）
 │   ├── draft/        # 选秀组件（7 个：CaptainDraftPanel / DraftAdminPanel / DraftCountdown /
 │   │                 #   DraftLiveRoom / PlayerInfoPopover / PlayerPool / TeamDraftGrid）
 │   ├── captains/     # 队长投票组件（2 个：CaptainConfirmPanel / CaptainVotingPanel）
 │   ├── teams/        # 队伍组件（5 个：TeamCard / TeamGrid / TeamLogoUpload / TeamNameForm / TeamRosterCard）
-│   └── matches/      # 赛程组件（28 个：MatchCard / MatchTeamFilter / CreateMatchForm /
+│   └── matches/      # 赛程组件（36 个：MatchCard / MatchTeamFilter / CreateMatchForm /
 │                     #   AdminMatchFilter / AdminMatchRow / AdminRosterDialog / BatchDeadlineCard / BracketView /
-│                     #   DeleteMatchButton / GeneratePlayoffCard / GenerateScheduleCard /
-│                     #   MapByMapInput / MatchMvpVote / MatchRosterForm / MatchRosterView /
-│                     #   MatchStatusBadge / MatchTabsSection / MatchTimeNegotiation /
-│                     #   PlayerStatsTable / ScheduledAtInput / ScoreInput / StandingsTable /
-│                     #   StatsLeaderboard / StatsOCRPanel / SwissBracket / TimeProposalHistory /
-│                     #   VetoInputDialog / VetoView）
+│                     #   CompletedAtInput / DeleteMatchButton / GeneratePlayoffCard / GenerateScheduleCard /
+│                     #   MapByMapInput / MapPoolRadarChart / MatchHeadToHead / MatchLineupsH2H /
+│                     #   MatchMvpVote / MatchRosterForm / MatchRosterView / MatchStatusBadge /
+│                     #   MatchSummaryStats / MatchTabsSection / MatchTimeNegotiation /
+│                     #   PlayerRadarChart / PlayerStatsTable / ScheduledAtInput / ScoreInput /
+│                     #   StandingsTable / StatsLeaderboard / StatsOCRPanel / SwissBracket /
+│                     #   TeamStatsCompare / TimeProposalHistory / VetoInputDialog / VetoView）
 └── types/            # 共享 TypeScript 类型
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -45,16 +45,34 @@ export default async function DraftPage({ params }: DraftPageProps) {
   if (season.status !== "drafting") {
     const stageLabel = SEASON_STATUS_LABELS[season.status] ?? season.status;
     const draftFinished = season.status === "playing" || season.status === "finished";
+
+    if (!draftFinished) {
+      return (
+        <main className="container mx-auto max-w-5xl px-4 py-10 space-y-8">
+          <Panel pad={32}>
+            <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
+            <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
+              选秀尚未开放 · 当前阶段：{stageLabel}
+            </p>
+          </Panel>
+        </main>
+      );
+    }
+
+    // 选秀已结束：加载历史记录并以只读模式展示
+    const data = await getDraftData(season.id);
     return (
-      <main className="container mx-auto max-w-5xl px-4 py-10 space-y-8">
-        <Panel pad={32}>
-          <h1 className="text-2xl font-bold">选秀直播间 · {season.name}</h1>
-          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">
-            {draftFinished
-              ? "选秀已结束"
-              : `选秀尚未开放 · 当前阶段：${stageLabel}`}
-          </p>
-        </Panel>
+      <main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">
+        <Marker sub="选秀已结束，以下为完整选人记录。">
+          选秀回顾 · {season.name}
+        </Marker>
+        <DraftLiveRoom
+          data={data}
+          seasonId={season.id}
+          seasonSlug={seasonSlug}
+          seasonPositions={season.positions}
+          readonly
+        />
       </main>
     );
   }

--- a/src/app/[seasonSlug]/draft/page.tsx
+++ b/src/app/[seasonSlug]/draft/page.tsx
@@ -59,7 +59,6 @@ export default async function DraftPage({ params }: DraftPageProps) {
       );
     }
 
-    // 选秀已结束：加载历史记录并以只读模式展示
     const data = await getDraftData(season.id);
     return (
       <main className="container mx-auto max-w-7xl px-4 py-10 space-y-8">

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -263,7 +263,7 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
                         border: "1px solid var(--color-border)",
                       }}
                     >
-                      <div className="flex items-center gap-8">
+                      <div className="flex items-center gap-8 flex-1 min-w-0">
                         <div className="min-w-0 flex-1 flex items-center justify-end gap-2">
                           <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
                             {match.teamAName ?? "TBD"}

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -47,6 +47,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
   const hsExpr     = weightedAvg("mps.hs_percent");
   const kprExpr    = perRoundRate("mps.kills");
   const fkprExpr   = perRoundRate("mps.first_kills");
+  const mkprExpr   = perRoundRate("mps.multi_kills");
   const cprExpr    = perRoundRate("mps.clutches");
 
   const sortColumn = (() => {
@@ -58,6 +59,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
       case "we":     return sql`avg(mps.we)`;
       case "rws":    return sql`avg(mps.rws)`;
       case "fk":     return fkprExpr;
+      case "mk":     return mkprExpr;
       case "clutch": return cprExpr;
       case "maps":   return sql`count(*)`;
       default:       return sql`avg(mps.rating_pro)`;
@@ -87,6 +89,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
         ELSE NULL END                                                        AS kd_ratio,
       round(${kprExpr}::numeric, 2)                                         AS kpr,
       round(${fkprExpr}::numeric, 4)                                        AS fkpr,
+      round(${mkprExpr}::numeric, 4)                                        AS mkpr,
       round(${cprExpr}::numeric, 4)                                         AS cpr
     FROM match_player_stats mps
     JOIN matches m ON m.id = mps.match_id
@@ -122,6 +125,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     kdRatio:    toNumOrNull(r.kd_ratio),
     kpr:        toNum(r.kpr),
     fkpr:       toNum(r.fkpr),
+    mkpr:       toNum(r.mkpr),
     cpr:        toNum(r.cpr),
   }));
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,13 +1,21 @@
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { ne, asc } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { users } from "@/db/schema/users";
-import { seasons } from "@/db/schema/seasons";
+import { users, seasons } from "@/db/schema";
 import { requireSuperAdmin } from "@/lib/auth/session";
-import { Marker } from "@/components/rivalhub";
+import { Marker, Panel, Btn } from "@/components/rivalhub";
 import { AdminUserList } from "@/components/admin/AdminUserList";
+import { UserSearchBar } from "@/components/admin/UserSearchBar";
+import { formatCST } from "@/lib/utils/date";
+import { getDisplayName } from "@/lib/utils/display-name";
 
-export default async function AdminUsersPage() {
+interface PageProps {
+  searchParams: Promise<{ tab?: string; q?: string; filter?: string }>;
+}
+
+export default async function AdminUsersPage({ searchParams }: PageProps) {
   let admin;
   try {
     admin = await requireSuperAdmin();
@@ -15,33 +23,201 @@ export default async function AdminUsersPage() {
     redirect("/admin/login");
   }
 
-  const [adminUsers, allSeasons] = await Promise.all([
-    db.query.users.findMany({
-      where: ne(users.role, "user"),
-      orderBy: [asc(users.createdAt)],
-    }),
-    db.query.seasons.findMany(),
+  const { tab = "admins", q = "", filter = "all" } = await searchParams;
+
+  // ── 管理员 Tab ──────────────────────────────────────────────────────────
+  if (tab !== "users") {
+    const [adminUsers, allSeasons] = await Promise.all([
+      db.query.users.findMany({
+        where: ne(users.role, "user"),
+        orderBy: [asc(users.createdAt)],
+      }),
+      db.query.seasons.findMany(),
+    ]);
+    const seasonMap = Object.fromEntries(allSeasons.map((s) => [s.id, s.name]));
+
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+        <Marker>用户管理</Marker>
+        <TabBar tab="admins" />
+        <AdminUserList
+          users={adminUsers.map((u) => ({
+            id: u.id,
+            email: u.email,
+            steamName: u.steamName,
+            displayName: u.displayName,
+            perfectName: u.perfectName,
+            role: u.role as "super_admin" | "season_admin",
+            adminSeasonIds: u.adminSeasonIds,
+            createdAt: u.createdAt.toISOString(),
+          }))}
+          seasonMap={seasonMap}
+          currentUserId={admin.userId}
+        />
+      </div>
+    );
+  }
+
+  // ── 所有用户 Tab ────────────────────────────────────────────────────────
+  const havingClause =
+    filter === "participated"
+      ? sql`HAVING COUNT(DISTINCT sr.season_id) > 0`
+      : filter === "none"
+        ? sql`HAVING COUNT(DISTINCT sr.season_id) = 0`
+        : sql``;
+
+  const searchClause = q
+    ? sql`AND (u.email ILIKE ${"%" + q + "%"} OR u.display_name ILIKE ${"%" + q + "%"} OR u.perfect_name ILIKE ${"%" + q + "%"} OR u.steam_name ILIKE ${"%" + q + "%"})`
+    : sql``;
+
+  const [{ rows }, { rows: statsRows }] = await Promise.all([
+    db.execute(sql`
+      SELECT
+        u.id,
+        u.email,
+        u.display_name,
+        u.perfect_name,
+        u.steam_name,
+        u.created_at,
+        COUNT(DISTINCT sr.season_id)::int AS season_count
+      FROM users u
+      LEFT JOIN season_registrations sr ON sr.user_id = u.id
+      WHERE u.role = 'user'
+        ${searchClause}
+      GROUP BY u.id
+      ${havingClause}
+      ORDER BY u.created_at DESC
+      LIMIT 200
+    `),
+    db.execute(sql`
+      SELECT
+        COUNT(*)::int                                                             AS total,
+        COUNT(*) FILTER (WHERE season_count > 0)::int                           AS participated,
+        COUNT(*) FILTER (WHERE season_count = 0)::int                           AS not_participated,
+        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '30 days')::int   AS recent_30d
+      FROM (
+        SELECT u.id, u.created_at, COUNT(DISTINCT sr.season_id) AS season_count
+        FROM users u
+        LEFT JOIN season_registrations sr ON sr.user_id = u.id
+        WHERE u.role = 'user'
+        GROUP BY u.id, u.created_at
+      ) sub
+    `),
   ]);
 
-  const seasonMap = Object.fromEntries(allSeasons.map((s) => [s.id, s.name]));
+  const stats = statsRows[0] ?? {};
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-2xl">
-      <Marker>管理员列表</Marker>
-      <AdminUserList
-        users={adminUsers.map((u) => ({
-          id: u.id,
-          email: u.email,
-          steamName: u.steamName,
-          displayName: u.displayName,
-          perfectName: u.perfectName,
-          role: u.role as "super_admin" | "season_admin",
-          adminSeasonIds: u.adminSeasonIds,
-          createdAt: u.createdAt.toISOString(),
-        }))}
-        seasonMap={seasonMap}
-        currentUserId={admin.userId}
-      />
+    <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
+      <Marker>用户管理</Marker>
+      <TabBar tab="users" />
+
+      {/* 统计卡片 */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: "总注册用户", value: stats.total ?? 0 },
+          { label: "参赛过", value: stats.participated ?? 0, accent: true },
+          { label: "仅注册未参赛", value: stats.not_participated ?? 0 },
+          { label: "近 30 天新增", value: stats.recent_30d ?? 0 },
+        ].map(({ label, value, accent }) => (
+          <Panel key={label} pad={16}>
+            <p
+              className="text-2xl font-bold tabular-nums"
+              style={accent ? { color: "var(--color-accent)" } : undefined}
+            >
+              {String(value)}
+            </p>
+            <p className="text-xs text-[var(--color-fg-dim)] mt-0.5">{label}</p>
+          </Panel>
+        ))}
+      </div>
+
+      {/* 搜索 + 筛选 */}
+      <UserSearchBar q={q} filter={filter} />
+
+      {/* 表格 */}
+      <Panel pad={0} className="overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm min-w-[560px]">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-[10px] uppercase tracking-wider text-[var(--color-fg-dim)]">
+                <th className="px-4 py-3 text-left">选手</th>
+                <th className="px-4 py-3 text-left">邮箱</th>
+                <th className="px-4 py-3 text-center">参赛赛季</th>
+                <th className="px-4 py-3 text-right">注册时间</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--color-border)]">
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-8 text-center text-[var(--color-fg-dim)] text-sm">
+                    暂无匹配用户
+                  </td>
+                </tr>
+              )}
+              {rows.map((r) => {
+                const name = getDisplayName({
+                  displayName: r.display_name as string | null,
+                  perfectName: r.perfect_name as string | null,
+                  steamName: r.steam_name as string | null,
+                });
+                const seasonCount = Number(r.season_count);
+                const hasParticipated = seasonCount > 0;
+                return (
+                  <tr
+                    key={r.id as string}
+                    className="hover:bg-[var(--color-surface-raised)] transition-colors"
+                  >
+                    <td className="px-4 py-2.5 font-medium text-[var(--color-fg)]">
+                      {hasParticipated ? (
+                        <Link
+                          href={`/players/${r.id}`}
+                          className="hover:text-[var(--color-accent)] transition-colors"
+                        >
+                          {name}
+                        </Link>
+                      ) : (
+                        <span className="text-[var(--color-fg-mid)]">{name}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs text-[var(--color-fg-mid)]">
+                      {r.email as string}
+                    </td>
+                    <td className="px-4 py-2.5 text-center tabular-nums text-sm">
+                      {hasParticipated ? (
+                        <span style={{ color: "var(--color-accent)" }}>{seasonCount}</span>
+                      ) : (
+                        <span className="text-[var(--color-fg-dim)]">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-xs text-[var(--color-fg-dim)] tabular-nums">
+                      {formatCST(r.created_at as string)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Panel>
+      {rows.length === 200 && (
+        <p className="text-xs text-center text-[var(--color-fg-dim)]">
+          仅显示最近 200 条，请使用搜索缩小范围
+        </p>
+      )}
+    </div>
+  );
+}
+
+function TabBar({ tab }: { tab: string }) {
+  return (
+    <div className="flex gap-1">
+      <Btn small ghost={tab !== "admins"} asChild>
+        <Link href="/admin/users?tab=admins">管理员</Link>
+      </Btn>
+      <Btn small ghost={tab !== "users"} asChild>
+        <Link href="/admin/users?tab=users">所有用户</Link>
+      </Btn>
     </div>
   );
 }

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -199,6 +199,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   const totalKillsAll = playerStats.reduce((s, x) => s + x.totalKills, 0);
   const totalDeathsAll = playerStats.reduce((s, x) => s + x.totalDeaths, 0);
   const totalFirstKillsAll = playerStats.reduce((s, x) => s + x.totalFirstKills, 0);
+  const totalMultiKillsAll = playerStats.reduce((s, x) => s + x.totalMultiKills, 0);
   const totalClutchesAll = playerStats.reduce((s, x) => s + x.totalClutches, 0);
   const totalRoundsAll = playerStats.reduce((s, x) => s + (x as any).totalRounds, 0);
   const mvpCount = mvpWinCount;
@@ -342,7 +343,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                 { label: "WE", value: wAvg(playerStats, "avgWe") },
                 { label: "KPR", value: totalRoundsAll > 0 ? (totalKillsAll / totalRoundsAll).toFixed(2) : "—" },
                 { label: "FKPR /100r", value: totalRoundsAll > 0 ? (totalFirstKillsAll / totalRoundsAll * 100).toFixed(1) : "—" },
-                { label: "多杀", value: sAvg(playerStats, "totalMultiKills") },
+                { label: "MKPR /100r", value: totalRoundsAll > 0 ? (totalMultiKillsAll / totalRoundsAll * 100).toFixed(1) : "—" },
                 { label: "CPR /100r", value: totalRoundsAll > 0 ? (totalClutchesAll / totalRoundsAll * 100).toFixed(1) : "—" },
                 {
                   label: "HS%",

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -11,7 +11,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
-import { wAvg, sAvg } from "@/lib/utils/stats";
+import { wAvg } from "@/lib/utils/stats";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import type { HexagonScores } from "@/lib/utils/hexagon";
 import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";

--- a/src/components/admin/AdminUserList.tsx
+++ b/src/components/admin/AdminUserList.tsx
@@ -5,10 +5,8 @@ import { toast } from "sonner";
 import { revokeUserAdminRole } from "@/actions/admin";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { formatCST } from "@/lib/utils/date";
-import { Button } from "@/components/ui/button";
+import { Panel, Btn } from "@/components/rivalhub";
 import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 
 interface AdminUserRow {
   id: string;
@@ -45,62 +43,74 @@ export function AdminUserList({ users, seasonMap, currentUserId }: AdminUserList
 
   if (localUsers.length === 0) {
     return (
-      <p className="text-sm text-[var(--color-fg-mid)] py-4 text-center">
+      <Panel pad={32} className="text-center text-[var(--color-fg-mid)] text-sm">
         暂无管理员用户
-      </p>
+      </Panel>
     );
   }
 
   return (
-    <div className="space-y-2 mt-4">
-      {localUsers.map((u) => (
-        <Card
-          key={u.id}
-          className="p-3 flex items-center justify-between gap-4"
-        >
-          <div className="flex items-center gap-3 min-w-0 flex-wrap">
-            <span className="font-medium text-sm truncate">
-              {getDisplayName(u)}
-              {u.id === currentUserId && (
-                <span className="text-xs text-[var(--color-fg-mid)] ml-1">（你）</span>
-              )}
-            </span>
-            <Badge variant={u.role === "super_admin" ? "default" : "outline"}>
-              {u.role === "super_admin" ? "超级管理员" : "赛季管理员"}
-            </Badge>
-            {u.role === "season_admin" &&
-              u.adminSeasonIds.map((sid) => {
-                const name = seasonMap[sid];
-                if (!name) return null;
-                return (
-                  <span
-                    key={sid}
-                    className="text-xs text-[var(--color-fg-dim)]"
+    <Panel pad={0} className="overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--color-border)] text-[10px] uppercase tracking-wider text-[var(--color-fg-dim)]">
+            <th className="px-4 py-3 text-left">管理员</th>
+            <th className="px-4 py-3 text-left">邮箱</th>
+            <th className="px-4 py-3 text-left">权限范围</th>
+            <th className="px-4 py-3 text-right">加入时间</th>
+            <th className="px-4 py-3" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[var(--color-border)]">
+          {localUsers.map((u) => (
+            <tr key={u.id} className="hover:bg-[var(--color-surface-raised)] transition-colors">
+              <td className="px-4 py-3 font-medium text-[var(--color-fg)]">
+                <span className="flex items-center gap-2">
+                  {getDisplayName(u)}
+                  {u.id === currentUserId && (
+                    <span className="text-[10px] text-[var(--color-fg-dim)] border border-[var(--color-border)] rounded px-1 py-px">
+                      你
+                    </span>
+                  )}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-xs text-[var(--color-fg-mid)]">{u.email}</td>
+              <td className="px-4 py-3">
+                <span className="flex items-center gap-1.5 flex-wrap">
+                  <Badge variant={u.role === "super_admin" ? "default" : "outline"} className="text-[10px]">
+                    {u.role === "super_admin" ? "超级管理员" : "赛季管理员"}
+                  </Badge>
+                  {u.role === "season_admin" &&
+                    u.adminSeasonIds.map((sid) => {
+                      const name = seasonMap[sid];
+                      if (!name) return null;
+                      return (
+                        <span key={sid} className="text-[10px] text-[var(--color-fg-dim)]">
+                          {name}
+                        </span>
+                      );
+                    })}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-right text-xs text-[var(--color-fg-dim)] tabular-nums">
+                {formatCST(u.createdAt)}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {u.id !== currentUserId && (
+                  <Btn
+                    small
+                    ghost
+                    onClick={() => handleRevoke(u.id)}
+                    className="text-[var(--color-danger)] hover:text-[var(--color-danger)]"
                   >
-                    {name}
-                  </span>
-                );
-              })}
-          </div>
-
-          <div className="flex items-center gap-2 text-xs text-[var(--color-fg-mid)] shrink-0">
-            <span>创建于 {formatCST(u.createdAt)}</span>
-            {u.id !== currentUserId && (
-              <>
-                <Separator orientation="vertical" className="h-3" />
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-xs h-auto py-0 text-[var(--color-danger)] hover:text-[var(--color-danger)]"
-                  onClick={() => handleRevoke(u.id)}
-                >
-                  撤销权限
-                </Button>
-              </>
-            )}
-          </div>
-        </Card>
-      ))}
-    </div>
+                    撤销
+                  </Btn>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Panel>
   );
 }

--- a/src/components/admin/UserSearchBar.tsx
+++ b/src/components/admin/UserSearchBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useRef } from "react";
+import { Btn } from "@/components/rivalhub";
+
+const FILTERS = [
+  { key: "all",          label: "全部" },
+  { key: "participated", label: "参赛过" },
+  { key: "none",         label: "仅注册" },
+] as const;
+
+export function UserSearchBar({ q, filter }: { q: string; filter: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const push = useCallback(
+    (updates: Record<string, string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", "users");
+      for (const [k, v] of Object.entries(updates)) {
+        if (v) params.set(k, v);
+        else params.delete(k);
+      }
+      router.replace(`/admin/users?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  function handleSearch(e: React.ChangeEvent<HTMLInputElement>) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => push({ q: e.target.value }), 300);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <input
+        type="search"
+        defaultValue={q}
+        onChange={handleSearch}
+        placeholder="搜索名字 / 邮箱…"
+        className="w-full max-w-sm rounded-md border border-[var(--color-border)] bg-[var(--color-panel)] px-3 py-1.5 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-dim)] outline-none focus:border-[var(--color-accent)] transition-colors"
+      />
+      <div className="flex gap-1">
+        {FILTERS.map(({ key, label }) => (
+          <Btn key={key} small ghost={filter !== key} onClick={() => push({ filter: key })}>
+            {label}
+          </Btn>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -237,8 +237,8 @@ export function DraftLiveRoom({
         </div>
       )}
 
-      {/* 已完成 pick 历史 —— 仅直播模式 */}
-      {!isReadonly && completedPicks.length > 0 && (
+      {/* 已完成 pick 历史 */}
+      {completedPicks.length > 0 && (
         <section>
           <h2 className="text-sm font-semibold text-[var(--color-fg-mid)] mb-3 uppercase tracking-wider">
             选秀记录

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -48,13 +48,13 @@ export function MatchCard({
       className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-panel-hi)] transition-colors duration-150"
     >
       <div className="flex items-center gap-3 flex-1 min-w-0">
-        <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
+        <span className="font-semibold truncate min-w-0 flex-1 text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
         <span className="text-[var(--color-fg-mid)] text-sm shrink-0">
           {status === "finished"
             ? `${scoreA ?? 0} : ${scoreB ?? 0}`
             : "vs"}
         </span>
-        <span className="font-semibold truncate text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
+        <span className="font-semibold truncate min-w-0 flex-1 text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
       </div>
       <div className="flex items-center gap-2 shrink-0">
         {timeText && (

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -18,6 +18,7 @@ interface LeaderboardRow {
   kdRatio: number | null;
   kpr: number;
   fkpr: number;
+  mkpr: number;
   cpr: number;
 }
 
@@ -37,6 +38,7 @@ const SORT_OPTIONS = [
   { key: "we",      label: "WE" },
   { key: "rws",     label: "RWS" },
   { key: "fk",      label: "FKPR /100r" },
+  { key: "mk",      label: "MKPR /100r" },
   { key: "clutch",  label: "CPR /100r" },
   { key: "maps",    label: "场次" },
 ];
@@ -110,6 +112,12 @@ const COLS: ColDef[] = [
     key: "fk",
     label: "FKPR /100r",
     getValue: (r) => r.fkpr,
+    format: (v) => (v != null ? (v * 100).toFixed(1) : "—"),
+  },
+  {
+    key: "mk",
+    label: "MKPR /100r",
+    getValue: (r) => r.mkpr,
     format: (v) => (v != null ? (v * 100).toFixed(1) : "—"),
   },
   {

--- a/src/lib/standings.ts
+++ b/src/lib/standings.ts
@@ -64,11 +64,10 @@ export function calculateStandings(
     return { teamId: t.id, teamName: t.name, draftOrder: t.draftOrder, ...s, seed: 0 };
   });
 
-  // 排序：胜场 → 净胜 → 总胜回合 → 相互战绩 → draftOrder（稳定）
+  // 排序：胜场 → 净胜回合 → 相互战绩 → 总胜回合 → draftOrder（稳定）
   standings.sort((a, b) => {
     if (b.wins !== a.wins) return b.wins - a.wins;
     if (b.netRounds !== a.netRounds) return b.netRounds - a.netRounds;
-    if (b.totalRoundsWon !== a.totalRoundsWon) return b.totalRoundsWon - a.totalRoundsWon;
 
     // 相互战绩：查 finishedMatches 中两队之间的比赛
     const h2h = finishedMatches.find(
@@ -83,6 +82,8 @@ export function calculateStandings(
       if (aWonH2H) return -1;
       return 1;
     }
+
+    if (b.totalRoundsWon !== a.totalRoundsWon) return b.totalRoundsWon - a.totalRoundsWon;
 
     // 最终 fallback：draftOrder（选秀顺位）
     return a.draftOrder - b.draftOrder;

--- a/tests/unit/components/matches/StatsLeaderboard.test.tsx
+++ b/tests/unit/components/matches/StatsLeaderboard.test.tsx
@@ -34,7 +34,7 @@ describe("StatsLeaderboard", () => {
             teamName: "Alpha", teamId: "t1",
             maps: 10, avgRating: 1.25, avgAdr: 92.3,
             avgRws: 12.5, avgWe: 10.5, avgHs: 45.0,
-            kdRatio: 2.03, kpr: 20.5, fkpr: 2.1, cpr: 0.3,
+            kdRatio: 2.03, kpr: 20.5, fkpr: 2.1, mkpr: 1.5, cpr: 0.3,
           },
         ]}
       />
@@ -56,7 +56,7 @@ describe("StatsLeaderboard", () => {
             teamName: "Beta", teamId: "t2",
             maps: 5, avgRating: 1.1, avgAdr: 88.0,
             avgRws: 10.0, avgWe: 8.5, avgHs: 38.0,
-            kdRatio: 1.50, kpr: 18.0, fkpr: 1.8, cpr: 0.2,
+            kdRatio: 1.50, kpr: 18.0, fkpr: 1.8, mkpr: 1.2, cpr: 0.2,
           },
         ]}
       />
@@ -76,7 +76,7 @@ describe("StatsLeaderboard", () => {
             teamName: "Gamma", teamId: "t3",
             maps: 8, avgRating: 1.3, avgAdr: 90.0,
             avgRws: 13.0, avgWe: 11.0, avgHs: 42.0,
-            kdRatio: 2.44, kpr: 22.0, fkpr: 2.3, cpr: 0.4,
+            kdRatio: 2.44, kpr: 22.0, fkpr: 2.3, mkpr: 1.8, cpr: 0.4,
           },
         ]}
       />


### PR DESCRIPTION
## Summary

### Added
- **MKPR /100r**：数据排行榜新增多杀率列与排序 Tab，选手个人页同步改为 per-round 口径
- **选秀回顾**：选秀结束后 `/draft` 页保留完整选人记录（只读模式）
- **用户管理——所有用户 Tab**：统计卡片（总注册/参赛/仅注册/近30天）+ 搜索 + 筛选；优化管理员列表为表格布局

### Fixed
- **积分榜平局判定**：调整为 胜场 → 净胜回合差 → H2H → 总胜回合数 → 选秀顺位
- **队名溢出**：MatchCard 与首页 Next Match 区块队名长时正确截断

## Test plan
- [ ] `pnpm tsc --noEmit` 通过
- [ ] `pnpm test` 通过
- [ ] `pnpm build` 通过
- [ ] 数据排行榜 MKPR 列正常显示与排序
- [ ] 选秀结束赛季 `/draft` 页显示选人记录
- [ ] 管理后台用户管理"所有用户" Tab 可用