### PR TITLE
v1.25.1: 修复公开页面赛程状态显示"待排期"而非"待进行"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.24.0。
+部署：Vercel（`match.starfie1d.top`），当前 v1.25.1。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.1] - 2026-05-25
+
+### Fixed
+- **公开页面赛程状态显示"待排期"而非"待进行"**：`MatchCard` 漏传 `scheduledAt` prop 给 `MatchStatusBadge`，1.23.5 引入该 prop 时仅传了 `AdminMatchRow` 和 `MatchHeroHeader`，公开赛程页遗漏
+
 ## [1.25.0] - 2026-05-25
 
 ### Added
@@ -781,6 +786,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.25.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.0...v1.25.1
+[1.25.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.24.0...v1.25.0
 [1.24.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.7...v1.24.0
 [1.23.7]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.6...v1.23.7
 [1.23.6]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.5...v1.23.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -68,7 +68,7 @@ export function MatchCard({
         <Badge variant="outline" className="text-xs text-[var(--color-fg-mid)]">
           {MATCH_FORMAT_LABELS[format]}
         </Badge>
-        <MatchStatusBadge status={status} isForfeit={isForfeit} />
+        <MatchStatusBadge status={status} isForfeit={isForfeit} scheduledAt={scheduledAt} />
       </div>
     </Link>
   );


### PR DESCRIPTION
## Summary
- **fix**: `MatchCard` 补传 `scheduledAt` prop 给 `MatchStatusBadge`，公开赛程页已排期比赛正确显示"待进行"（此前始终显示"待排期"）

## Test plan
- [x] pnpm tsc --noEmit
- [ ] dev 环境验证公开赛程页状态 badge