### PR TITLE
v1.20.1: 移动端布局修复 + MatchCard 对战对称 + 六维取上场前5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1] - 2026-05-20
+
+### Fixed
+- **移动端布局**：首页 Next Match 区块右侧溢出修复（stage + 时间改为右侧竖排）；MatchCard badges 行加 flex-wrap 避免窄屏换行溢出；TeamCard 队名加 break-words、选手名加 truncate
+- **MatchCard 对战对称**：TeamA 队名改为右对齐，vs / 比分居中，布局对称
+- **队伍页六维雷达图**：改为取上场最多的前 5 名队员（原为首发标记），更准确反映实际出场情况
+
 ## [1.20.0] - 2026-05-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -257,38 +257,34 @@ export default async function SeasonPage({ params }: SeasonPageProps) {
                 {upcomingMatches.map((match) => (
                   <Link key={match.id} href={`/${seasonSlug}/matches/${match.id}` as never}>
                     <div
-                      className="flex items-center gap-2.5 p-2.5 rounded-sm transition-colors hover:bg-[var(--color-panel-hi)] hover:border-[var(--color-border-hi)]"
+                      className="flex items-center gap-2 p-2.5 rounded-sm transition-colors hover:bg-[var(--color-panel-hi)] hover:border-[var(--color-border-hi)]"
                       style={{
                         background: "var(--color-panel-low)",
                         border: "1px solid var(--color-border)",
                       }}
                     >
-                      <div className="flex items-center gap-8 flex-1 min-w-0">
-                        <div className="min-w-0 flex-1 flex items-center justify-end gap-2">
-                          <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
-                            {match.teamAName ?? "TBD"}
-                          </span>
-                        </div>
+                      <div className="flex items-center gap-2 flex-1 min-w-0">
+                        <span className="text-sm font-semibold text-[var(--color-fg)] truncate flex-1 text-right">
+                          {match.teamAName ?? "TBD"}
+                        </span>
                         <span className="font-mono text-xs text-[var(--color-fg-dim)] shrink-0">vs</span>
-                        <div className="min-w-0 flex-1 flex items-center gap-2">
-                          <span className="text-sm font-semibold text-[var(--color-fg)] truncate">
-                            {match.teamBName ?? "TBD"}
-                          </span>
-                        </div>
-                        <div className="shrink-0">
-                          {match.status === "in_progress" ? (
-                            <span className="font-mono text-[11px] text-[var(--color-ok)]">● LIVE</span>
-                          ) : match.scheduledAt ? (
-                            <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">
-                              {formatCSTDateTime(match.scheduledAt)}
-                            </span>
-                          ) : (
-                            <span className="font-mono text-[11px] text-[var(--color-fg-dim)]">待定</span>
-                          )}
-                        </div>
+                        <span className="text-sm font-semibold text-[var(--color-fg)] truncate flex-1">
+                          {match.teamBName ?? "TBD"}
+                        </span>
                       </div>
-                      <div className="mt-1.5 font-mono text-[10px] text-[var(--color-fg-dim)] uppercase tracking-wider">
-                        {match.stage}
+                      <div className="shrink-0 flex flex-col items-end gap-0.5">
+                        <span className="font-mono text-[10px] text-[var(--color-fg-dim)] uppercase tracking-wider">
+                          {match.stage}
+                        </span>
+                        {match.status === "in_progress" ? (
+                          <span className="font-mono text-[10px] text-[var(--color-ok)]">● LIVE</span>
+                        ) : match.scheduledAt ? (
+                          <span className="font-mono text-[10px] text-[var(--color-fg-dim)]">
+                            {formatCSTDateTime(match.scheduledAt)}
+                          </span>
+                        ) : (
+                          <span className="font-mono text-[10px] text-[var(--color-fg-dim)]">待定</span>
+                        )}
                       </div>
                     </div>
                   </Link>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -136,20 +136,6 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     getTeamBanStats(teamId, matchIds),
   ]);
 
-  // 六维雷达图数据
-  const starterUserIds = starters.map((s) => s.userId).filter(Boolean) as string[];
-  const hexagonByPlayer = new Map<string, HexagonScores>();
-  if (starterUserIds.length > 0) {
-    const seasonScores = await getSeasonHexagonScores(season.id);
-    for (const uid of starterUserIds) {
-      const s = seasonScores.get(uid);
-      if (s) hexagonByPlayer.set(uid, s);
-    }
-  }
-  const teamScores = hexagonByPlayer.size > 0
-    ? computeTeamDimensions([...hexagonByPlayer.values()])
-    : null;
-
   // 历史对阵（按对手分组）
   interface HeadToHead { opponentId: string; wins: number; losses: number }
   const h2hMap = new Map<string, HeadToHead>();
@@ -215,6 +201,24 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
       });
     }
   }
+
+  // 六维雷达图数据（上场最多的前 5 人）
+  const top5UserIds = [...typedStats]
+    .sort((a, b) => Number(b.maps) - Number(a.maps))
+    .slice(0, 5)
+    .map((r) => r.user_id)
+    .filter(Boolean) as string[];
+  const hexagonByPlayer = new Map<string, HexagonScores>();
+  if (top5UserIds.length > 0) {
+    const seasonScores = await getSeasonHexagonScores(season.id);
+    for (const uid of top5UserIds) {
+      const s = seasonScores.get(uid);
+      if (s) hexagonByPlayer.set(uid, s);
+    }
+  }
+  const teamScores = hexagonByPlayer.size > 0
+    ? computeTeamDimensions([...hexagonByPlayer.values()])
+    : null;
 
   // 队伍均值（K/D 用总杀/总死，避免平均的平均）
   const hasStats = typedStats.length > 0;
@@ -435,7 +439,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
             <PlayerRadarChart
               players={[
                 ...[...hexagonByPlayer.entries()].map(([uid, scores]) => {
-                  const player = starters.find((s) => s.userId === uid);
+                  const player = roster.find((r) => r.userId === uid);
                   return {
                     name: player ? (player.perfectName ?? player.steamName ?? "未知") : uid,
                     scores,
@@ -452,7 +456,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
             />
           </Panel>
           <p className="text-[11px] text-[var(--color-fg-dim)] px-1 leading-relaxed">
-            队伍六维 = 当前阵容选手六维均值，六维评分在本赛事内标准化。
+            队伍六维 = 上场最多的前 5 名队员六维均值，六维评分在本赛事内标准化。
           </p>
         </section>
       )}

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -48,7 +48,7 @@ export function MatchCard({
       className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-panel-hi)] transition-colors duration-150"
     >
       <div className="flex items-center gap-3 flex-1 min-w-0">
-        <span className="font-semibold truncate min-w-0 flex-1 text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
+        <span className="font-semibold truncate min-w-0 flex-1 text-right text-[var(--color-fg)] text-sm sm:text-base">{teamAName}</span>
         <span className="text-[var(--color-fg-mid)] text-sm shrink-0">
           {status === "finished"
             ? `${scoreA ?? 0} : ${scoreB ?? 0}`
@@ -56,7 +56,7 @@ export function MatchCard({
         </span>
         <span className="font-semibold truncate min-w-0 flex-1 text-[var(--color-fg)] text-sm sm:text-base">{teamBName}</span>
       </div>
-      <div className="flex items-center gap-2 shrink-0">
+      <div className="flex items-center gap-2 shrink-0 flex-wrap">
         {timeText && (
           <span className="text-xs text-[var(--color-fg-mid)]">{timeText}</span>
         )}

--- a/src/components/teams/TeamCard.tsx
+++ b/src/components/teams/TeamCard.tsx
@@ -39,9 +39,9 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
                 <span className="text-sm font-bold text-[var(--color-fg-dim)]">{initial}</span>
               )}
             </div>
-            <div>
+            <div className="min-w-0">
               <span className="text-xs text-[var(--color-fg-mid)]">#{draftOrder}</span>
-              <h3 className="font-bold text-lg text-[var(--color-fg)] leading-tight">{teamName}</h3>
+              <h3 className="font-bold text-lg text-[var(--color-fg)] leading-tight break-words">{teamName}</h3>
             </div>
           </div>
 
@@ -49,14 +49,14 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
           <div className="space-y-1.5">
             {starters.map((p) => (
               <div key={p.name} className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 min-w-0">
                   {p.isCaptain && <PosChip pos="C" small />}
                   {p.userId ? (
-                    <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors">
+                    <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors truncate">
                       {p.name}
                     </Link>
                   ) : (
-                    <span className="text-sm text-[var(--color-fg)]">{p.name}</span>
+                    <span className="text-sm text-[var(--color-fg)] truncate">{p.name}</span>
                   )}
                 </div>
                 <span className="text-xs text-[var(--color-fg-mid)]">


### PR DESCRIPTION
## Summary

- **移动端布局修复**：首页 Next Match 右溢、MatchCard badges 换行、TeamCard 队名/选手名溢出
- **MatchCard 对战样式**：TeamA 右对齐，vs/比分居中，对称布局
- **队伍页六维雷达图**：改为上场最多前 5 人（而非首发标记）

## Test plan
- [ ] 移动端（375px）首页 Next Match 区块无右溢
- [ ] 赛程页 MatchCard 已结束比赛 badges 不换行溢出
- [ ] 队伍列表页长队名正常截断
- [ ] 队伍详情页六维雷达图显示上场最多的队员