### PR TITLE
v1.23.2: db pool 重试修复 + bracket sync 修正 + UI 修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.2] - 2026-05-24
+
+### Fixed
+- **DB Pool 重建后重试仍打到 localhost**：`rebuildPool` 后 retry 仍调用旧 Pool 的原始 query，导致冷启动后 DATABASE_URL 为空时第二次查询也 ECONNREFUSED；改为在各 Pool 对象上保存 `__orig` 引用，重试时读取当前 Pool 的最新原始 query
+- **syncBracketMatches 漏检**：qualifier round-robin 与 playoff double_elim 的 bracket match ID 可能重叠（均从 0 开始），仅按 `bracketNodeId` 查找会将 qualifier 比赛误认为 playoff 比赛已存在；改为按 `(bracketNodeId, stage)` 复合键匹配，确保不同 stage 的比赛独立跟踪
+- **公开页 2:0 后仍显示图三 tab**：已结束比赛仍渲染所有 map（含 BP 占位行），改为 finished 时只渲染已录入比分的图
+- **MVP 投票爆头率小数溢出**：BO3 取多图均值时 HS% 未做舍入，出现 33.33333333333% 等长小数；fmt 函数加 `toFixed(0)`
+
+### Changed
+- **整场汇总 UI 重构**：两队分卡布局（独立背景卡片 + 左侧色条区分），Tailwind class 替换 inline style，列定义统一为 COLS 数组
+
 ## [1.23.1] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -779,37 +779,73 @@ export async function correctMapScore(
  * 扫描当前 bracket_data，将已确定对阵但 DB 中缺失的比赛补全。
  * 用于修复历史 bug 导致的漏创建情况，正常流程不需要调用。
  */
-export async function syncBracketMatches(seasonId: string): Promise<ActionResult<{ created: number }>> {
+export async function syncBracketMatches(seasonId: string): Promise<ActionResult<{ created: number; fixed: number }>> {
   try {
     await requireSeasonAdmin(seasonId);
     const season = await getSeasonOrThrow(seasonId);
-    if (!season.bracketData) return ok({ created: 0 });
+    if (!season.bracketData) return ok({ created: 0, fixed: 0 });
 
-    const allResolved = collectResolvedMatches(season.bracketData as Database);
+    const bracketData = season.bracketData as Database;
+    const allResolved = collectResolvedMatches(bracketData);
 
-    // 读取已有的 bracket match 记录（按 bracketNodeId）
+    // 建立 participant id → team 的正确映射（名称查找）
+    const seasonTeams = await db.query.teams.findMany({ where: eq(teams.seasonId, seasonId) });
+    const teamByName = new Map(seasonTeams.map((t) => [t.name, t]));
+    const participants = bracketData.participant as { id: number; name: string }[];
+    const participantNameById = new Map(participants.map((p) => [p.id, p.name]));
+
+    // 读取现有 bracket match 记录（含 id, bracketNodeId, teamAId, teamBId）
     const existingBracketMatches = await db.query.matches.findMany({
       where: eq(matches.seasonId, seasonId),
-      columns: { bracketNodeId: true },
+      columns: { id: true, bracketNodeId: true, teamAId: true, teamBId: true },
     });
-    const existingNodeIds = new Set(
-      existingBracketMatches.map((m) => m.bracketNodeId).filter(Boolean)
+    const existingByNodeId = new Map(
+      existingBracketMatches
+        .filter((m) => m.bracketNodeId !== null)
+        .map((m) => [m.bracketNodeId!, m]),
     );
 
-    const missing = allResolved.filter((m) => !existingNodeIds.has(m.bracketMatchId.toString()));
-    if (missing.length === 0) return ok({ created: 0 });
-
     const stagePlan = normalizeStagePlan(season.stagePlan);
+    const dbStages = bracketData.stage as BracketStageRef[];
+    let created = 0;
+    let fixed = 0;
 
     await db.transaction(async (tx) => {
-      await insertResolvedBracketMatches(
-        tx, seasonId, "playoff",
-        season.bracketData as Database, missing,
-        stagePlan,
-      );
+      for (const bm of allResolved) {
+        const nameA = participantNameById.get(bm.teamAParticipantId);
+        const nameB = participantNameById.get(bm.teamBParticipantId);
+        const teamA = nameA ? teamByName.get(nameA) : undefined;
+        const teamB = nameB ? teamByName.get(nameB) : undefined;
+        if (!teamA || !teamB) continue;
+
+        const nodeIdStr = bm.bracketMatchId.toString();
+        const existing = existingByNodeId.get(nodeIdStr);
+
+        if (!existing) {
+          // 缺失：补充创建
+          const bmStageName = dbStages.find((s) => s.id === bm.stageId)?.name;
+          const stage = stagePlan.find((s) => s.name === bmStageName)?.key ?? "playoff";
+          await tx.insert(matches).values({
+            seasonId,
+            teamAId: teamA.id,
+            teamBId: teamB.id,
+            stage,
+            format: resolveMatchFormat(stagePlan, stage, bm.roundNumber),
+            status: "scheduled",
+            bracketNodeId: nodeIdStr,
+          });
+          created++;
+        } else if (existing.teamAId !== teamA.id || existing.teamBId !== teamB.id) {
+          // 存在但队伍映射错误：修正
+          await tx.update(matches)
+            .set({ teamAId: teamA.id, teamBId: teamB.id, updatedAt: new Date() })
+            .where(eq(matches.id, existing.id));
+          fixed++;
+        }
+      }
     });
 
-    return ok({ created: missing.length });
+    return ok({ created, fixed });
   } catch (e) {
     return actionError("syncBracketMatches", e);
   }

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -787,6 +787,8 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
 
     const bracketData = season.bracketData as Database;
     const allResolved = collectResolvedMatches(bracketData);
+    const stagePlan = normalizeStagePlan(season.stagePlan);
+    const dbStages = bracketData.stage as BracketStageRef[];
 
     // 建立 participant id → team 的正确映射（名称查找）
     const seasonTeams = await db.query.teams.findMany({ where: eq(teams.seasonId, seasonId) });
@@ -794,19 +796,26 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
     const participants = bracketData.participant as { id: number; name: string }[];
     const participantNameById = new Map(participants.map((p) => [p.id, p.name]));
 
-    // 读取现有 bracket match 记录（含 id, bracketNodeId, teamAId, teamBId）
+    // bracket stage id → 赛季 stage key 映射
+    const stageIdToKey = new Map<number, string>();
+    for (const s of dbStages) {
+      const sk = stagePlan.find((p) => p.name === s.name)?.key;
+      if (sk) stageIdToKey.set(s.id, sk);
+    }
+
+    // 读取现有 bracket match 记录，按 (bracketNodeId, stage) 索引
+    // 不同 stage（qualifier vs playoff）可能共享同一 bracketNodeId
     const existingBracketMatches = await db.query.matches.findMany({
       where: eq(matches.seasonId, seasonId),
-      columns: { id: true, bracketNodeId: true, teamAId: true, teamBId: true },
+      columns: { id: true, bracketNodeId: true, stage: true, teamAId: true, teamBId: true },
     });
-    const existingByNodeId = new Map(
-      existingBracketMatches
-        .filter((m) => m.bracketNodeId !== null)
-        .map((m) => [m.bracketNodeId!, m]),
-    );
+    const existingByKey = new Map<string, typeof existingBracketMatches[number]>();
+    for (const m of existingBracketMatches) {
+      if (m.bracketNodeId && m.stage) {
+        existingByKey.set(`${m.bracketNodeId}:${m.stage}`, m);
+      }
+    }
 
-    const stagePlan = normalizeStagePlan(season.stagePlan);
-    const dbStages = bracketData.stage as BracketStageRef[];
     let created = 0;
     let fixed = 0;
 
@@ -819,12 +828,10 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
         if (!teamA || !teamB) continue;
 
         const nodeIdStr = bm.bracketMatchId.toString();
-        const existing = existingByNodeId.get(nodeIdStr);
+        const stage = stageIdToKey.get(bm.stageId) ?? "playoff";
+        const existing = existingByKey.get(`${nodeIdStr}:${stage}`);
 
         if (!existing) {
-          // 缺失：补充创建
-          const bmStageName = dbStages.find((s) => s.id === bm.stageId)?.name;
-          const stage = stagePlan.find((s) => s.name === bmStageName)?.key ?? "playoff";
           await tx.insert(matches).values({
             seasonId,
             teamAId: teamA.id,
@@ -836,7 +843,6 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
           });
           created++;
         } else if (existing.teamAId !== teamA.id || existing.teamBId !== teamB.id) {
-          // 存在但队伍映射错误：修正
           await tx.update(matches)
             .set({ teamAId: teamA.id, teamBId: teamB.id, updatedAt: new Date() })
             .where(eq(matches.id, existing.id));

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -404,7 +404,8 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                   整场汇总
                 </TabsTrigger>
               )}
-              {maps.map((map) => (
+              {/* 已结束比赛仅显示已录入比分的图；进行中/未开始显示所有地图 */}
+              {(isFinished ? maps.filter((m) => m.scoreA !== null && m.scoreB !== null) : maps).map((map) => (
                 <TabsTrigger key={map.id} value={map.id} className="text-xs">
                   {mapLabel(map.mapName)}
                   {map.pickedByTeamId && (
@@ -437,7 +438,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
             )}
 
             {/* 单图 Tab */}
-            {maps.map((map) => (
+            {(isFinished ? maps.filter((m) => m.scoreA !== null && m.scoreB !== null) : maps).map((map) => (
               <TabsContent key={map.id} value={map.id}>
                 <Panel pad={16} className="space-y-3">
                   <div className="flex items-center justify-between gap-4">

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -222,7 +222,7 @@ export function MatchMvpVote({
               </div>
 
               <div className="grid grid-cols-4 gap-1 text-center text-[11px] mb-2">
-                <StatCell label="HS%" value={c.hsPercent} fmt={(v) => `${v}%`} />
+                <StatCell label="HS%" value={c.hsPercent} fmt={(v) => `${v.toFixed(0)}%`} />
                 <StatCell label="FK" value={c.firstKills} />
                 <StatCell label="MK" value={c.multiKills} />
                 <StatCell label="残局" value={c.clutches} />
@@ -265,7 +265,7 @@ const STAT_COLS = [
   { key: "kills" as const,     label: "K",    fmt: undefined as ((v: number) => string) | undefined },
   { key: "deaths" as const,    label: "D",    fmt: undefined },
   { key: "assists" as const,   label: "A",    fmt: undefined },
-  { key: "hsPercent" as const, label: "HS%",  fmt: (v: number) => `${v}%` },
+  { key: "hsPercent" as const, label: "HS%",  fmt: (v: number) => `${v.toFixed(0)}%` },
   { key: "firstKills" as const,label: "FK",   fmt: undefined },
   { key: "multiKills" as const,label: "MK",   fmt: undefined },
   { key: "clutches" as const,  label: "残局", fmt: undefined },

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
 import { Panel } from "@/components/rivalhub";
 
 export interface SummaryPlayer {
@@ -28,37 +29,17 @@ interface MatchSummaryStatsProps {
   seasonSlug: string;
 }
 
-const COL_HEADER_STYLE: React.CSSProperties = {
-  color: "var(--color-fg-dim)",
-  fontSize: 11,
-  fontWeight: 700,
-  letterSpacing: "0.05em",
-  textTransform: "uppercase" as const,
-  textAlign: "right" as const,
-  padding: "4px 8px",
-  whiteSpace: "nowrap",
-};
-
-const CELL_STYLE: React.CSSProperties = {
-  color: "var(--color-fg)",
-  fontSize: 13,
-  textAlign: "right" as const,
-  padding: "6px 8px",
-  fontFamily: "var(--font-mono)",
-  whiteSpace: "nowrap",
-};
-
-function fmt1(v: number | null): string {
-  return v != null ? v.toFixed(1) : "—";
-}
-
-function fmt2(v: number | null): string {
-  return v != null ? v.toFixed(2) : "—";
-}
-
-function fmtPct(v: number | null): string {
-  return v != null ? `${v.toFixed(0)}%` : "—";
-}
+const COLS = [
+  { key: "mapsPlayed", label: "图数" },
+  { key: "ratingPro", label: "Rating", fmt: (v: number | null) => v != null ? v.toFixed(2) : "—" },
+  { key: "adr", label: "ADR", fmt: (v: number | null) => v != null ? v.toFixed(1) : "—" },
+  { key: "kills", label: "K" },
+  { key: "deaths", label: "D" },
+  { key: "assists", label: "A" },
+  { key: "hsPercent", label: "HS%", fmt: (v: number | null) => v != null ? `${v.toFixed(0)}%` : "—" },
+  { key: "firstKills", label: "FK" },
+  { key: "clutches", label: "残局" },
+] as const;
 
 interface PlayerRowProps {
   player: SummaryPlayer;
@@ -69,91 +50,87 @@ function PlayerRow({ player, seasonSlug }: PlayerRowProps) {
   const ratingHigh = player.ratingPro != null && player.ratingPro >= 1.2;
 
   return (
-    <tr className="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-panel-hi)] transition-colors">
-      {/* 选手名 */}
-      <td style={{ padding: "6px 8px", whiteSpace: "nowrap" }}>
+    <tr className="border-b border-[var(--color-border)] last:border-0">
+      <td className="py-1.5 pl-3 pr-1 whitespace-nowrap">
         {player.userId ? (
           <Link
             href={`/players/${player.userId}`}
-            className="text-sm font-medium hover:underline"
-            style={{ color: "var(--color-fg)" }}
+            className="text-sm font-medium hover:text-[var(--color-accent)] transition-colors"
           >
             {player.perfectName}
           </Link>
         ) : (
-          <span className="text-sm" style={{ color: "var(--color-fg)" }}>
-            {player.perfectName}
-          </span>
+          <span className="text-sm text-[var(--color-fg)]">{player.perfectName}</span>
         )}
       </td>
-
-      {/* 图数 */}
-      <td style={CELL_STYLE}>{player.mapsPlayed}</td>
-
-      {/* Rating */}
-      <td
-        style={{
-          ...CELL_STYLE,
-          color: ratingHigh ? "var(--color-accent)" : "var(--color-fg)",
-          fontWeight: ratingHigh ? 700 : 400,
-        }}
-      >
-        {fmt2(player.ratingPro)}
-      </td>
-
-      {/* ADR */}
-      <td style={CELL_STYLE}>{fmt1(player.adr)}</td>
-
-      {/* K */}
-      <td style={CELL_STYLE}>{player.kills}</td>
-
-      {/* D */}
-      <td style={{ ...CELL_STYLE, color: "var(--color-fg-mid)" }}>{player.deaths}</td>
-
-      {/* A */}
-      <td style={CELL_STYLE}>{player.assists}</td>
-
-      {/* HS% */}
-      <td style={CELL_STYLE}>{fmtPct(player.hsPercent)}</td>
-
-      {/* FK */}
-      <td style={CELL_STYLE}>{player.firstKills}</td>
-
-      {/* 残局 */}
-      <td style={CELL_STYLE}>{player.clutches}</td>
+      {COLS.map((col) => {
+        const raw = player[col.key as keyof SummaryPlayer] as number | null;
+        const val = "fmt" in col && col.fmt ? col.fmt(raw) : (raw ?? "—");
+        return (
+          <td
+            key={col.key}
+            className={cn(
+              "tabular-nums text-right px-1.5 py-1.5 text-xs whitespace-nowrap",
+              col.key === "deaths" && "text-[var(--color-fg-mid)]",
+            )}
+          >
+            <span
+              className={cn(
+                col.key === "ratingPro" && ratingHigh && "font-bold text-[var(--color-accent)]",
+              )}
+            >
+              {String(val)}
+            </span>
+          </td>
+        );
+      })}
     </tr>
   );
 }
 
-interface TeamSectionProps {
+interface TeamBlockProps {
   teamName: string;
-  teamColor: string;
+  borderColor: string;
+  bgColor: string;
   players: SummaryPlayer[];
   seasonSlug: string;
 }
 
-function TeamSection({ teamName, teamColor, players, seasonSlug }: TeamSectionProps) {
+function TeamBlock({ teamName, borderColor, bgColor, players, seasonSlug }: TeamBlockProps) {
+  if (players.length === 0) return null;
   return (
-    <>
-      <tr>
-        <td
-          colSpan={10}
-          style={{
-            padding: "10px 8px 4px",
-            fontSize: 11,
-            fontWeight: 700,
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
-            color: teamColor,
-          }}
-        >
-          {teamName}
-        </td>
-      </tr>
-      {players.map((p) => (
-        <PlayerRow key={p.userId ?? p.perfectName} player={p} seasonSlug={seasonSlug} />
-      ))}
-    </>
+    <div className="rounded-md overflow-hidden" style={{ backgroundColor: bgColor }}>
+      <div
+        className="px-3 py-2 text-[11px] font-bold tracking-widest uppercase"
+        style={{ borderLeft: `3px solid ${borderColor}` }}
+      >
+        {teamName}
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full" style={{ minWidth: 560 }}>
+          <thead>
+            <tr className="border-b border-[var(--color-border)]">
+              <th className="text-left text-[10px] text-[var(--color-fg-dim)] font-medium py-1 pl-3 pr-1 whitespace-nowrap">
+                选手
+              </th>
+              {COLS.map((col) => (
+                <th
+                  key={col.key}
+                  className="text-right text-[10px] text-[var(--color-fg-dim)] font-medium px-1.5 py-1 whitespace-nowrap"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((p) => (
+              <PlayerRow key={p.userId ?? p.perfectName} player={p} seasonSlug={seasonSlug} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }
 
@@ -169,43 +146,21 @@ export function MatchSummaryStats({
   const teamBPlayers = players.filter((p) => p.teamId === teamBId);
 
   return (
-    <Panel pad={0}>
-      <div className="overflow-x-auto">
-        <table className="w-full" style={{ minWidth: 600 }}>
-          <thead>
-            <tr className="border-b border-[var(--color-border)]">
-              <th style={{ ...COL_HEADER_STYLE, textAlign: "left" }}>选手</th>
-              <th style={COL_HEADER_STYLE}>图数</th>
-              <th style={COL_HEADER_STYLE}>Rating</th>
-              <th style={COL_HEADER_STYLE}>ADR</th>
-              <th style={COL_HEADER_STYLE}>K</th>
-              <th style={COL_HEADER_STYLE}>D</th>
-              <th style={COL_HEADER_STYLE}>A</th>
-              <th style={COL_HEADER_STYLE}>HS%</th>
-              <th style={COL_HEADER_STYLE}>FK</th>
-              <th style={COL_HEADER_STYLE}>残局</th>
-            </tr>
-          </thead>
-          <tbody>
-            {teamAPlayers.length > 0 && (
-              <TeamSection
-                teamName={teamAName}
-                teamColor="var(--color-accent)"
-                players={teamAPlayers}
-                seasonSlug={seasonSlug}
-              />
-            )}
-            {teamBPlayers.length > 0 && (
-              <TeamSection
-                teamName={teamBName}
-                teamColor="var(--color-accent-b)"
-                players={teamBPlayers}
-                seasonSlug={seasonSlug}
-              />
-            )}
-          </tbody>
-        </table>
-      </div>
+    <Panel pad={12} className="space-y-4">
+      <TeamBlock
+        teamName={teamAName}
+        borderColor="var(--color-accent)"
+        bgColor="rgba(77,212,122,0.04)"
+        players={teamAPlayers}
+        seasonSlug={seasonSlug}
+      />
+      <TeamBlock
+        teamName={teamBName}
+        borderColor="var(--color-accent-b)"
+        bgColor="rgba(66,170,255,0.04)"
+        players={teamBPlayers}
+        seasonSlug={seasonSlug}
+      />
     </Panel>
   );
 }

--- a/src/components/matches/SyncBracketButton.tsx
+++ b/src/components/matches/SyncBracketButton.tsx
@@ -6,13 +6,13 @@ import { Btn } from "@/components/rivalhub";
 
 export function SyncBracketButton({ seasonId }: { seasonId: string }) {
   const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
-  const [created, setCreated] = useState(0);
+  const [result, setResult] = useState({ created: 0, fixed: 0 });
 
   async function handleSync() {
     setStatus("loading");
-    const result = await syncBracketMatches(seasonId);
-    if (result.success) {
-      setCreated(result.data.created);
+    const res = await syncBracketMatches(seasonId);
+    if (res.success) {
+      setResult(res.data);
       setStatus("done");
     } else {
       setStatus("error");
@@ -22,11 +22,13 @@ export function SyncBracketButton({ seasonId }: { seasonId: string }) {
   return (
     <div className="flex items-center gap-3">
       <Btn ghost onClick={handleSync} disabled={status === "loading"}>
-        {status === "loading" ? "修复中…" : "修复 Bracket 缺失比赛"}
+        {status === "loading" ? "修复中…" : "修复 Bracket 比赛"}
       </Btn>
       {status === "done" && (
         <span className="text-xs text-[var(--color-fg-mid)]">
-          {created > 0 ? `已创建 ${created} 场` : "无缺失比赛"}
+          {result.created === 0 && result.fixed === 0
+            ? "无问题"
+            : `创建 ${result.created} 场，修正 ${result.fixed} 场`}
         </span>
       )}
       {status === "error" && (

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -79,11 +79,19 @@ function setupPoolGuard(p: Pool) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const _orig = (p as any).query.bind(p);
+  // 将原始 query 挂到 pool 上，rebuildPool 后 retry 可通过 pool.__orig 拿到新 Pool 的原始 query
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (p as any).__orig = _orig;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (p as any).query = async function (...args: any[]) {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        return await _orig(...args);
+        // attempt 0：用当前 pool 的原始 query
+        // attempt 1（rebuild 后）：pool 已指向新 Pool，用新 Pool 的原始 query
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const queryFn = attempt === 0 ? _orig : ((pool as any).__orig ?? _orig);
+        return await queryFn(...args);
       } catch (err: unknown) {
         const e = err as NodeJS.ErrnoException;
         if (
@@ -91,7 +99,7 @@ function setupPoolGuard(p: Pool) {
           (e.code === "ECONNREFUSED" || e.code === "ENOTFOUND" || e.message?.includes("Connection terminated"))
         ) {
           await rebuildPool();
-          continue; // 重试查询
+          continue;
         }
         throw err;
       }


### PR DESCRIPTION
## Summary
- **fix**: `rebuildPool` 后 retry 用新 Pool 的 `__orig` 而非旧 Pool，修复冷启动后重试仍打到 localhost
- **fix**: `syncBracketMatches` 按 `(bracketNodeId, stage)` 复合键匹配，避免 qualifier/playoff match ID 冲突导致漏检
- **fix**: 公开赛程页 2:0 后不再显示未进行比赛的图三 tab
- **fix**: MVP 投票爆头率取均值后小数溢出，加 `toFixed(0)`
- **refactor**: 整场汇总面板 UI 重构，两队分卡 + Tailwind + 设计 token 统一

## Test plan
- [ ] 后台点击「修复 Bracket 比赛」，确认创建 WB R2 + LB R1 两场
- [ ] 打开 2:0 已结束比赛的公开页，确认无图三 tab
- [ ] MVP 投票页确认 HS% 显示为整数百分比
- [ ] 整场汇总面板确认两队分卡显示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)