### PR TITLE
release: v1.22.1 — OCR 未匹配用户高亮并阻止保存

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.1] - 2026-05-23
+
+### Fixed
+- **OCR 未匹配用户阻止保存**：`StatsOCRPanel` 新增 `unmatchedCount` 计算，未匹配行的「匹配用户」下拉框高亮红色边框，有未匹配行时禁用保存按钮并显示提示，防止错误数据写入数据库
+
 ## [1.22.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.22.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.22.0...v1.22.1
+[1.22.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.21.1...v1.22.0
+[1.21.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.21.0...v1.21.1
 [1.21.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.5...v1.21.0
 [1.20.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.4...v1.20.5
 [1.20.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.20.3...v1.20.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -211,6 +211,11 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
     return count;
   }, [drafts]);
 
+  const unmatchedCount = useMemo(
+    () => drafts.filter((row) => row.userId === null).length,
+    [drafts],
+  );
+
   async function handleClear() {
     setSaving(true);
     const result = await deletePlayerStatsByMap(mapId);
@@ -352,7 +357,10 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
                             value={row.userId ?? "__none__"}
                             onValueChange={(v) => handleUserChange(idx, v)}
                           >
-                            <SelectTrigger className="h-7 text-xs">
+                            <SelectTrigger className={cn(
+                              "h-7 text-xs",
+                              row.userId === null && "border-[var(--color-danger)] text-[var(--color-danger)]",
+                            )}>
                               <SelectValue placeholder="未匹配" />
                             </SelectTrigger>
                             <SelectContent>
@@ -405,10 +413,15 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
                 <Button
                   size="sm"
                   onClick={handleSave}
-                  disabled={saving || errorCount > 0}
+                  disabled={saving || errorCount > 0 || unmatchedCount > 0}
                 >
                   {saving ? "保存中…" : "确认保存"}
                 </Button>
+                {unmatchedCount > 0 && (
+                  <p className="text-xs text-[var(--color-danger)]">
+                    ⚠ {unmatchedCount} 行未匹配用户，请在下拉框中选择对应选手后再保存
+                  </p>
+                )}
                 {errorCount > 0 && (
                   <p className="text-xs text-[var(--color-danger)]">
                     ⚠ {errorCount} 处数据超出合法范围，请修正后再保存


### PR DESCRIPTION
## Summary
- OCR 录入面板（`StatsOCRPanel`）新增未匹配用户检测：`userId = null` 的行下拉框高亮红色边框，并在底部显示计数提示
- 有未匹配行时禁用「确认保存」按钮，防止错误/空 userId 数据写入数据库
- 与现有数值超范围阻止逻辑并列，两者均满足才允许保存

## Test plan
- [ ] OCR 识别截图后，名单匹配不上的行下拉框变红
- [ ] 底部出现「X 行未匹配用户…」提示，保存按钮禁用
- [ ] 手动从下拉框选中用户后，红色消失，所有行匹配完毕后按钮恢复可用
- [ ] 数值超范围逻辑不受影响