### PR TITLE
release: v1.23.0 — 弃赛系统 + 逐图比分修正 + MapByMapInput UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-05-23
+
+### Added
+- **弃赛系统**：新增 `forfeitMatch` action，管理员可在赛程页对 scheduled / in_progress 比赛判负弃赛；弃赛方选择后按格式写入标准比分（BO1 13:0 / BO3 2:0 / BO5 3:0）并推进 bracket；`MatchStatusBadge` 弃赛场次显示"弃赛"而非"已结束"；`matches` 表新增 `is_forfeit` 列（需执行 `pnpm db:push`）
+- **逐图比分修正**：新增 `correctMapScore` action，赛后可修改已录入的单图回合数，大比分自动重算；后台赛程页有逐图记录时以逐图修改入口替换旧的直接改大比分入口
+
+### Changed
+- **逐图录入绑定 format**：`MapByMapInput` 改为在 BO3 / BO5 格式比赛进行时展示，不再限于淘汰赛阶段
+- **MapByMapInput UX**：BP 已记录选边时不再重复展示选边下拉框；比分输入框上方新增队伍名标签；决胜图选边标签统一为"{队伍名} 起始边"
+- **图三 OCR 过滤**：BO3 系列赛 2:0 结束后，BP 预占的第三图占位行不再出现在 OCR 录入面板
+
 ## [1.22.1] - 2026-05-23
 
 ### Fixed

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -151,14 +151,22 @@ cancelled
 | 当前状态 | 可迁移至 | 触发方 | 备注 |
 |---|---|---|---|
 | `scheduled` | `in_progress` | admin | 比赛开始 |
-| `scheduled` | `cancelled` | admin | 双方队伍弃权或赛程调整 |
-| `in_progress` | `finished` | admin | 录入比分（`recordMatchResult` 接受 scheduled 或 in_progress） |
+| `scheduled` | `cancelled` | admin | 赛程调整 |
+| `scheduled` | `finished` | admin | 弃赛判负（`forfeitMatch`，跳过 BP 要求） |
+| `in_progress` | `finished` | admin | 录入比分（`recordMatchResult` / `recordMapResult`） |
+| `in_progress` | `finished` | admin | 弃赛判负（`forfeitMatch`，跳过 BP 要求） |
 | `in_progress` | `cancelled` | admin | 特殊情况 |
 
 ### 禁止迁移
 
 - `finished` → 任何状态（比赛结果不可撤销，需 admin 特权操作并写 audit_log）
 - `cancelled` → `in_progress`（取消后不可恢复，需重新创建比赛）
+
+### 弃赛（isForfeit）
+
+`matches.is_forfeit = true` 表示该场比赛为弃赛判负，status 仍为 `finished`。
+比分按格式写入标准弃赛分（BO1: 13:0，BO3: 2:0，BO5: 3:0），bracket 正常推进。
+`MatchStatusBadge` 在 `isForfeit=true` 时显示"弃赛"而非"已结束"。
 
 ### 比分录入规则
 

--- a/drizzle/migrations/0019_is_forfeit.sql
+++ b/drizzle/migrations/0019_is_forfeit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "matches" ADD COLUMN "is_forfeit" boolean NOT NULL DEFAULT false;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1715100000000,
       "tag": "0018_mvp_winner",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1748044800000,
+      "tag": "0019_is_forfeit",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,5 +1,5 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
-export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, updateMatchCompletedAt } from "./results";
+export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch } from "./results";
 export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster, updateMatchRoster } from "./roster";
 export { saveVetoSteps } from "./veto";

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -693,3 +693,159 @@ export async function updateMatchCompletedAt(
     return actionError("updateMatchCompletedAt", e);
   }
 }
+
+// ── 修正单图比分 ──────────────────────────────────────────────────────────────
+
+/**
+ * 修正已完成比赛中某张地图的比分，并自动重算系列赛大比分。
+ * 不重新判定胜负，不影响 bracket 晋级结果。
+ */
+export async function correctMapScore(
+  mapId: string,
+  scoreA: number,
+  scoreB: number,
+): Promise<ActionResult<void>> {
+  try {
+    if (isNaN(scoreA) || isNaN(scoreB) || scoreA < 0 || scoreB < 0) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "请输入有效的非负整数");
+    }
+    if (scoreA === scoreB) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "单图不能平局");
+    }
+
+    const mapRecord = await db.query.matchMaps.findFirst({
+      where: eq(matchMaps.id, mapId),
+    });
+    if (!mapRecord) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
+    if (mapRecord.scoreA === null) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "该图尚未录入比分，无法修正");
+    }
+
+    const match = await getMatchOrThrow(mapRecord.matchId);
+    const session = await requireSeasonAdmin(match.seasonId);
+
+    if (match.status !== "finished") {
+      throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "只有已结束的比赛才能修正比分");
+    }
+
+    const season = await getSeasonOrThrow(match.seasonId);
+
+    await db.transaction(async (tx) => {
+      await tx.update(matchMaps)
+        .set({ scoreA, scoreB })
+        .where(eq(matchMaps.id, mapId));
+
+      // 事务内重新读取所有图（含刚更新的），重算系列赛比分
+      const allMaps = await tx.query.matchMaps.findMany({
+        where: eq(matchMaps.matchId, mapRecord.matchId),
+      });
+      let seriesA = 0;
+      let seriesB = 0;
+      for (const m of allMaps) {
+        if (m.scoreA !== null && m.scoreB !== null) {
+          if (m.scoreA > m.scoreB) seriesA++;
+          else if (m.scoreB > m.scoreA) seriesB++;
+        }
+      }
+
+      await tx.update(matches)
+        .set({ scoreA: seriesA, scoreB: seriesB, updatedAt: new Date() })
+        .where(eq(matches.id, mapRecord.matchId));
+
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "match.correct_map_score",
+        actorId: auditActorId(session),
+        targetId: mapRecord.matchId,
+        targetType: "match",
+        meta: { mapId, mapName: mapRecord.mapName, prevScoreA: mapRecord.scoreA, prevScoreB: mapRecord.scoreB, scoreA, scoreB, seriesA, seriesB },
+      });
+    });
+
+    revalidateMatchPaths(season.slug, mapRecord.matchId);
+    return ok(undefined);
+  } catch (e) {
+    return actionError("correctMapScore", e);
+  }
+}
+
+// ── 弃赛判负 ─────────────────────────────────────────────────────────────────
+
+const FORFEIT_WINNER_SCORE: Record<"bo1" | "bo3" | "bo5", number> = {
+  bo1: 13,
+  bo3: 2,
+  bo5: 3,
+};
+
+/**
+ * 记录弃赛结果：跳过 BP 要求，按格式写入标准弃赛比分并推进 bracket。
+ * 可在 scheduled 或 in_progress 状态调用。
+ */
+export async function forfeitMatch(
+  matchId: string,
+  loserTeamId: string
+): Promise<ActionResult<void>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const session = await requireSeasonAdmin(match.seasonId);
+
+    assertMatchTransition(match.status, "finished");
+
+    if (loserTeamId !== match.teamAId && loserTeamId !== match.teamBId) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "弃赛队伍不属于本场比赛");
+    }
+
+    const winnerScore = FORFEIT_WINNER_SCORE[match.format];
+    const isLoserA = loserTeamId === match.teamAId;
+    const scoreA = isLoserA ? 0 : winnerScore;
+    const scoreB = isLoserA ? winnerScore : 0;
+
+    const season = await getSeasonOrThrow(match.seasonId);
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(matches)
+        .set({
+          scoreA,
+          scoreB,
+          status: "finished",
+          isForfeit: true,
+          completedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(matches.id, matchId));
+
+      if (season.bracketData && match.bracketNodeId) {
+        const { updatedData, newResolvedMatches } = await bracketAdvance(
+          match.bracketNodeId,
+          scoreA,
+          scoreB,
+          season.bracketData as Database
+        );
+        await tx
+          .update(seasons)
+          .set({ bracketData: updatedData as Database, updatedAt: new Date() })
+          .where(eq(seasons.id, match.seasonId));
+        await insertResolvedBracketMatches(
+          tx, match.seasonId, match.stage,
+          updatedData as Database, newResolvedMatches,
+          normalizeStagePlan(season.stagePlan),
+        );
+      }
+
+      await tx.insert(auditLogs).values({
+        seasonId: match.seasonId,
+        action: "match.forfeit",
+        actorId: auditActorId(session),
+        targetId: matchId,
+        targetType: "match",
+        meta: { loserTeamId, scoreA, scoreB, format: match.format },
+      });
+    });
+
+    revalidateMatchPaths(season.slug, matchId);
+    return ok(undefined);
+  } catch (e) {
+    return actionError("forfeitMatch", e);
+  }
+}

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -51,8 +51,10 @@ function mapPendingMaps(records: { mapOrder: number; mapName: string; scoreA: nu
     }));
 }
 
-function mapFinishedMaps(records: { id: string; mapName: string }[]) {
-  return records.map((r) => ({ id: r.id, mapName: r.mapName }));
+function mapFinishedMaps(records: { id: string; mapName: string; scoreA: number | null; scoreB: number | null }[]) {
+  return records
+    .filter((r) => r.scoreA !== null && r.scoreB !== null)
+    .map((r) => ({ id: r.id, mapName: r.mapName, scoreA: r.scoreA as number, scoreB: r.scoreB as number }));
 }
 
 function sortMatches<T extends { status: string; scheduledAt: Date | null; completedAt: Date | null }>(list: T[]): T[] {

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -9,6 +9,8 @@ import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
 import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
 import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
 import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
+import { ForfeitButton } from "@/components/matches/ForfeitButton";
+import { MapScoreCorrectInput } from "@/components/matches/MapScoreCorrectInput";
 import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
 import { CompletedAtInput } from "@/components/matches/CompletedAtInput";
 import { toCSTDateTimeInput } from "@/lib/utils/date";
@@ -34,6 +36,7 @@ interface AdminMatchRowProps {
     id: string;
     status: "scheduled" | "in_progress" | "finished" | "cancelled";
     format: "bo1" | "bo3" | "bo5";
+    isForfeit: boolean;
     scoreA: number | null;
     scoreB: number | null;
     scheduledAt: Date | null;
@@ -66,7 +69,7 @@ interface AdminMatchRowProps {
     pickedByTeamId: string | null;
     teamAStartSide: "t" | "ct" | null;
   }[];
-  finishedMaps: { id: string; mapName: string }[];
+  finishedMaps: { id: string; mapName: string; scoreA: number; scoreB: number }[];
 }
 
 export function AdminMatchRow({
@@ -107,6 +110,7 @@ export function AdminMatchRow({
           <StatusPill status={MATCH_FORMAT_LABELS[match.format]} />
           <MatchStatusBadge
             status={match.status}
+            isForfeit={match.isForfeit}
           />
         </div>
       </div>
@@ -150,7 +154,7 @@ export function AdminMatchRow({
                   currentScheduledAt={match.scheduledAt}
                   currentCompletionDeadline={match.completionDeadline}
                 />
-                {isPlayoff && match.status === "in_progress" ? (
+                {(match.format === "bo3" || match.format === "bo5") && match.status === "in_progress" ? (
                   <MapByMapInput
                     matchId={match.id}
                     format={match.format}
@@ -171,6 +175,13 @@ export function AdminMatchRow({
                     format={match.format}
                   />
                 )}
+                <ForfeitButton
+                  matchId={match.id}
+                  teamAId={match.teamAId}
+                  teamBId={match.teamBId}
+                  teamAName={teamAName}
+                  teamBName={teamBName}
+                />
               </>
             )}
             {match.status === "finished" && (
@@ -187,15 +198,32 @@ export function AdminMatchRow({
                     matchStatus="finished"
                   />
                 </div>
-                <ScoreInput
-                  matchId={match.id}
-                  teamAName={teamAName}
-                  teamBName={teamBName}
-                  currentStatus="finished"
-                  format={match.format}
-                  currentScoreA={match.scoreA}
-                  currentScoreB={match.scoreB}
-                />
+                {finishedMaps.length > 0 ? (
+                  <div className="space-y-1">
+                    <p className="text-xs text-[var(--color-fg-mid)]">逐图比分（修改后大比分自动更新）</p>
+                    {finishedMaps.map((map) => (
+                      <MapScoreCorrectInput
+                        key={map.id}
+                        mapId={map.id}
+                        mapName={map.mapName}
+                        scoreA={map.scoreA}
+                        scoreB={map.scoreB}
+                        teamAName={teamAName}
+                        teamBName={teamBName}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <ScoreInput
+                    matchId={match.id}
+                    teamAName={teamAName}
+                    teamBName={teamBName}
+                    currentStatus="finished"
+                    format={match.format}
+                    currentScoreA={match.scoreA}
+                    currentScoreB={match.scoreB}
+                  />
+                )}
                 <CompletedAtInput
                   matchId={match.id}
                   initialValue={toCSTDateTimeInput(match.completedAt)}

--- a/src/components/matches/ForfeitButton.tsx
+++ b/src/components/matches/ForfeitButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { forfeitMatch } from "@/actions/matches";
+
+interface ForfeitButtonProps {
+  matchId: string;
+  teamAId: string;
+  teamBId: string;
+  teamAName: string;
+  teamBName: string;
+}
+
+export function ForfeitButton({
+  matchId,
+  teamAId,
+  teamBId,
+  teamAName,
+  teamBName,
+}: ForfeitButtonProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleForfeit(loserTeamId: string) {
+    startTransition(async () => {
+      const result = await forfeitMatch(matchId, loserTeamId);
+      if (result.success) {
+        toast.success("弃赛已记录");
+        setExpanded(false);
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  if (!expanded) {
+    return (
+      <Button size="sm" variant="outline" onClick={() => setExpanded(true)}>
+        判负弃赛
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="text-xs text-[var(--color-fg-mid)]">确认弃赛方：</span>
+      <Button
+        size="sm"
+        variant="destructive"
+        disabled={isPending}
+        onClick={() => handleForfeit(teamAId)}
+      >
+        {teamAName} 弃赛
+      </Button>
+      <Button
+        size="sm"
+        variant="destructive"
+        disabled={isPending}
+        onClick={() => handleForfeit(teamBId)}
+      >
+        {teamBName} 弃赛
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={isPending}
+        onClick={() => setExpanded(false)}
+      >
+        取消
+      </Button>
+    </div>
+  );
+}

--- a/src/components/matches/MapByMapInput.tsx
+++ b/src/components/matches/MapByMapInput.tsx
@@ -89,7 +89,9 @@ export function MapByMapInput({
     const pickedByTeamId = nextPending
       ? nextPending.pickedByTeamId
       : (manualPickedBy === "decider" ? null : manualPickedBy);
-    const side = teamAStartSide === "none" ? null : teamAStartSide as "t" | "ct";
+    // BP 已记录选边时直接沿用，否则读取表单选择
+    const side = nextPending?.teamAStartSide
+      ?? (teamAStartSide === "none" ? null : teamAStartSide as "t" | "ct");
 
     startTransition(async () => {
       const result = await recordMapResult(matchId, nextMapOrder, resolvedMapName, a, b, pickedByTeamId, side);
@@ -182,26 +184,37 @@ export function MapByMapInput({
               </>
             )}
 
-            <div className="space-y-1">
-              <Label className="text-xs text-[var(--color-fg-mid)]">{teamAName} 起始边</Label>
-              <Select value={teamAStartSide} onValueChange={setTeamAStartSide}>
-                <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="t" className="text-xs">{SIDE_LABELS.t}</SelectItem>
-                  <SelectItem value="ct" className="text-xs">{SIDE_LABELS.ct}</SelectItem>
-                  <SelectItem value="none" className="text-xs">不填</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {/* 仅在 BP 未记录选边时（决胜图或无 BP）才显示选边下拉 */}
+            {!nextPending?.teamAStartSide && (
+              <div className="space-y-1">
+                <Label className="text-xs text-[var(--color-fg-mid)]">
+                  {teamAName} 起始边
+                </Label>
+                <Select value={teamAStartSide} onValueChange={setTeamAStartSide}>
+                  <SelectTrigger className="h-8 text-xs"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="t" className="text-xs">{SIDE_LABELS.t}</SelectItem>
+                    <SelectItem value="ct" className="text-xs">{SIDE_LABELS.ct}</SelectItem>
+                    <SelectItem value="none" className="text-xs">不填</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             <div className="space-y-1 col-span-2 sm:col-span-1">
               <Label className="text-xs text-[var(--color-fg-mid)]">回合数</Label>
-              <div className="flex items-center gap-1">
-                <Input type="number" min="0" value={scoreA} onChange={(e) => setScoreA(e.target.value)}
-                  className="w-14 text-center h-8 text-xs" placeholder="0" />
-                <span className="text-[var(--color-fg-mid)] text-xs">:</span>
-                <Input type="number" min="0" value={scoreB} onChange={(e) => setScoreB(e.target.value)}
-                  className="w-14 text-center h-8 text-xs" placeholder="0" />
+              <div className="flex items-end gap-1">
+                <div className="space-y-1">
+                  <span className="text-[10px] text-[var(--color-fg-dim)]">{teamAName}</span>
+                  <Input type="number" min="0" value={scoreA} onChange={(e) => setScoreA(e.target.value)}
+                    className="w-14 text-center h-8 text-xs" placeholder="0" />
+                </div>
+                <span className="text-[var(--color-fg-mid)] text-xs pb-1.5">:</span>
+                <div className="space-y-1">
+                  <span className="text-[10px] text-[var(--color-fg-dim)]">{teamBName}</span>
+                  <Input type="number" min="0" value={scoreB} onChange={(e) => setScoreB(e.target.value)}
+                    className="w-14 text-center h-8 text-xs" placeholder="0" />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/matches/MapScoreCorrectInput.tsx
+++ b/src/components/matches/MapScoreCorrectInput.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { correctMapScore } from "@/actions/matches";
+import { mapLabel } from "@/lib/maps";
+
+interface MapScoreCorrectInputProps {
+  mapId: string;
+  mapName: string;
+  scoreA: number;
+  scoreB: number;
+  teamAName: string;
+  teamBName: string;
+}
+
+export function MapScoreCorrectInput({
+  mapId,
+  mapName,
+  scoreA,
+  scoreB,
+  teamAName,
+  teamBName,
+}: MapScoreCorrectInputProps) {
+  const [editing, setEditing] = useState(false);
+  const [valA, setValA] = useState(String(scoreA));
+  const [valB, setValB] = useState(String(scoreB));
+  const [isPending, startTransition] = useTransition();
+
+  function handleEdit() {
+    setValA(String(scoreA));
+    setValB(String(scoreB));
+    setEditing(true);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const a = parseInt(valA, 10);
+    const b = parseInt(valB, 10);
+    if (isNaN(a) || isNaN(b) || a < 0 || b < 0) {
+      toast.error("请输入有效的非负整数");
+      return;
+    }
+    if (a === b) {
+      toast.error("单图不能平局");
+      return;
+    }
+    startTransition(async () => {
+      const result = await correctMapScore(mapId, a, b);
+      if (result.success) {
+        toast.success(`${mapLabel(mapName)} 比分已修正，大比分已自动更新`);
+        setEditing(false);
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap text-xs">
+      <span className="text-[var(--color-fg-mid)] w-20 shrink-0">{mapLabel(mapName)}</span>
+      {!editing ? (
+        <>
+          <span className="font-mono text-[var(--color-fg)]">
+            {scoreA} : {scoreB}
+          </span>
+          <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={handleEdit}>
+            修改
+          </Button>
+        </>
+      ) : (
+        <form onSubmit={handleSubmit} className="flex items-end gap-2">
+          <div className="space-y-1">
+            <Label className="text-[10px] text-[var(--color-fg-dim)]">{teamAName}</Label>
+            <Input
+              type="number"
+              min="0"
+              value={valA}
+              onChange={(e) => setValA(e.target.value)}
+              className="w-14 text-center h-7 text-xs"
+              disabled={isPending}
+            />
+          </div>
+          <span className="text-[var(--color-fg-mid)] pb-1">:</span>
+          <div className="space-y-1">
+            <Label className="text-[10px] text-[var(--color-fg-dim)]">{teamBName}</Label>
+            <Input
+              type="number"
+              min="0"
+              value={valB}
+              onChange={(e) => setValB(e.target.value)}
+              className="w-14 text-center h-7 text-xs"
+              disabled={isPending}
+            />
+          </div>
+          <Button type="submit" size="sm" className="h-7 text-xs" disabled={isPending}>
+            确认
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs"
+            disabled={isPending}
+            onClick={() => setEditing(false)}
+          >
+            取消
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/components/matches/MatchStatusBadge.tsx
+++ b/src/components/matches/MatchStatusBadge.tsx
@@ -9,10 +9,17 @@ const STATUS_STYLES: Record<MatchStatus, string> = {
   cancelled:   "border-[rgba(255,84,112,0.3)] text-[var(--color-danger)] bg-[rgba(255,84,112,0.08)]",
 };
 
-export function MatchStatusBadge({ status }: { status: MatchStatus }) {
+export function MatchStatusBadge({
+  status,
+  isForfeit = false,
+}: {
+  status: MatchStatus;
+  isForfeit?: boolean;
+}) {
+  const label = isForfeit && status === "finished" ? "弃赛" : MATCH_STATUS_LABELS[status];
   return (
     <Badge variant="outline" className={STATUS_STYLES[status]}>
-      {MATCH_STATUS_LABELS[status]}
+      {label}
     </Badge>
   );
 }

--- a/src/db/schema/matches.ts
+++ b/src/db/schema/matches.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, integer, text, timestamp, pgEnum, check } from "drizzle-orm/pg-core";
+import { pgTable, uuid, integer, text, timestamp, pgEnum, check, boolean } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { seasons } from "./seasons";
 import { teams } from "./teams";
@@ -32,6 +32,7 @@ export const matches = pgTable("matches", {
   scoreB: integer("score_b"),
 
   status: matchStatusEnum("status").notNull().default("scheduled"),
+  isForfeit: boolean("is_forfeit").notNull().default(false),
   bracketNodeId: text("bracket_node_id"),  // brackets-manager 节点引用
 
   scheduledAt: timestamp("scheduled_at", { withTimezone: true }),

--- a/src/lib/match-transitions.test.ts
+++ b/src/lib/match-transitions.test.ts
@@ -34,8 +34,8 @@ describe("assertMatchTransition", () => {
     expect(() => assertMatchTransition("cancelled", "finished")).toThrow(AppError);
   });
 
-  it("rejects scheduled → finished (no playing)", () => {
-    expect(() => assertMatchTransition("scheduled", "finished")).toThrow(AppError);
+  it("allows scheduled → finished (forfeit)", () => {
+    expect(() => assertMatchTransition("scheduled", "finished")).not.toThrow();
   });
 });
 

--- a/src/lib/match-transitions.ts
+++ b/src/lib/match-transitions.ts
@@ -6,6 +6,7 @@ export type MatchStatus = "scheduled" | "in_progress" | "finished" | "cancelled"
 export const MATCH_TRANSITIONS: Partial<Record<`${MatchStatus}→${MatchStatus}`, true>> = {
   "scheduled→in_progress": true,
   "scheduled→cancelled": true,
+  "scheduled→finished": true,
   "in_progress→finished": true,
   "in_progress→cancelled": true,
 };


### PR DESCRIPTION
## Summary
- **弃赛系统**：`forfeitMatch` action + `ForfeitButton` UI，管理员选择弃赛方后按格式写入标准比分（BO1 13:0 / BO3 2:0 / BO5 3:0）并推进 bracket；`matches` 表新增 `is_forfeit` 列；badge 显示"弃赛"
- **逐图比分修正**：`correctMapScore` action，修改单图回合数后大比分自动重算；赛后有逐图记录时替换旧的直接改大比分入口
- **逐图录入绑定 format**：`MapByMapInput` 改为对 BO3 / BO5 格式通用，不再限于淘汰赛阶段
- **MapByMapInput UX**：BP 已记录选边时不再重复询问；比分输入框加队伍名标签；选边标签统一
- **图三 OCR 过滤**：BO3 2:0 结束后，BP 预占的第三图不再出现在 OCR 面板

## ⚠️ 部署前必须执行
```bash
pnpm db:push   # 为 matches 表添加 is_forfeit 列
```

## Test plan
- [ ] 弃赛：在 scheduled / in_progress 比赛点「判负弃赛」，选择弃赛方，确认比分写入且 badge 显示「弃赛」
- [ ] 弃赛推进 bracket：淘汰赛比赛弃赛后，下一轮对阵自动生成
- [ ] 逐图比分修正：赛后点某图「修改」，改分后大比分自动更新
- [ ] BO3 进行中：MapByMapInput 正常显示（不限淘汰赛）
- [ ] BP 已有选边：录入比分时不出现选边下拉
- [ ] 2:0 结束：图三不出现在 OCR 面板