### PR TITLE
fix: bracket LB minor round 标签错误 + 赛程 Tab 默认选中当前赛段 (v1.23.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.4] - 2026-05-25
+
+### Fixed
+- **Bracket LB minor round 标签错误**：`computeSlotLabel` 中 LB minor round 的 op1/op2 来源写反（UB 降组者应为 op1，LB 晋级者应为 op2），且 UB 场次索引顺序也相反；修正槽位分配与反向索引，LB R2/R4 等 minor round 的待定提示现可正确显示
+- **已结束源比赛仍显示「A vs B 胜者」**：`winnerLabel`/`loserLabel` 在源比赛有 result 时直接返回胜者/败者队名，不再展示冗余格式
+- **赛程 Tab 默认不跳到当前赛段**：公开页和后台赛程页改为自动选中 stagePlan 中最靠后且已有比赛记录的阶段，支持任意阶段数，进入正赛后无需手动切换 Tab
+
 ## [1.23.3] - 2026-05-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -142,6 +142,13 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   const hasQualifier = !!qualifierStage;
   const hasPlayoff = !!playoffStage;
 
+  // 默认显示 stagePlan 中最靠后且已有比赛记录的阶段，支持任意数量阶段
+  const stagesWithMatches = new Set(allMatches.map((m) => m.stage));
+  const defaultStageKey =
+    [...stagePlan].reverse().find((s) => stagesWithMatches.has(s.key))?.key ??
+    stagePlan[0]?.key ??
+    qualifierKey;
+
   if (allMatches.length === 0 && allTeams.length === 0) {
     return (
       <div className="container mx-auto px-4 py-16 text-center text-[var(--color-fg-mid)]">
@@ -165,13 +172,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
 
       <Panel pad={24}>
       <Tabs
-        defaultValue={
-          hasPlayoff && (allQualifierFinished || playoffMatchesAll.length > 0)
-            ? playoffKey
-            : hasQualifier
-              ? qualifierKey
-              : playoffKey
-        }
+        defaultValue={defaultStageKey}
         className="w-full"
       >
         <TabsList className="mb-6 bg-[var(--color-panel)] border border-[var(--color-border)] p-1">

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -190,6 +190,13 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   const hasQualifier = !!qualifierStage;
   const hasPlayoff = !!playoffStage;
 
+  // 默认显示 stagePlan 中最靠后且已有比赛记录的阶段，支持任意数量阶段
+  const stagesWithMatches = new Set(allMatches.map((m) => m.stage));
+  const defaultStageKey =
+    [...stagePlan].reverse().find((s) => stagesWithMatches.has(s.key))?.key ??
+    stagePlan[0]?.key ??
+    qualifierKey;
+
   const batchDeadlineGroups: { label: string; stage: string; round?: number | null; entryRound?: string | null; matchCount: number }[] = [];
   if (matchCount > 0) {
     const activeMatches = allMatches.filter(
@@ -384,7 +391,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
 
       {/* Tab 面板 */}
       {matchCount > 0 && (
-        <Tabs defaultValue={filterStage && filterStage !== "all" ? filterStage : (hasQualifier ? qualifierKey : playoffKey)}>
+        <Tabs defaultValue={filterStage && filterStage !== "all" ? filterStage : defaultStageKey}>
           <TabsList>
             {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
             {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -77,12 +77,24 @@ function computeSlotLabel(
 
   const winnerLabel = (m: BracketMatch | undefined): string => {
     if (!m) return "TBD";
+    if (m.opponent1?.result === "win" && m.opponent1.id != null) {
+      return participantById.get(m.opponent1.id) ?? "TBD";
+    }
+    if (m.opponent2?.result === "win" && m.opponent2.id != null) {
+      return participantById.get(m.opponent2.id) ?? "TBD";
+    }
     const [a, b] = teamsOf(m);
     return a && b ? `${a} vs ${b} 胜者` : "TBD";
   };
 
   const loserLabel = (m: BracketMatch | undefined): string => {
     if (!m) return "TBD";
+    if (m.opponent1?.result === "loss" && m.opponent1.id != null) {
+      return participantById.get(m.opponent1.id) ?? "TBD";
+    }
+    if (m.opponent2?.result === "loss" && m.opponent2.id != null) {
+      return participantById.get(m.opponent2.id) ?? "TBD";
+    }
     const [a, b] = teamsOf(m);
     return a && b ? `${a} vs ${b} 败者` : "TBD";
   };
@@ -116,17 +128,18 @@ function computeSlotLabel(
     // r >= 2: 偶数轮 minor / 奇数轮 major
     const isMinor = roundNum % 2 === 0;
     if (isMinor) {
-      // op1: 上一 LB 轮胜者（反向配对）
-      // op2: 本 minor 对应的 UB 轮败者，UB 轮号 = roundNum/2 + 1
+      // brackets-manager 实际路由：op1 = UB 降组者（反向配对），op2 = LB 晋级者（顺序配对）
       const prevLb = matchesInRound(group.id, roundNum - 1);
       const ubRoundIdx = roundNum / 2 + 1;
       const ubRound = matchesInRound(ubGroupId, ubRoundIdx);
       if (slotIdx === 0) {
-        const source = prevLb[prevLb.length - matchNum];
-        return winnerLabel(source);
+        // op1: 本 minor 对应的 UB 轮败者，反向配对，UB 轮号 = roundNum/2 + 1
+        const source = ubRound[ubRound.length - matchNum];
+        return loserLabel(source);
       }
-      const source = ubRound[matchNum - 1];
-      return loserLabel(source);
+      // op2: 上一 LB 轮胜者，顺序配对
+      const source = prevLb[matchNum - 1];
+      return winnerLabel(source);
     }
 
     // major: 两侧均来自上一 LB 轮的胜者，顺序配对


### PR DESCRIPTION
## Summary

- **Bracket LB minor round 标签修复**：`computeSlotLabel` 中 op1/op2 来源写反（UB 降组者应为 op1，LB 晋级者应为 op2），且 UB 场次索引也反向；同时修复已结束源比赛仍显示「A vs B 胜者」格式的问题，改为直接返回队名
- **赛程 Tab 自动跳当前赛段**：公开页与后台赛程页改为自动选中 stagePlan 中最靠后且已有比赛的阶段，进入正赛后无需手动切换，支持任意阶段数

## Root cause

`computeSlotLabel` LB minor round 分支的槽位假设与 brackets-manager 实际约定相反：作者以为 op1 = LB 晋级老兵，op2 = UB 新降队伍；实际上 brackets-manager 约定 op1 = 从 UB 落入者，op2 = 从 LB 晋级者。数据库 bracket_data 本身正确，无需修改。

## Test plan

- [ ] 进入正赛页面，LB R2 待定槽位标签应正确显示「Team Clarys vs Team Plasma 败者」/「超级无敌大猛男队 vs Team D'avenir 败者」等
- [ ] 赛程页（公开 + 后台）进入时直接显示正赛 Tab，无需手动切换
- [ ] 已结束比赛的下游待定槽位显示胜者队名，不再显示「A vs B 胜者」格式