### PR TITLE
v1.23.7: pick 率分母剔除 BO1 + 管理员"参赛过"补漏 + 队伍页新增 pick 率列

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.20.3，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.23.7，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.7] - 2026-05-25
+
+### Added
+- **队伍页地图表现新增 pick 率列**：在"地图表现"表格中新增 pick 率列，与胜率、ban 率并排展示
+
+### Fixed
+- **pick 率分母被 BO1 比赛稀释**：`getTeamVetoActionStats` 中 `bpMatchCount` 原统计所有有 veto 步骤的比赛（含 BO1），但 BO1 只有 ban/decider 无 pick 步骤，导致 pick 率百分比很低；改为只统计有对应 actionType 步骤的比赛，pick 率分母仅 BO3/BO5
+- **管理后台"参赛过"统计漏掉参赛的管理员**：stats 卡片子查询中 `WHERE u.role = 'user'` 排除了 season_admin/super_admin 角色的玩家，导致 56 人参赛但只显示 49 人"参赛过"；去掉 stats 子查询的 role 过滤
+
 ## [1.23.6] - 2026-05-25
 
 ### Fixed
@@ -743,6 +752,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.23.7]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.6...v1.23.7
 [1.23.6]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.5...v1.23.6
 [1.23.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.4...v1.23.5
 [1.23.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.3...v1.23.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动的多赛事模型支持各类赛制（选秀联赛、公开赛、杯赛等）的全流程运营：报名 → 审核 → 队长投票 → 蛇形选秀 → 队伍展示 → 赛程 + Bracket 视图 → 部署。
 
-当前阶段：**v1.20.3，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
+当前阶段：**v1.23.7，站点部署在 `match.starfie1d.top`。比赛模块已深度补齐（BO1/BP/Roster/OCR/Tab/删除）。UI Optimization v2 已上线（动态 Hero / PhaseStep / 双栏赛季页 / design token 体系）。v2 赛制引擎（StageExecutor + 5 个 executor + entrySeeds 种子轮空 + finalFormat 决赛 BO5）代码已就绪，待 2026 NJU Major 赛季开始时启用。**
 
 ## 版本路线图
 
@@ -230,7 +230,7 @@ src/
 │   ├── validators/   # Zod schema（registration / vote / match）
 │   └── utils/        # date（UTC/CST）+ season（capability 工具）+ password（scrypt）+ cn
 ├── components/
-│   ├── layout/       # Header / Footer / AdminShortcut / HeaderClient / SeasonNav / Breadcrumb / OnlineCounter
+│   ├── layout/       # Header / Footer / AdminShortcut / HeaderClient / SeasonNav / Breadcrumb / OnlineCounter / SeasonNav.test
 │   ├── ui/           # shadcn 组件（按需 add，已覆盖 button/input/badge/card/skeleton/select/dialog/tabs/table/textarea）
 │   ├── rivalhub/     # Tactical Grid 组件（16 个：Panel/Btn/Field/Marker/Stat/
 │   │                 #   StatusBanner/InlineConfirm/EmptyState/ErrorState/Skeleton/
@@ -250,15 +250,15 @@ src/
 │   ├── draft/        # 选秀组件（7 个：CaptainDraftPanel / DraftAdminPanel / DraftCountdown /
 │   │                 #   DraftLiveRoom / PlayerInfoPopover / PlayerPool / TeamDraftGrid）
 │   ├── captains/     # 队长投票组件（2 个：CaptainConfirmPanel / CaptainVotingPanel）
-│   ├── teams/        # 队伍组件（5 个：TeamCard / TeamGrid / TeamLogoUpload / TeamNameForm / TeamRosterCard）
-│   └── matches/      # 赛程组件（36 个：MatchCard / MatchTeamFilter / CreateMatchForm /
+│   ├── teams/        # 队伍组件（6 个：TeamCard / TeamGrid / TeamLogoUpload / TeamNameForm / TeamRosterCard / TeamCard.test）
+│   └── matches/      # 赛程组件（40 个：MatchCard / MatchTeamFilter / CreateMatchForm / ForfeitButton /
 │                     #   AdminMatchFilter / AdminMatchRow / AdminRosterDialog / BatchDeadlineCard / BracketView /
 │                     #   CompletedAtInput / DeleteMatchButton / GeneratePlayoffCard / GenerateScheduleCard /
-│                     #   MapByMapInput / MapPoolRadarChart / MatchHeadToHead / MatchHeroHeader / MatchLineupsH2H /
+│                     #   MapByMapInput / MapPoolRadarChart / MapScoreCorrectInput / MatchHeadToHead / MatchHeroHeader / MatchLineupsH2H /
 │                     #   MatchMvpVote / MatchRosterForm / MatchRosterView / MatchStatusBadge /
 │                     #   MatchSummaryStats / MatchTabsSection / MatchTimeNegotiation /
 │                     #   PlayerRadarChart / PlayerStatsTable / ScheduledAtInput / ScoreInput /
-│                     #   StandingsTable / StatsLeaderboard / StatsOCRPanel / SwissBracket /
+│                     #   StandingsTable / StatsLeaderboard / StatsLeaderboard.test / StatsOCRPanel / SwissBracket / SyncBracketButton /
 │                     #   TeamStatsCompare / TimeProposalHistory / VetoInputDialog / VetoView）
 └── types/            # 共享 TypeScript 类型
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.23.6",
+  "version": "1.23.7",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -12,7 +12,7 @@ import { POSITION_LABELS } from "@/lib/validators/registration";
 import { CS2_POSITIONS, normalizeRegistrationConfig } from "@/types/season";
 import { getUserSession, checkAdminSession } from "@/lib/auth/session";
 import { getDisplayName } from "@/lib/utils/display-name";
-import { getTeamMapWinStats, getTeamBanStats } from "@/lib/teams/data";
+import { getTeamMapWinStats, getTeamBanStats, getTeamPickStats } from "@/lib/teams/data";
 import { mapLabel } from "@/lib/maps";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import { computeTeamDimensions } from "@/lib/utils/hexagon";
@@ -131,9 +131,10 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 
   // 地图表现统计
   const matchIds = teamMatches.map((m) => m.id);
-  const [mapStats, { banCount, bpMatchCount }] = await Promise.all([
+  const [mapStats, { banCount, bpMatchCount: banBpCount }, { pickCount, bpMatchCount: pickBpCount }] = await Promise.all([
     getTeamMapWinStats(teamId, teamMatches),
     getTeamBanStats(teamId, matchIds),
+    getTeamPickStats(teamId, matchIds),
   ]);
 
   // 历史对阵（按对手分组）
@@ -385,17 +386,19 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
       <section>
         <Panel pad={0} className="overflow-hidden" label="地图表现">
           <div className="overflow-x-auto">
-            <table className="w-full text-sm min-w-[340px]">
+            <table className="w-full text-sm min-w-[440px]">
               <thead>
                 <tr className="border-b border-[var(--color-border)] text-[var(--color-fg-mid)] text-xs uppercase tracking-wide">
                   <th className="px-5 py-3 text-left font-medium">地图</th>
                   <th className="px-5 py-3 text-center font-medium">胜率</th>
+                  <th className="px-5 py-3 text-center font-medium">pick 率</th>
                   <th className="px-5 py-3 text-center font-medium">ban 率</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--color-border)]">
                 {seasonMapPool.map((mapName) => {
                   const stat = mapStats.get(mapName);
+                  const picks = pickCount.get(mapName) ?? 0;
                   const bans = banCount.get(mapName) ?? 0;
                   return (
                     <tr key={mapName}>
@@ -412,10 +415,18 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         })() : <span className="text-[var(--color-fg-dim)]">—</span>}
                       </td>
                       <td className="px-5 py-3 text-center">
-                        {bpMatchCount > 0 ? (
+                        {pickBpCount > 0 ? (
                           <>
-                            <div className="font-semibold text-[var(--color-fg)]">{pct(bans, bpMatchCount).text}</div>
-                            <div className="text-xs text-[var(--color-fg-mid)]">{bpMatchCount} 对局</div>
+                            <div className="font-semibold text-[var(--color-fg)]">{pct(picks, pickBpCount).text}</div>
+                            <div className="text-xs text-[var(--color-fg-mid)]">{pickBpCount} 对局</div>
+                          </>
+                        ) : <span className="text-[var(--color-fg-dim)]">—</span>}
+                      </td>
+                      <td className="px-5 py-3 text-center">
+                        {banBpCount > 0 ? (
+                          <>
+                            <div className="font-semibold text-[var(--color-fg)]">{pct(bans, banBpCount).text}</div>
+                            <div className="text-xs text-[var(--color-fg-mid)]">{banBpCount} 对局</div>
                           </>
                         ) : <span className="text-[var(--color-fg-dim)]">—</span>}
                       </td>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -99,7 +99,6 @@ export default async function AdminUsersPage({ searchParams }: PageProps) {
         SELECT u.id, u.created_at, COUNT(DISTINCT sr.season_id) AS season_count
         FROM users u
         LEFT JOIN season_registrations sr ON sr.user_id = u.id
-        WHERE u.role = 'user'
         GROUP BY u.id, u.created_at
       ) sub
     `),

--- a/src/lib/teams/data.ts
+++ b/src/lib/teams/data.ts
@@ -84,7 +84,12 @@ async function getTeamVetoActionStats(
     db
       .selectDistinct({ matchId: matchVetoSteps.matchId })
       .from(matchVetoSteps)
-      .where(inArray(matchVetoSteps.matchId, matchIds)),
+      .where(
+        and(
+          inArray(matchVetoSteps.matchId, matchIds),
+          eq(matchVetoSteps.actionType, actionType),
+        ),
+      ),
     db
       .select({ mapName: matchVetoSteps.mapName })
       .from(matchVetoSteps)


### PR DESCRIPTION
## Summary
- **pick 率分母剔除 BO1 比赛**：`bpMatchCount` 只统计有对应 actionType 步骤的比赛，pick 率仅计算 BO3/BO5
- **队伍页地图表现新增 pick 率列**：胜率 / pick 率 / ban 率三列并排
- **管理后台"参赛过"补漏**：stats 子查询去掉 role 过滤，参赛管理员不再被排除
- **CLAUDE.md 组件清单补全**：6 个遗漏条目

## Test plan
- [x] `pnpm tsc --noEmit` 零错误
- [x] `pnpm test` 449 passed
- [x] `zsh scripts/check-claude-md.sh` 通过
- [ ] 队伍页验证 pick 率列显示正确
- [ ] 管理后台验证"参赛过"数据修复
- [ ] release workflow 通过后验证 GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)