### PR TITLE
v1.25.2: BP 选边修复 + BO1 汇总

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.25.1。
+部署：Vercel（`match.starfie1d.top`），当前 v1.25.2。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.2] - 2026-05-25
+
+### Added
+- **BO1 启用整场汇总**：已结束的 BO1 比赛现在也显示整场汇总 Tab，与其他赛制一致
+
+### Changed
+- **单图数据列扩展为完整 10 列**：PlayerStatsTable 从旧 6 列（选手/K/D/A/ADR/Rating）扩展为完整 10 列（图数/Rating/ADR/K/D/A/HS%/FK/残局），复用 MatchSummaryStats 组件
+
+### Fixed
+- **BP pick 选边改为对手视角**：A pick 图 → B 选边（而非 A 选边），匹配 CS2 标准 BP 流程
+- **BP decider 支持选边方及 side 录入**：图三现在可以指定哪支队选边及选哪边，公开页面正确显示起始边
+- **移除 SideSelect 重复代码**：pick 与 decider 的 side 选择器提取为共用组件
+- **移除 PlayerStatsTable 闲置 matchId 参数**：重构后不再需要内部查询 matches 表
+- **选边 "自动" → "未选择"**：避免误导（不存在自动逻辑）
+
 ## [1.25.1] - 2026-05-25
 
 ### Fixed
@@ -786,6 +801,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.25.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.1...v1.25.2
 [1.25.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.0...v1.25.1
 [1.25.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.24.0...v1.25.0
 [1.24.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.23.7...v1.24.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -52,6 +52,9 @@ export async function saveVetoSteps(
     if (steps.some((s) => s.actionType !== "decider" && !s.teamId)) {
       throw new AppError(ErrorCode.VALIDATION_FAILED, "非 decider 步骤必须指定操作队伍");
     }
+    if (steps.some((s) => s.actionType === "decider" && s.side && !s.teamId)) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "decider 指定了选边时必须指定选边队伍");
+    }
     const mapNames = steps.map((s) => s.mapName);
     if (new Set(mapNames).size !== mapNames.length) {
       throw new AppError(ErrorCode.VALIDATION_FAILED, "地图不能重复");
@@ -95,7 +98,13 @@ export async function saveVetoSteps(
               mapOrder: i + 1,
               mapName: s.mapName,
               pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
-              teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
+              teamAStartSide: resolveTeamASide(
+                s.side ?? "",
+                s.actionType === "pick"
+                  ? (s.teamId === match.teamAId ? match.teamBId : match.teamAId)
+                  : s.teamId,
+                match.teamAId,
+              ),
             })),
           );
         }
@@ -118,7 +127,13 @@ export async function saveVetoSteps(
               mapOrder: i + 1,
               mapName: s.mapName,
               pickedByTeamId: s.actionType === "pick" ? s.teamId : null,
-              teamAStartSide: resolveTeamASide(s.side ?? "", s.teamId, match.teamAId),
+              teamAStartSide: resolveTeamASide(
+                s.side ?? "",
+                s.actionType === "pick"
+                  ? (s.teamId === match.teamAId ? match.teamBId : match.teamAId)
+                  : s.teamId,
+                match.teamAId,
+              ),
             })),
           );
         }

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -484,7 +484,6 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                   </div>
                   {isFinished && (
                     <PlayerStatsTable
-                      matchId={match.id}
                       mapId={map.id}
                       teamAId={match.teamAId}
                       teamBId={match.teamBId}

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -354,7 +354,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
     }
   }
 
-  const showSummaryTab = isFinished && match.format !== "bo1" && summaryPlayers.length > 0;
+  const showSummaryTab = isFinished && summaryPlayers.length > 0;
   const defaultTab = showSummaryTab ? "summary" : (maps[0]?.id ?? "");
 
   return (
@@ -482,7 +482,18 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                       )}
                     </div>
                   </div>
-                  {isFinished && <PlayerStatsTable matchId={match.id} mapId={map.id} />}
+                  {isFinished && (
+                    <PlayerStatsTable
+                      matchId={match.id}
+                      mapId={map.id}
+                      teamAId={match.teamAId}
+                      teamBId={match.teamBId}
+                      teamAName={teamA?.name ?? "队伍 A"}
+                      teamBName={teamB?.name ?? "队伍 B"}
+                      seasonId={season.id}
+                      seasonSlug={seasonSlug}
+                    />
+                  )}
                   {!isFinished && map.scoreA == null && (
                     <p className="text-xs text-[var(--color-fg-dim)] py-2">比赛未开始</p>
                   )}
@@ -495,13 +506,28 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       ) : isFinished && match.scoreA != null && match.scoreB != null ? (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-[var(--color-fg)]">比赛结果</h2>
-          <Panel pad={16}>
-            <p className="text-sm text-[var(--color-fg-mid)]">
-              {match.isForfeit
-                ? "本场比赛以弃赛结束，未进行实际对局。"
-                : `${MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：${match.scoreA} : ${match.scoreB}`}
-            </p>
-          </Panel>
+          {match.isForfeit ? (
+            <Panel pad={16}>
+              <p className="text-sm text-[var(--color-fg-mid)]">
+                本场比赛以弃赛结束，未进行实际对局。
+              </p>
+            </Panel>
+          ) : summaryPlayers.length > 0 ? (
+            <MatchSummaryStats
+              players={summaryPlayers}
+              teamAId={match.teamAId}
+              teamBId={match.teamBId}
+              teamAName={teamA?.name ?? "队伍 A"}
+              teamBName={teamB?.name ?? "队伍 B"}
+              seasonSlug={seasonSlug}
+            />
+          ) : (
+            <Panel pad={16}>
+              <p className="text-sm text-[var(--color-fg-mid)]">
+                {MATCH_FORMAT_LABELS[match.format] ?? match.format.toUpperCase()} 系列赛总分：{match.scoreA} : {match.scoreB}
+              </p>
+            </Panel>
+          )}
         </section>
       ) : null}
 

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 import { Panel } from "@/components/rivalhub";
@@ -27,6 +28,8 @@ interface MatchSummaryStatsProps {
   teamAName: string;
   teamBName: string;
   seasonSlug: string;
+  /** 不包裹 Panel，供外部已有 Panel 包裹的场景使用（如单图 tab） */
+  noPanel?: boolean;
 }
 
 const COLS = [
@@ -141,12 +144,13 @@ export function MatchSummaryStats({
   teamAName,
   teamBName,
   seasonSlug,
+  noPanel = false,
 }: MatchSummaryStatsProps) {
   const teamAPlayers = players.filter((p) => p.teamId === teamAId);
   const teamBPlayers = players.filter((p) => p.teamId === teamBId);
 
-  return (
-    <Panel pad={12} className="space-y-4">
+  const content = (
+    <>
       <TeamBlock
         teamName={teamAName}
         borderColor="var(--color-accent)"
@@ -161,6 +165,14 @@ export function MatchSummaryStats({
         players={teamBPlayers}
         seasonSlug={seasonSlug}
       />
+    </>
+  );
+
+  if (noPanel) return content;
+
+  return (
+    <Panel pad={12} className="space-y-4">
+      {content}
     </Panel>
   );
 }

--- a/src/components/matches/PlayerStatsTable.tsx
+++ b/src/components/matches/PlayerStatsTable.tsx
@@ -7,7 +7,6 @@ import { seasonRegistrations } from "@/db/schema/registrations";
 import { MatchSummaryStats, type SummaryPlayer } from "./MatchSummaryStats";
 
 interface PlayerStatsTableProps {
-  matchId: string;
   mapId: string;
   teamAId: string;
   teamBId: string;
@@ -94,7 +93,6 @@ function toSummaryPlayer(s: StatRow, teamId: string): SummaryPlayer {
 }
 
 export async function PlayerStatsTable({
-  matchId: _matchId,
   mapId,
   teamAId,
   teamBId,

--- a/src/components/matches/PlayerStatsTable.tsx
+++ b/src/components/matches/PlayerStatsTable.tsx
@@ -1,37 +1,40 @@
 import React from "react";
-import Link from "next/link";
-import { cn } from "@/lib/utils/cn";
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { teamMembers } from "@/db/schema/teams";
 import { seasonRegistrations } from "@/db/schema/registrations";
-import { matches } from "@/db/schema/matches";
+import { MatchSummaryStats, type SummaryPlayer } from "./MatchSummaryStats";
 
 interface PlayerStatsTableProps {
   matchId: string;
   mapId: string;
+  teamAId: string;
+  teamBId: string;
+  teamAName: string;
+  teamBName: string;
+  seasonId: string;
+  seasonSlug: string;
 }
 
-async function getStatsGroupedByTeam(mapId: string, matchId: string) {
+async function getStatsGroupedByTeam(
+  mapId: string,
+  teamAId: string,
+  teamBId: string,
+  seasonId: string,
+) {
   const stats = await db.query.matchPlayerStats.findMany({
     where: eq(matchPlayerStats.mapId, mapId),
     orderBy: (t, { desc }) => [desc(t.ratingPro)],
   });
 
-  if (stats.length === 0) return { teamA: [], teamB: [] };
-
-  const matchData = await db.query.matches.findFirst({
-    where: eq(matches.id, matchId),
-    columns: { teamAId: true, teamBId: true, seasonId: true },
-  });
-  if (!matchData) return { teamA: stats.slice(0, 5), teamB: stats.slice(5) };
+  if (stats.length === 0) return { teamA: [] as SummaryPlayer[], teamB: [] as SummaryPlayer[] };
 
   const userIds = stats.map((s) => s.userId).filter(Boolean) as string[];
   const registrations = userIds.length
     ? await db.query.seasonRegistrations.findMany({
         where: (t, { inArray: inArr, and, eq: eqFn }) =>
-          and(inArr(t.userId, userIds), eqFn(t.seasonId, matchData.seasonId)),
+          and(inArr(t.userId, userIds), eqFn(t.seasonId, seasonId)),
         columns: { id: true, userId: true },
       })
     : [];
@@ -41,7 +44,7 @@ async function getStatsGroupedByTeam(mapId: string, matchId: string) {
         where: (t, { inArray: inArr, and, eq: eqFn, or: orFn }) =>
           and(
             inArr(t.registrationId, regIds),
-            orFn(eqFn(t.teamId, matchData.teamAId), eqFn(t.teamId, matchData.teamBId)),
+            orFn(eqFn(t.teamId, teamAId), eqFn(t.teamId, teamBId)),
           ),
         columns: { registrationId: true, teamId: true },
       })
@@ -53,106 +56,68 @@ async function getStatsGroupedByTeam(mapId: string, matchId: string) {
     if (mship) userIdToTeam.set(reg.userId, mship.teamId);
   }
 
-  const teamA = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === matchData.teamAId);
-  const teamB = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === matchData.teamBId);
+  const teamARows = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === teamAId);
+  const teamBRows = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === teamBId);
   const unmatched = stats.filter((s) => !s.userId || !userIdToTeam.has(s.userId));
   const half = Math.ceil(unmatched.length / 2);
 
   return {
-    teamA: [...teamA, ...unmatched.slice(0, half)],
-    teamB: [...teamB, ...unmatched.slice(half)],
+    teamA: [...teamARows, ...unmatched.slice(0, half)].map((s) =>
+      toSummaryPlayer(s, teamAId),
+    ),
+    teamB: [...teamBRows, ...unmatched.slice(half)].map((s) =>
+      toSummaryPlayer(s, teamBId),
+    ),
   };
 }
 
-type StatRow = Awaited<ReturnType<typeof getStatsGroupedByTeam>>["teamA"][number];
+type StatRow = typeof matchPlayerStats.$inferSelect;
 
-export async function PlayerStatsTable({ matchId, mapId }: PlayerStatsTableProps) {
-  const { teamA, teamB } = await getStatsGroupedByTeam(mapId, matchId);
+function toSummaryPlayer(s: StatRow, teamId: string): SummaryPlayer {
+  return {
+    userId: s.userId,
+    perfectName: s.perfectName,
+    teamId,
+    kills: s.kills ?? 0,
+    deaths: s.deaths ?? 0,
+    assists: s.assists ?? 0,
+    hsPercent: s.hsPercent,
+    firstKills: s.firstKills ?? 0,
+    multiKills: s.multiKills ?? 0,
+    clutches: s.clutches ?? 0,
+    adr: s.adr,
+    rws: s.rws,
+    ratingPro: s.ratingPro,
+    we: s.we,
+    mapsPlayed: 1,
+  };
+}
+
+export async function PlayerStatsTable({
+  matchId: _matchId,
+  mapId,
+  teamAId,
+  teamBId,
+  teamAName,
+  teamBName,
+  seasonId,
+  seasonSlug,
+}: PlayerStatsTableProps) {
+  const { teamA, teamB } = await getStatsGroupedByTeam(mapId, teamAId, teamBId, seasonId);
 
   if (teamA.length === 0 && teamB.length === 0) {
-    return (
-      <p className="text-xs text-[var(--color-fg-dim)] py-2">暂无玩家数据</p>
-    );
+    return <p className="text-xs text-[var(--color-fg-dim)] py-2">暂无玩家数据</p>;
   }
 
-  const cols = ["选手", "K", "D", "A", "ADR", "Rating"];
-
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2">
-      <StatTeamBlock label="队伍 A" players={teamA} cols={cols} />
-      <StatTeamBlock label="队伍 B" players={teamB} cols={cols} />
-    </div>
-  );
-}
-
-function StatTeamBlock({
-  label,
-  players,
-  cols,
-}: {
-  label: string;
-  players: StatRow[];
-  cols: string[];
-}) {
-  return (
-    <div className="rounded-md bg-[var(--color-panel-hi)] p-3">
-      <p className="text-[11px] text-[var(--color-fg-mid)] mb-2 font-medium">
-        {label}
-      </p>
-      <div className="overflow-x-auto">
-        <div
-          className="grid gap-x-2 gap-y-1 text-xs min-w-[320px]"
-          style={{ gridTemplateColumns: `1.5fr repeat(${cols.length - 1}, 1fr)` }}
-        >
-        {cols.map((c, i) => (
-          <span key={c} className={cn("text-[var(--color-fg-dim)] text-[10px]", i > 0 && "text-right")}>
-            {c}
-          </span>
-        ))}
-        {players.map((p) => (
-          <PlayerStatRow key={p.id} stat={p} />
-        ))}
-      </div>
-      </div>
-    </div>
-  );
-}
-
-function PlayerStatRow({ stat }: { stat: StatRow }) {
-  return (
-    <>
-      <span className="text-[var(--color-fg)] truncate">
-        {stat.userId ? (
-          <Link href={`/players/${stat.userId}`} className="hover:text-[var(--color-accent)] transition-colors">
-            {stat.perfectName}
-          </Link>
-        ) : (
-          stat.perfectName
-        )}
-      </span>
-      <span className="tabular-nums text-right text-[var(--color-fg)]">
-        {stat.kills ?? "—"}
-      </span>
-      <span className="tabular-nums text-right text-[var(--color-fg)]">
-        {stat.deaths ?? "—"}
-      </span>
-      <span className="tabular-nums text-right text-[var(--color-fg)]">
-        {stat.assists ?? "—"}
-      </span>
-      <span className="tabular-nums text-right text-[var(--color-fg-mid)]">
-        {stat.adr != null ? stat.adr.toFixed(1) : "—"}
-      </span>
-      <span
-        className="tabular-nums text-right font-semibold"
-        style={{
-          color:
-            stat.ratingPro != null && stat.ratingPro >= 1.2
-              ? "var(--color-accent)"
-              : "var(--color-fg)",
-        }}
-      >
-        {stat.ratingPro != null ? stat.ratingPro.toFixed(2) : "—"}
-      </span>
-    </>
+    <MatchSummaryStats
+      players={[...teamA, ...teamB]}
+      teamAId={teamAId}
+      teamBId={teamBId}
+      teamAName={teamAName}
+      teamBName={teamBName}
+      seasonSlug={seasonSlug}
+      noPanel
+    />
   );
 }

--- a/src/components/matches/VetoInputDialog.tsx
+++ b/src/components/matches/VetoInputDialog.tsx
@@ -49,6 +49,39 @@ const ACTION_LABELS: Record<VetoActionType, string> = {
   decider: "decider",
 };
 
+function SideSelect({
+  label,
+  side,
+  onSideChange,
+}: {
+  label: string;
+  side: "t" | "ct" | null;
+  onSideChange: (side: "t" | "ct" | null) => void;
+}) {
+  return (
+    <>
+      <span className="text-[11px] text-[var(--color-fg-mid)] shrink-0">{label}</span>
+      <div className="w-20">
+        <Select
+          value={side ?? "_none"}
+          onValueChange={(v) =>
+            onSideChange(v === "_none" ? null : (v as "t" | "ct"))
+          }
+        >
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="边" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="_none">未选择</SelectItem>
+            <SelectItem value="t">{SIDE_LABELS.t}</SelectItem>
+            <SelectItem value="ct">{SIDE_LABELS.ct}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </>
+  );
+}
+
 // ── BP 模板 ─────────────────────────────────────────────────────────────────
 
 function buildTemplate(
@@ -135,8 +168,9 @@ export function VetoInputDialog({
   function isValid(): boolean {
     // 所有步骤必须填满地图
     if (steps.some((s) => !s.mapName)) return false;
-    // 所有步骤必须有 teamId（decider 可以没有）
+    // 所有步骤必须有 teamId（decider 可以没有，但指定了 side 时必须有）
     if (steps.some((s) => s.actionType !== "decider" && !s.teamId)) return false;
+    if (steps.some((s) => s.actionType === "decider" && s.side && !s.teamId)) return false;
     // 无重复地图
     const maps = steps.map((s) => s.mapName);
     if (new Set(maps).size !== maps.length) return false;
@@ -233,38 +267,32 @@ export function VetoInputDialog({
               </span>
 
               {/* 执行队伍 */}
-              {step.actionType === "decider" && step.teamId === null ? (
-                <span className="text-sm text-[var(--color-fg-mid)] w-16">
-                  刀赛/剩余
-                </span>
-              ) : (
-                <div className="flex gap-1">
-                  <button
-                    type="button"
-                    onClick={() => updateStep(i, { teamId: teamAId })}
-                    className={cn(
-                      "px-2.5 py-1 text-xs rounded border transition-colors",
-                      step.teamId === teamAId
-                        ? "bg-[var(--color-accent)] text-white border-[var(--color-accent)]"
-                        : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
-                    )}
-                  >
-                    A
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => updateStep(i, { teamId: teamBId })}
-                    className={cn(
-                      "px-2.5 py-1 text-xs rounded border transition-colors",
-                      step.teamId === teamBId
-                        ? "bg-[var(--color-accent-b)] text-white border-[var(--color-accent-b)]"
-                        : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
-                    )}
-                  >
-                    B
-                  </button>
-                </div>
-              )}
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={() => updateStep(i, { teamId: step.teamId === teamAId ? null : teamAId, side: step.teamId === teamAId ? null : step.side })}
+                  className={cn(
+                    "px-2.5 py-1 text-xs rounded border transition-colors",
+                    step.teamId === teamAId
+                      ? "bg-[var(--color-accent)] text-white border-[var(--color-accent)]"
+                      : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+                  )}
+                >
+                  A
+                </button>
+                <button
+                  type="button"
+                  onClick={() => updateStep(i, { teamId: step.teamId === teamBId ? null : teamBId, side: step.teamId === teamBId ? null : step.side })}
+                  className={cn(
+                    "px-2.5 py-1 text-xs rounded border transition-colors",
+                    step.teamId === teamBId
+                      ? "bg-[var(--color-accent-b)] text-white border-[var(--color-accent-b)]"
+                      : "border-[var(--color-border)] text-[var(--color-fg-mid)] hover:text-[var(--color-fg)]"
+                  )}
+                >
+                  B
+                </button>
+              </div>
 
               {/* 地图 */}
               <div className="flex-1">
@@ -285,27 +313,20 @@ export function VetoInputDialog({
                 </Select>
               </div>
 
-              {/* 选边（仅 pick / decider 显示）*/}
-              {(step.actionType === "pick" || step.actionType === "decider") && (
-                <div className="w-20">
-                  <Select
-                    value={step.side ?? "_none"}
-                    onValueChange={(v) =>
-                      updateStep(i, {
-                        side: v === "_none" ? null : (v as "t" | "ct"),
-                      })
-                    }
-                  >
-                    <SelectTrigger className="h-8 text-xs">
-                      <SelectValue placeholder="边" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="_none">自动</SelectItem>
-                      <SelectItem value="t">{SIDE_LABELS.t}</SelectItem>
-                      <SelectItem value="ct">{SIDE_LABELS.ct}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+              {/* 选边（pick: 对手选边；decider: 选中队伍选边）*/}
+              {step.actionType === "pick" && step.teamId && (
+                <SideSelect
+                  label={`→ ${teamName(step.teamId === teamAId ? teamBId : teamAId)}选边`}
+                  side={step.side}
+                  onSideChange={(side) => updateStep(i, { side })}
+                />
+              )}
+              {step.actionType === "decider" && step.teamId && (
+                <SideSelect
+                  label="→ 选边"
+                  side={step.side}
+                  onSideChange={(side) => updateStep(i, { side })}
+                />
               )}
             </div>
           ))}

--- a/src/components/matches/VetoView.tsx
+++ b/src/components/matches/VetoView.tsx
@@ -48,6 +48,12 @@ export async function VetoView({
     return "";
   }
 
+  function opponentName(teamId: string | null): string {
+    if (teamId === teamAId) return teamBName;
+    if (teamId === teamBId) return teamAName;
+    return "";
+  }
+
   return (
     <section className="space-y-3">
       <h2 className="text-lg font-semibold text-[var(--color-fg)]">BP 流程</h2>
@@ -89,11 +95,27 @@ export async function VetoView({
                   {mapLabel(step.mapName)}
                 </span>
 
-                {step.side && (
-                  <span className="text-xs text-[var(--color-fg-mid)]">
-                    ({SIDE_LABELS[step.side] ?? step.side})
-                  </span>
-                )}
+                {step.side && (() => {
+                  if (step.actionType === "pick" && step.teamId) {
+                    return (
+                      <span className="text-xs text-[var(--color-fg-mid)]">
+                        → {opponentName(step.teamId)}选{SIDE_LABELS[step.side] ?? step.side}先
+                      </span>
+                    );
+                  }
+                  if (step.actionType === "decider" && step.teamId) {
+                    return (
+                      <span className="text-xs text-[var(--color-fg-mid)]">
+                        → {formatTeam(step.teamId)}选{SIDE_LABELS[step.side] ?? step.side}先
+                      </span>
+                    );
+                  }
+                  return (
+                    <span className="text-xs text-[var(--color-fg-mid)]">
+                      ({SIDE_LABELS[step.side] ?? step.side})
+                    </span>
+                  );
+                })()}
               </div>
             );
           })}

--- a/tests/unit/components/matches/PlayerStatsTable.test.tsx
+++ b/tests/unit/components/matches/PlayerStatsTable.test.tsx
@@ -7,9 +7,6 @@ vi.mock("@/db/client", () => ({
   db: {
     query: {
       matchPlayerStats: { findMany: mockFindMany },
-      matches: {
-        findFirst: vi.fn().mockResolvedValue({ teamAId: "ta", teamBId: "tb", seasonId: "s1" }),
-      },
       seasonRegistrations: { findMany: vi.fn().mockResolvedValue([]) },
       teamMembers: { findMany: vi.fn().mockResolvedValue([]) },
     },
@@ -20,11 +17,9 @@ vi.mock("@/db/schema/player-stats", () => ({
   matchPlayerStats: {
     id: {}, mapId: {}, userId: {}, perfectName: {},
     kills: {}, deaths: {}, assists: {}, adr: {}, ratingPro: {},
+    hsPercent: {}, firstKills: {}, multiKills: {}, clutches: {},
+    rws: {}, we: {},
   },
-}));
-
-vi.mock("@/db/schema/matches", () => ({
-  matches: { id: {}, teamAId: {}, teamBId: {}, seasonId: {} },
 }));
 
 vi.mock("@/db/schema/teams", () => ({
@@ -37,30 +32,43 @@ vi.mock("@/db/schema/registrations", () => ({
 
 import { PlayerStatsTable } from "@/components/matches/PlayerStatsTable";
 
+const baseProps = {
+  matchId: "m1",
+  mapId: "mp1",
+  teamAId: "ta",
+  teamBId: "tb",
+  teamAName: "队伍 A",
+  teamBName: "队伍 B",
+  seasonId: "s1",
+  seasonSlug: "test",
+};
+
 describe("PlayerStatsTable", () => {
   it("renders empty state when no stats", async () => {
     mockFindMany.mockResolvedValue([]);
-    const jsx = await PlayerStatsTable({ matchId: "m1", mapId: "mp1" });
+    const jsx = await PlayerStatsTable(baseProps);
     render(jsx);
     expect(screen.getByText("暂无玩家数据")).toBeDefined();
   });
 
-  it("renders two columns for team A and team B", async () => {
+  it("renders team names and player names", async () => {
     mockFindMany.mockResolvedValue([
-      { id: "p1", userId: null, perfectName: "选手1", kills: 10, deaths: 5, assists: 3, adr: 80, ratingPro: 1.1 },
-      { id: "p2", userId: null, perfectName: "选手2", kills: 5, deaths: 10, assists: 1, adr: 50, ratingPro: 0.8 },
+      { id: "p1", userId: null, perfectName: "选手1", kills: 10, deaths: 5, assists: 3, adr: 80, ratingPro: 1.1, hsPercent: 50, firstKills: 2, multiKills: 1, clutches: 0, rws: 12, we: 1.5 },
+      { id: "p2", userId: null, perfectName: "选手2", kills: 5, deaths: 10, assists: 1, adr: 50, ratingPro: 0.8, hsPercent: 40, firstKills: 0, multiKills: 0, clutches: 0, rws: 8, we: 0.8 },
     ]);
-    const jsx = await PlayerStatsTable({ matchId: "m1", mapId: "mp1" });
+    const jsx = await PlayerStatsTable(baseProps);
     render(jsx);
     expect(screen.getByText("选手1")).toBeDefined();
     expect(screen.getByText("选手2")).toBeDefined();
+    expect(screen.getByText("队伍 A")).toBeDefined();
+    expect(screen.getByText("队伍 B")).toBeDefined();
   });
 
-  it("highlights rating >= 1.2 with season primary color", async () => {
+  it("renders rating values", async () => {
     mockFindMany.mockResolvedValue([
-      { id: "p1", userId: null, perfectName: "高Rating选手", kills: 25, deaths: 8, assists: 5, adr: 95, ratingPro: 1.35 },
+      { id: "p1", userId: null, perfectName: "高Rating选手", kills: 25, deaths: 8, assists: 5, adr: 95, ratingPro: 1.35, hsPercent: 60, firstKills: 3, multiKills: 2, clutches: 1, rws: 15, we: 2.0 },
     ]);
-    const jsx = await PlayerStatsTable({ matchId: "m1", mapId: "mp1" });
+    const jsx = await PlayerStatsTable(baseProps);
     render(jsx);
     expect(screen.getByText("1.35")).toBeDefined();
   });

--- a/tests/unit/components/matches/PlayerStatsTable.test.tsx
+++ b/tests/unit/components/matches/PlayerStatsTable.test.tsx
@@ -33,7 +33,6 @@ vi.mock("@/db/schema/registrations", () => ({
 import { PlayerStatsTable } from "@/components/matches/PlayerStatsTable";
 
 const baseProps = {
-  matchId: "m1",
   mapId: "mp1",
   teamAId: "ta",
   teamBId: "tb",


### PR DESCRIPTION
## Summary
- **BP pick 选边改为对手视角**：A pick 图 → B 选边，匹配 CS2 标准 BP 流程
- **BP decider 支持选边方及 side 录入**：图三可指定选边方，公开页面正确显示起始边
- **BO1 启用整场汇总**：已结束 BO1 显示汇总 Tab
- **单图数据列扩展为完整 10 列**：PlayerStatsTable 复用 MatchSummaryStats
- 提取 SideSelect 共用组件、移除闲置 matchId、"自动"→"未选择"

## Test plan
- [x] pnpm test (449 tests)
- [x] pnpm tsc --noEmit
- [ ] dev 环境手动验证 BO3 BP 选边流程 + 公开页面地图起始边显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)