### PR TITLE
v1.25.3: bracket 自动创建修复 + 公开页面 UI 优化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.25.2。
+部署：Vercel（`match.starfie1d.top`），当前 v1.25.3。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.3] - 2026-05-27
+
+### Fixed
+- **Bracket 比赛自动创建修复**：`advanceMatch` 中 `prevResolved` 快照必须在 `manager.update.match()` 之前完成；`InMemoryDatabase.setData()` 存引用导致更新后 `currentData` 同步变化，diff 永远为空，下一轮比赛从未被自动创建
+- **移除重复的「查看对阵图」导航按钮**：与「返回赛程总览」指向同一页面（`#bracket` 锚点无感知），去掉冗余入口
+- **数据汇总表列统一缩写并重排**：去掉「图数」列，新增 MK（多杀）、WE；列顺序调整为 Rating → K/D/A → ADR → HS% → FK → MK → CL → WE，标签全部改为英文缩写
+
 ## [1.25.2] - 2026-05-25
 
 ### Added
@@ -801,6 +808,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.25.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.2...v1.25.3
 [1.25.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.1...v1.25.2
 [1.25.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.0...v1.25.1
 [1.25.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.24.0...v1.25.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/components/matches/MatchHeroHeader.tsx
+++ b/src/components/matches/MatchHeroHeader.tsx
@@ -52,14 +52,6 @@ export function MatchHeroHeader({
         >
           ← 返回赛程总览
         </Link>
-        {match.stage === "playoff" && match.bracketNodeId && (
-          <Link
-            href={`/${seasonSlug}/matches#bracket`}
-            className="text-sm text-[var(--color-fg-mid)] hover:text-[var(--color-fg)] transition-colors"
-          >
-            查看对阵图 →
-          </Link>
-        )}
       </div>
 
       <div

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -33,15 +33,16 @@ interface MatchSummaryStatsProps {
 }
 
 const COLS = [
-  { key: "mapsPlayed", label: "图数" },
   { key: "ratingPro", label: "Rating", fmt: (v: number | null) => v != null ? v.toFixed(2) : "—" },
-  { key: "adr", label: "ADR", fmt: (v: number | null) => v != null ? v.toFixed(1) : "—" },
-  { key: "kills", label: "K" },
-  { key: "deaths", label: "D" },
-  { key: "assists", label: "A" },
+  { key: "kills",     label: "K" },
+  { key: "deaths",    label: "D" },
+  { key: "assists",   label: "A" },
+  { key: "adr",       label: "ADR", fmt: (v: number | null) => v != null ? v.toFixed(1) : "—" },
   { key: "hsPercent", label: "HS%", fmt: (v: number | null) => v != null ? `${v.toFixed(0)}%` : "—" },
-  { key: "firstKills", label: "FK" },
-  { key: "clutches", label: "残局" },
+  { key: "firstKills",  label: "FK" },
+  { key: "multiKills",  label: "MK" },
+  { key: "clutches",    label: "CL" },
+  { key: "we",          label: "WE", fmt: (v: number | null) => v != null ? v.toFixed(1) : "—" },
 ] as const;
 
 interface PlayerRowProps {

--- a/src/lib/bracket/index.ts
+++ b/src/lib/bracket/index.ts
@@ -161,6 +161,10 @@ export async function advanceMatch(
 ): Promise<{ updatedData: Database; newResolvedMatches: ResolvedBracketMatch[] }> {
   const { manager, db } = buildManager(currentData);
 
+  // 必须在 manager.update.match() 之前快照，否则 InMemoryDatabase.setData()
+  // 存的是引用，manager 更新内存后 currentData 也会被同步修改，导致 diff 永远为空。
+  const prevResolved = new Set(collectResolvedMatches(currentData).map((m) => m.bracketMatchId));
+
   const matchId = parseInt(bracketNodeId, 10);
   const isWinA = scoreA > scoreB;
 
@@ -173,8 +177,6 @@ export async function advanceMatch(
 
   const updatedData = await manager.export();
 
-  // 找出本次更新后新增的已确定对阵（对比更新前已有的 bracketMatchId 集合）
-  const prevResolved = new Set(collectResolvedMatches(currentData).map((m) => m.bracketMatchId));
   const allResolved = collectResolvedMatches(updatedData);
   const newResolvedMatches = allResolved.filter((m) => !prevResolved.has(m.bracketMatchId));
 


### PR DESCRIPTION
## Summary

### Fixed
- **Bracket 比赛自动创建**：`advanceMatch` 中 `prevResolved` 在 `manager.update.match()` 之后才快照，导致 `InMemoryDatabase` 引用被改写后 diff 永远为空，下一轮比赛从未自动创建；将快照移至更新前修复
- **移除重复导航按钮**：「查看对阵图」与「返回赛程总览」指向同一页面，去掉冗余入口
- **数据汇总表列重排**：去掉「图数」，新增 MK（多杀）、WE（一位小数）；列顺序调整为 Rating → K/D/A → ADR → HS% → FK → MK → CL → WE，标签全部统一为英文缩写

## Test plan
- [ ] `pnpm tsc --noEmit`
- [ ] `pnpm test`
- [ ] 录入比赛结果后确认下一轮 bracket 比赛自动出现
- [ ] 比赛公开页面确认只有一个返回按钮、数据列正确显示