### PR TITLE
v1.23.1: bracket 晋级比赛映射修复 + OCR 超时延长

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] - 2026-05-24
+
+### Fixed
+- **Bracket 晋级比赛漏创建**：`insertResolvedBracketMatches` 之前用 bracket participant ID 作为 draft_order 数组下标查队伍，两者顺序不一致导致映射错误、晋级比赛被静默跳过；改为通过 participant name → team name 查找，同时新增 `syncBracketMatches` action 及后台「修复 Bracket 缺失比赛」按钮供一次性补全历史遗漏
+- **OCR 超时**：`siliconflow.ts` 请求超时从 60s 延长至 180s，修复 Qwen3-VL-8B-Instruct 在高负载时处理大截图超时报错
+
 ## [1.23.0] - 2026-05-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,5 +1,5 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
-export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch } from "./results";
+export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch, syncBracketMatches } from "./results";
 export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster, updateMatchRoster } from "./roster";
 export { saveVetoSteps } from "./veto";

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -7,7 +7,7 @@ import { ok } from "@/types/action";
 import type { ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { requireSeasonAdmin, auditActorId } from "@/lib/auth/session";
-import { advanceMatch as bracketAdvance, type BracketStageRef, type ResolvedBracketMatch } from "@/lib/bracket";
+import { advanceMatch as bracketAdvance, collectResolvedMatches, type BracketStageRef, type ResolvedBracketMatch } from "@/lib/bracket";
 import type { Database } from "brackets-manager";
 import {
   type MatchStatus,
@@ -39,12 +39,16 @@ async function insertResolvedBracketMatches(
 ) {
   const seasonTeams = await tx.query.teams.findMany({
     where: eq(teams.seasonId, seasonId),
-    orderBy: [asc(teams.draftOrder)],
   });
+  const participants = updatedData.participant as { id: number; name: string }[];
+  const participantNameById = new Map(participants.map((p) => [p.id, p.name]));
+  const teamByName = new Map(seasonTeams.map((t) => [t.name, t]));
   const dbStages = updatedData.stage as BracketStageRef[];
   for (const bm of resolvedMatches) {
-    const teamA = seasonTeams[bm.teamAParticipantId];
-    const teamB = seasonTeams[bm.teamBParticipantId];
+    const nameA = participantNameById.get(bm.teamAParticipantId);
+    const nameB = participantNameById.get(bm.teamBParticipantId);
+    const teamA = nameA ? teamByName.get(nameA) : undefined;
+    const teamB = nameB ? teamByName.get(nameB) : undefined;
     if (!teamA || !teamB) continue;
     const bmStageName = dbStages.find((s) => s.id === bm.stageId)?.name;
     const stage = stagePlan.find((s) => s.name === bmStageName)?.key ?? defaultStage;
@@ -766,6 +770,48 @@ export async function correctMapScore(
     return ok(undefined);
   } catch (e) {
     return actionError("correctMapScore", e);
+  }
+}
+
+// ── 修复缺失的 bracket 比赛 ───────────────────────────────────────────────────
+
+/**
+ * 扫描当前 bracket_data，将已确定对阵但 DB 中缺失的比赛补全。
+ * 用于修复历史 bug 导致的漏创建情况，正常流程不需要调用。
+ */
+export async function syncBracketMatches(seasonId: string): Promise<ActionResult<{ created: number }>> {
+  try {
+    await requireSeasonAdmin(seasonId);
+    const season = await getSeasonOrThrow(seasonId);
+    if (!season.bracketData) return ok({ created: 0 });
+
+    const allResolved = collectResolvedMatches(season.bracketData as Database);
+
+    // 读取已有的 bracket match 记录（按 bracketNodeId）
+    const existingBracketMatches = await db.query.matches.findMany({
+      where: eq(matches.seasonId, seasonId),
+      columns: { bracketNodeId: true },
+    });
+    const existingNodeIds = new Set(
+      existingBracketMatches.map((m) => m.bracketNodeId).filter(Boolean)
+    );
+
+    const missing = allResolved.filter((m) => !existingNodeIds.has(m.bracketMatchId.toString()));
+    if (missing.length === 0) return ok({ created: 0 });
+
+    const stagePlan = normalizeStagePlan(season.stagePlan);
+
+    await db.transaction(async (tx) => {
+      await insertResolvedBracketMatches(
+        tx, seasonId, "playoff",
+        season.bracketData as Database, missing,
+        stagePlan,
+      );
+    });
+
+    return ok({ created: missing.length });
+  } catch (e) {
+    return actionError("syncBracketMatches", e);
   }
 }
 

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -13,6 +13,7 @@ import { StandingsTable } from "@/components/matches/StandingsTable";
 import { AdminMatchRow } from "@/components/matches/AdminMatchRow";
 import type { TeamMemberData, RosterData } from "@/components/matches/AdminMatchRow";
 import { BatchDeadlineCard } from "@/components/matches/BatchDeadlineCard";
+import { SyncBracketButton } from "@/components/matches/SyncBracketButton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Panel } from "@/components/rivalhub";
 import { getFirstStageOfType, normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
@@ -369,6 +370,11 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
           stageName={playoffStage.name}
           standings={standings}
         />
+      )}
+
+      {/* 修复 Bracket 缺失比赛（bracket 已初始化时显示） */}
+      {hasPlayoff && (
+        <SyncBracketButton seasonId={season.id} />
       )}
 
       {/* 批量设置截止时间 */}

--- a/src/components/matches/SyncBracketButton.tsx
+++ b/src/components/matches/SyncBracketButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { syncBracketMatches } from "@/actions/matches";
+import { Btn } from "@/components/rivalhub";
+
+export function SyncBracketButton({ seasonId }: { seasonId: string }) {
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [created, setCreated] = useState(0);
+
+  async function handleSync() {
+    setStatus("loading");
+    const result = await syncBracketMatches(seasonId);
+    if (result.success) {
+      setCreated(result.data.created);
+      setStatus("done");
+    } else {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <Btn ghost onClick={handleSync} disabled={status === "loading"}>
+        {status === "loading" ? "修复中…" : "修复 Bracket 缺失比赛"}
+      </Btn>
+      {status === "done" && (
+        <span className="text-xs text-[var(--color-fg-mid)]">
+          {created > 0 ? `已创建 ${created} 场` : "无缺失比赛"}
+        </span>
+      )}
+      {status === "error" && (
+        <span className="text-xs text-[var(--color-destructive)]">操作失败，请刷新重试</span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -310,7 +310,7 @@ export async function seedPlayoff(
 /**
  * 从 Database JSON 中筛选出双方参与者均已确定的比赛（非 TBD/BYE）。
  */
-function collectResolvedMatches(data: Database): ResolvedBracketMatch[] {
+export function collectResolvedMatches(data: Database): ResolvedBracketMatch[] {
   const roundMap = new Map<number, { stageId: number; number: number }>();
   for (const r of data.round as BracketRoundRef[]) {
     roundMap.set(r.id, { stageId: r.stage_id, number: r.number });

--- a/src/lib/ocr/siliconflow.ts
+++ b/src/lib/ocr/siliconflow.ts
@@ -80,7 +80,7 @@ async function callAPI(params: CallParams) {
   }
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 60000);
+  const timer = setTimeout(() => controller.abort(), 180000);
 
   let response: Response;
   try {


### PR DESCRIPTION
## Summary
- **fix**: `insertResolvedBracketMatches` 用 participant name 而非 ID 下标查队伍，修复双败淘汰晋级比赛漏创建
- **fix**: OCR 请求超时从 60s 延长至 180s，解决大截图高负载下 AbortError
- **feat**: 新增 `syncBracketMatches` action + 后台「修复 Bracket 缺失比赛」按钮，供一次性补全历史遗漏

## Test plan
- [ ] 后台点击「修复 Bracket 缺失比赛」，确认 WB R2 和 LB R1 两场比赛被创建
- [ ] 录入正赛比赛结果后，验证下一轮比赛自动创建且队伍映射正确
- [ ] 重传大截图 OCR，确认不再偶发超时报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)