### PR TITLE
v1.25.4: 修复幽灵提议问题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.25.3。
+部署：Vercel（`match.starfie1d.top`），当前 v1.25.4。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.4] - 2026-05-28
+
+### Fixed
+- **幽灵提议修复**：管理员后台直接设置比赛时间时未联动清理同场 pending 提议，导致提议永远显示「即将自动采纳」。`updateMatchScheduledAt` 现在在事务内同步将 pending 提议标为 expired；cron 的 `autoAcceptSingleProposal` 增加兜底逻辑，比赛不再是 scheduled 状态或已有 scheduledAt 时直接清理残留 pending 提议
+
 ## [1.25.3] - 2026-05-27
 
 ### Fixed
@@ -808,6 +813,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.25.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.3...v1.25.4
 [1.25.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.2...v1.25.3
 [1.25.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.1...v1.25.2
 [1.25.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.0...v1.25.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -2,7 +2,7 @@
 
 import { eq, asc, and, inArray, isNull } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, matches, matchMaps, matchVetoSteps, matchRosters, matchRosterPlayers, teams, teamMembers, auditLogs } from "@/db/schema";
+import { seasons, matches, matchMaps, matchVetoSteps, matchRosters, matchRosterPlayers, teams, teamMembers, auditLogs, matchTimeProposals } from "@/db/schema";
 import { ok } from "@/types/action";
 import type { ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
@@ -379,10 +379,24 @@ export async function updateMatchScheduledAt(
 
     const seasonForSch = await getSeasonOrThrow(match.seasonId);
     await db.transaction(async (tx) => {
+      const now = new Date();
       await tx
         .update(matches)
-        .set({ scheduledAt, updatedAt: new Date() })
+        .set({ scheduledAt, updatedAt: now })
         .where(eq(matches.id, matchId));
+
+      // 比赛时间被管理员直接设定后，同场所有 pending 提议失效，避免幽灵提议卡在 pending。
+      if (scheduledAt) {
+        await tx
+          .update(matchTimeProposals)
+          .set({ status: "expired", updatedAt: now })
+          .where(
+            and(
+              eq(matchTimeProposals.matchId, matchId),
+              eq(matchTimeProposals.status, "pending"),
+            ),
+          );
+      }
 
       await tx.insert(auditLogs).values({
         seasonId: match.seasonId,

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -330,11 +330,12 @@ async function autoAcceptSingleProposal(
 ): Promise<boolean> {
   return db.transaction(async (tx) => {
     const [match] = await tx.select().from(matches).where(eq(matches.id, matchId)).for("update");
-    if (!match || match.status !== "scheduled") {
+    if (!match) {
       return false;
     }
-    // 如果比赛时间已经确定了（被其他提议抢先），跳过
-    if (match.scheduledAt) {
+    // 比赛已经不是 scheduled（in_progress / finished / cancelled），或时间已被抢先确定：
+    // 残留 pending 提议直接过期清理，避免幽灵提议永远卡在 pending。
+    if (match.status !== "scheduled" || match.scheduledAt) {
       await tx
         .update(matchTimeProposals)
         .set({ status: "expired", updatedAt: now })


### PR DESCRIPTION
## Summary
- 修复：管理员后台直接设置比赛时间时未联动清理同场 pending 提议，导致提议永远显示「即将自动采纳」
- 修复：cron autoAcceptSingleProposal 增加兜底逻辑，比赛不再是 scheduled 状态时清理残留 pending 提议

## Test plan
- [ ] pnpm test
- [ ] pnpm tsc --noEmit
- [ ] 在比赛详情页确认无残留 pending 提议