### PR TITLE
v1.20.2: 队伍详情页选手行移动端布局 + Vercel Speed Insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-05-20
+
+### Fixed
+- **队伍详情页选手行移动端布局**：手机端选手行改为竖排，数据行加 flex-wrap 窄屏自动折行，地图芯片与位置标签手机横排
+- **Vercel Speed Insights**：引入 `@vercel/speed-insights` 性能监控
+
 ## [1.20.1] - 2026-05-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.49.4",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "brackets-manager": "^1.9.1",
     "brackets-memory-db": "^1.0.5",
     "brackets-model": "^1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       brackets-manager:
         specifier: ^1.9.1
         version: 1.9.1
@@ -1710,6 +1713,32 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -4175,6 +4204,11 @@ snapshots:
       '@types/node': 22.19.17
 
   '@vercel/analytics@2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    optionalDependencies:
+      next: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+
+  '@vercel/speed-insights@2.0.0(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -292,7 +292,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
               const stats = p.userId ? playerStatsMap.get(p.userId) : undefined;
               return (
                 <div key={p.registrationId} className="py-2.5 px-2 -mx-2 hover:bg-[var(--color-panel-hi)] transition-colors rounded">
-                  <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1.5 sm:gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         {p.registrationId === team.captainRegistrationId && <PosChip pos="C" small />}
@@ -307,7 +307,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         )}
                       </div>
                       {stats && (
-                        <div className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
                           <span>{stats.maps}图</span>
                           <span className="text-[var(--color-fg-dim)]">·</span>
                           <span style={stats.avgRating >= 1.2 ? { color: "var(--color-accent)" } : undefined}>
@@ -320,13 +320,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         </div>
                       )}
                     </div>
-                    <div className="text-right shrink-0">
-                      <span className="text-xs text-[var(--color-fg-mid)]">
+                    <div className="flex items-start gap-2 sm:flex-col sm:items-end sm:shrink-0">
+                      <span className="text-xs text-[var(--color-fg-mid)] whitespace-nowrap shrink-0">
                         {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
                       </span>
-                      <div className="mt-1 flex justify-end">
-                        <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
-                      </div>
+                      <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
                     </div>
                   </div>
                 </div>
@@ -342,7 +340,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                   const stats = p.userId ? playerStatsMap.get(p.userId) : undefined;
                   return (
                     <div key={p.registrationId} className="py-2.5 px-2 -mx-2 opacity-70 hover:bg-[var(--color-panel-hi)] transition-colors rounded">
-                      <div className="flex items-start justify-between gap-3">
+                      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1.5 sm:gap-3">
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
                             {p.userId ? (
@@ -354,7 +352,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                             )}
                           </div>
                           {stats && (
-                            <div className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
                               <span>{stats.maps}图</span>
                               <span className="text-[var(--color-fg-dim)]">·</span>
                               <span style={stats.avgRating >= 1.2 ? { color: "var(--color-accent)" } : undefined}>
@@ -367,13 +365,11 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                             </div>
                           )}
                         </div>
-                        <div className="text-right shrink-0">
-                          <span className="text-xs text-[var(--color-fg-mid)]">
+                        <div className="flex items-start gap-2 sm:flex-col sm:items-end sm:shrink-0">
+                          <span className="text-xs text-[var(--color-fg-mid)] whitespace-nowrap shrink-0">
                             {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
                           </span>
-                          <div className="mt-1 flex justify-end">
-                            <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
-                          </div>
+                          <MapPreferenceChips preferences={p.mapPreferences ?? []} compact minLevel="playable" />
                         </div>
                       </div>
                     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "@/components/ui/sonner";
 import { APP_BRAND } from "@/lib/branding";
 
@@ -53,6 +54,7 @@ export default function RootLayout({
         <Footer />
         <Toaster richColors position="top-right" />
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- **队伍详情页选手行移动端布局修复**：手机端改为竖排，数据行 flex-wrap 自动折行，地图芯片与位置标签横排
- **Vercel Speed Insights**：性能监控集成