### PR TITLE
v1.23.6: 数据统计页昵称碎片化 + 个人页出场统计 + orphan map 清理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.6] - 2026-05-25
+
+### Fixed
+- **数据统计页昵称碎片化导致排行榜数据丢失**：`match_player_stats.perfect_name` 因 OCR 识别错误/玩家改名存在多种变体，原 `GROUP BY user_id, perfect_name` 将同一玩家的不同名称拆成多行，各变体不足 3 图时被 `HAVING count(*) >= 3` 静默丢弃；改为 `LEFT JOIN users` 取当前昵称，`GROUP BY user_id, COALESCE(u.perfect_name, mps.perfect_name)` 彻底根治
+- **个人页"出场"统计失真**：原逻辑统计队伍所有已结束比赛（团队维度），未上场队员也被计入；改为以 `match_player_stats` 中该玩家的 distinct matchId 为准，准确反映个人有数据的出场数
+- **比赛结算后留下未打地图的 DB 占位行**：BO3/BO5 提前结束或弃赛时，未打的图（`score_a IS NULL`）残留在 `match_maps` 表中；在 `recordMapResult` 的 `seriesFinished` 分支和 `forfeitMatch` 事务内新增清理逻辑，删除所有未录入比分的图记录
+
 ## [1.23.5] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -743,6 +743,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.23.6]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.5...v1.23.6
 [1.23.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.4...v1.23.5
 [1.23.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.3...v1.23.4
 [1.23.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.2...v1.23.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ npm version major    # 1.4.0 → 2.0.0
 ```
 
 **CHANGELOG 必须在 `npm version` 之前更新并提交**，否则 release workflow checkout tag commit 时找不到对应版本的条目，导致 GitHub Release body 为空。
+**同时必须在 CHANGELOG 末尾补上新版本的 compare 链接**，格式 `[v1.X.Y]: https://github.com/.../compare/v1.X.(Y-1)...v1.X.Y`，紧跟上一版 compare 链接之后。
 
 **push 时必须带 tag**：`npm version` 只创建本地 tag，普通 `git push` 不会推送。GitHub Release workflow（`.github/workflows/release.yml`）由 `v*` tag 触发，tag 不到远程就不会发布。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,7 @@ npm version minor    # 1.3.2 → 1.4.0
 npm version major    # 1.4.0 → 2.0.0
 ```
 
-**CHANGELOG 必须在 `npm version` 之前更新并提交**，否则 release workflow checkout tag commit 时找不到对应版本的条目，导致 GitHub Release body 为空。
-**同时必须在 CHANGELOG 末尾补上新版本的 compare 链接**，格式 `[v1.X.Y]: https://github.com/.../compare/v1.X.(Y-1)...v1.X.Y`，紧跟上一版 compare 链接之后。
-
-**push 时必须带 tag**：`npm version` 只创建本地 tag，普通 `git push` 不会推送。GitHub Release workflow（`.github/workflows/release.yml`）由 `v*` tag 触发，tag 不到远程就不会发布。
-
-```bash
-git push origin dev --follow-tags    # ✅ 推送提交并带上本地 tag
-git push origin v1.6.0               # 或单独推 tag
-```
-
+**发版必须调用 `/release` skill 或严格按 `.claude/skills/release.md` 9 步流程执行**（CHANGELOG → compare 链接 → npm version → tag 对齐 → push → PR）。禁止凭记忆跳步。
 每次 main 合并都需经过 `pnpm type-check` + `pnpm test` + `pnpm build` 全绿。
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq, asc, and, inArray } from "drizzle-orm";
+import { eq, asc, and, inArray, isNull } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, matchMaps, matchVetoSteps, matchRosters, matchRosterPlayers, teams, teamMembers, auditLogs } from "@/db/schema";
 import { ok } from "@/types/action";
@@ -310,6 +310,10 @@ export async function recordMapResult(
       }
 
       if (seriesFinished) {
+        await tx.delete(matchMaps).where(
+          and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA))
+        );
+
         await tx.update(matches).set({
           scoreA: mapWinsA,
           scoreB: mapWinsB,
@@ -891,6 +895,10 @@ export async function forfeitMatch(
     const season = await getSeasonOrThrow(match.seasonId);
 
     await db.transaction(async (tx) => {
+      await tx.delete(matchMaps).where(
+        and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA))
+      );
+
       await tx
         .update(matches)
         .set({

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -76,7 +76,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
   const { rows } = await db.execute(sql`
     SELECT
       mps.user_id,
-      mps.perfect_name,
+      COALESCE(u.perfect_name, mps.perfect_name) AS perfect_name,
       sr.primary_position,
       t.name  AS team_name,
       t.id    AS team_id,
@@ -96,6 +96,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     FROM match_player_stats mps
     JOIN matches m ON m.id = mps.match_id
     JOIN match_maps mm ON mm.id = mps.map_id
+    LEFT JOIN users u ON u.id = mps.user_id
     LEFT JOIN season_registrations sr
       ON sr.user_id = mps.user_id AND sr.season_id = m.season_id
     LEFT JOIN team_members tm ON tm.registration_id = sr.id
@@ -103,7 +104,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     WHERE m.season_id = ${season.id}
       AND mps.verified_by_admin IS NOT NULL
       ${positionFilter}
-    GROUP BY mps.user_id, mps.perfect_name, sr.primary_position, t.name, t.id
+    GROUP BY mps.user_id, COALESCE(u.perfect_name, mps.perfect_name), sr.primary_position, t.name, t.id
     HAVING count(*) >= 3
     ORDER BY ${sortColumn} DESC
     LIMIT 100

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { eq, or, and, asc, inArray, sql } from "drizzle-orm";
+import { eq, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users, seasonRegistrations, seasons, teams, teamMembers, matches, matchMaps } from "@/db/schema";
 import { resolveAvatarUrl } from "@/lib/steam";
@@ -159,21 +159,30 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
 
   const regIdToTeam = new Map(teamMemberRows.map((r) => [r.registrationId, r]));
 
-  // ── 跨赛季比赛战绩 ────────────────────────────────────────────────────
+  // ── 跨赛季比赛战绩（以个人 OCR 出场记录为准）───────────────────────
   const teamIds = [...new Set(teamMemberRows.map((r) => r.teamId).filter(Boolean))];
-  const allMatches = teamIds.length
+
+  const ocrMatchIdRows = await db
+    .selectDistinct({ matchId: matchPlayerStats.matchId })
+    .from(matchPlayerStats)
+    .where(
+      and(
+        eq(matchPlayerStats.userId, userId),
+        sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+      )
+    );
+  const ocrMatchIds = ocrMatchIdRows.map((r) => r.matchId);
+
+  const allMatches = ocrMatchIds.length
     ? await db.query.matches.findMany({
         where: and(
           eq(matches.status, "finished"),
-          or(
-            inArray(matches.teamAId, teamIds),
-            inArray(matches.teamBId, teamIds),
-          )
+          inArray(matches.id, ocrMatchIds),
         ),
       })
     : [];
 
-  // 聚合：总场次/胜负（以队伍为单位，因为 match 记录的是队伍，不是个人）
+  // 聚合：总场次/胜负（基于个人有 OCR 数据的比赛）
   const teamIdSet = new Set(teamIds);
   let totalWins = 0;
   let totalLosses = 0;


### PR DESCRIPTION
## Summary
- **数据统计页昵称碎片化**：OCR 识别错误/玩家改名导致 `perfect_name` 变体将同一玩家拆分多行，`HAVING count >= 3` 静默丢弃数据。改为 `LEFT JOIN users` 取当前昵称 + `GROUP BY user_id`，彻底根治
- **个人页"出场"统计失真**：原逻辑统计队伍所有已结束比赛，未上场队员也被计入。改为以 `match_player_stats` 中该玩家的 distinct matchId 为准
- **比赛结算 orphan map**：`recordMapResult` / `forfeitMatch` 事务内新增清理未打地图（`score_a IS NULL`）的逻辑，同步清理了历史 2 条占位行
- 数据库脏数据修复：统一了 20 个玩家的 `perfect_name` 变体

## Test plan
- [x] `pnpm tsc --noEmit` 零错误
- [ ] 数据统计页验证：克里斯甜等曾碎片化的玩家排行榜正确合并
- [ ] 个人页验证：出场数 = 有 OCR 数据的比赛场次
- [ ] BO3/BO5 提前结束时不再残留未打图记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)