### PR TITLE
v1.26.2: 修复 Stats 500 错误、Demo 导入页 BO1 不显示、公开页移除 Demo 导入

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.26.1。
+部署：Vercel（`match.starfie1d.top`），当前 v1.26.2。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.26.2] - 2026-05-29
+
+### Fixed
+- **Stats 页面 500 错误**：修复 `season-demo-stats.ts` 中 4 个函数对 `db.execute()` 返回结果未解构 `rows`，直接调用 `.map()` 报 `(intermediate value).map is not a function`
+- **Demo 导入页面 BO1 不显示**：移除 `isNotNull(matchMaps.scoreA)` 过滤，使排位赛阶段 BP 产出的无比分地图记录也能展示
+- **公开页面移除 OCR/Demo 导入**：从比赛详情页移除管理员可见的 OCR/Demo 导入面板，统一放在后台比赛管理行（AdminMatchRow 直接嵌入 DemoImportPanel）
+
 ## [1.26.1] - 2026-05-29
 
 ### Added
@@ -905,6 +912,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.26.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.1...v1.26.2
 [1.26.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.0...v1.26.1
 [1.26.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.6...v1.26.0
 [1.25.6]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.5...v1.25.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/season-demo-stats.ts
+++ b/src/actions/season-demo-stats.ts
@@ -47,7 +47,7 @@ export interface PlayerWeaponStats {
 export async function getSeasonDemoStats(
   seasonId: string,
 ): Promise<ActionResult<DemoLeaderboardData[]>> {
-  const rows = await db.execute(sql`
+  const { rows } = await db.execute(sql`
     SELECT
       dps.user_id,
       COALESCE(dp.name, 'Unknown') AS perfect_name,
@@ -135,7 +135,7 @@ export async function getSeasonDemoStats(
 export async function getSeasonWeaponStats(
   seasonId: string,
 ): Promise<ActionResult<PlayerWeaponStats[]>> {
-  const rows = await db.execute(sql`
+  const { rows } = await db.execute(sql`
     SELECT
       dps.user_id,
       COALESCE(dp.name, 'Unknown') AS perfect_name,
@@ -161,9 +161,8 @@ export async function getSeasonWeaponStats(
 
   // 按 userId 分组
   const playerMap = new Map<string, PlayerWeaponStats>();
-  const rawRows = rows as unknown as any[];
 
-  for (const r of rawRows) {
+  for (const r of rows as any[]) {
     const uid = (r.user_id as string) ?? `steam_${r.steam_id64}`;
     if (!playerMap.has(uid)) {
       playerMap.set(uid, {
@@ -214,7 +213,7 @@ export interface WeaponKillStatsRow {
  * 只统计 demo_kills（由 matchMaps.activeStatSource='demo_import' 过滤）
  */
 export async function getWeaponKillStats(seasonId: string): Promise<WeaponKillStatsRow[]> {
-  const rows = await db.execute(sql`
+  const { rows } = await db.execute(sql`
     SELECT
       dp.user_id,
       dp.name AS perfect_name,
@@ -268,7 +267,7 @@ export interface PlayerHighlightStats {
 export async function getSeasonHighlightStats(
   seasonId: string,
 ): Promise<ActionResult<PlayerHighlightStats[]>> {
-  const rows = await db.execute(sql`
+  const { rows } = await db.execute(sql`
     SELECT
       dps.user_id,
       COALESCE(dp.name, 'Unknown') AS perfect_name,

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -10,8 +10,6 @@ import { mapLabel } from "@/lib/maps";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MATCH_FORMAT_LABELS, SIDE_LABELS } from "@/types/match";
 import { PlayerStatsTable } from "@/components/matches/PlayerStatsTable";
-import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
-import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
 import { TimeProposalHistory } from "@/components/matches/TimeProposalHistory";
 import { MatchTimeNegotiation } from "@/components/matches/MatchTimeNegotiation";
 import { MatchRosterView } from "@/components/matches/MatchRosterView";
@@ -526,8 +524,6 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                   {!isFinished && map.scoreA == null && (
                     <p className="text-xs text-[var(--color-fg-dim)] py-2">比赛未开始</p>
                   )}
-                  {isFinished && isSeasonAdmin && <StatsOCRPanel mapId={map.id} mapName={map.mapName} />}
-                  {isFinished && isSeasonAdmin && <DemoImportPanel mapId={map.id} mapName={map.mapName} />}
                   {/* Demo 明细区块 */}
                   {isFinished && (() => {
                     const demoResult = demoDataByMapId.get(map.id);
@@ -537,7 +533,7 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
                           <div className="py-4 text-center text-sm text-[var(--color-fg-dim)]">
                             暂无 Demo 数据
                             {isSeasonAdmin ? (
-                              <span> — 请在上方导入 Demo</span>
+                              <span> — 请在比赛管理页面导入 Demo</span>
                             ) : (
                               <span>（比赛结束后可联系管理员导入）</span>
                             )}

--- a/src/app/admin/[seasonSlug]/demos/page.tsx
+++ b/src/app/admin/[seasonSlug]/demos/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
-import { eq, asc, inArray, and, isNotNull } from "drizzle-orm";
+import { eq, asc, inArray, and } from "drizzle-orm";
 import { db } from "@/db/client";
 import { seasons, matches, teams, matchMaps, demoImports } from "@/db/schema";
 import { requireSeasonAdmin } from "@/lib/auth/session";
 import { mapLabel } from "@/lib/maps";
 import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
+import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
 interface PageProps {
@@ -53,7 +54,6 @@ export default async function AdminDemosPage({ params }: PageProps) {
   const allMaps = await db.query.matchMaps.findMany({
     where: and(
       inArray(matchMaps.matchId, finishedMatchIds),
-      isNotNull(matchMaps.scoreA),
     ),
     orderBy: [asc(matchMaps.matchId), asc(matchMaps.mapOrder)],
   });
@@ -90,6 +90,7 @@ export default async function AdminDemosPage({ params }: PageProps) {
 
           const teamAName = teamMap.get(m.teamAId) ?? "队伍 A";
           const teamBName = teamMap.get(m.teamBId) ?? "队伍 B";
+          const isBO1 = m.format === "bo1";
 
           return (
             <div
@@ -107,6 +108,9 @@ export default async function AdminDemosPage({ params }: PageProps) {
                   </Link>
                   <span className="text-xs text-[var(--color-fg-mid)] font-mono">
                     {m.scoreA} : {m.scoreB}
+                  </span>
+                  <span className="text-xs text-[var(--color-fg-dim)]">
+                    {MATCH_FORMAT_LABELS[m.format] ?? m.format.toUpperCase()}
                   </span>
                 </div>
                 <Link
@@ -131,7 +135,7 @@ export default async function AdminDemosPage({ params }: PageProps) {
                           {mapLabel(map.mapName)}
                         </span>
                         <span className="font-mono text-sm text-[var(--color-fg)]">
-                          {map.scoreA} : {map.scoreB}
+                          {map.scoreA != null ? `${map.scoreA} : ${map.scoreB}` : "—"}
                         </span>
                         {hasDemo && (
                           <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(77,212,122,0.12)] text-[var(--color-ok)]">

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -9,6 +9,7 @@ import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
 import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
 import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
 import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
+import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
 import { ForfeitButton } from "@/components/matches/ForfeitButton";
 import { MapScoreCorrectInput } from "@/components/matches/MapScoreCorrectInput";
 import { DeleteMatchButton } from "@/components/matches/DeleteMatchButton";
@@ -232,12 +233,7 @@ export function AdminMatchRow({
                 {finishedMaps.map((map) => (
                   <div key={map.id} className="space-y-1">
                     <StatsOCRPanel mapId={map.id} mapName={map.mapName} />
-                    <Link
-                      href={`/admin/${seasonSlug}/demos` as any}
-                      className="text-xs text-[var(--color-fg-mid)] hover:text-[var(--color-accent)] transition-colors"
-                    >
-                      导入 Demo →
-                    </Link>
+                    <DemoImportPanel mapId={map.id} mapName={map.mapName} />
                   </div>
                 ))}
               </>


### PR DESCRIPTION
## Summary
- 修复 Stats 页面 500 错误（`season-demo-stats` 中 `db.execute` 未解构 `rows` 导致 `.map is not a function`）
- 修复 Demo 导入页面 BO1 比赛不显示（移除 `isNotNull(scoreA)` 过滤）
- 公开比赛详情页移除 OCR/Demo 导入面板，统一放到后台比赛管理页面（AdminMatchRow 直接嵌入 Demo 导入）

## Test plan
- [ ] pnpm test
- [ ] pnpm tsc --noEmit