### PR TITLE
fix: OCR 录入昵称只读 + 与 users.perfectName 强制同步 (v1.23.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.3] - 2026-05-25
+
+### Fixed
+- **OCR 昵称可手动篡改**：`StatsOCRPanel` 左列「昵称」Input 改为只读展示，管理员无法手动编辑 OCR 识别结果；右列选中用户后，左列自动同步为 `users.perfectName`
+- **OCR 录入昵称与注册昵称不一致**：`savePlayerStats` 保存前对有 `userId` 的行从 `users` 表查真实 `perfectName` 并覆盖，确保 `matchPlayerStats.perfectName` 始终与 `users.perfectName` 一致
+
 ## [1.23.2] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -144,15 +144,27 @@ export async function savePlayerStats(
       );
     }
 
+    // 对有 userId 的行，用 users.perfectName 覆盖 OCR 识别昵称，保证数据库一致性
+    const userIds = stats.map((s) => s.userId).filter(Boolean) as string[];
+    const userRows = userIds.length
+      ? await db.select({ id: users.id, perfectName: users.perfectName })
+          .from(users).where(inArray(users.id, userIds))
+      : [];
+    const userPerfectNames = new Map(userRows.map((u) => [u.id, u.perfectName]));
+    const normalizedStats = stats.map((s) => ({
+      ...s,
+      perfectName: (s.userId && userPerfectNames.get(s.userId)) || (s.perfectName as string),
+    }));
+
     await db.transaction(async (tx) => {
       await tx.delete(matchPlayerStats).where(eq(matchPlayerStats.mapId, mapId));
 
-      if (stats.length > 0) {
+      if (normalizedStats.length > 0) {
         await tx.insert(matchPlayerStats).values(
-          stats.map((s) => ({
+          normalizedStats.map((s) => ({
             matchId: map.matchId,
             mapId,
-            perfectName: s.perfectName as string,
+            perfectName: s.perfectName,
             userId: s.userId ?? undefined,
             kills: s.kills ?? undefined,
             deaths: s.deaths ?? undefined,

--- a/src/components/matches/StatsOCRPanel.tsx
+++ b/src/components/matches/StatsOCRPanel.tsx
@@ -149,17 +149,20 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
     );
   }
 
-  function handleNameChange(idx: number, value: string) {
-    setDrafts((prev) =>
-      prev.map((row, i) => (i === idx ? { ...row, perfectName: value } : row))
-    );
-  }
-
   function handleUserChange(idx: number, userId: string) {
+    const selectedPlayer = userId !== "__none__"
+      ? playerOptions.find((p) => p.userId === userId)
+      : null;
     setDrafts((prev) =>
       prev.map((row, i) =>
-        i === idx ? { ...row, userId: userId === "__none__" ? null : userId } : row
-      )
+        i === idx
+          ? {
+              ...row,
+              userId: userId === "__none__" ? null : userId,
+              ...(selectedPlayer ? { perfectName: selectedPlayer.perfectName } : {}),
+            }
+          : row,
+      ),
     );
   }
 
@@ -346,11 +349,12 @@ export function StatsOCRPanel({ mapId, mapName }: Props) {
                     {drafts.map((row, idx) => (
                       <TableRow key={idx}>
                         <TableCell>
-                          <Input
-                            className="h-7 text-xs"
-                            value={row.perfectName as string}
-                            onChange={(e) => handleNameChange(idx, e.target.value)}
-                          />
+                          <span className={cn(
+                            "block text-xs px-2 py-1 truncate max-w-[9rem]",
+                            !(row.perfectName as string) && "text-[var(--color-fg-dim)] italic",
+                          )}>
+                            {(row.perfectName as string) || "—"}
+                          </span>
                         </TableCell>
                         <TableCell>
                           <Select


### PR DESCRIPTION
## Summary

- OCR 录入面板左列「昵称」字段改为只读展示，不再允许手动编辑 OCR 识别结果
- 右列「匹配用户」Select 选中用户后，左列昵称自动同步为该用户的 users.perfectName
- savePlayerStats 服务端对所有有 userId 的行，强制用 users.perfectName 覆盖再写入 matchPlayerStats，前端联动 + 服务端双重保障

## Background

管理员反馈 OCR 录入界面行为异常。排查发现左列昵称 Input 可自由编辑，若 OCR 识别错误而管理员未手动修正，错误字符串会直接写入数据库；即使右列正确匹配了用户，matchPlayerStats.perfectName 仍存 OCR 字符串而非注册昵称。

## Test plan

- [ ] OCR 识别后，左列昵称只读，无法点击编辑
- [ ] 右列下拉选中用户后，左列昵称自动变为该用户注册昵称
- [ ] 保存后数据库 match_player_stats.perfect_name 与 users.perfect_name 一致