### PR TITLE
release: v1.21.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ vite.config.ts.timestamp-*
 .codex/
 .claude/*
 !.claude/skills
+
+# Local tool connectors and generated design workspace
+.mcp.json
+.stitch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-05-22
+
+### Added
+- **赛季名录摘要**：队伍页与选手页新增赛事阶段、参赛规模和统计覆盖摘要，帮助快速浏览当前赛季阵容与数据完成度
+
+### Changed
+- **队伍页信息密度**：队伍目录按排位赛积分或正赛种子排序，收紧队伍卡片布局并补充队伍地图、战绩和成员数据
+- **选手页信息密度**：选手卡片改为更紧凑的展示，补齐当前与巅峰段位/RT 信息，并按地图数、赛事 RT 和兜底顺序排序
+- **数据统计桌面布局**：排行榜视图和排序控件改为更紧凑的横向布局，位置筛选改用英文位置标记，桌面端减少横向滚动
+- **赛季导航排序**：队伍与选手入口并列收拢，重排赛季导航顺序以匹配浏览路径
+
+### Fixed
+- **数据统计排序兼容**：历史排行榜排序链接自动归一到当前排序参数，避免旧查询参数落入错误视图
+- **瑞士轮队伍目录排序**：正赛阶段按种子顺序展示队伍，选手筛选摘要按实际队伍范围统计
+
 ## [1.20.5] - 2026-05-21
 
 ### Fixed
@@ -648,6 +663,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.21.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.5...v1.21.0
 [1.20.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.4...v1.20.5
 [1.20.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.3...v1.20.4
 [1.20.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.2...v1.20.3

--- a/docs/superpowers/plans/2026-05-21-season-directory-ui-optimization.md
+++ b/docs/superpowers/plans/2026-05-21-season-directory-ui-optimization.md
@@ -1,0 +1,159 @@
+# Season Directory UI Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the team directory, player directory, and season stats leaderboard into a denser season competition experience with a desktop-friendly core leaderboard.
+
+**Architecture:** Keep pages as Server Components and move reusable directory presentation into focused display components. Reuse season-scoped SQL and page queries for overview and competition summaries, while the stats leaderboard owns its metric view grouping and responsive table columns.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, Drizzle SQL, Tailwind CSS v4, Vitest, React Testing Library.
+
+---
+
+## File Structure
+
+- `src/components/matches/StatsLeaderboard.tsx`: metric views, English position presentation, compact desktop table.
+- `src/components/matches/StatsLeaderboard.test.tsx`: leaderboard view and label tests.
+- `src/app/[seasonSlug]/stats/page.tsx`: pass metric-view search state to leaderboard.
+- `src/components/teams/TeamCard.tsx`: wider team summary card presentation.
+- `src/components/teams/TeamCard.test.tsx`: team record and summary stat tests.
+- `src/app/[seasonSlug]/teams/page.tsx`: season overview and team summary data aggregation.
+- `src/components/players/PlayerDirectoryRow.tsx`: player directory row/card presentation.
+- `src/components/players/PlayerDirectoryRow.test.tsx`: competition-summary and fallback tests.
+- `src/app/[seasonSlug]/players/page.tsx`: season overview and verified-stat player directory data.
+
+### Task 1: Focus Stats Leaderboard
+
+**Files:**
+- Modify: `src/components/matches/StatsLeaderboard.tsx`
+- Create: `src/components/matches/StatsLeaderboard.test.tsx`
+- Modify: `src/app/[seasonSlug]/stats/page.tsx`
+
+- [ ] **Step 1: Write failing leaderboard tests**
+
+```tsx
+it("shows the compact core metrics and English position label by default", () => {
+  render(<StatsLeaderboard rows={[row]} sort="rating" position="" seasonSlug="spring" view="core" />);
+  expect(screen.getByRole("columnheader", { name: "Pos" })).toBeInTheDocument();
+  expect(screen.getByText("AWPer")).toBeInTheDocument();
+  expect(screen.queryByRole("columnheader", { name: "FKPR /100r" })).not.toBeInTheDocument();
+});
+
+it("shows impact metrics after switching to the impact view prop", () => {
+  render(<StatsLeaderboard rows={[row]} sort="fk" position="" seasonSlug="spring" view="impact" />);
+  expect(screen.getByRole("columnheader", { name: "FKPR /100r" })).toBeInTheDocument();
+  expect(screen.queryByRole("columnheader", { name: "HS%" })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the leaderboard test and confirm it fails**
+
+Run: `pnpm vitest run src/components/matches/StatsLeaderboard.test.tsx`
+
+Expected: FAIL because `StatsLeaderboard` does not accept `view` and still renders all metric columns.
+
+- [ ] **Step 3: Implement metric view grouping**
+
+Add view-aware sort controls, split metric columns into core/impact/advanced groups, render English position labels, and pass `view` from the stats page search params.
+
+- [ ] **Step 4: Re-run leaderboard tests**
+
+Run: `pnpm vitest run src/components/matches/StatsLeaderboard.test.tsx`
+
+Expected: PASS.
+
+### Task 2: Add Team Directory Summaries
+
+**Files:**
+- Modify: `src/components/teams/TeamCard.tsx`
+- Create: `src/components/teams/TeamCard.test.tsx`
+- Modify: `src/app/[seasonSlug]/teams/page.tsx`
+
+- [ ] **Step 1: Write failing team card tests**
+
+```tsx
+it("renders a team record and verified stat summary", () => {
+  render(<TeamCard {...props} record={{ played: 4, wins: 3, losses: 1, winRate: "75%" }} summary={{ maps: 12, avgRating: 1.14, avgAdr: 78.2 }} />);
+  expect(screen.getByText("3-1")).toBeInTheDocument();
+  expect(screen.getByText("75% WR")).toBeInTheDocument();
+  expect(screen.getByText("1.14")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the team card test and confirm it fails**
+
+Run: `pnpm vitest run src/components/teams/TeamCard.test.tsx`
+
+Expected: FAIL because `TeamCard` has no record or summary presentation.
+
+- [ ] **Step 3: Implement team overview and card summary data**
+
+Aggregate season matches and verified team stats on the team list page, add compact page overview stats, move the list to wider desktop cards, and add identity/record/stat summary layers to each team card.
+
+- [ ] **Step 4: Re-run team card tests**
+
+Run: `pnpm vitest run src/components/teams/TeamCard.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Build Player Directory Rows
+
+**Files:**
+- Create: `src/components/players/PlayerDirectoryRow.tsx`
+- Create: `src/components/players/PlayerDirectoryRow.test.tsx`
+- Modify: `src/app/[seasonSlug]/players/page.tsx`
+
+- [ ] **Step 1: Write failing player directory row tests**
+
+```tsx
+it("prioritizes season competition stats when they exist", () => {
+  render(<PlayerDirectoryRow player={{ ...player, stats: { maps: 8, avgRating: 1.21, avgAdr: 82.4 } }} />);
+  expect(screen.getByText("8 Maps")).toBeInTheDocument();
+  expect(screen.getByText("1.21")).toBeInTheDocument();
+  expect(screen.getByText("82.4")).toBeInTheDocument();
+});
+
+it("falls back to a no-stats state without losing registration context", () => {
+  render(<PlayerDirectoryRow player={{ ...player, stats: null }} />);
+  expect(screen.getByText("No verified stats")).toBeInTheDocument();
+  expect(screen.getByText("Peak")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the player directory row tests and confirm they fail**
+
+Run: `pnpm vitest run src/components/players/PlayerDirectoryRow.test.tsx`
+
+Expected: FAIL because `PlayerDirectoryRow` does not exist yet.
+
+- [ ] **Step 3: Implement player overview and row directory**
+
+Add a season stats query keyed by player registration/user, add overview counts, keep English role filters, and render desktop row-like player entries with mobile-friendly wrapping.
+
+- [ ] **Step 4: Re-run player row tests**
+
+Run: `pnpm vitest run src/components/players/PlayerDirectoryRow.test.tsx`
+
+Expected: PASS.
+
+### Task 4: Verify Full UI Change
+
+**Files:**
+- Verify changed files above.
+
+- [ ] **Step 1: Run focused tests**
+
+Run: `pnpm vitest run src/components/matches/StatsLeaderboard.test.tsx src/components/teams/TeamCard.test.tsx src/components/players/PlayerDirectoryRow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm type-check`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run browser verification**
+
+Start the local dev server and inspect the three target routes on desktop and mobile widths. Confirm the stats Core view has no desktop horizontal scrolling, position labels are English and horizontal, and directory surfaces wrap cleanly.
+

--- a/docs/superpowers/specs/2026-05-21-season-directory-ui-optimization-design.md
+++ b/docs/superpowers/specs/2026-05-21-season-directory-ui-optimization-design.md
@@ -1,0 +1,233 @@
+# Season Directory UI Optimization Design
+
+## Summary
+
+Optimize three season-level directory pages so they feel closer in visual quality and information value to the existing match and stats experiences:
+
+- Team list page: `/[seasonSlug]/teams`
+- Player list page: `/[seasonSlug]/players`
+- Season leaderboard page: `/[seasonSlug]/stats`
+
+The design direction is **overview + directory**. Team and player pages gain lightweight season context and competition summaries at the directory layer. The stats page becomes a focused leaderboard with a desktop-friendly core view and separate advanced metric views.
+
+This work does not redesign the team detail page or global player detail page. Detail pages may receive only small supporting adjustments if list links or shared labels require them.
+
+## Goals
+
+1. Raise the perceived quality and information density of the team and player directory pages.
+2. Shift directory cards away from registration-only summaries toward season competition context.
+3. Make the default stats leaderboard fit common desktop viewports without horizontal scrolling.
+4. Replace Chinese position labels in the stats leaderboard with horizontal English position labels.
+5. Preserve the current RivalHub tactical-grid visual language and responsive behavior.
+
+## Non-Goals
+
+- Rebuild team detail or player detail pages.
+- Add a broad cross-page recommendation hub for "hot teams" or "featured players".
+- Turn player directory into an admin search interface with many filters.
+- Force the full leaderboard table to fit on small mobile viewports.
+- Change stats aggregation semantics beyond view grouping and presentation needs.
+
+## Current State
+
+### Team List
+
+The current team list renders team cards in a narrow three-column desktop grid inside an outer panel. Each card emphasizes team name and roster preview. This is useful after draft creation, but it does not expose enough competition context once matches and verified stats exist.
+
+### Player List
+
+The current player list uses three-column player cards. Card content is centered on registration information: primary position, secondary position, peak rank, current rating, and team name when available. It reads like an approved-registration directory more than a playing-season player directory.
+
+### Stats Leaderboard
+
+The current leaderboard displays all visible metrics at once in a table with `min-w-[900px]`. Its metric list includes core and advanced metrics together. The position table header and position values use Chinese labels, which worsens width pressure and causes awkward vertical wrapping in narrow desktop layouts.
+
+## Design Direction
+
+The three pages should share a season-directory rhythm:
+
+1. Page title and season context.
+2. A small overview band that helps interpret the directory below.
+3. Focused filters or metric view controls.
+4. A directory surface optimized for scanning.
+
+The overview band must stay restrained. It exists to explain the page below, not to duplicate the season homepage.
+
+## Team Directory
+
+### Layout
+
+Use a two-part layout:
+
+1. **Overview band**
+   - Keep the team page marker/title and admin shortcut.
+   - Add compact season-level summary stats such as team count, player count, matches, and data readiness or average maps.
+   - If results exist, a compact lead signal may identify the strongest visible record, but it must not become a standings panel.
+
+2. **Team directory**
+   - Move desktop presentation from narrow three-column cards toward wider two-column summary cards.
+   - Keep mobile rendering as stacked cards.
+
+### Team Summary Card
+
+Each team card should prioritize:
+
+1. Team identity
+   - Team logo or fallback initial.
+   - Team name.
+   - Draft order.
+   - Captain signal.
+
+2. Competition summary
+   - Record and win rate when matches exist.
+   - A small verified-stats summary when available, such as maps, average rating, and average ADR.
+   - Empty-data fallback that keeps the card useful from roster information alone.
+
+3. Roster shape
+   - Starters remain visible at directory level.
+   - Position labels use compact English role labels where width matters.
+   - Substitutes remain present but lower-priority than starters, record, and team identity.
+
+### Rationale
+
+Team cards should answer both "who is on this team" and "what has this team done so far". Wider summary cards make those layers readable without turning the page into a full standings table.
+
+## Player Directory
+
+### Layout
+
+Use a denser directory layout than the team page:
+
+1. **Overview band**
+   - Keep the player page marker/title.
+   - Add compact stats such as approved players, players with teams, players with verified data, and the current filtered position count.
+
+2. **Position filter**
+   - Keep position filtering.
+   - Use English labels in the filter: `All`, `IGL`, `AWPer`, `Opener`, `Closer`, `Anchor`.
+
+3. **Player directory rows**
+   - Prefer compact desktop directory rows or row-like cards over the current three-column registration cards.
+   - On mobile, let rows fold into stacked cards.
+
+### Player Directory Row
+
+Each player entry should prioritize:
+
+1. Player identity
+   - Display name.
+   - Primary position badge.
+   - Team name when available.
+
+2. Competition summary
+   - Maps, rating, and ADR when verified season stats exist.
+   - A clear no-stats fallback when the player has not yet produced verified stats.
+
+3. Registration context
+   - Keep a small amount of registration identity such as peak rank or current rating.
+   - Secondary position becomes supporting information rather than a peer of primary position.
+
+### Rationale
+
+The player directory should read as a playing-season roster index, not just an approval result list. The competitive summary should rise in priority once data exists, while registration context remains useful for players without official match stats.
+
+## Stats Leaderboard
+
+### Default Core View
+
+The default desktop leaderboard should be a compact **Core** view intended to fit common desktop widths without horizontal scrolling.
+
+Recommended visible columns:
+
+- Rank
+- Player
+- Position
+- Team
+- Maps
+- Rating
+- ADR
+- K/D
+- KPR
+- HS%
+
+Position presentation changes:
+
+- Table header becomes `Pos`.
+- Table values are horizontal English labels such as `IGL`, `AWPer`, `Opener`, `Closer`, and `Anchor`.
+- Chinese position labels are not used in the stats leaderboard.
+
+### Metric Views
+
+Advanced metrics should move out of the default full-width table.
+
+Recommended control model:
+
+- `Core`: core player comparison metrics.
+- `Impact`: entry and high-impact rate metrics such as FKPR, MKPR, and CPR.
+- `Advanced`: secondary rating-style metrics such as WE and RWS.
+
+Names may be adjusted during implementation if a metric grouping becomes clearer, but the design requirement is stable: the default core table does not display every leaderboard metric at once.
+
+Sort controls must follow the active metric view so the toolbar does not become a long wrapped list of metrics that are not visible in the current table.
+
+### Width Strategy
+
+- Remove the assumption that the default desktop table must preserve a wide all-metric minimum width.
+- Give player and team columns flexible readable space.
+- Use compact numeric columns and tabular numerals for metrics.
+- Shorten headers and keep visible labels consistent in English where width matters.
+- Keep mobile horizontal scrolling acceptable for data tables.
+
+### Rationale
+
+The leaderboard should be a readable comparison surface. Splitting core and advanced metrics solves the desktop width problem structurally instead of compressing every column until labels and values degrade.
+
+## Data and Reuse
+
+Reuse current season-scoped data semantics wherever possible:
+
+- Team detail already exposes record and team-level stat aggregation patterns that can inform team directory summaries.
+- Player detail and stats pages already expose verified player stat aggregation patterns.
+- New directory summaries should remain season-scoped and must not hardcode season IDs or slugs.
+
+Any write behavior remains outside scope. These pages stay read-oriented Server Components and shared display components.
+
+## Responsive Behavior
+
+### Desktop
+
+- Team page uses wider summary cards.
+- Player page uses compact row-like directory entries.
+- Stats Core view fits common desktop widths without page-level left-right movement.
+
+### Mobile
+
+- Overview bands wrap into small responsive stat grids.
+- Team summary cards stack.
+- Player rows collapse into stacked cards.
+- Stats tables may scroll horizontally when needed.
+
+## Visual Rules
+
+- Preserve existing dark tactical-grid styling and existing RivalHub component vocabulary.
+- Favor restrained density and clear hierarchy over new decorative flourishes.
+- Avoid nested-card-heavy page sections.
+- Use compact English role labels where role text participates in width-sensitive directories or tables.
+- Keep competition summary values visually subordinate to the primary identity unless a metric is the current leaderboard sort target.
+
+## Empty and Partial Data States
+
+- Team summary cards without official stats still show identity and roster shape.
+- Player rows without verified stats fall back to registration context without looking broken.
+- Stats leaderboard empty state remains explicit.
+- Overview-band stats must avoid implying competition results when no matches or verified stats exist.
+
+## Verification Criteria
+
+1. Team page exposes team identity, roster shape, and competition summary in the list view when data exists.
+2. Player page exposes player identity, team context, and season competition summary in the list view when data exists.
+3. Player list entries degrade cleanly when a player has no verified stats.
+4. Stats default Core view uses English horizontal position labels.
+5. Stats default Core view does not require horizontal scrolling on common desktop widths during browser verification.
+6. Mobile layouts remain readable and do not rely on desktop row layouts being squeezed below their usable width.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.20.5",
+  "version": "1.21.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/players/page.tsx
+++ b/src/app/[seasonSlug]/players/page.tsx
@@ -1,11 +1,13 @@
 import { cache } from "react";
 import { notFound } from "next/navigation";
-import { eq, and, asc, or } from "drizzle-orm";
+import { eq, and, asc, or, sql } from "drizzle-orm";
 import Link from "next/link";
 import { db } from "@/db/client";
 import { seasons, seasonRegistrations, users, teams, teamMembers } from "@/db/schema";
-import { Marker, PosChip, Panel } from "@/components/rivalhub";
-import { POS_ABBR, positionLabel, positionValues } from "@/lib/validators/registration";
+import { Marker, Stat } from "@/components/rivalhub";
+import { PlayerDirectoryRow } from "@/components/players/PlayerDirectoryRow";
+import { sortPlayerDirectory } from "@/lib/players/directory-order";
+import { positionLabel, positionValues } from "@/lib/validators/registration";
 import { getDisplayName } from "@/lib/utils/display-name";
 import type { Metadata } from "next";
 
@@ -55,6 +57,8 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
       primaryPosition: seasonRegistrations.primaryPosition,
       secondaryPosition: seasonRegistrations.secondaryPosition,
       peakRank: seasonRegistrations.peakRank,
+      peakRating: seasonRegistrations.peakRating,
+      currentRank: seasonRegistrations.currentSeasonPeakRank,
       currentRating: seasonRegistrations.currentRating,
       perfectName: users.perfectName,
       steamName: users.steamName,
@@ -78,14 +82,64 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
 
   const teamByRegId = new Map(teamMemberRows.map((r) => [r.registrationId, r.teamName]));
 
+  const playerStatResult = await db.execute(sql`
+    SELECT
+      mps.user_id,
+      count(distinct mps.map_id)::int AS maps,
+      round(avg(mps.rating_pro)::numeric, 2) AS avg_rating,
+      round(avg(mps.adr)::numeric, 1) AS avg_adr,
+      round((sum(mps.kills)::numeric / nullif(sum(mps.deaths), 0)), 2) AS avg_kd
+    FROM match_player_stats mps
+    JOIN matches m ON m.id = mps.match_id
+    WHERE m.season_id = ${season.id}
+      AND mps.verified_by_admin IS NOT NULL
+      AND mps.user_id IS NOT NULL
+    GROUP BY mps.user_id
+  `);
+  const statsByUserId = new Map(
+    playerStatResult.rows.map((row) => [
+      row.user_id as string,
+      {
+        maps: Number(row.maps),
+        avgRating: Number(row.avg_rating),
+        avgAdr: Number(row.avg_adr),
+        avgKd: row.avg_kd == null ? null : Number(row.avg_kd),
+      },
+    ]),
+  );
+
   const positionFilters = [
     { value: "", label: "All" },
     ...positionValues.map((p) => ({ value: p, label: positionLabel(p) })),
   ];
+  const filteredPlayersWithStats = registrations.filter((reg) => statsByUserId.has(reg.userId)).length;
+  const directoryPlayers = sortPlayerDirectory(
+    registrations.map((reg) => ({
+      userId: reg.userId,
+      registrationId: reg.registrationId,
+      displayName: getDisplayName(reg),
+      name: getDisplayName(reg),
+      primaryPosition: reg.primaryPosition,
+      secondaryPosition: reg.secondaryPosition,
+      peakRank: reg.peakRank,
+      peakRating: reg.peakRating,
+      currentRank: reg.currentRank,
+      currentRating: reg.currentRating,
+      teamName: teamByRegId.get(reg.registrationId) ?? null,
+      stats: statsByUserId.get(reg.userId) ?? null,
+    })),
+  );
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
+    <div className="container mx-auto px-4 py-12 max-w-6xl space-y-8">
       <Marker sub={`${season.name} · ${registrations.length} 人已通过审核`}>选手名单</Marker>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+        <Stat label="PLAYERS" value={registrations.length} />
+        <Stat label="WITH TEAM" value={teamByRegId.size} />
+        <Stat label="DATA READY" value={filteredPlayersWithStats} accent />
+        <Stat label="POSITION" value={position ? positionLabel(position) : "ALL"} />
+      </div>
 
       {/* 位置筛选 */}
       <div className="flex gap-2 flex-wrap">
@@ -112,56 +166,13 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
       {registrations.length === 0 ? (
         <div className="text-center py-16 text-[var(--color-fg-mid)]">暂无符合条件的选手</div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {registrations.map((reg) => {
-            const displayName = getDisplayName(reg);
-            const teamName = teamByRegId.get(reg.registrationId);
-            const posLabel = positionLabel(reg.primaryPosition);
-            const secPosLabel = reg.secondaryPosition ? positionLabel(reg.secondaryPosition) : null;
-
-            return (
-              <Link
-                key={reg.registrationId}
-                href={`/players/${reg.userId}` as never}
-                className="block"
-              >
-                <Panel hoverable className="h-full cursor-pointer">
-                  <div className="flex items-start justify-between gap-2 mb-3">
-                    <span className="font-semibold text-[var(--color-fg)] truncate text-base">
-                      {displayName}
-                    </span>
-                    <PosChip pos={POS_ABBR[reg.primaryPosition] ?? reg.primaryPosition.slice(0, 1).toUpperCase()} small />
-                  </div>
-                  <div className="space-y-1 text-sm text-[var(--color-fg-mid)]">
-                    <div className="flex justify-between">
-                      <span>主位置</span>
-                      <span className="text-[var(--color-fg)]">{posLabel}</span>
-                    </div>
-                    {secPosLabel && (
-                      <div className="flex justify-between">
-                        <span>副位置</span>
-                        <span className="text-[var(--color-fg-mid)]">{secPosLabel}</span>
-                      </div>
-                    )}
-                    <div className="flex justify-between">
-                      <span>历史最高</span>
-                      <span className="text-[var(--color-fg)]">{reg.peakRank}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>当前 Rating</span>
-                      <span className="text-[var(--color-fg)]">{reg.currentRating}</span>
-                    </div>
-                    {teamName && (
-                      <div className="flex justify-between">
-                        <span>队伍</span>
-                        <span className="text-[var(--color-accent)] font-medium truncate max-w-[120px]">{teamName}</span>
-                      </div>
-                    )}
-                  </div>
-                </Panel>
-              </Link>
-            );
-          })}
+        <div className="space-y-3">
+          {directoryPlayers.map((player) => (
+            <PlayerDirectoryRow
+              key={player.registrationId}
+              player={player}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/src/app/[seasonSlug]/players/page.tsx
+++ b/src/app/[seasonSlug]/players/page.tsx
@@ -6,7 +6,7 @@ import { db } from "@/db/client";
 import { seasons, seasonRegistrations, users, teams, teamMembers } from "@/db/schema";
 import { Marker, Stat } from "@/components/rivalhub";
 import { PlayerDirectoryRow } from "@/components/players/PlayerDirectoryRow";
-import { sortPlayerDirectory } from "@/lib/players/directory-order";
+import { countDirectoryPlayersWithTeam, sortPlayerDirectory } from "@/lib/players/directory-order";
 import { positionLabel, positionValues } from "@/lib/validators/registration";
 import { getDisplayName } from "@/lib/utils/display-name";
 import type { Metadata } from "next";
@@ -136,7 +136,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
         <Stat label="PLAYERS" value={registrations.length} />
-        <Stat label="WITH TEAM" value={teamByRegId.size} />
+        <Stat label="WITH TEAM" value={countDirectoryPlayersWithTeam(registrations, teamByRegId)} />
         <Stat label="DATA READY" value={filteredPlayersWithStats} accent />
         <Stat label="POSITION" value={position ? positionLabel(position) : "ALL"} />
       </div>

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -3,7 +3,8 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { sql } from "drizzle-orm";
-import { StatsLeaderboard, type LeaderboardView } from "@/components/matches/StatsLeaderboard";
+import { StatsLeaderboard } from "@/components/matches/StatsLeaderboard";
+import { normalizeLeaderboardState } from "@/lib/matches/leaderboard-view";
 import { Marker } from "@/components/rivalhub";
 import type { Metadata } from "next";
 
@@ -24,9 +25,8 @@ export async function generateMetadata({ params }: StatsPageProps): Promise<Meta
 
 export default async function StatsPage({ params, searchParams }: StatsPageProps) {
   const { seasonSlug } = await params;
-  const { sort = "rating", position = "", view: rawView = "core" } = await searchParams;
-  const view: LeaderboardView =
-    rawView === "impact" || rawView === "advanced" ? rawView : "core";
+  const { sort: rawSort, position = "", view: rawView } = await searchParams;
+  const { sort, view } = normalizeLeaderboardState({ sort: rawSort, view: rawView });
 
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -3,13 +3,13 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { sql } from "drizzle-orm";
-import { StatsLeaderboard } from "@/components/matches/StatsLeaderboard";
+import { StatsLeaderboard, type LeaderboardView } from "@/components/matches/StatsLeaderboard";
 import { Marker } from "@/components/rivalhub";
 import type { Metadata } from "next";
 
 interface StatsPageProps {
   params: Promise<{ seasonSlug: string }>;
-  searchParams: Promise<{ sort?: string; position?: string }>;
+  searchParams: Promise<{ sort?: string; position?: string; view?: string }>;
 }
 
 export async function generateMetadata({ params }: StatsPageProps): Promise<Metadata> {
@@ -24,7 +24,9 @@ export async function generateMetadata({ params }: StatsPageProps): Promise<Meta
 
 export default async function StatsPage({ params, searchParams }: StatsPageProps) {
   const { seasonSlug } = await params;
-  const { sort = "rating", position = "" } = await searchParams;
+  const { sort = "rating", position = "", view: rawView = "core" } = await searchParams;
+  const view: LeaderboardView =
+    rawView === "impact" || rawView === "advanced" ? rawView : "core";
 
   const season = await db.query.seasons.findFirst({
     where: eq(seasons.slug, seasonSlug),
@@ -137,6 +139,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
         sort={sort}
         position={position}
         seasonSlug={seasonSlug}
+        view={view}
       />
     </div>
   );

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
-import { eq, asc, inArray } from "drizzle-orm";
+import { eq, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, teamMembers, seasonRegistrations, users } from "@/db/schema";
-import { Panel, Marker } from "@/components/rivalhub";
+import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
+import { Marker, Stat } from "@/components/rivalhub";
 import { TeamCard } from "@/components/teams/TeamCard";
-import { CS2_POSITIONS } from "@/types/season";
+import { calculateStandings } from "@/lib/standings";
+import { sortTeamDirectory } from "@/lib/teams/directory-order";
+import { CS2_POSITIONS, getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
@@ -35,23 +37,43 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
     );
   }
 
-  const allMembers = await db
-    .select({
-      teamId: teamMembers.teamId,
-      registrationId: teamMembers.registrationId,
-      captainRegId: teams.captainRegistrationId,
-      isStarter: teamMembers.isStarter,
-      primaryPosition: seasonRegistrations.primaryPosition,
-      steamName: users.steamName,
-      perfectName: users.perfectName,
-      email: users.email,
-      userId: users.id,
-    })
-    .from(teamMembers)
-    .innerJoin(teams, eq(teamMembers.teamId, teams.id))
-    .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
-    .innerJoin(users, eq(seasonRegistrations.userId, users.id))
-    .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id)));
+  const [allMembers, seasonMatches, teamStatResult] = await Promise.all([
+    db
+      .select({
+        teamId: teamMembers.teamId,
+        registrationId: teamMembers.registrationId,
+        captainRegId: teams.captainRegistrationId,
+        isStarter: teamMembers.isStarter,
+        primaryPosition: seasonRegistrations.primaryPosition,
+        steamName: users.steamName,
+        perfectName: users.perfectName,
+        email: users.email,
+        userId: users.id,
+      })
+      .from(teamMembers)
+      .innerJoin(teams, eq(teamMembers.teamId, teams.id))
+      .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
+      .innerJoin(users, eq(seasonRegistrations.userId, users.id))
+      .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id))),
+    db.query.matches.findMany({
+      where: eq(matches.seasonId, season.id),
+    }),
+    db.execute(sql`
+      SELECT
+        tm.team_id,
+        count(distinct mps.map_id)::int AS maps,
+        round(avg(mps.rating_pro)::numeric, 2) AS avg_rating,
+        round(avg(mps.adr)::numeric, 1) AS avg_adr
+      FROM match_player_stats mps
+      JOIN matches m ON m.id = mps.match_id
+      JOIN season_registrations sr
+        ON sr.user_id = mps.user_id AND sr.season_id = m.season_id
+      JOIN team_members tm ON tm.registration_id = sr.id
+      WHERE m.season_id = ${season.id}
+        AND mps.verified_by_admin IS NOT NULL
+      GROUP BY tm.team_id
+    `),
+  ]);
 
   const membersByTeam = new Map<string, typeof allMembers>();
   for (const m of allMembers) {
@@ -59,8 +81,70 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
     membersByTeam.get(m.teamId)!.push(m);
   }
 
+  const teamRecordMap = new Map<string, { played: number; wins: number; losses: number; winRate: string }>();
+  for (const team of allTeams) {
+    let wins = 0;
+    let losses = 0;
+    for (const match of seasonMatches) {
+      if (match.status !== "finished") continue;
+      if (match.teamAId !== team.id && match.teamBId !== team.id) continue;
+      const isTeamA = match.teamAId === team.id;
+      const ownScore = isTeamA ? (match.scoreA ?? 0) : (match.scoreB ?? 0);
+      const opponentScore = isTeamA ? (match.scoreB ?? 0) : (match.scoreA ?? 0);
+      if (ownScore > opponentScore) wins++;
+      else losses++;
+    }
+    const played = wins + losses;
+    teamRecordMap.set(team.id, {
+      played,
+      wins,
+      losses,
+      winRate: played > 0 ? `${Math.round((wins / played) * 100)}%` : "—",
+    });
+  }
+
+  const teamSummaryMap = new Map(
+    teamStatResult.rows.map((row) => [
+      row.team_id as string,
+      {
+        maps: Number(row.maps),
+        avgRating: Number(row.avg_rating),
+        avgAdr: Number(row.avg_adr),
+      },
+    ]),
+  );
+  const stagePlan = normalizeStagePlan(season.stagePlan);
+  const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
+  const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
+  const qualifierMatches = qualifierStage
+    ? seasonMatches.filter((match) => match.stage === qualifierStage.key)
+    : [];
+  const playoffMatches = playoffStage
+    ? seasonMatches.filter((match) => match.stage === playoffStage.key)
+    : [];
+  const finishedQualifierMatches = qualifierMatches.filter((match) => match.status === "finished");
+  const standings = qualifierStage?.type === "round_robin" && finishedQualifierMatches.length > 0
+    ? calculateStandings(
+        allTeams,
+        finishedQualifierMatches,
+      )
+    : [];
+  const standingsOrder = standings.map((standing) => standing.teamId);
+  const isPlayoffDirectory = playoffMatches.length > 0;
+  const sortedTeams = sortTeamDirectory(allTeams, {
+    mode: isPlayoffDirectory ? "playoff" : "qualifier",
+    standingsOrder,
+    // V1 round-robin playoffs are seeded directly from qualifier standings.
+    playoffSeedOrder: isPlayoffDirectory ? standingsOrder : [],
+  });
+  const orderLabel = isPlayoffDirectory && standingsOrder.length > 0
+    ? "正赛种子顺序"
+    : standingsOrder.length > 0
+      ? "排位赛积分顺序"
+      : "选秀顺位";
+
   return (
-    <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
+    <div className="container mx-auto px-4 py-12 max-w-6xl space-y-8">
       <div className="flex items-center justify-between">
         <Marker sub={season.name}>参赛队伍</Marker>
         {adminSession && (
@@ -68,9 +152,19 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
         )}
       </div>
 
-      <Panel pad={20}>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {allTeams.map((team) => {
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+        <Stat label="TEAMS" value={allTeams.length} />
+        <Stat label="PLAYERS" value={allMembers.length} />
+        <Stat label="MATCHES" value={`${seasonMatches.filter((match) => match.status === "finished").length}/${seasonMatches.length}`} />
+        <Stat label="DATA READY" value={`${teamSummaryMap.size}/${allTeams.length}`} accent />
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs uppercase text-[var(--color-fg-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+          Directory order · {orderLabel}
+        </p>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {sortedTeams.map((team) => {
           const members = (membersByTeam.get(team.id) ?? [])
             .map((m) => ({
               name: getDisplayName(m),
@@ -95,11 +189,13 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
               draftOrder={team.draftOrder}
               logoUrl={team.logoUrl}
               players={members}
+              record={teamRecordMap.get(team.id)}
+              summary={teamSummaryMap.get(team.id) ?? null}
             />
           );
         })}
         </div>
-      </Panel>
+      </div>
     </div>
   );
 }

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -1,12 +1,12 @@
 import { notFound } from "next/navigation";
 import { eq, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
+import { seasons, teams, teamMembers, seasonRegistrations, users, matches, swissStandings } from "@/db/schema";
 import { Marker, Stat } from "@/components/rivalhub";
 import { TeamCard } from "@/components/teams/TeamCard";
 import { calculateStandings } from "@/lib/standings";
-import { sortTeamDirectory } from "@/lib/teams/directory-order";
-import { CS2_POSITIONS, getFirstStageOfType, normalizeStagePlan } from "@/types/season";
+import { getSwissDirectoryOrder, sortTeamDirectory } from "@/lib/teams/directory-order";
+import { CS2_POSITIONS, getFirstStageOfType, getPreviousStage, normalizeStagePlan } from "@/types/season";
 import { getDisplayName } from "@/lib/utils/display-name";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
@@ -37,7 +37,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
     );
   }
 
-  const [allMembers, seasonMatches, teamStatResult] = await Promise.all([
+  const [allMembers, seasonMatches, seasonSwissStandings, teamStatResult] = await Promise.all([
     db
       .select({
         teamId: teamMembers.teamId,
@@ -57,6 +57,10 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id))),
     db.query.matches.findMany({
       where: eq(matches.seasonId, season.id),
+    }),
+    db.query.swissStandings.findMany({
+      where: eq(swissStandings.seasonId, season.id),
+      orderBy: [asc(swissStandings.seed)],
     }),
     db.execute(sql`
       SELECT
@@ -129,13 +133,28 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
         finishedQualifierMatches,
       )
     : [];
-  const standingsOrder = standings.map((standing) => standing.teamId);
+  const qualifierSwissStages = stagePlan.filter((stage) => stage.type === "swiss");
+  const activeSwissStage = [...qualifierSwissStages]
+    .reverse()
+    .find((stage) => seasonSwissStandings.some((standing) => standing.stage === stage.key));
+  const activeSwissRows = activeSwissStage
+    ? seasonSwissStandings.filter((standing) => standing.stage === activeSwissStage.key)
+    : [];
+  const standingsOrder = qualifierStage?.type === "swiss"
+    ? getSwissDirectoryOrder(activeSwissRows)
+    : standings.map((standing) => standing.teamId);
   const isPlayoffDirectory = playoffMatches.length > 0;
+  const previousPlayoffStage = playoffStage ? getPreviousStage(stagePlan, playoffStage.key) : null;
+  const playoffSeedOrder = previousPlayoffStage?.type === "swiss"
+    ? seasonSwissStandings
+        .filter((standing) => standing.stage === previousPlayoffStage.key && standing.status === "advanced")
+        .sort((a, b) => a.seed - b.seed)
+        .map((standing) => standing.teamId)
+    : standingsOrder;
   const sortedTeams = sortTeamDirectory(allTeams, {
     mode: isPlayoffDirectory ? "playoff" : "qualifier",
     standingsOrder,
-    // V1 round-robin playoffs are seeded directly from qualifier standings.
-    playoffSeedOrder: isPlayoffDirectory ? standingsOrder : [],
+    playoffSeedOrder: isPlayoffDirectory ? playoffSeedOrder : [],
   });
   const orderLabel = isPlayoffDirectory && standingsOrder.length > 0
     ? "正赛种子顺序"

--- a/src/components/layout/SeasonNav.test.tsx
+++ b/src/components/layout/SeasonNav.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SeasonNav } from "./SeasonNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/spring/teams",
+}));
+
+describe("SeasonNav", () => {
+  it("keeps workflow links first and groups teams with players", () => {
+    render(
+      <SeasonNav
+        slug="spring"
+        hasCaptainVoting
+        hasDraft
+        hasMatches
+        hasStats
+        hasPlayers
+      />,
+    );
+
+    expect(screen.getAllByRole("link").map((link) => link.textContent)).toEqual([
+      "首页",
+      "报名",
+      "队长投票",
+      "选秀",
+      "队伍",
+      "选手",
+      "赛程",
+      "数据统计",
+    ]);
+  });
+});

--- a/src/components/layout/SeasonNav.tsx
+++ b/src/components/layout/SeasonNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -32,10 +33,10 @@ export function SeasonNav({
   const items: NavItem[] = [
     { label: "首页", href: `/${slug}` },
     { label: "报名", href: `/${slug}/register` },
-    ...(hasPlayers ? [{ label: "选手", href: `/${slug}/players` }] : []),
     ...(hasCaptainVoting ? [{ label: "队长投票", href: `/${slug}/captains` }] : []),
     ...(hasDraft ? [{ label: "选秀", href: `/${slug}/draft` }] : []),
     { label: "队伍", href: `/${slug}/teams` },
+    ...(hasPlayers ? [{ label: "选手", href: `/${slug}/players` }] : []),
     ...(hasMatches ? [{ label: "赛程", href: `/${slug}/matches` }] : []),
     ...(hasStats ? [{ label: "数据统计", href: `/${slug}/stats` }] : []),
   ];

--- a/src/components/matches/StatsLeaderboard.test.tsx
+++ b/src/components/matches/StatsLeaderboard.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatsLeaderboard } from "./StatsLeaderboard";
+
+const row = {
+  userId: "player-1",
+  perfectName: "Star Entry",
+  position: "awper",
+  teamName: "Rival Orange",
+  teamId: "team-1",
+  maps: 8,
+  avgRating: 1.21,
+  avgAdr: 82.4,
+  avgRws: 10.18,
+  avgWe: 13.5,
+  avgHs: 48.2,
+  kdRatio: 1.34,
+  kpr: 0.81,
+  fkpr: 0.19,
+  mkpr: 0.12,
+  cpr: 0.04,
+};
+
+describe("StatsLeaderboard", () => {
+  it("shows compact core metrics and English position text by default", () => {
+    render(
+      <StatsLeaderboard
+        rows={[row]}
+        sort="rating"
+        position=""
+        seasonSlug="spring"
+        view="core"
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Pos" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "AWPer" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "HS%" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "FKPR /100r" })).not.toBeInTheDocument();
+  });
+
+  it("shows impact metrics in the impact view", () => {
+    render(
+      <StatsLeaderboard
+        rows={[row]}
+        sort="fk"
+        position=""
+        seasonSlug="spring"
+        view="impact"
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "FKPR /100r" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "MKPR /100r" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "HS%" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { Panel, Btn } from "@/components/rivalhub";
-import { POSITION_LABELS } from "@/lib/validators/registration";
+import { positionLabel } from "@/lib/validators/registration";
 
 interface LeaderboardRow {
   userId: string | null;
@@ -27,20 +27,15 @@ interface StatsLeaderboardProps {
   sort: string;
   position: string;
   seasonSlug: string;
+  view?: LeaderboardView;
 }
 
-const SORT_OPTIONS = [
-  { key: "rating",  label: "Rating" },
-  { key: "adr",     label: "ADR" },
-  { key: "kd",      label: "K/D" },
-  { key: "kpr",     label: "KPR" },
-  { key: "hs",      label: "HS%" },
-  { key: "we",      label: "WE" },
-  { key: "rws",     label: "RWS" },
-  { key: "fk",      label: "FKPR /100r" },
-  { key: "mk",      label: "MKPR /100r" },
-  { key: "clutch",  label: "CPR /100r" },
-  { key: "maps",    label: "场次" },
+export type LeaderboardView = "core" | "impact" | "advanced";
+
+const VIEWS: { key: LeaderboardView; label: string; defaultSort: string }[] = [
+  { key: "core", label: "Core", defaultSort: "rating" },
+  { key: "impact", label: "Impact", defaultSort: "fk" },
+  { key: "advanced", label: "Advanced", defaultSort: "we" },
 ];
 
 const POSITIONS = [
@@ -59,13 +54,17 @@ interface ColDef {
   format: (v: number | null) => string;
 }
 
-const COLS: ColDef[] = [
+const BASE_COLS: ColDef[] = [
   {
     key: "maps",
-    label: "图数",
+    label: "Maps",
     getValue: (r) => r.maps,
     format: (v) => String(v ?? 0),
   },
+];
+
+const CORE_COLS: ColDef[] = [
+  ...BASE_COLS,
   {
     key: "rating",
     label: "Rating",
@@ -96,16 +95,14 @@ const COLS: ColDef[] = [
     getValue: (r) => r.avgHs,
     format: (v) => (v ?? 0).toFixed(1) + "%",
   },
+];
+
+const IMPACT_COLS: ColDef[] = [
+  ...BASE_COLS,
   {
-    key: "we",
-    label: "WE",
-    getValue: (r) => r.avgWe,
-    format: (v) => (v ?? 0).toFixed(1),
-  },
-  {
-    key: "rws",
-    label: "RWS",
-    getValue: (r) => r.avgRws,
+    key: "rating",
+    label: "Rating",
+    getValue: (r) => r.avgRating,
     format: (v) => (v ?? 0).toFixed(2),
   },
   {
@@ -128,7 +125,35 @@ const COLS: ColDef[] = [
   },
 ];
 
-export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLeaderboardProps) {
+const ADVANCED_COLS: ColDef[] = [
+  ...BASE_COLS,
+  {
+    key: "rating",
+    label: "Rating",
+    getValue: (r) => r.avgRating,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "we",
+    label: "WE",
+    getValue: (r) => r.avgWe,
+    format: (v) => (v ?? 0).toFixed(1),
+  },
+  {
+    key: "rws",
+    label: "RWS",
+    getValue: (r) => r.avgRws,
+    format: (v) => (v ?? 0).toFixed(2),
+  },
+];
+
+const VIEW_COLS: Record<LeaderboardView, ColDef[]> = {
+  core: CORE_COLS,
+  impact: IMPACT_COLS,
+  advanced: ADVANCED_COLS,
+};
+
+export function StatsLeaderboard({ rows, sort, position, seasonSlug, view = "core" }: StatsLeaderboardProps) {
   if (rows.length === 0) {
     return (
       <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
@@ -139,45 +164,84 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLead
 
   const sortColBg = "rgba(255,107,26,0.04)";
   const accentText = "var(--color-accent)";
+  const cols = VIEW_COLS[view];
+  const statsHref = ({
+    nextSort = sort,
+    nextPosition = position,
+    nextView = view,
+  }: {
+    nextSort?: string;
+    nextPosition?: string;
+    nextView?: LeaderboardView;
+  }) => {
+    const params = new URLSearchParams({ sort: nextSort });
+    if (nextPosition) params.set("position", nextPosition);
+    if (nextView !== "core") params.set("view", nextView);
+    return `/${seasonSlug}/stats?${params.toString()}`;
+  };
 
   return (
     <div>
-      {/* 排序 Tab */}
-      <div className="flex gap-1 flex-wrap mb-2">
-        {SORT_OPTIONS.map(({ key, label }) => (
-          <Btn key={key} small ghost={sort !== key} asChild>
-            <a href={`/${seasonSlug}/stats?sort=${key}${position ? `&position=${position}` : ""}`}>
-              {label}
-            </a>
-          </Btn>
-        ))}
+      <div className="flex flex-col gap-3 mb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase text-[var(--color-fg-dim)] mb-1.5" style={{ fontFamily: "var(--font-mono)" }}>
+            Metric view
+          </p>
+          <div className="flex gap-1 flex-wrap">
+            {VIEWS.map(({ key, label, defaultSort }) => (
+              <Btn key={key} small ghost={view !== key} asChild>
+                <a href={statsHref({ nextSort: defaultSort, nextView: key })}>{label}</a>
+              </Btn>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-semibold uppercase text-[var(--color-fg-dim)] mb-1.5" style={{ fontFamily: "var(--font-mono)" }}>
+            Sort
+          </p>
+          <div className="flex gap-1 flex-wrap">
+            {cols.map(({ key, label }) => (
+              <Btn key={key} small ghost={sort !== key} asChild>
+                <a href={statsHref({ nextSort: key })}>{label}</a>
+              </Btn>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* 位置筛选 */}
       <div className="flex gap-1 flex-wrap mb-4">
         {POSITIONS.map(({ key, label }) => (
           <Btn key={key} small ghost={position !== key} asChild>
-            <a href={`/${seasonSlug}/stats?sort=${sort}${key ? `&position=${key}` : ""}`}>
+            <a href={statsHref({ nextPosition: key })}>
               {label}
             </a>
           </Btn>
         ))}
       </div>
 
-      {/* 表格：min-w 确保桌面端不压缩，移动端横向滚动 */}
+      {/* 核心视图压进桌面宽度；窄屏仍可横向滚动。 */}
       <Panel pad={0} className="overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full text-sm min-w-[900px]">
+          <table className="w-full text-sm min-w-[680px] table-fixed">
+            <colgroup>
+              <col className="w-9" />
+              <col />
+              <col className="w-24" />
+              <col className="w-[18%]" />
+              {cols.map((col) => <col key={col.key} className="w-[8%]" />)}
+            </colgroup>
             <thead>
               <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
-                <th className="px-3 py-3 text-left w-8">#</th>
-                <th className="px-3 py-3 text-left">选手</th>
-                <th className="px-3 py-3 text-left">位置</th>
-                <th className="px-3 py-3 text-left">队伍</th>
-                {COLS.map((col) => (
+                <th className="px-2.5 py-3 text-left">#</th>
+                <th className="px-2.5 py-3 text-left">Player</th>
+                <th className="px-2.5 py-3 text-left">Pos</th>
+                <th className="px-2.5 py-3 text-left">Team</th>
+                {cols.map((col) => (
                   <th
                     key={col.key}
-                    className="px-3 py-3 text-center whitespace-nowrap"
+                    className="px-1.5 py-3 text-center whitespace-nowrap"
                     style={sort === col.key ? { background: sortColBg, color: accentText } : undefined}
                   >
                     {col.label}
@@ -188,7 +252,7 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLead
             <tbody className="divide-y divide-[var(--color-border)]">
               {rows.map((r, i) => (
                 <tr key={r.userId ?? r.perfectName} className="hover:bg-[var(--color-surface-raised)] transition-colors">
-                  <td className="px-3 py-2.5 text-xs">
+                  <td className="px-2.5 py-2.5 text-xs">
                     <span
                       className={i < 3 ? "font-bold" : "text-[var(--color-fg-dim)]"}
                       style={i < 3 ? { color: accentText } : undefined}
@@ -196,7 +260,7 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLead
                       {i + 1}
                     </span>
                   </td>
-                  <td className="px-3 py-2.5 font-medium text-[var(--color-fg)]">
+                  <td className="px-2.5 py-2.5 font-medium text-[var(--color-fg)] truncate">
                     {r.userId ? (
                       <Link
                         href={`/players/${r.userId}`}
@@ -208,12 +272,10 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLead
                       r.perfectName
                     )}
                   </td>
-                  <td className="px-3 py-2.5 text-xs text-[var(--color-fg-mid)]">
-                    {r.position
-                      ? (POSITION_LABELS[r.position as keyof typeof POSITION_LABELS]?.cn ?? r.position)
-                      : "—"}
+                  <td className="px-2.5 py-2.5 text-xs text-[var(--color-fg-mid)] whitespace-nowrap">
+                    {r.position ? positionLabel(r.position) : "—"}
                   </td>
-                  <td className="px-3 py-2.5 text-xs text-[var(--color-fg-mid)]">
+                  <td className="px-2.5 py-2.5 text-xs text-[var(--color-fg-mid)] truncate">
                     {r.teamId ? (
                       <Link
                         href={`/${seasonSlug}/teams/${r.teamId}`}
@@ -225,14 +287,14 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug }: StatsLead
                       r.teamName ?? "—"
                     )}
                   </td>
-                  {COLS.map((col) => {
+                  {cols.map((col) => {
                     const val = col.getValue(r);
                     const isSort = sort === col.key;
                     const isHighRating = col.key === "rating" && (val ?? 0) >= 1.2;
                     return (
                       <td
                         key={col.key}
-                        className={`px-3 py-2.5 text-center tabular-nums ${
+                        className={`px-1.5 py-2.5 text-center tabular-nums whitespace-nowrap ${
                           isSort || isHighRating ? "font-semibold" : "text-[var(--color-fg)]"
                         }`}
                         style={

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { Panel, Btn } from "@/components/rivalhub";
+import type { LeaderboardView } from "@/lib/matches/leaderboard-view";
 import { positionLabel } from "@/lib/validators/registration";
 
 interface LeaderboardRow {
@@ -29,8 +30,6 @@ interface StatsLeaderboardProps {
   seasonSlug: string;
   view?: LeaderboardView;
 }
-
-export type LeaderboardView = "core" | "impact" | "advanced";
 
 const VIEWS: { key: LeaderboardView; label: string; defaultSort: string }[] = [
   { key: "core", label: "Core", defaultSort: "rating" },

--- a/src/components/players/PlayerDirectoryRow.test.tsx
+++ b/src/components/players/PlayerDirectoryRow.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlayerDirectoryRow } from "./PlayerDirectoryRow";
+
+const player = {
+  userId: "player-1",
+  registrationId: "registration-1",
+  displayName: "Star Entry",
+  primaryPosition: "opener",
+  secondaryPosition: "closer",
+  peakRank: "S",
+  peakRating: 1.42,
+  currentRank: "A+",
+  currentRating: 1.18,
+  teamName: "Rival Orange",
+  stats: null,
+};
+
+describe("PlayerDirectoryRow", () => {
+  it("prioritizes season competition stats when they exist", () => {
+    render(
+      <PlayerDirectoryRow
+        player={{
+          ...player,
+          stats: { maps: 8, avgRating: 1.21, avgAdr: 82.4, avgKd: 1.36 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Maps")).toBeInTheDocument();
+    expect(screen.getByText("Secondary Closer")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("1.21")).toBeInTheDocument();
+    expect(screen.getByText("82.4")).toBeInTheDocument();
+    expect(screen.getByText("1.36")).toBeInTheDocument();
+  });
+
+  it("keeps registration context when verified stats are missing", () => {
+    render(<PlayerDirectoryRow player={player} />);
+
+    expect(screen.getByText("No verified stats")).toBeInTheDocument();
+    expect(screen.getByText("Peak Rank")).toBeInTheDocument();
+    expect(screen.getByText("S")).toBeInTheDocument();
+    expect(screen.getByText("Peak RT")).toBeInTheDocument();
+    expect(screen.getByText("1.42")).toBeInTheDocument();
+    expect(screen.getByText("Current Rank")).toBeInTheDocument();
+    expect(screen.getByText("A+")).toBeInTheDocument();
+  });
+});

--- a/src/components/players/PlayerDirectoryRow.tsx
+++ b/src/components/players/PlayerDirectoryRow.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import Link from "next/link";
+import { Panel, PosChip } from "@/components/rivalhub";
+import { positionLabel } from "@/lib/validators/registration";
+
+export interface PlayerDirectoryData {
+  userId: string;
+  registrationId: string;
+  displayName: string;
+  primaryPosition: string;
+  secondaryPosition: string | null;
+  peakRank: string;
+  peakRating: number;
+  currentRank: string;
+  currentRating: number;
+  teamName: string | null;
+  stats: {
+    maps: number;
+    avgRating: number;
+    avgAdr: number;
+    avgKd: number | null;
+  } | null;
+}
+
+function DirectoryMetric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="min-w-[58px]">
+      <p className="text-[10px] uppercase text-[var(--color-fg-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+        {label}
+      </p>
+      <p className="mt-0.5 text-sm font-bold text-[var(--color-fg)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function PlayerDirectoryRow({ player }: { player: PlayerDirectoryData }) {
+  return (
+    <Panel hoverable pad={12}>
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.15fr)_auto] lg:items-center">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <Link
+              href={`/players/${player.userId}`}
+              className="truncate text-sm font-semibold text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors sm:text-base"
+            >
+              {player.displayName}
+            </Link>
+            <PosChip pos={positionLabel(player.primaryPosition)} />
+            {player.secondaryPosition && (
+              <span className="text-[11px] text-[var(--color-fg-dim)]">
+                Secondary {positionLabel(player.secondaryPosition)}
+              </span>
+            )}
+            <span className="text-xs text-[var(--color-fg-mid)]">
+              {player.teamName ?? "Awaiting team assignment"}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+            <DirectoryMetric label="Peak Rank" value={player.peakRank} />
+            <DirectoryMetric label="Peak RT" value={player.peakRating.toFixed(2)} />
+            <DirectoryMetric label="Current Rank" value={player.currentRank} />
+            <DirectoryMetric label="Current RT" value={player.currentRating.toFixed(2)} />
+          </div>
+        </div>
+
+        {player.stats ? (
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5 border-t border-[var(--color-border)] pt-2 lg:justify-end lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
+            <DirectoryMetric label="Maps" value={player.stats.maps} />
+            <DirectoryMetric label="Rating" value={player.stats.avgRating.toFixed(2)} />
+            <DirectoryMetric label="ADR" value={player.stats.avgAdr.toFixed(1)} />
+            <DirectoryMetric label="K/D" value={player.stats.avgKd != null ? player.stats.avgKd.toFixed(2) : "—"} />
+          </div>
+        ) : (
+          <div className="border-t border-[var(--color-border)] pt-2 text-xs uppercase text-[var(--color-fg-dim)] lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0 lg:text-right" style={{ fontFamily: "var(--font-mono)" }}>
+            No verified stats
+          </div>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/src/components/rivalhub/ScrollHint.tsx
+++ b/src/components/rivalhub/ScrollHint.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { cn } from "@/lib/utils/cn";
 import type { ReactNode } from "react";
 

--- a/src/components/teams/TeamCard.test.tsx
+++ b/src/components/teams/TeamCard.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TeamCard } from "./TeamCard";
+
+const props = {
+  teamId: "team-1",
+  teamName: "Rival Orange",
+  seasonSlug: "spring",
+  draftOrder: 2,
+  logoUrl: null,
+  players: [
+    {
+      name: "Captain Star",
+      primaryPosition: "igl",
+      isStarter: true,
+      isCaptain: true,
+      userId: "player-1",
+    },
+    {
+      name: "Anchor Star",
+      primaryPosition: "anchor",
+      isStarter: true,
+      isCaptain: false,
+      userId: "player-2",
+    },
+  ],
+};
+
+describe("TeamCard", () => {
+  it("renders record and verified summary stats", () => {
+    render(
+      <TeamCard
+        {...props}
+        record={{ played: 4, wins: 3, losses: 1, winRate: "75%" }}
+        summary={{ maps: 12, avgRating: 1.14, avgAdr: 78.2 }}
+      />,
+    );
+
+    expect(screen.getByText("3-1")).toBeInTheDocument();
+    expect(screen.getByText("75% WR")).toBeInTheDocument();
+    expect(screen.getByText("1.14")).toBeInTheDocument();
+    expect(screen.getByText("78.2")).toBeInTheDocument();
+  });
+});

--- a/src/components/teams/TeamCard.tsx
+++ b/src/components/teams/TeamCard.tsx
@@ -1,7 +1,8 @@
+import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Panel, PosChip } from "@/components/rivalhub";
-import { POSITION_LABELS } from "@/lib/validators/registration";
+import { positionLabel } from "@/lib/validators/registration";
 
 interface PlayerPreview {
   name: string;
@@ -18,20 +19,52 @@ interface TeamCardProps {
   draftOrder: number;
   logoUrl?: string | null;
   players: PlayerPreview[];
+  record?: {
+    played: number;
+    wins: number;
+    losses: number;
+    winRate: string;
+  };
+  summary?: {
+    maps: number;
+    avgRating: number;
+    avgAdr: number;
+  } | null;
 }
 
-export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, players }: TeamCardProps) {
+function SummaryStat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="min-w-0 border border-[var(--color-border)] bg-[var(--color-panel-low)] px-2.5 py-2">
+      <p className="text-[10px] uppercase text-[var(--color-fg-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+        {label}
+      </p>
+      <p className="mt-1 truncate text-sm font-bold text-[var(--color-fg)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function TeamCard({
+  teamId,
+  teamName,
+  seasonSlug,
+  draftOrder,
+  logoUrl,
+  players,
+  record,
+  summary,
+}: TeamCardProps) {
   const starters = players.filter((p) => p.isStarter);
   const subs = players.filter((p) => !p.isStarter);
+  const captain = players.find((p) => p.isCaptain);
   const initial = teamName.trim()[0]?.toUpperCase() ?? "?";
 
   return (
-    <Link href={`/${seasonSlug}/teams/${teamId}`}>
-      <Panel className="hover:border-[var(--color-border-hi)] transition-colors cursor-pointer h-full">
-        <div className="space-y-4">
-          {/* 队名 + logo */}
-          <div className="flex items-center gap-3">
-            {/* 小 logo：40×40 */}
+    <Panel className="h-full hover:border-[var(--color-border-hi)] transition-colors">
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <Link href={`/${seasonSlug}/teams/${teamId}`} className="group flex min-w-0 items-center gap-3">
             <div className="relative w-10 h-10 rounded-md overflow-hidden shrink-0 border border-[var(--color-border)] bg-[var(--color-panel-low)] flex items-center justify-center">
               {logoUrl ? (
                 <Image src={logoUrl} alt={`${teamName} logo`} fill className="object-cover" />
@@ -40,51 +73,74 @@ export function TeamCard({ teamId, teamName, seasonSlug, draftOrder, logoUrl, pl
               )}
             </div>
             <div className="min-w-0">
-              <span className="text-xs text-[var(--color-fg-mid)]">#{draftOrder}</span>
-              <h3 className="font-bold text-lg text-[var(--color-fg)] leading-tight break-words">{teamName}</h3>
+              <span className="text-xs text-[var(--color-fg-mid)]">Draft #{draftOrder}</span>
+              <h3 className="font-bold text-lg text-[var(--color-fg)] leading-tight break-words group-hover:text-[var(--color-accent)] transition-colors">
+                {teamName}
+              </h3>
             </div>
-          </div>
+          </Link>
 
-          {/* 首发阵容 */}
-          <div className="space-y-1.5">
-            {starters.map((p) => (
-              <div key={p.name} className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2 min-w-0">
-                  {p.isCaptain && <PosChip pos="C" small />}
-                  {p.userId ? (
-                    <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors truncate">
-                      {p.name}
-                    </Link>
-                  ) : (
-                    <span className="text-sm text-[var(--color-fg)] truncate">{p.name}</span>
-                  )}
-                </div>
-                <span className="text-xs text-[var(--color-fg-mid)]">
-                  {POSITION_LABELS[p.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? p.primaryPosition}
-                </span>
-              </div>
-            ))}
-          </div>
-
-          {/* 替补 */}
-          {subs.length > 0 && (
-            <div className="border-t border-[var(--color-border)] pt-2 space-y-1">
-              {subs.map((p) => (
-                <div key={p.name} className="flex items-center justify-between gap-2 opacity-60">
-                  {p.userId ? (
-                    <Link href={`/players/${p.userId}`} className="text-xs text-[var(--color-fg-mid)] hover:text-[var(--color-accent)] transition-colors">
-                      {p.name}
-                    </Link>
-                  ) : (
-                    <span className="text-xs text-[var(--color-fg-mid)]">{p.name}</span>
-                  )}
-                  <span className="text-[10px] text-[var(--color-fg-mid)]">替补</span>
-                </div>
-              ))}
+          {record && (
+            <div className="shrink-0 text-right">
+              <p className="text-base font-black text-[var(--color-fg)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+                {record.wins}-{record.losses}
+              </p>
+              <p className="text-[10px] uppercase text-[var(--color-fg-mid)]" style={{ fontFamily: "var(--font-mono)" }}>
+                {record.played > 0 ? `${record.winRate} WR` : "No results"}
+              </p>
             </div>
           )}
         </div>
-      </Panel>
-    </Link>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--color-fg-mid)]">
+          <span>
+            Captain <span className="font-medium text-[var(--color-fg)]">{captain?.name ?? "TBD"}</span>
+          </span>
+          <span>{starters.length} starters</span>
+          {subs.length > 0 && <span>{subs.length} subs</span>}
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <SummaryStat label="Maps" value={summary?.maps ?? "—"} />
+          <SummaryStat label="Rating" value={summary ? summary.avgRating.toFixed(2) : "—"} />
+          <SummaryStat label="ADR" value={summary ? summary.avgAdr.toFixed(1) : "—"} />
+        </div>
+
+        <div className="space-y-1.5 border-t border-[var(--color-border)] pt-3">
+          {starters.map((p) => (
+            <div key={p.name} className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                {p.isCaptain && <PosChip pos="C" small />}
+                {p.userId ? (
+                  <Link href={`/players/${p.userId}`} className="text-sm text-[var(--color-fg)] hover:text-[var(--color-accent)] transition-colors truncate">
+                    {p.name}
+                  </Link>
+                ) : (
+                  <span className="text-sm text-[var(--color-fg)] truncate">{p.name}</span>
+                )}
+              </div>
+              <PosChip pos={positionLabel(p.primaryPosition)} small />
+            </div>
+          ))}
+        </div>
+
+        {subs.length > 0 && (
+          <div className="border-t border-[var(--color-border)] pt-2 flex flex-wrap gap-x-3 gap-y-1 opacity-70">
+            {subs.map((p) => (
+              <span key={p.name} className="inline-flex items-center gap-1 text-xs text-[var(--color-fg-mid)]">
+                {p.userId ? (
+                  <Link href={`/players/${p.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
+                    {p.name}
+                  </Link>
+                ) : (
+                  p.name
+                )}
+                <span className="text-[10px] uppercase text-[var(--color-fg-dim)]">Sub</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </Panel>
   );
 }

--- a/src/lib/matches/leaderboard-view.test.ts
+++ b/src/lib/matches/leaderboard-view.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLeaderboardState } from "./leaderboard-view";
+
+describe("normalizeLeaderboardState", () => {
+  it("opens legacy impact sort links in the impact view", () => {
+    expect(normalizeLeaderboardState({ sort: "fk" })).toEqual({
+      sort: "fk",
+      view: "impact",
+    });
+  });
+
+  it("falls back to the current view default when sort is incompatible", () => {
+    expect(normalizeLeaderboardState({ sort: "we", view: "impact" })).toEqual({
+      sort: "fk",
+      view: "impact",
+    });
+  });
+});

--- a/src/lib/matches/leaderboard-view.ts
+++ b/src/lib/matches/leaderboard-view.ts
@@ -1,0 +1,45 @@
+export type LeaderboardView = "core" | "impact" | "advanced";
+
+const VIEW_SORTS = {
+  core: ["maps", "rating", "adr", "kd", "kpr", "hs"],
+  impact: ["maps", "rating", "fk", "mk", "clutch"],
+  advanced: ["maps", "rating", "we", "rws"],
+} as const satisfies Record<LeaderboardView, readonly string[]>;
+
+const DEFAULT_SORT: Record<LeaderboardView, string> = {
+  core: "rating",
+  impact: "fk",
+  advanced: "we",
+};
+
+function isLeaderboardView(value: string | undefined): value is LeaderboardView {
+  return value === "core" || value === "impact" || value === "advanced";
+}
+
+function viewForSort(sort: string | undefined): LeaderboardView | null {
+  if (!sort) return null;
+  for (const [view, sorts] of Object.entries(VIEW_SORTS) as [LeaderboardView, readonly string[]][]) {
+    if (sorts.includes(sort)) return view;
+  }
+  return null;
+}
+
+export function normalizeLeaderboardState({
+  sort,
+  view,
+}: {
+  sort?: string;
+  view?: string;
+}) {
+  const explicitView = isLeaderboardView(view) ? view : null;
+  const normalizedView = explicitView ?? viewForSort(sort) ?? "core";
+  const availableSorts: readonly string[] = VIEW_SORTS[normalizedView];
+  const normalizedSort = availableSorts.includes(sort ?? "")
+    ? sort!
+    : DEFAULT_SORT[normalizedView];
+
+  return {
+    sort: normalizedSort,
+    view: normalizedView,
+  };
+}

--- a/src/lib/players/directory-order.test.ts
+++ b/src/lib/players/directory-order.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { sortPlayerDirectory } from "./directory-order";
+
+const players = [
+  { id: "alpha", name: "Alpha", currentRating: 1.2, stats: { maps: 4, avgRating: 1.1 } },
+  { id: "bravo", name: "Bravo", currentRating: 1.3, stats: { maps: 6, avgRating: 1.02 } },
+  { id: "charlie", name: "Charlie", currentRating: 1.4, stats: { maps: 6, avgRating: 1.28 } },
+  { id: "delta", name: "Delta", currentRating: 1.5, stats: null },
+  { id: "echo", name: "Echo", currentRating: 1.6, stats: null },
+];
+
+describe("sortPlayerDirectory", () => {
+  it("prioritizes verified maps and season rating before registration fallback", () => {
+    expect(sortPlayerDirectory(players).map((player) => player.id)).toEqual([
+      "charlie",
+      "bravo",
+      "alpha",
+      "echo",
+      "delta",
+    ]);
+  });
+
+  it("uses the player name as a stable final tie breaker", () => {
+    const tiedPlayers = [
+      { id: "zulu", name: "Zulu", currentRating: 1.2, stats: null },
+      { id: "alpha", name: "Alpha", currentRating: 1.2, stats: null },
+    ];
+
+    expect(sortPlayerDirectory(tiedPlayers).map((player) => player.id)).toEqual(["alpha", "zulu"]);
+  });
+});

--- a/src/lib/players/directory-order.test.ts
+++ b/src/lib/players/directory-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sortPlayerDirectory } from "./directory-order";
+import { countDirectoryPlayersWithTeam, sortPlayerDirectory } from "./directory-order";
 
 const players = [
   { id: "alpha", name: "Alpha", currentRating: 1.2, stats: { maps: 4, avgRating: 1.1 } },
@@ -27,5 +27,18 @@ describe("sortPlayerDirectory", () => {
     ];
 
     expect(sortPlayerDirectory(tiedPlayers).map((player) => player.id)).toEqual(["alpha", "zulu"]);
+  });
+
+  it("counts team assignments only inside the filtered directory", () => {
+    const teamByRegId = new Map([
+      ["registration-a", "Team A"],
+      ["registration-b", "Team B"],
+      ["registration-outside", "Team C"],
+    ]);
+
+    expect(countDirectoryPlayersWithTeam(
+      [{ registrationId: "registration-a" }, { registrationId: "registration-empty" }],
+      teamByRegId,
+    )).toBe(1);
   });
 });

--- a/src/lib/players/directory-order.ts
+++ b/src/lib/players/directory-order.ts
@@ -21,3 +21,10 @@ export function sortPlayerDirectory<T extends DirectoryPlayer>(players: T[]): T[
     return a.name.localeCompare(b.name);
   });
 }
+
+export function countDirectoryPlayersWithTeam(
+  players: { registrationId: string }[],
+  teamByRegId: Map<string, unknown>,
+) {
+  return players.filter((player) => teamByRegId.has(player.registrationId)).length;
+}

--- a/src/lib/players/directory-order.ts
+++ b/src/lib/players/directory-order.ts
@@ -1,0 +1,23 @@
+interface DirectoryPlayer {
+  name: string;
+  currentRating: number;
+  stats: {
+    maps: number;
+    avgRating: number;
+  } | null;
+}
+
+export function sortPlayerDirectory<T extends DirectoryPlayer>(players: T[]): T[] {
+  return [...players].sort((a, b) => {
+    const mapsDiff = (b.stats?.maps ?? -1) - (a.stats?.maps ?? -1);
+    if (mapsDiff !== 0) return mapsDiff;
+
+    const seasonRatingDiff = (b.stats?.avgRating ?? -1) - (a.stats?.avgRating ?? -1);
+    if (seasonRatingDiff !== 0) return seasonRatingDiff;
+
+    const registrationRatingDiff = b.currentRating - a.currentRating;
+    if (registrationRatingDiff !== 0) return registrationRatingDiff;
+
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/src/lib/teams/directory-order.test.ts
+++ b/src/lib/teams/directory-order.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { sortTeamDirectory } from "./directory-order";
+
+const teams = [
+  { id: "team-a", draftOrder: 1 },
+  { id: "team-b", draftOrder: 2 },
+  { id: "team-c", draftOrder: 3 },
+];
+
+describe("sortTeamDirectory", () => {
+  it("uses standings order during the qualifier stage", () => {
+    const sorted = sortTeamDirectory(teams, {
+      mode: "qualifier",
+      standingsOrder: ["team-c", "team-a", "team-b"],
+    });
+
+    expect(sorted.map((team) => team.id)).toEqual(["team-c", "team-a", "team-b"]);
+  });
+
+  it("uses playoff seeds before standings in the main stage", () => {
+    const sorted = sortTeamDirectory(teams, {
+      mode: "playoff",
+      playoffSeedOrder: ["team-b", "team-c"],
+      standingsOrder: ["team-c", "team-a", "team-b"],
+    });
+
+    expect(sorted.map((team) => team.id)).toEqual(["team-b", "team-c", "team-a"]);
+  });
+
+  it("falls back to draft order when stage order data is missing", () => {
+    const sorted = sortTeamDirectory([...teams].reverse(), {
+      mode: "playoff",
+      playoffSeedOrder: [],
+      standingsOrder: [],
+    });
+
+    expect(sorted.map((team) => team.id)).toEqual(["team-a", "team-b", "team-c"]);
+  });
+});

--- a/src/lib/teams/directory-order.test.ts
+++ b/src/lib/teams/directory-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sortTeamDirectory } from "./directory-order";
+import { getSwissDirectoryOrder, sortTeamDirectory } from "./directory-order";
 
 const teams = [
   { id: "team-a", draftOrder: 1 },
@@ -35,5 +35,14 @@ describe("sortTeamDirectory", () => {
     });
 
     expect(sorted.map((team) => team.id)).toEqual(["team-a", "team-b", "team-c"]);
+  });
+
+  it("orders Swiss standings by record, BU score, and original seed", () => {
+    expect(getSwissDirectoryOrder([
+      { teamId: "team-a", seed: 1, wins: 2, losses: 1, buScore: 3, status: "active" },
+      { teamId: "team-b", seed: 2, wins: 3, losses: 0, buScore: 1, status: "advanced" },
+      { teamId: "team-c", seed: 3, wins: 2, losses: 1, buScore: 5, status: "active" },
+      { teamId: "team-d", seed: 4, wins: 0, losses: 3, buScore: -2, status: "eliminated" },
+    ])).toEqual(["team-b", "team-c", "team-a", "team-d"]);
   });
 });

--- a/src/lib/teams/directory-order.ts
+++ b/src/lib/teams/directory-order.ts
@@ -9,6 +9,15 @@ type TeamDirectoryOrderOptions = {
   playoffSeedOrder?: string[];
 };
 
+type SwissDirectoryStanding = {
+  teamId: string;
+  seed: number;
+  wins: number;
+  losses: number;
+  buScore: number;
+  status: string;
+};
+
 function buildOrderMap(ids: string[] | undefined) {
   return new Map((ids ?? []).map((id, index) => [id, index]));
 }
@@ -39,4 +48,15 @@ export function sortTeamDirectory<T extends DirectoryTeam>(
   }
 
   return sortedByOrder(teams, []);
+}
+
+export function getSwissDirectoryOrder(standings: SwissDirectoryStanding[]) {
+  return [...standings]
+    .sort((a, b) => {
+      if (b.wins !== a.wins) return b.wins - a.wins;
+      if (a.losses !== b.losses) return a.losses - b.losses;
+      if (b.buScore !== a.buScore) return b.buScore - a.buScore;
+      return a.seed - b.seed;
+    })
+    .map((standing) => standing.teamId);
 }

--- a/src/lib/teams/directory-order.ts
+++ b/src/lib/teams/directory-order.ts
@@ -1,0 +1,42 @@
+type DirectoryTeam = {
+  id: string;
+  draftOrder: number;
+};
+
+type TeamDirectoryOrderOptions = {
+  mode: "qualifier" | "playoff";
+  standingsOrder?: string[];
+  playoffSeedOrder?: string[];
+};
+
+function buildOrderMap(ids: string[] | undefined) {
+  return new Map((ids ?? []).map((id, index) => [id, index]));
+}
+
+function sortedByOrder<T extends DirectoryTeam>(teams: T[], ids: string[] | undefined) {
+  const order = buildOrderMap(ids);
+  return [...teams].sort((a, b) => {
+    const aOrder = order.get(a.id);
+    const bOrder = order.get(b.id);
+
+    if (aOrder !== undefined && bOrder !== undefined) return aOrder - bOrder;
+    if (aOrder !== undefined) return -1;
+    if (bOrder !== undefined) return 1;
+    return a.draftOrder - b.draftOrder;
+  });
+}
+
+export function sortTeamDirectory<T extends DirectoryTeam>(
+  teams: T[],
+  options: TeamDirectoryOrderOptions,
+) {
+  if (options.mode === "playoff" && options.playoffSeedOrder?.length) {
+    return sortedByOrder(teams, options.playoffSeedOrder);
+  }
+
+  if (options.standingsOrder?.length) {
+    return sortedByOrder(teams, options.standingsOrder);
+  }
+
+  return sortedByOrder(teams, []);
+}

--- a/tests/unit/components/matches/StatsLeaderboard.test.tsx
+++ b/tests/unit/components/matches/StatsLeaderboard.test.tsx
@@ -3,13 +3,13 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 vi.mock("@/lib/validators/registration", () => ({
-  POSITION_LABELS: {
-    awper: { cn: "AWPer" },
-    opener: { cn: "Opener" },
-    igl: { cn: "IGL" },
-    closer: { cn: "Closer" },
-    anchor: { cn: "Anchor" },
-  },
+  positionLabel: (position: string) => ({
+    awper: "AWPer",
+    opener: "Opener",
+    igl: "IGL",
+    closer: "Closer",
+    anchor: "Anchor",
+  })[position] ?? position,
 }));
 
 import { StatsLeaderboard } from "@/components/matches/StatsLeaderboard";


### PR DESCRIPTION
## 概要
- 发布 v1.21.0，合入赛季队伍页、选手页与数据统计页的信息密度和桌面布局优化
- 队伍目录按排位积分或正赛种子排序，选手目录按地图数与赛事 RT 排序并补充段位信息
- 收紧数据统计筛选与排序区域，补齐历史排序参数兼容和瑞士轮目录统计修正

## 验证
- CI=true pnpm type-check
- pnpm test
- pnpm build

## 发布
- CHANGELOG 已补充 v1.21.0 条目与 compare 链接
- 已通过 npm version minor 生成 v1.21.0 tag