### PR TITLE
release: v1.22.0 — bracket 修复 + 正赛阶段协商规则

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.0] - 2026-05-23
+
+### Added
+- **Bracket 空槽位显示**：`BracketView` 在 brackets-viewer 渲染后注入对阵来源标签——UB R2+ 显示「队伍A vs 队伍B 胜者」，LB 各轮显示「胜者/败者」，未确定则显示 TBD；同时把对阵卡片加宽到 280px、原生 hint 翻译为中文
+- **正赛推荐解说时段**：协商面板在正赛阶段新增软提示，列出 14:00–17:00 / 19:00–22:00 两个推荐时段；队长提议落在区间外时即时给出「可正常进行但不保证解说」的警告
+- **阶段感知的协商缓冲**：`getTimeBufferHoursForStage` 让排位赛沿用 24h 缓冲，正赛改为 0（与最晚完成时间一致），`proposeMatchTime` / `respondToTimeProposal` / `autoAwardMatchTime` 均按阶段读取
+
+### Fixed
+- **Bracket 右侧 "null"**：`serializeBracket` 之前把 `undefined` 比分写成 `null`，brackets-viewer 用 `void 0 === e.score` 判空导致渲染成字符串 "null"；改为透传 `undefined`
+- **Bracket 比赛无法点击 / hover 异常**：`BracketMatch` 缺少 `child_count` 字段导致 brackets-viewer 把每场比赛误识别为 match-game，DOM 挂的是 `data-match-game-id` 而非 `data-match-id`，跳转 map 和 hover 样式全部失效；补齐字段后点击跳转、hover 橙色都恢复
+- **默认 tab 留在排位赛**：进入正赛阶段（排位赛全部完赛或正赛已有比赛）后公开赛程页面默认切换到正赛 tab，不需要手动再点一次
+
 ## [1.21.1] - 2026-05-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -395,7 +395,7 @@ export async function updateMatchScheduledAt(
 
 /**
  * 设置或清除比赛的最晚完成时间。
- * 队长时间协商的确认截止时间 = completionDeadline - 24h。
+ * 队长时间协商的确认截止时间 = completionDeadline - 缓冲（排位赛 24h，正赛 0h）。
  */
 export async function updateMatchCompletionDeadline(
   matchId: string,

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -13,6 +13,7 @@ import {
   assertBeforeTimeConfirmationCutoff,
   assertProposedTimeFitsDeadline,
   getTimeConfirmationCutoff,
+  getTimeBufferHoursForStage,
 } from "@/lib/matches/time-rules";
 import { getTeamIdForCaptain } from "./_shared";
 
@@ -40,7 +41,9 @@ export async function proposeMatchTime(
     if (match.status !== "scheduled") {
       throw new AppError(ErrorCode.VALIDATION_FAILED, "只能在 scheduled 状态下提议时间");
     }
-    assertBeforeTimeConfirmationCutoff(match.completionDeadline);
+    const season = await getSeasonOrThrow(match.seasonId);
+    const bufferHours = getTimeBufferHoursForStage(season.stagePlan, match.stage);
+    assertBeforeTimeConfirmationCutoff(match.completionDeadline, bufferHours);
     assertProposedTimeFitsDeadline(proposedTime, match.completionDeadline);
 
     if (!(await getTeamIdForCaptain(session.userId, match))) {
@@ -65,7 +68,6 @@ export async function proposeMatchTime(
       meta: { proposalId: proposal.id, proposedTime: proposedTime.toISOString() },
     });
 
-    const season = await getSeasonOrThrow(match.seasonId);
     revalidateMatchPaths(season.slug, matchId);
 
     return ok({ proposalId: proposal.id });
@@ -98,7 +100,9 @@ export async function respondToTimeProposal(
     }
 
     const match = await getMatchOrThrow(proposal.matchId);
-    assertBeforeTimeConfirmationCutoff(match.completionDeadline);
+    const season = await getSeasonOrThrow(match.seasonId);
+    const bufferHours = getTimeBufferHoursForStage(season.stagePlan, match.stage);
+    assertBeforeTimeConfirmationCutoff(match.completionDeadline, bufferHours);
     if (action === "accept") {
       assertProposedTimeFitsDeadline(proposal.proposedTime, match.completionDeadline);
     }
@@ -155,7 +159,6 @@ export async function respondToTimeProposal(
       meta: { matchId: match.id, action, rejectReason: rejectReason ?? null },
     });
 
-    const season = await getSeasonOrThrow(match.seasonId);
     revalidateMatchPaths(season.slug, proposal.matchId);
 
     return ok(undefined);
@@ -405,7 +408,11 @@ async function autoAwardMatchTime(
       return { awarded: false };
     }
 
-    const cutoff = getTimeConfirmationCutoff(match.completionDeadline);
+    const season = await tx.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+    });
+    const bufferHours = getTimeBufferHoursForStage(season?.stagePlan, match.stage);
+    const cutoff = getTimeConfirmationCutoff(match.completionDeadline, bufferHours);
     if (!cutoff || now.getTime() < cutoff.getTime()) {
       return { awarded: false };
     }
@@ -420,10 +427,6 @@ async function autoAwardMatchTime(
     if (!proposal) {
       return { awarded: false };
     }
-
-    const season = await tx.query.seasons.findFirst({
-      where: eq(seasons.id, match.seasonId),
-    });
     if (!season) {
       return { awarded: false };
     }

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -24,6 +24,7 @@ import { MatchHeadToHead } from "@/components/matches/MatchHeadToHead";
 import { MatchSummaryStats } from "@/components/matches/MatchSummaryStats";
 import { getMatchMvpResults, ensureMvpWinner } from "@/actions/player-stats";
 import { getTimeProposals } from "@/actions/matches/scheduling";
+import { getTimeBufferHoursForStage } from "@/lib/matches/time-rules";
 import { getMatchRoster } from "@/actions/matches/roster";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import { computeTeamDimensions } from "@/lib/utils/hexagon";
@@ -553,6 +554,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
               currentCompletionDeadline={match.completionDeadline}
               initialProposals={timeProposals}
               hasSubmittedRoster={captainRoster?.status === "submitted"}
+              bufferHours={getTimeBufferHoursForStage(season.stagePlan, match.stage)}
             />
           </Panel>
           <Panel pad={16}>

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -128,6 +128,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
       const parentId = game.parent_id;
       return typeof parentId === "number" && playoffBracketMatchIds.has(parentId);
     }),
+    group: fullBracketData.group.filter((g) => playoffBracketStageIds.has(g.stage_id)),
+    round: fullBracketData.round.filter((r) => playoffBracketStageIds.has(r.stage_id)),
   };
 
   // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转
@@ -162,7 +164,16 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
       )}
 
       <Panel pad={24}>
-      <Tabs defaultValue={hasQualifier ? qualifierKey : playoffKey} className="w-full">
+      <Tabs
+        defaultValue={
+          hasPlayoff && (allQualifierFinished || playoffMatchesAll.length > 0)
+            ? playoffKey
+            : hasQualifier
+              ? qualifierKey
+              : playoffKey
+        }
+        className="w-full"
+      >
         <TabsList className="mb-6 bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
           {qualifierStage && <TabsTrigger value={qualifierKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{qualifierStage.name}</TabsTrigger>}
           {playoffStage && <TabsTrigger value={playoffKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{playoffStage.name}</TabsTrigger>}

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Script from "next/script";
-import type { BracketData } from "@/lib/bracket";
+import type { BracketData, BracketMatch } from "@/lib/bracket";
 
 declare global {
   interface Window {
@@ -14,6 +14,7 @@ declare global {
         participants: unknown[];
         matchGames: unknown[];
       }, config?: { selector?: string; clear?: boolean }): Promise<void>;
+      addLocale?(lang: string, bundle: Record<string, unknown>): Promise<void>;
     };
   }
 }
@@ -35,11 +36,152 @@ function bracketThemeStyle(themeColor?: string | null): React.CSSProperties {
     "--hint-color": "var(--color-fg-dim)",
     "--connector-color": "var(--color-border-hi)",
     "--border-color": "var(--color-border)",
-    "--border-hover-color": "var(--color-accent)",
+    // 默认禁用 hover 描边；可点击比赛由 JS 直接写 inline style 触发橙色
+    "--border-hover-color": "var(--color-border)",
     "--border-selected-color": themeColor ?? "var(--color-accent)",
     "--win-color": "var(--color-success)",
     "--loss-color": "var(--color-danger)",
+    // 队伍名 + "vs" + 队伍名 + 胜者/败者 标签较长，加宽对阵卡片
+    "--match-width": "280px",
   } as React.CSSProperties;
+}
+
+/**
+ * 根据 bracket 结构推断某场比赛某个空槽位的来源。
+ * 返回展示文案；若两支来源队伍均已知，会写明「队伍A vs 队伍B 胜者/败者」，否则 TBD。
+ */
+function computeSlotLabel(
+  match: BracketMatch,
+  slotIdx: 0 | 1,
+  data: BracketData,
+  participantById: Map<number, string>,
+): string {
+  const group = data.group.find((g) => g.id === match.group_id);
+  const round = data.round.find((r) => r.id === match.round_id);
+  if (!group || !round) return "TBD";
+
+  const matchesInRound = (groupId: number, roundNumber: number): BracketMatch[] => {
+    const r = data.round.find(
+      (rr) => rr.group_id === groupId && rr.number === roundNumber,
+    );
+    if (!r) return [];
+    return data.match
+      .filter((m) => m.round_id === r.id)
+      .sort((a, b) => a.number - b.number);
+  };
+
+  const teamsOf = (m: BracketMatch): [string | null, string | null] => [
+    m.opponent1?.id != null ? participantById.get(m.opponent1.id) ?? null : null,
+    m.opponent2?.id != null ? participantById.get(m.opponent2.id) ?? null : null,
+  ];
+
+  const winnerLabel = (m: BracketMatch | undefined): string => {
+    if (!m) return "TBD";
+    const [a, b] = teamsOf(m);
+    return a && b ? `${a} vs ${b} 胜者` : "TBD";
+  };
+
+  const loserLabel = (m: BracketMatch | undefined): string => {
+    if (!m) return "TBD";
+    const [a, b] = teamsOf(m);
+    return a && b ? `${a} vs ${b} 败者` : "TBD";
+  };
+
+  const groupNum = group.number; // 1=UB, 2=LB, 3=GF
+  const roundNum = round.number;
+  const matchNum = match.number;
+
+  // UB (winner_bracket)
+  if (groupNum === 1) {
+    if (roundNum === 1) return "TBD";
+    const prev = matchesInRound(group.id, roundNum - 1);
+    const source = prev[2 * matchNum - 2 + slotIdx];
+    return winnerLabel(source);
+  }
+
+  // LB (loser_bracket)
+  if (groupNum === 2) {
+    const ubGroup = data.group.find(
+      (g) => g.stage_id === group.stage_id && g.number === 1,
+    );
+    const ubGroupId = ubGroup?.id ?? -1;
+
+    if (roundNum === 1) {
+      // 来自 UB R1 的败者
+      const ubR1 = matchesInRound(ubGroupId, 1);
+      const source = ubR1[2 * matchNum - 2 + slotIdx];
+      return loserLabel(source);
+    }
+
+    // r >= 2: 偶数轮 minor / 奇数轮 major
+    const isMinor = roundNum % 2 === 0;
+    if (isMinor) {
+      // op1: 上一 LB 轮胜者（反向配对）
+      // op2: 本 minor 对应的 UB 轮败者，UB 轮号 = roundNum/2 + 1
+      const prevLb = matchesInRound(group.id, roundNum - 1);
+      const ubRoundIdx = roundNum / 2 + 1;
+      const ubRound = matchesInRound(ubGroupId, ubRoundIdx);
+      if (slotIdx === 0) {
+        const source = prevLb[prevLb.length - matchNum];
+        return winnerLabel(source);
+      }
+      const source = ubRound[matchNum - 1];
+      return loserLabel(source);
+    }
+
+    // major: 两侧均来自上一 LB 轮的胜者，顺序配对
+    const prevLb = matchesInRound(group.id, roundNum - 1);
+    const source = prevLb[2 * matchNum - 2 + slotIdx];
+    return winnerLabel(source);
+  }
+
+  // GF (grand_final)
+  if (groupNum === 3) {
+    const ubGroup = data.group.find(
+      (g) => g.stage_id === group.stage_id && g.number === 1,
+    );
+    const lbGroup = data.group.find(
+      (g) => g.stage_id === group.stage_id && g.number === 2,
+    );
+    if (matchNum === 1) {
+      // 第一场 GF: UB 总冠军 vs LB 总冠军
+      if (slotIdx === 0 && ubGroup) {
+        const ubRounds = data.round
+          .filter((r) => r.group_id === ubGroup.id)
+          .sort((a, b) => b.number - a.number);
+        const last = ubRounds[0];
+        if (last) {
+          const ubFinal = data.match.find((m) => m.round_id === last.id);
+          return winnerLabel(ubFinal);
+        }
+      }
+      if (slotIdx === 1 && lbGroup) {
+        const lbRounds = data.round
+          .filter((r) => r.group_id === lbGroup.id)
+          .sort((a, b) => b.number - a.number);
+        const last = lbRounds[0];
+        if (last) {
+          const lbFinal = data.match.find((m) => m.round_id === last.id);
+          return winnerLabel(lbFinal);
+        }
+      }
+    }
+    // bracket reset 第二场：双方为第一场 GF 胜负者
+    if (matchNum === 2) {
+      const gfRound = data.round.find(
+        (r) => r.group_id === group.id && r.number === 1,
+      );
+      if (gfRound) {
+        const gf1 = data.match.find(
+          (m) => m.round_id === gfRound.id && m.number === 1,
+        );
+        return slotIdx === 0 ? winnerLabel(gf1) : loserLabel(gf1);
+      }
+    }
+    return "TBD";
+  }
+
+  return "TBD";
 }
 
 export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: BracketViewProps) {
@@ -50,6 +192,22 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
   useEffect(() => {
     if (!scriptReady || !window.bracketsViewer || data.stage.length === 0) return;
     if (data.match.length === 0) return;
+
+    // 注入中文 locale：把 BYE 翻译为 TBD，并将 origin hint 翻译为中文
+    if (window.bracketsViewer.addLocale) {
+      window.bracketsViewer
+        .addLocale("en", {
+          common: { bye: "TBD" },
+          "origin-hint": {
+            seed: "种子 {{position}}",
+            "winner-bracket": "胜者组 R{{round}}.{{position}}",
+            "winner-bracket-semi-final": "胜者组半决赛.{{position}}",
+            "winner-bracket-final": "胜者组决赛",
+            "grand-final": "胜者组决赛胜者",
+          },
+        })
+        .catch(() => {});
+    }
 
     window.bracketsViewer
       .render(
@@ -64,7 +222,7 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
       .then(() => {
         if (!containerRef.current) return;
 
-        // 将 brackets-viewer 默认的 "BYE" 文本替换为 "TBD"
+        // 兜底：如果上面 addLocale 在 render 之前未生效，把残留的 BYE 字面量替换为 TBD
         const walker = document.createTreeWalker(
           containerRef.current,
           NodeFilter.SHOW_TEXT,
@@ -72,18 +230,63 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         );
         let node: Text | null;
         while ((node = walker.nextNode() as Text | null)) {
-          if (node.textContent === "BYE") {
-            node.textContent = "TBD";
-          }
+          if (node.textContent === "BYE") node.textContent = "TBD";
         }
 
+        // ── 为每场比赛的空槽位注入 feeder 标签 ─────────────────────────
+        const participantById = new Map<number, string>(
+          data.participant.map((p) => [p.id, p.name]),
+        );
+        const matchById = new Map<number, BracketMatch>(
+          data.match.map((m) => [m.id, m]),
+        );
+
+        containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
+          const bracketId = el.getAttribute("data-match-id");
+          if (!bracketId) return;
+          const match = matchById.get(parseInt(bracketId, 10));
+          if (!match) return;
+
+          const participants = el.querySelectorAll<HTMLElement>(".participant");
+          [0, 1].forEach((idx) => {
+            const slot = participants[idx];
+            if (!slot) return;
+            const nameEl = slot.querySelector<HTMLElement>(".name");
+            if (!nameEl) return;
+            const opponent = idx === 0 ? match.opponent1 : match.opponent2;
+            if (opponent && opponent.id != null) return;
+            const label = computeSlotLabel(match, idx as 0 | 1, data, participantById);
+            nameEl.innerText = label;
+            nameEl.title = label;
+            nameEl.classList.add("hint");
+          });
+        });
+
+        // ── 点击跳转 & hover 视觉 ──────────────────────────────────────
         if (matchNodeMap && seasonSlug) {
+          const accentColor = getComputedStyle(containerRef.current)
+            .getPropertyValue("--color-accent")
+            .trim() || "#ff6a00";
+
           containerRef.current.querySelectorAll<HTMLElement>("[data-match-id]").forEach((el) => {
             const bracketId = el.getAttribute("data-match-id");
             if (!bracketId) return;
-            if (!matchNodeMap.has(bracketId)) return;
+            if (!matchNodeMap.has(bracketId)) {
+              // 不可点击的比赛：去除 cursor，避免误导
+              el.style.cursor = "default";
+              return;
+            }
             el.style.cursor = "pointer";
             el.title = "点击查看比赛详情";
+            // 用 inline style 在 mouseenter/leave 上覆盖 brackets-viewer 自带样式
+            const onEnter = () => {
+              el.style.borderColor = accentColor;
+            };
+            const onLeave = () => {
+              el.style.borderColor = "";
+            };
+            el.addEventListener("mouseenter", onEnter);
+            el.addEventListener("mouseleave", onLeave);
           });
 
           const handleClick = (e: MouseEvent) => {
@@ -121,9 +324,7 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
         strategy="afterInteractive"
         onReady={() => setScriptReady(true)}
       />
-      <div
-        className="overflow-x-auto"
-      >
+      <div className="overflow-x-auto">
         <div
           id="bracket-container"
           className="brackets-viewer"

--- a/src/components/matches/MatchTimeNegotiation.tsx
+++ b/src/components/matches/MatchTimeNegotiation.tsx
@@ -13,6 +13,20 @@ type Proposal = typeof matchTimeProposals.$inferSelect;
 
 const PROPOSAL_AUTO_ACCEPT_HOURS = 24;
 
+/** 推荐有解说覆盖的时间段（按 Asia/Shanghai 当地时间）。 */
+const CASTER_SLOTS: readonly { start: number; end: number }[] = [
+  { start: 14, end: 17 }, // 14:00 – 17:00
+  { start: 19, end: 22 }, // 19:00 – 22:00
+];
+
+/** 判断给定时间（北京时间起点）是否落在推荐解说时段内。 */
+function isWithinCasterSlot(date: Date | null): boolean {
+  if (!date || Number.isNaN(date.getTime())) return false;
+  // 用东八区小时数判断；Date 内部是 UTC，加偏移得到 CST 小时。
+  const cstHour = (date.getUTCHours() + 8) % 24;
+  return CASTER_SLOTS.some((slot) => cstHour >= slot.start && cstHour < slot.end);
+}
+
 interface MatchTimeNegotiationProps {
   matchId: string;
   isCaptainA: boolean;
@@ -23,6 +37,8 @@ interface MatchTimeNegotiationProps {
   currentCompletionDeadline: Date | null;
   initialProposals: Proposal[];
   hasSubmittedRoster: boolean;
+  /** 协商缓冲小时数，排位赛默认 24，正赛 0。决定 confirmationCutoff = completionDeadline - bufferHours。 */
+  bufferHours?: number;
 }
 
 export function MatchTimeNegotiation({
@@ -35,7 +51,10 @@ export function MatchTimeNegotiation({
   currentCompletionDeadline,
   initialProposals,
   hasSubmittedRoster = false,
+  bufferHours = 24,
 }: MatchTimeNegotiationProps) {
+  // 0 缓冲（=与最晚完成时间一致）目前仅正赛使用，沿用作为是否显示解说时段提示的判据。
+  const isPlayoff = bufferHours === 0;
   const [isPending, startTransition] = useTransition();
   const [proposedTime, setProposedTime] = useState("");
   const [rejectReasons, setRejectReasons] = useState<Record<string, string>>({});
@@ -47,7 +66,7 @@ export function MatchTimeNegotiation({
     ? new Date(currentCompletionDeadline)
     : null;
   const confirmationCutoff = completionDeadline
-    ? new Date(completionDeadline.getTime() - 24 * 60 * 60 * 1000)
+    ? new Date(completionDeadline.getTime() - bufferHours * 60 * 60 * 1000)
     : null;
   const isNegotiationClosed =
     confirmationCutoff !== null && Date.now() >= confirmationCutoff.getTime();
@@ -219,6 +238,13 @@ export function MatchTimeNegotiation({
               提议
             </Button>
           </div>
+          {isPlayoff &&
+            proposedTime &&
+            !isWithinCasterSlot(parseCSTInput(proposedTime)) && (
+              <p className="text-xs text-[var(--color-warn,#f59e0b)]">
+                所选时间在推荐解说时段外，比赛可正常进行，但不保证有官方解说。
+              </p>
+            )}
         </div>
       )}
 
@@ -228,11 +254,19 @@ export function MatchTimeNegotiation({
           最晚完成时间：{completionDeadline ? formatCST(completionDeadline) : "管理员暂未设置"}
         </div>
         <div>
-          协商截止时间：{confirmationCutoff ? formatCST(confirmationCutoff) : "设置最晚完成时间后自动生成"}
+          协商截止时间：
+          {confirmationCutoff
+            ? `${formatCST(confirmationCutoff)}${bufferHours > 0 ? `（最晚完成时间前 ${bufferHours} 小时）` : "（与最晚完成时间一致）"}`
+            : "设置最晚完成时间后自动生成"}
         </div>
         <div>
           单条提议超时：对方 24 小时未回应将自动采纳
         </div>
+        {isPlayoff && (
+          <div className="mt-1 text-[var(--color-fg)]">
+            推荐解说时段：每天 14:00–17:00 / 19:00–22:00（有官方解说覆盖）；可在此之外协商时间，但不保证解说。
+          </div>
+        )}
         {isNegotiationClosed && (
           <div className="mt-1 text-[var(--color-danger)]">
             队长时间协商已截止，请联系管理员指定比赛时间。

--- a/src/components/matches/ScheduledAtInput.tsx
+++ b/src/components/matches/ScheduledAtInput.tsx
@@ -123,7 +123,7 @@ export function ScheduledAtInput({
           </Button>
         )}
         <span className="text-xs text-[var(--color-fg-dim)]">
-          队长需在此时间前 24 小时完成协商
+          队长协商截止：排位赛 = 此时间前 24 小时；正赛 = 即此时间
         </span>
       </div>
     </div>

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -22,7 +22,9 @@ export type BracketStageRef = { id: number; name: string };
 /** brackets-manager participant 的轻量引用 */
 export type BracketParticipantRef = { id: number; name: string };
 /** brackets-manager round 的轻量引用 */
-export type BracketRoundRef = { id: number; stage_id: number; number: number };
+export type BracketRoundRef = { id: number; stage_id: number; group_id: number; number: number };
+/** brackets-manager group 的轻量引用（number: 1=winner_bracket, 2=loser_bracket, 3=grand_final） */
+export type BracketGroupRef = { id: number; stage_id: number; number: number };
 
 export interface BracketStage {
   id: number;
@@ -40,8 +42,11 @@ export interface BracketMatch {
   round_id: number;
   number: number;
   status: number;
-  opponent1: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
-  opponent2: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+  // brackets-viewer 用 `"child_count" in t` 区分 match 与 match-game。
+  // 不传这个字段会被当成 match-game，导致元素挂的是 data-match-game-id 而非 data-match-id。
+  child_count: number;
+  opponent1: { id: number | null; score?: number; result?: "win" | "loss" } | null;
+  opponent2: { id: number | null; score?: number; result?: "win" | "loss" } | null;
 }
 
 export interface BracketMatchGame {
@@ -50,8 +55,8 @@ export interface BracketMatchGame {
   stage_id?: number;
   number?: number;
   status?: number;
-  opponent1?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
-  opponent2?: { id: number | null; score: number | null; result?: "win" | "loss" } | null;
+  opponent1?: { id: number | null; score?: number; result?: "win" | "loss" } | null;
+  opponent2?: { id: number | null; score?: number; result?: "win" | "loss" } | null;
 }
 
 export interface BracketData {
@@ -59,6 +64,8 @@ export interface BracketData {
   match: BracketMatch[];
   match_game: BracketMatchGame[];
   participant: { id: number; name: string }[];
+  group: BracketGroupRef[];
+  round: BracketRoundRef[];
 }
 
 // 封装的"已确定双方"比赛信息，供调用者批量创建 DB match 记录
@@ -182,7 +189,7 @@ export function serializeBracket(
   teams: Team[]
 ): BracketData {
   if (!data) {
-    return { stage: [], match: [], match_game: [], participant: [] };
+    return { stage: [], match: [], match_game: [], participant: [], group: [], round: [] };
   }
 
   // participant 表只有 name；id 顺序对应 teams 按 draft_order 排列
@@ -217,6 +224,7 @@ export function serializeBracket(
       round_id: number;
       number: number;
       status: number;
+      child_count?: number;
       opponent1: { id: number | null; score: number | null; result?: string } | null;
       opponent2: { id: number | null; score: number | null; result?: string } | null;
     }>
@@ -227,20 +235,36 @@ export function serializeBracket(
     round_id: m.round_id,
     number: m.number,
     status: m.status,
+    child_count: m.child_count ?? 0,
     opponent1: m.opponent1
       ? {
           id: m.opponent1.id,
-          score: m.opponent1.score ?? null,
+          // 注意：brackets-viewer 用 `void 0 === e.score` 判断空分数，
+          // 必须传 undefined（JSON 序列化后字段缺失）而非 null，否则会渲染成字符串 "null"。
+          score: m.opponent1.score ?? undefined,
           result: m.opponent1.result as "win" | "loss" | undefined,
         }
       : null,
     opponent2: m.opponent2
       ? {
           id: m.opponent2.id,
-          score: m.opponent2.score ?? null,
+          score: m.opponent2.score ?? undefined,
           result: m.opponent2.result as "win" | "loss" | undefined,
         }
       : null,
+  }));
+
+  const group: BracketGroupRef[] = (data.group as BracketGroupRef[]).map((g) => ({
+    id: g.id,
+    stage_id: g.stage_id,
+    number: g.number,
+  }));
+
+  const round: BracketRoundRef[] = (data.round as BracketRoundRef[]).map((r) => ({
+    id: r.id,
+    stage_id: r.stage_id,
+    group_id: r.group_id,
+    number: r.number,
   }));
 
   return {
@@ -248,6 +272,8 @@ export function serializeBracket(
     match,
     match_game: (data.match_game as unknown as BracketMatchGame[] | undefined) ?? [],
     participant,
+    group,
+    round,
   };
 }
 

--- a/src/lib/matches/time-rules.ts
+++ b/src/lib/matches/time-rules.ts
@@ -1,17 +1,36 @@
 import { AppError, ErrorCode } from "@/lib/errors";
+import { getStageByKey, type StagePlan } from "@/types/season";
 
 export const TIME_CONFIRMATION_BUFFER_HOURS = 24;
 
-export function getTimeConfirmationCutoff(completionDeadline: Date | null): Date | null {
+/**
+ * 根据比赛所属阶段返回协商缓冲小时数。
+ * 排位赛通常给较长窗口（默认 24h 缓冲，方便补打），正赛阶段窗口紧，取消缓冲。
+ */
+export function getTimeBufferHoursForStage(
+  stagePlan: StagePlan | null | undefined,
+  stageKey: string,
+): number {
+  const stage = getStageByKey(stagePlan, stageKey);
+  if (!stage) return TIME_CONFIRMATION_BUFFER_HOURS;
+  if (stage.type === "double_elim" || stage.type === "single_elim") return 0;
+  return TIME_CONFIRMATION_BUFFER_HOURS;
+}
+
+export function getTimeConfirmationCutoff(
+  completionDeadline: Date | null,
+  bufferHours: number = TIME_CONFIRMATION_BUFFER_HOURS,
+): Date | null {
   if (!completionDeadline) return null;
-  return new Date(completionDeadline.getTime() - TIME_CONFIRMATION_BUFFER_HOURS * 60 * 60 * 1000);
+  return new Date(completionDeadline.getTime() - bufferHours * 60 * 60 * 1000);
 }
 
 export function assertBeforeTimeConfirmationCutoff(
   completionDeadline: Date | null,
+  bufferHours: number = TIME_CONFIRMATION_BUFFER_HOURS,
   now = new Date(),
 ): void {
-  const cutoff = getTimeConfirmationCutoff(completionDeadline);
+  const cutoff = getTimeConfirmationCutoff(completionDeadline, bufferHours);
   if (cutoff && now.getTime() >= cutoff.getTime()) {
     throw new AppError(
       ErrorCode.VALIDATION_FAILED,

--- a/src/lib/validators/match-scheduling.test.ts
+++ b/src/lib/validators/match-scheduling.test.ts
@@ -10,7 +10,7 @@ describe("validateTimeProposal", () => {
     const completionDeadline = new Date("2026-01-05T10:00:00Z");
     const proposedTime = new Date("2026-01-03T10:00:00Z");
 
-    expect(() => assertBeforeTimeConfirmationCutoff(completionDeadline, now)).not.toThrow();
+    expect(() => assertBeforeTimeConfirmationCutoff(completionDeadline, 24, now)).not.toThrow();
     expect(() => assertProposedTimeFitsDeadline(proposedTime, completionDeadline, now)).not.toThrow();
   });
 

--- a/tests/unit/components/matches/BracketView.test.tsx
+++ b/tests/unit/components/matches/BracketView.test.tsx
@@ -36,8 +36,9 @@ const bracketData: BracketData = {
       round_id: 3,
       number: 1,
       status: 2,
-      opponent1: { id: 0, score: null },
-      opponent2: { id: 1, score: null },
+      child_count: 0,
+      opponent1: { id: 0 },
+      opponent2: { id: 1 },
     },
   ],
   participant: [
@@ -45,6 +46,8 @@ const bracketData: BracketData = {
     { id: 1, name: "Team 2" },
   ],
   match_game: [],
+  group: [{ id: 0, stage_id: 1, number: 1 }],
+  round: [{ id: 3, stage_id: 1, group_id: 0, number: 1 }],
 };
 
 describe("BracketView", () => {


### PR DESCRIPTION
## Summary
- **Bracket 显示与交互修复**：补齐 `child_count` 修复 brackets-viewer 把 match 误识别为 match-game 导致的点击跳转/ hover 全部失效；score 透传 `undefined` 修复右侧字符串 "null"；UB R2+ / LB 各轮空槽位注入「队伍A vs 队伍B 胜者/败者」/「TBD」标签
- **默认 tab 切换**：进入正赛阶段（排位赛全部完赛或正赛已有比赛）后公开赛程页面默认切到正赛 tab
- **阶段感知协商缓冲**：`getTimeBufferHoursForStage` 让排位赛保留 24h 缓冲，正赛 = 0（与最晚完成时间一致）
- **正赛推荐解说时段提示**：协商面板列出 14:00–17:00 / 19:00–22:00 推荐时段；队长提议落在区间外时即时给出「不保证解说」软警告，不阻止提交

## Test plan
- [x] `pnpm tsc --noEmit` 通过
- [x] `pnpm test`（449/449）通过
- [ ] 公开赛程页面 bracket：WB R2+ / LB 空槽位显示「胜者/败者」标签，已建好的比赛 hover 变橙、点击进入详情
- [ ] 进入正赛阶段后默认 tab 切到正赛
- [ ] 排位赛：completionDeadline 前 24h 协商按规则关闭
- [ ] 正赛：completionDeadline 当下才关闭协商，输入区间外时间触发警告