### PR TITLE
fix: 弃赛状态显示修复 + 比赛排期状态标签区分 (v1.23.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -736,6 +736,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.23.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.4...v1.23.5
+[1.23.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.3...v1.23.4
+[1.23.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.2...v1.23.3
+[1.23.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.1...v1.23.2
+[1.23.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.0...v1.23.1
+[1.23.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.22.1...v1.23.0
 [1.22.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.21.1...v1.22.0
 [1.21.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.21.0...v1.21.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.5] - 2026-05-25
+
+### Fixed
+- **弃赛状态公开页面不显示**：`MatchCard`、`MatchTabsSection`、队伍页 `MatchCard` 均未传递 `isForfeit`，导致公开赛程列表和队伍历史战绩的状态 badge 始终显示"已结束"而非"弃赛"；补全传递链路
+- **弃赛详情页状态 badge 不显示**：`MatchHeroHeader` 未在 `MatchHeroMatch` 接口声明 `isForfeit`，且未传给 `MatchStatusBadge`；补全后详情页 badge 正确显示"弃赛"
+- **弃赛详情页"比赛结果"文案错误**：无地图记录的已结束比赛显示"BO3 系列赛总分：0 : 2"，弃赛语义不符；`isForfeit` 为 true 时改为显示"本场比赛以弃赛结束，未进行实际对局。"
+
+### Changed
+- **比赛状态标签区分排期状态**：`MatchStatusBadge` 新增 `scheduledAt` prop，`scheduled` 状态下有排期时间显示"待进行"，无排期时间显示"待排期"（原统一显示"待进行"）；后台 `AdminMatchRow` 和详情页 `MatchHeroHeader` 均已传入
+
 ## [1.23.4] - 2026-05-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -477,8 +477,9 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">比赛结果</h2>
           <Panel pad={16}>
             <p className="text-sm text-[var(--color-fg-mid)]">
-              {MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：{match.scoreA} :{" "}
-              {match.scoreB}
+              {match.isForfeit
+                ? "本场比赛以弃赛结束，未进行实际对局。"
+                : `${MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：${match.scoreA} : ${match.scoreB}`}
             </p>
           </Panel>
         </section>

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -519,6 +519,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                   format={m.format as "bo1" | "bo3" | "bo5"}
                   status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                   scheduledAt={m.scheduledAt}
+                  isForfeit={m.isForfeit}
                 />
               );
             })}
@@ -553,6 +554,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                     format={m.format as "bo1" | "bo3" | "bo5"}
                     status={m.status as "scheduled" | "in_progress" | "finished" | "cancelled"}
                     scheduledAt={m.scheduledAt}
+                    isForfeit={m.isForfeit}
                   />
                 );
               })}

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -111,6 +111,7 @@ export function AdminMatchRow({
           <MatchStatusBadge
             status={match.status}
             isForfeit={match.isForfeit}
+            scheduledAt={match.scheduledAt}
           />
         </div>
       </div>

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -17,6 +17,7 @@ interface MatchCardProps {
   status: "scheduled" | "in_progress" | "finished" | "cancelled";
   scheduledAt?: Date | string | null;
   completedAt?: Date | string | null;
+  isForfeit?: boolean;
 }
 
 export function MatchCard({
@@ -31,6 +32,7 @@ export function MatchCard({
   status,
   scheduledAt,
   completedAt,
+  isForfeit = false,
 }: MatchCardProps) {
   const finishedTime = completedAt ?? scheduledAt ?? null;
   const timeText =
@@ -66,7 +68,7 @@ export function MatchCard({
         <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
           {MATCH_FORMAT_LABELS[format]}
         </Badge>
-        <MatchStatusBadge status={status} />
+        <MatchStatusBadge status={status} isForfeit={isForfeit} />
       </div>
     </Link>
   );

--- a/src/components/matches/MatchHeroHeader.tsx
+++ b/src/components/matches/MatchHeroHeader.tsx
@@ -25,6 +25,7 @@ interface MatchHeroMatch {
   scheduledAt: Date | null;
   completedAt: Date | null;
   bracketNodeId: string | null;
+  isForfeit: boolean;
 }
 
 interface MatchHeroHeaderProps {
@@ -148,7 +149,7 @@ export function MatchHeroHeader({
           <div className="mt-2 flex items-center justify-center gap-2 flex-wrap">
             <PosChip pos={MATCH_STAGE_LABELS[match.stage] ?? match.stage} />
             <PosChip pos={MATCH_FORMAT_LABELS[match.format] ?? match.format} />
-            <MatchStatusBadge status={match.status as "scheduled" | "in_progress" | "finished" | "cancelled"} />
+            <MatchStatusBadge status={match.status as "scheduled" | "in_progress" | "finished" | "cancelled"} isForfeit={match.isForfeit} scheduledAt={match.scheduledAt} />
           </div>
         </div>
 

--- a/src/components/matches/MatchStatusBadge.tsx
+++ b/src/components/matches/MatchStatusBadge.tsx
@@ -12,11 +12,14 @@ const STATUS_STYLES: Record<MatchStatus, string> = {
 export function MatchStatusBadge({
   status,
   isForfeit = false,
+  scheduledAt,
 }: {
   status: MatchStatus;
   isForfeit?: boolean;
+  scheduledAt?: Date | string | null;
 }) {
-  const label = isForfeit && status === "finished" ? "弃赛" : MATCH_STATUS_LABELS[status];
+  let label = isForfeit && status === "finished" ? "弃赛" : MATCH_STATUS_LABELS[status];
+  if (status === "scheduled") label = scheduledAt ? "待进行" : "待排期";
   return (
     <Badge variant="outline" className={STATUS_STYLES[status]}>
       {label}

--- a/src/components/matches/MatchTabsSection.tsx
+++ b/src/components/matches/MatchTabsSection.tsx
@@ -12,6 +12,7 @@ interface MatchRow {
   status: string;
   scheduledAt: Date | null;
   completedAt: Date | null;
+  isForfeit: boolean;
 }
 
 interface MatchTabsSectionProps {
@@ -54,6 +55,7 @@ export function MatchTabsSection({
                 format={isMatchFormat(m.format) ? m.format : "bo1"}
                 status={isMatchStatus(m.status) ? m.status : "scheduled"}
                 scheduledAt={m.scheduledAt}
+                isForfeit={m.isForfeit}
               />
             ))}
           </div>
@@ -78,6 +80,7 @@ export function MatchTabsSection({
                 status={isMatchStatus(m.status) ? m.status : "scheduled"}
                 scheduledAt={m.scheduledAt}
                 completedAt={m.completedAt}
+                isForfeit={m.isForfeit}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary

- 修复弃赛比赛在公开赛程列表、队伍页、比赛详情页状态 badge 均不显示"弃赛"的问题（`isForfeit` 传递链路断开）
- 修复弃赛详情页"比赛结果"区块错误显示"BO3 系列赛总分：0 : 2"，改为语义正确的文案
- `MatchStatusBadge` 新增 `scheduledAt` prop，`scheduled` 状态细分为"待进行"（已排期）和"待排期"（未排期）

## Test plan

- [ ] 公开赛程页：弃赛比赛列表显示"弃赛" badge
- [ ] 队伍详情页历史战绩：弃赛比赛显示"弃赛" badge
- [ ] 比赛详情页：弃赛比赛 badge 显示"弃赛"，结果区块显示"本场比赛以弃赛结束，未进行实际对局。"
- [ ] 后台比赛行：已排期比赛显示"待进行"，未排期显示"待排期"
- [ ] 比赛详情页：未排期比赛显示"待排期" badge