### PR TITLE
v1.25.5: 自动采纳提议时页面轮询刷新 + 公开显示提示

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.25.4。
+部署：Vercel（`match.starfie1d.top`），当前 v1.25.5。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.5] - 2026-05-28
+
+### Added
+- **自动采纳提示及页面轮询**：提议被 cron 自动采纳后，页面绿色提示条公开显示「比赛时间已自动设定」，不再只靠手动刷新才能看到状态变化；pending 提议存在时每 30 秒自动轮询
+
 ## [1.25.4] - 2026-05-28
 
 ### Fixed
@@ -813,6 +818,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.25.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.4...v1.25.5
 [1.25.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.3...v1.25.4
 [1.25.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.2...v1.25.3
 [1.25.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.1...v1.25.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.25.4",
+  "version": "1.25.5",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/components/matches/MatchTimeNegotiation.tsx
+++ b/src/components/matches/MatchTimeNegotiation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { proposeMatchTime, respondToTimeProposal, forceSetMatchTime } from "@/actions/matches/scheduling";
 import { Button } from "@/components/ui/button";
@@ -53,6 +54,7 @@ export function MatchTimeNegotiation({
   hasSubmittedRoster = false,
   bufferHours = 24,
 }: MatchTimeNegotiationProps) {
+  const router = useRouter();
   // 0 缓冲（=与最晚完成时间一致）目前仅正赛使用，沿用作为是否显示解说时段提示的判据。
   const isPlayoff = bufferHours === 0;
   const [isPending, startTransition] = useTransition();
@@ -70,6 +72,20 @@ export function MatchTimeNegotiation({
     : null;
   const isNegotiationClosed =
     confirmationCutoff !== null && Date.now() >= confirmationCutoff.getTime();
+
+  // 有 pending 提议时自动轮询，确保自动采纳后页面及时更新
+  useEffect(() => {
+    if (pendingProposals.length === 0) return;
+    const timer = window.setInterval(() => router.refresh(), 30_000);
+    return () => window.clearInterval(timer);
+  }, [pendingProposals.length, router]);
+
+  // 检测被系统自动采纳的提议
+  const autoAcceptedProposal = initialProposals.find((p) => {
+    if (p.status !== "accepted" || !p.responseAt) return false;
+    const elapsed = new Date(p.responseAt).getTime() - new Date(p.createdAt).getTime();
+    return elapsed >= PROPOSAL_AUTO_ACCEPT_HOURS * 60 * 60 * 1000 - 1800_000; // 23.5h+
+  });
 
   const handlePropose = () => {
     if (!proposedTime) return;
@@ -133,6 +149,16 @@ export function MatchTimeNegotiation({
           {currentScheduledAt ? formatCST(currentScheduledAt) : "待协商"}
         </span>
       </div>
+
+      {/* 系统自动采纳提示 */}
+      {autoAcceptedProposal && currentScheduledAt && (
+        <div className="rounded border p-3 text-sm" style={{ borderColor: "rgba(34,197,94,0.35)", background: "rgba(34,197,94,0.06)" }}>
+          <p className="font-medium text-[var(--color-fg)]">比赛时间已自动设定</p>
+          <p className="text-xs text-[var(--color-fg-dim)] mt-0.5">
+            对方 24 小时内未回应，比赛时间已按提议自动采纳为 {formatCST(autoAcceptedProposal.proposedTime)}。
+          </p>
+        </div>
+      )}
 
       {/* 所有待回应的提议 */}
       {pendingProposals.length > 0 && (


### PR DESCRIPTION
## Summary
- 新增：自动采纳提议时页面公开显示绿色提示条，所有访客可见
- 新增：pending 提议存在时每 30 秒自动轮询，自动采纳后页面自动更新

## Test plan
- [ ] pnpm test
- [ ] pnpm tsc --noEmit
- [ ] 确认比赛详情页自动采纳提示的正确显示