### PR TITLE
v1.27.0: RR/PRISM 评分系统 + Demo 批量导入

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.26.2。
+部署：Vercel（`match.starfie1d.top`），当前 v1.27.0。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.0] - 2026-05-29
+
+### Added
+- **RR/PRISM 评分系统（框架）**：引入 `rival-rating` 算法引擎，新增 `player_ratings` 表；`recomputeSeasonRatings` Server Action 读取全赛季 demo 数据、计算每名选手的 RR 绝对刻度标量与 PRISM 八维风格百分位，管理员在 Demo 页面一键重算
+- **Demo 批量导入**：管理后台新增"批量导入"折叠区域，支持一次选择多个 zip；客户端自动解析 manifest + match.json 提取地图/队名，服务端按 mapName + 队名模糊匹配到对应 matchMap，匹配结果表格支持手动修正，逐个顺序导入并实时显示进度
+
+### Fixed
+- **Demo 解析 totalRounds 误差**：`playerStatsRowSchema` 补充 `rounds` 字段（exporter v2.1.2+），修复 fallback 用 kills+deaths 估算导致 per-round 指标偏低约 20%
+- **Demo 暖场数据污染**：`parseDemoPackage` 过滤 `roundNumber=0` 的击杀、投掷物等事件，防止暖场数据进入统计
+- **时间协商 Banner 显示错误 + 竞态**：修复"比赛时间已自动设定"提示使用 proposal 记录时间而非 match 实际时间导致的不一致；`autoAcceptExpiredProposals` 改为按 matchId 分组只处理最早提议，消除并行处理同场多条超时提议时的非确定性锁竞争
+
 ## [1.26.2] - 2026-05-29
 
 ### Fixed
@@ -912,6 +923,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.27.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.2...v1.27.0
 [1.26.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.1...v1.26.2
 [1.26.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.0...v1.26.1
 [1.26.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.25.6...v1.26.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **RR/PRISM 评分系统（框架）**：引入 `rival-rating` 算法引擎，新增 `player_ratings` 表；`recomputeSeasonRatings` Server Action 读取全赛季 demo 数据、计算每名选手的 RR 绝对刻度标量与 PRISM 八维风格百分位，管理员在 Demo 页面一键重算
 - **Demo 批量导入**：管理后台新增"批量导入"折叠区域，支持一次选择多个 zip；客户端自动解析 manifest + match.json 提取地图/队名，服务端按 mapName + 队名模糊匹配到对应 matchMap，匹配结果表格支持手动修正，逐个顺序导入并实时显示进度
+- **全站 RR 门面评分体系**：排行榜 RR 列提升为首位（Core/Impact/Advanced 三视图通用）；选手目录/队伍卡片/队伍详情新增 RR 列；选手主页生涯总计 RR 加权计算；队伍详情综合统计以 RR 替换 WE 作为门面指标
+- **通用 N 轴 RadarChart 组件**：支持任意轴数，现有六维雷达图保持兼容；选手主页按赛季检测 PRISM 数据 → 有则渲染 PRISM 八维（火力/开局/首攻/补枪/残局/狙击/道具/生存），否则回退六维
+
+### Changed
+- **评分标签统一**：全站「完美 Rating」/「完美 RT」/孤立的「Rating」标签统一为 `Rating Pro`；OCR `matchPlayerStats.ratingPro` 均明确标注为第三方数据（非平台自有评分），不再与 RR 混淆
+- **全站数据来源过滤修复**：选手主页生涯查询、选手目录、队伍目录、队伍详情 4 处聚合查询补充 `source = COALESCE(active_stat_source, 'manual_ocr')` 过滤，消除同一地图 OCR/demo 双来源行同时计入导致的均值和地图数翻倍；队伍详情 `count(*)` → `count(distinct map_id)` 修复地图数双算
+- **比赛详情 OCR 汇总表**：表头列「Rating」→「Rating Pro」，与全站标签保持一致
 
 ### Fixed
 - **Demo 解析 totalRounds 误差**：`playerStatsRowSchema` 补充 `rounds` 字段（exporter v2.1.2+），修复 fallback 用 kills+deaths 估算导致 per-round 指标偏低约 20%

--- a/drizzle/migrations/0025_overrated_longshot.sql
+++ b/drizzle/migrations/0025_overrated_longshot.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "player_ratings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"user_id" uuid,
+	"steam_id_64" text NOT NULL,
+	"rr_score" numeric(8, 4),
+	"rr_weights_version" text,
+	"prism_firepower" numeric(6, 2),
+	"prism_opening" numeric(6, 2),
+	"prism_clutch" numeric(6, 2),
+	"prism_sniping" numeric(6, 2),
+	"prism_survival" numeric(6, 2),
+	"prism_utility" numeric(6, 2),
+	"prism_trading" numeric(6, 2),
+	"prism_entry" numeric(6, 2),
+	"prism_weights_version" text,
+	"map_count" integer DEFAULT 0 NOT NULL,
+	"computed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "player_ratings" ADD CONSTRAINT "player_ratings_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "player_ratings" ADD CONSTRAINT "player_ratings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "player_ratings_season_steam_uniq" ON "player_ratings" USING btree ("season_id","steam_id_64");

--- a/drizzle/migrations/meta/0025_snapshot.json
+++ b/drizzle/migrations/meta/0025_snapshot.json
@@ -1,0 +1,4836 @@
+{
+  "id": "8f94b768-df44-4024-ac15-d2711f0e47f1",
+  "prevId": "bf410431-a0c6-4399-8e32-26a9b8d73979",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_blinds": {
+      "name": "demo_blinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flasher_steam_id64": {
+          "name": "flasher_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flashed_steam_id64": {
+          "name": "flashed_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flasher_team_key": {
+          "name": "flasher_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flashed_team_key": {
+          "name": "flashed_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flasher_side": {
+          "name": "flasher_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flashed_side": {
+          "name": "flashed_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_blinds_import_batch_id_map_id_index": {
+          "name": "demo_blinds_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_blinds_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_blinds_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_blinds",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_blinds_map_id_match_maps_id_fk": {
+          "name": "demo_blinds_map_id_match_maps_id_fk",
+          "tableFrom": "demo_blinds",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_bombs": {
+      "name": "demo_bombs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site": {
+          "name": "site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_steam_id64": {
+          "name": "actor_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_team_key": {
+          "name": "actor_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_side": {
+          "name": "actor_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_bombs_import_batch_id_map_id_index": {
+          "name": "demo_bombs_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_bombs_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_bombs_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_bombs",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_bombs_map_id_match_maps_id_fk": {
+          "name": "demo_bombs_map_id_match_maps_id_fk",
+          "tableFrom": "demo_bombs",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_clutches": {
+      "name": "demo_clutches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutcher_steam_id64": {
+          "name": "clutcher_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutcher_team_key": {
+          "name": "clutcher_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutcher_side": {
+          "name": "clutcher_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_count": {
+          "name": "opponent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survived": {
+          "name": "survived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kill_count": {
+          "name": "kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_clutches_import_batch_id_map_id_index": {
+          "name": "demo_clutches_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_clutches_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_clutches_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_clutches",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_clutches_map_id_match_maps_id_fk": {
+          "name": "demo_clutches_map_id_match_maps_id_fk",
+          "tableFrom": "demo_clutches",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_damages": {
+      "name": "demo_damages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attacker_steam_id64": {
+          "name": "attacker_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_steam_id64": {
+          "name": "victim_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attacker_team_key": {
+          "name": "attacker_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_team_key": {
+          "name": "victim_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attacker_side": {
+          "name": "attacker_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_side": {
+          "name": "victim_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weapon": {
+          "name": "weapon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hitgroup": {
+          "name": "hitgroup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_damage": {
+          "name": "health_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "armor_damage": {
+          "name": "armor_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_health_before": {
+          "name": "victim_health_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_health_after": {
+          "name": "victim_health_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_armor_before": {
+          "name": "victim_armor_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_armor_after": {
+          "name": "victim_armor_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_damages_import_batch_id_map_id_index": {
+          "name": "demo_damages_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_damages_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_damages_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_damages",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_damages_map_id_match_maps_id_fk": {
+          "name": "demo_damages_map_id_match_maps_id_fk",
+          "tableFrom": "demo_damages",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_grenades": {
+      "name": "demo_grenades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "throw_tick": {
+          "name": "throw_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_tick": {
+          "name": "effect_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grenade": {
+          "name": "grenade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thrower_steam_id64": {
+          "name": "thrower_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thrower_team_key": {
+          "name": "thrower_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thrower_side": {
+          "name": "thrower_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "throw_position": {
+          "name": "throw_position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_position": {
+          "name": "effect_position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_grenades_import_batch_id_map_id_index": {
+          "name": "demo_grenades_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_grenades_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_grenades_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_grenades",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_grenades_map_id_match_maps_id_fk": {
+          "name": "demo_grenades_map_id_match_maps_id_fk",
+          "tableFrom": "demo_grenades",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_imports": {
+      "name": "demo_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo_hash": {
+          "name": "demo_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exporter_name": {
+          "name": "exporter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exporter_version": {
+          "name": "exporter_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parser_name": {
+          "name": "parser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tickrate": {
+          "name": "tickrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_by": {
+          "name": "imported_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "demo_imports_map_id_match_maps_id_fk": {
+          "name": "demo_imports_map_id_match_maps_id_fk",
+          "tableFrom": "demo_imports",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_imports_imported_by_users_id_fk": {
+          "name": "demo_imports_imported_by_users_id_fk",
+          "tableFrom": "demo_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "imported_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_kills": {
+      "name": "demo_kills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "killer_steam_id64": {
+          "name": "killer_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_steam_id64": {
+          "name": "victim_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assister_steam_id64": {
+          "name": "assister_steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killer_team_key": {
+          "name": "killer_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_team_key": {
+          "name": "victim_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killer_side": {
+          "name": "killer_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_side": {
+          "name": "victim_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weapon": {
+          "name": "weapon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headshot": {
+          "name": "headshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_assist": {
+          "name": "flash_assist",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_kill": {
+          "name": "trade_kill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_death": {
+          "name": "trade_death",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "through_smoke": {
+          "name": "through_smoke",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_scope": {
+          "name": "no_scope",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "penetrated_objects": {
+          "name": "penetrated_objects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "killer_position": {
+          "name": "killer_position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "victim_position": {
+          "name": "victim_position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_kills_import_batch_id_map_id_index": {
+          "name": "demo_kills_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_kills_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_kills_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_kills",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_kills_map_id_match_maps_id_fk": {
+          "name": "demo_kills_map_id_match_maps_id_fk",
+          "tableFrom": "demo_kills",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_player_economies": {
+      "name": "demo_player_economies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steam_id64": {
+          "name": "steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_key": {
+          "name": "team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_money": {
+          "name": "start_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "money_spent": {
+          "name": "money_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_value": {
+          "name": "equipment_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_player_economies_import_batch_id_map_id_index": {
+          "name": "demo_player_economies_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_player_economies_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_player_economies_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_player_economies",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_player_economies_map_id_match_maps_id_fk": {
+          "name": "demo_player_economies_map_id_match_maps_id_fk",
+          "tableFrom": "demo_player_economies",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_player_stats": {
+      "name": "demo_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steam_id64": {
+          "name": "steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_key": {
+          "name": "team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_health": {
+          "name": "damage_health",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_armor": {
+          "name": "damage_armor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utility_damage": {
+          "name": "utility_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_utility_damage_per_round": {
+          "name": "avg_utility_damage_per_round",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headshot_count": {
+          "name": "headshot_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kill_count": {
+          "name": "first_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_death_count": {
+          "name": "first_death_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_kill_count": {
+          "name": "trade_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trade_death_count": {
+          "name": "trade_death_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kast": {
+          "name": "kast",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "one_kill_count": {
+          "name": "one_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_kill_count": {
+          "name": "two_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "three_kill_count": {
+          "name": "three_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "four_kill_count": {
+          "name": "four_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "five_kill_count": {
+          "name": "five_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_one_count": {
+          "name": "vs_one_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_one_won_count": {
+          "name": "vs_one_won_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_one_lost_count": {
+          "name": "vs_one_lost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_two_count": {
+          "name": "vs_two_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_two_won_count": {
+          "name": "vs_two_won_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_two_lost_count": {
+          "name": "vs_two_lost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_three_count": {
+          "name": "vs_three_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_three_won_count": {
+          "name": "vs_three_won_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_three_lost_count": {
+          "name": "vs_three_lost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_four_count": {
+          "name": "vs_four_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_four_won_count": {
+          "name": "vs_four_won_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_four_lost_count": {
+          "name": "vs_four_lost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_five_count": {
+          "name": "vs_five_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_five_won_count": {
+          "name": "vs_five_won_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vs_five_lost_count": {
+          "name": "vs_five_lost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bomb_planted_count": {
+          "name": "bomb_planted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bomb_defused_count": {
+          "name": "bomb_defused_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallbang_kill_count": {
+          "name": "wallbang_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_scope_kill_count": {
+          "name": "no_scope_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collateral_kill_count": {
+          "name": "collateral_kill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_player_stats_import_batch_id_map_id_index": {
+          "name": "demo_player_stats_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_player_stats_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_player_stats_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_player_stats",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_player_stats_map_id_match_maps_id_fk": {
+          "name": "demo_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "demo_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_player_stats_user_id_users_id_fk": {
+          "name": "demo_player_stats_user_id_users_id_fk",
+          "tableFrom": "demo_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_players": {
+      "name": "demo_players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steam_id64": {
+          "name": "steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_key": {
+          "name": "team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_players_import_batch_id_map_id_index": {
+          "name": "demo_players_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_players_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_players_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_players",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_players_map_id_match_maps_id_fk": {
+          "name": "demo_players_map_id_match_maps_id_fk",
+          "tableFrom": "demo_players",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_players_user_id_users_id_fk": {
+          "name": "demo_players_user_id_users_id_fk",
+          "tableFrom": "demo_players",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_positions": {
+      "name": "demo_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steam_id64": {
+          "name": "steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_key": {
+          "name": "team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alive": {
+          "name": "alive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yaw": {
+          "name": "yaw",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health": {
+          "name": "health",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "armor": {
+          "name": "armor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "money": {
+          "name": "money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_weapon": {
+          "name": "active_weapon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_duration_remaining": {
+          "name": "flash_duration_remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_bomb": {
+          "name": "has_bomb",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_defuse_kit": {
+          "name": "has_defuse_kit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_positions_import_batch_id_map_id_index": {
+          "name": "demo_positions_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_positions_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_positions_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_positions",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_positions_map_id_match_maps_id_fk": {
+          "name": "demo_positions_map_id_match_maps_id_fk",
+          "tableFrom": "demo_positions",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_rounds": {
+      "name": "demo_rounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_tick": {
+          "name": "start_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freeze_end_tick": {
+          "name": "freeze_end_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_tick": {
+          "name": "end_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_side": {
+          "name": "team_a_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_b_side": {
+          "name": "team_b_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_score_before": {
+          "name": "team_a_score_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_b_score_before": {
+          "name": "team_b_score_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_economy": {
+          "name": "team_a_economy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_b_economy": {
+          "name": "team_b_economy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_team_key": {
+          "name": "winner_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_side": {
+          "name": "winner_side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_rounds_import_batch_id_map_id_index": {
+          "name": "demo_rounds_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_rounds_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_rounds_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_rounds",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_rounds_map_id_match_maps_id_fk": {
+          "name": "demo_rounds_map_id_match_maps_id_fk",
+          "tableFrom": "demo_rounds",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_shots": {
+      "name": "demo_shots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_batch_id": {
+          "name": "import_batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steam_id64": {
+          "name": "steam_id64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_key": {
+          "name": "team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "demo_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weapon": {
+          "name": "weapon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "velocity": {
+          "name": "velocity",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yaw": {
+          "name": "yaw",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch": {
+          "name": "pitch",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_shots_import_batch_id_map_id_index": {
+          "name": "demo_shots_import_batch_id_map_id_index",
+          "columns": [
+            {
+              "expression": "import_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "map_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_shots_import_batch_id_demo_imports_id_fk": {
+          "name": "demo_shots_import_batch_id_demo_imports_id_fk",
+          "tableFrom": "demo_shots",
+          "tableTo": "demo_imports",
+          "columnsFrom": [
+            "import_batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "demo_shots_map_id_match_maps_id_fk": {
+          "name": "demo_shots_map_id_match_maps_id_fk",
+          "tableFrom": "demo_shots",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "stat_profile": {
+          "name": "stat_profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"provider\":\"perfectworld\",\"inputFields\":[\"kills\",\"deaths\",\"assists\",\"hsPercent\",\"firstKills\",\"multiKills\",\"clutches\",\"adr\",\"rws\",\"ratingPro\",\"we\"],\"rankMetric\":\"ratingPro\"}'::json"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_stat_source": {
+          "name": "active_stat_source",
+          "type": "stat_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "stat_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual_ocr'"
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_source_unique": {
+          "name": "match_player_stats_map_id_perfect_name_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_ratings": {
+      "name": "player_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rr_score": {
+          "name": "rr_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rr_weights_version": {
+          "name": "rr_weights_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_firepower": {
+          "name": "prism_firepower",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_opening": {
+          "name": "prism_opening",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_clutch": {
+          "name": "prism_clutch",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_sniping": {
+          "name": "prism_sniping",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_survival": {
+          "name": "prism_survival",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_utility": {
+          "name": "prism_utility",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_trading": {
+          "name": "prism_trading",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_entry": {
+          "name": "prism_entry",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prism_weights_version": {
+          "name": "prism_weights_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_count": {
+          "name": "map_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_ratings_season_steam_uniq": {
+          "name": "player_ratings_season_steam_uniq",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "steam_id_64",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_ratings_season_id_seasons_id_fk": {
+          "name": "player_ratings_season_id_seasons_id_fk",
+          "tableFrom": "player_ratings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_ratings_user_id_users_id_fk": {
+          "name": "player_ratings_user_id_users_id_fk",
+          "tableFrom": "player_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.demo_side": {
+      "name": "demo_side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct",
+        "unknown"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.stat_source": {
+      "name": "stat_source",
+      "schema": "public",
+      "values": [
+        "manual_ocr",
+        "demo_import"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1780003787380,
       "tag": "0024_amazing_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1780057986648,
+      "tag": "0025_overrated_longshot",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.26.2",
+  "version": "1.27.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/compute-season-ratings.ts
+++ b/src/actions/compute-season-ratings.ts
@@ -1,0 +1,315 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, inArray, and, sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  seasons,
+  matches,
+  matchMaps,
+  demoImports,
+  demoPlayerStats,
+  demoBlinds,
+  demoKills,
+  demoGrenades,
+  demoPlayerEconomies,
+  auditLogs,
+  playerRatings,
+  users,
+} from "@/db/schema";
+import { ok, fail } from "@/types/action";
+import type { ActionResult } from "@/types/action";
+import { ErrorCode } from "@/lib/errors";
+import { actionError } from "@/lib/action-utils";
+import { requireSeasonAdmin, auditActorId } from "@/lib/auth/session";
+import { toRRIndicators } from "@/lib/demo/to-rr-indicators";
+import type { PlayerStatRow, BlindsRow } from "@/lib/demo/player-demo-stats";
+import { computeRR, computeLeagueMean } from "@/lib/rating/rr/compute";
+import { computePrism, rrToPercentile } from "@/lib/rating/prism/compute";
+import type { PrismComputeInput } from "@/lib/rating/prism/compute";
+import type { RRWeights } from "@/lib/rating/types/rr";
+import type { PrismWeights } from "@/lib/rating/types/prism";
+import rrWeightsRaw from "@/lib/rating/weights/rr-v1.json";
+import prismWeightsRaw from "@/lib/rating/weights/prism-v1.json";
+
+export async function recomputeSeasonRatings(
+  seasonId: string,
+): Promise<ActionResult<{ playerCount: number; weightsVersion: string }>> {
+  try {
+    const admin = await requireSeasonAdmin(seasonId);
+
+    // ── 1. 查出该赛季所有 matchMap id ─────────────────────────────────────
+    const seasonMatches = await db.query.matches.findMany({
+      where: eq(matches.seasonId, seasonId),
+      columns: { id: true },
+    });
+    if (seasonMatches.length === 0) {
+      return fail({ code: ErrorCode.NOT_FOUND, message: "该赛季暂无比赛数据" });
+    }
+
+    const matchIds = seasonMatches.map((m) => m.id);
+    const allMaps = await db.query.matchMaps.findMany({
+      where: inArray(matchMaps.matchId, matchIds),
+      columns: { id: true },
+    });
+    if (allMaps.length === 0) {
+      return fail({ code: ErrorCode.NOT_FOUND, message: "该赛季暂无地图数据" });
+    }
+
+    const mapIds = allMaps.map((m) => m.id);
+
+    // ── 2. 查出这些地图对应的 importBatchId ───────────────────────────────
+    const imports = await db.query.demoImports.findMany({
+      where: inArray(demoImports.mapId, mapIds),
+      columns: { id: true, mapId: true },
+    });
+    if (imports.length === 0) {
+      return fail({ code: ErrorCode.NOT_FOUND, message: "该赛季暂无已导入的 demo" });
+    }
+
+    const importIds = imports.map((i) => i.id);
+
+    // ── 3. 批量查出所有 demo 数据 ──────────────────────────────────────────
+    const [allStats, allBlinds, allKills, allGrenades, allEconomies] =
+      await Promise.all([
+        db.query.demoPlayerStats.findMany({
+          where: inArray(demoPlayerStats.importBatchId, importIds),
+        }),
+        db.query.demoBlinds.findMany({
+          where: inArray(demoBlinds.importBatchId, importIds),
+        }),
+        db.query.demoKills.findMany({
+          where: and(
+            inArray(demoKills.importBatchId, importIds),
+            eq(demoKills.flashAssist, true),
+          ),
+        }),
+        db.query.demoGrenades.findMany({
+          where: inArray(demoGrenades.importBatchId, importIds),
+        }),
+        db.query.demoPlayerEconomies.findMany({
+          where: inArray(demoPlayerEconomies.importBatchId, importIds),
+        }),
+      ]);
+
+    // ── 4. 按 steamId64 分组 ──────────────────────────────────────────────
+    // stats
+    const statsBySteam = new Map<string, PlayerStatRow[]>();
+    for (const s of allStats) {
+      const arr = statsBySteam.get(s.steamId64) ?? [];
+      arr.push(s as PlayerStatRow);
+      statsBySteam.set(s.steamId64, arr);
+    }
+
+    // blinds（flasher 维度）
+    const blindsBySteam = new Map<string, BlindsRow[]>();
+    for (const b of allBlinds) {
+      if (!b.flasherSteamId64) continue;
+      const arr = blindsBySteam.get(b.flasherSteamId64) ?? [];
+      arr.push(b as BlindsRow);
+      blindsBySteam.set(b.flasherSteamId64, arr);
+    }
+
+    // flashAssistCount（killerSteamId64，flashAssist=true 已在查询中过滤）
+    const flashAssistBySteam = new Map<string, number>();
+    for (const k of allKills) {
+      if (!k.killerSteamId64) continue;
+      flashAssistBySteam.set(
+        k.killerSteamId64,
+        (flashAssistBySteam.get(k.killerSteamId64) ?? 0) + 1,
+      );
+    }
+
+    // grenadeCount
+    const grenadeBySteam = new Map<string, number>();
+    for (const g of allGrenades) {
+      if (!g.throwerSteamId64) continue;
+      grenadeBySteam.set(
+        g.throwerSteamId64,
+        (grenadeBySteam.get(g.throwerSteamId64) ?? 0) + 1,
+      );
+    }
+
+    // economy per steam
+    type EcoAgg = {
+      ecoRounds: number;
+      forceRounds: number;
+      fullBuyRounds: number;
+      pistolRounds: number;
+      equipmentValueSum: number;
+      equipmentValueCount: number;
+    };
+    const ecoBySteam = new Map<string, EcoAgg>();
+    for (const e of allEconomies) {
+      const key = e.steamId64;
+      const agg = ecoBySteam.get(key) ?? {
+        ecoRounds: 0,
+        forceRounds: 0,
+        fullBuyRounds: 0,
+        pistolRounds: 0,
+        equipmentValueSum: 0,
+        equipmentValueCount: 0,
+      };
+      const t = (e.type ?? "").toLowerCase();
+      if (t === "eco") agg.ecoRounds++;
+      else if (t === "force") agg.forceRounds++;
+      else if (t === "full_buy" || t === "fullbuy") agg.fullBuyRounds++;
+      else if (t === "pistol") agg.pistolRounds++;
+      if (e.equipmentValue != null) {
+        agg.equipmentValueSum += e.equipmentValue;
+        agg.equipmentValueCount++;
+      }
+      ecoBySteam.set(key, agg);
+    }
+
+    // mapCount per steam（该选手出现在多少张不同地图中）
+    const mapCountBySteam = new Map<string, Set<string>>();
+    for (const s of allStats) {
+      const set = mapCountBySteam.get(s.steamId64) ?? new Set();
+      set.add(s.mapId);
+      mapCountBySteam.set(s.steamId64, set);
+    }
+
+    // ── 5. 查 userId 映射（steam64 → userId）─────────────────────────────
+    const steamList = [...statsBySteam.keys()];
+    const userRows = steamList.length > 0
+      ? await db.query.users.findMany({
+          where: inArray(users.steam64, steamList),
+          columns: { id: true, steam64: true },
+        })
+      : [];
+    const userIdBySteam = new Map(
+      userRows.filter((u) => u.steam64).map((u) => [u.steam64!, u.id]),
+    );
+
+    // ── 6. 计算每人的 RRIndicators 并调用 computeRR ───────────────────────
+    const rrWeights = rrWeightsRaw as unknown as RRWeights;
+    const prismWeights = prismWeightsRaw as unknown as PrismWeights;
+
+    const indicatorsList = steamList.map((steamId64) => {
+      const stats = statsBySteam.get(steamId64) ?? [];
+      const blinds = blindsBySteam.get(steamId64) ?? [];
+      const ecoAgg = ecoBySteam.get(steamId64);
+      const economy = ecoAgg
+        ? {
+            ecoRounds: ecoAgg.ecoRounds,
+            forceRounds: ecoAgg.forceRounds,
+            fullBuyRounds: ecoAgg.fullBuyRounds,
+            pistolRounds: ecoAgg.pistolRounds,
+            avgEquipmentValue:
+              ecoAgg.equipmentValueCount > 0
+                ? ecoAgg.equipmentValueSum / ecoAgg.equipmentValueCount
+                : 0,
+          }
+        : undefined;
+
+      return toRRIndicators({
+        steamId64,
+        stats,
+        blinds,
+        flashAssistCount: flashAssistBySteam.get(steamId64) ?? 0,
+        grenadeCount: grenadeBySteam.get(steamId64) ?? 0,
+        economy,
+      });
+    });
+
+    const rrResults = indicatorsList.map((ind) => computeRR(ind, rrWeights));
+
+    // ── 7. 锚定到联赛均值 ─────────────────────────────────────────────────
+    const leagueMean = computeLeagueMean(rrResults);
+    const anchoredRR = rrResults.map((r) => ({
+      ...r,
+      rr: leagueMean > 0 ? r.rr / leagueMean : r.rr,
+    }));
+
+    // ── 8. 构建 PRISM cohort 并计算 ──────────────────────────────────────
+    const allAnchored = anchoredRR.map((r) => r.rr);
+    const cohort: PrismComputeInput[] = indicatorsList.map((ind, i) => ({
+      indicators: ind,
+      mapCount: mapCountBySteam.get(ind.steamId64)?.size ?? 1,
+      rrPercentile: rrToPercentile(allAnchored, anchoredRR[i]?.rr ?? 1),
+    }));
+
+    const prismResults = computePrism(cohort, prismWeights);
+
+    // ── 9. Upsert player_ratings ──────────────────────────────────────────
+    const now = new Date();
+    const upsertRows = steamList.map((steamId64, i) => {
+      const rr = anchoredRR[i];
+      const prism = prismResults[i];
+      const mc = mapCountBySteam.get(steamId64)?.size ?? 0;
+
+      return {
+        seasonId,
+        userId: userIdBySteam.get(steamId64) ?? null,
+        steamId64,
+        rrScore: rr ? String(rr.rr.toFixed(4)) : null,
+        rrWeightsVersion: rrWeights.version,
+        prismFirepower: prism ? String(prism.axes.firepower.percentile.toFixed(2)) : null,
+        prismOpening:   prism ? String(prism.axes.opening.percentile.toFixed(2))   : null,
+        prismClutch:    prism ? String(prism.axes.clutch.percentile.toFixed(2))     : null,
+        prismSniping:   prism ? String(prism.axes.sniping.percentile.toFixed(2))    : null,
+        prismSurvival:  prism ? String(prism.axes.survival.percentile.toFixed(2))   : null,
+        prismUtility:   prism ? String(prism.axes.utility.percentile.toFixed(2))    : null,
+        prismTrading:   prism ? String(prism.axes.trading.percentile.toFixed(2))    : null,
+        prismEntry:     prism ? String(prism.axes.entry.percentile.toFixed(2))      : null,
+        prismWeightsVersion: prismWeights.version,
+        mapCount: mc,
+        computedAt: now,
+      };
+    });
+
+    if (upsertRows.length > 0) {
+      await db
+        .insert(playerRatings)
+        .values(upsertRows)
+        .onConflictDoUpdate({
+          target: [playerRatings.seasonId, playerRatings.steamId64],
+          set: {
+            userId:              sql`excluded.user_id`,
+            rrScore:             sql`excluded.rr_score`,
+            rrWeightsVersion:    sql`excluded.rr_weights_version`,
+            prismFirepower:      sql`excluded.prism_firepower`,
+            prismOpening:        sql`excluded.prism_opening`,
+            prismClutch:         sql`excluded.prism_clutch`,
+            prismSniping:        sql`excluded.prism_sniping`,
+            prismSurvival:       sql`excluded.prism_survival`,
+            prismUtility:        sql`excluded.prism_utility`,
+            prismTrading:        sql`excluded.prism_trading`,
+            prismEntry:          sql`excluded.prism_entry`,
+            prismWeightsVersion: sql`excluded.prism_weights_version`,
+            mapCount:            sql`excluded.map_count`,
+            computedAt:          sql`excluded.computed_at`,
+          },
+        });
+    }
+
+    // ── 10. 写 audit_log ──────────────────────────────────────────────────
+    await db.insert(auditLogs).values({
+      seasonId,
+      action: "season.recompute_ratings",
+      actorId: auditActorId(admin),
+      targetId: seasonId,
+      targetType: "season",
+      meta: {
+        playerCount: steamList.length,
+        rrWeightsVersion: rrWeights.version,
+        prismWeightsVersion: prismWeights.version,
+      },
+    });
+
+    // ── 11. 重新验证缓存 ──────────────────────────────────────────────────
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, seasonId),
+      columns: { slug: true },
+    });
+    if (season) {
+      revalidatePath(`/${season.slug}`);
+      revalidatePath(`/admin/${season.slug}/demos`);
+    }
+
+    return ok({ playerCount: steamList.length, weightsVersion: rrWeights.version });
+  } catch (e) {
+    return actionError("recomputeSeasonRatings", e);
+  }
+}

--- a/src/actions/demo-batch-import.ts
+++ b/src/actions/demo-batch-import.ts
@@ -1,0 +1,225 @@
+"use server";
+
+import { eq, and, inArray, asc } from "drizzle-orm";
+import { db } from "@/db/client";
+import { matchMaps } from "@/db/schema/match-maps";
+import { matches } from "@/db/schema/matches";
+import { teams } from "@/db/schema/teams";
+import { ok, type ActionResult } from "@/types/action";
+import { actionError } from "@/lib/action-utils";
+import { requireAdmin } from "@/lib/auth/session";
+
+export interface ZipManifestInfo {
+  /** zip 文件名（用于显示） */
+  fileName: string;
+  /** manifest.mapName，如 "de_ancient" */
+  mapName: string;
+  /** manifest.demo.hash */
+  demoHash: string;
+  /** match.json 里的 teamAName / teamBName */
+  teamAName?: string;
+  teamBName?: string;
+}
+
+export interface MatchResult {
+  fileName: string;
+  mapId: string | null;
+  confidence: "exact" | "fuzzy" | "none";
+  /** 显示给用户看的比赛标签，如 "NJU Rivals vs AE Falcons · de_ancient · 2026-05-29" */
+  matchLabel: string;
+  /** 有多个候选时显示 */
+  candidates: { mapId: string; label: string }[];
+}
+
+export async function matchZipsToMaps(
+  seasonId: string,
+  zips: ZipManifestInfo[],
+): Promise<ActionResult<MatchResult[]>> {
+  try {
+    await requireAdmin();
+
+    if (zips.length === 0) {
+      return ok([]);
+    }
+
+    // 查询该赛季所有 finished 比赛及其 matchMaps
+    const finishedMatches = await db.query.matches.findMany({
+      where: and(
+        eq(matches.seasonId, seasonId),
+        eq(matches.status, "finished"),
+      ),
+      orderBy: [asc(matches.completedAt)],
+    });
+
+    if (finishedMatches.length === 0) {
+      return ok(
+        zips.map((z) => ({
+          fileName: z.fileName,
+          mapId: null,
+          confidence: "none" as const,
+          matchLabel: "",
+          candidates: [],
+        })),
+      );
+    }
+
+    const matchIds = finishedMatches.map((m) => m.id);
+
+    const allMaps = await db.query.matchMaps.findMany({
+      where: inArray(matchMaps.matchId, matchIds),
+      orderBy: [asc(matchMaps.matchId), asc(matchMaps.mapOrder)],
+    });
+
+    const allTeamIds = Array.from(
+      new Set(finishedMatches.flatMap((m) => [m.teamAId, m.teamBId])),
+    );
+
+    const allTeams =
+      allTeamIds.length > 0
+        ? await db.query.teams.findMany({
+            where: inArray(teams.id, allTeamIds),
+          })
+        : [];
+
+    const teamNameById = new Map(allTeams.map((t) => [t.id, t.name]));
+    const matchById = new Map(finishedMatches.map((m) => [m.id, m]));
+
+    interface Candidate {
+      mapId: string;
+      mapName: string;
+      completedAt: Date | null;
+      teamAName: string;
+      teamBName: string;
+      label: string;
+    }
+
+    const candidates: Candidate[] = allMaps.map((mm) => {
+      const match = matchById.get(mm.matchId)!;
+      const teamAName = teamNameById.get(match.teamAId) ?? "队伍 A";
+      const teamBName = teamNameById.get(match.teamBId) ?? "队伍 B";
+      const dateStr = mm.completedAt
+        ? mm.completedAt.toISOString().slice(0, 10)
+        : (match.completedAt?.toISOString().slice(0, 10) ?? "未知日期");
+      const label = `${teamAName} vs ${teamBName} · ${mm.mapName} · ${dateStr}`;
+      return {
+        mapId: mm.id,
+        mapName: mm.mapName,
+        completedAt: mm.completedAt ?? match.completedAt ?? null,
+        teamAName,
+        teamBName,
+        label,
+      };
+    });
+
+    const results: MatchResult[] = zips.map((zip) => {
+      // 先按 mapName 过滤
+      const byMap = candidates.filter(
+        (c) => c.mapName.toLowerCase() === zip.mapName.toLowerCase(),
+      );
+
+      if (byMap.length === 0) {
+        return {
+          fileName: zip.fileName,
+          mapId: null,
+          confidence: "none" as const,
+          matchLabel: "",
+          candidates: [],
+        };
+      }
+
+      // 精确匹配：mapName 一致 + 队名 contains 匹配（不区分大小写）
+      const exactMatches =
+        zip.teamAName && zip.teamBName
+          ? byMap.filter((c) => {
+              const tA = zip.teamAName!.toLowerCase();
+              const tB = zip.teamBName!.toLowerCase();
+              const cA = c.teamAName.toLowerCase();
+              const cB = c.teamBName.toLowerCase();
+              // 正向匹配：A↔A, B↔B，或者 A↔B, B↔A（队伍顺序可能不同）
+              return (
+                ((cA.includes(tA) || tA.includes(cA)) &&
+                  (cB.includes(tB) || tB.includes(cB))) ||
+                ((cA.includes(tB) || tB.includes(cA)) &&
+                  (cB.includes(tA) || tA.includes(cB)))
+              );
+            })
+          : [];
+
+      if (exactMatches.length === 1) {
+        return {
+          fileName: zip.fileName,
+          mapId: exactMatches[0].mapId,
+          confidence: "exact" as const,
+          matchLabel: exactMatches[0].label,
+          candidates: [],
+        };
+      }
+
+      if (exactMatches.length > 1) {
+        return {
+          fileName: zip.fileName,
+          mapId: null,
+          confidence: "fuzzy" as const,
+          matchLabel: "",
+          candidates: exactMatches.map((c) => ({ mapId: c.mapId, label: c.label })),
+        };
+      }
+
+      // 模糊匹配：mapName 一致，用队名做二次收窄
+      const narrowed =
+        zip.teamAName || zip.teamBName
+          ? byMap.filter((c) => {
+              const tA = (zip.teamAName ?? "").toLowerCase();
+              const tB = (zip.teamBName ?? "").toLowerCase();
+              const cA = c.teamAName.toLowerCase();
+              const cB = c.teamBName.toLowerCase();
+              if (tA && tB) {
+                return (
+                  (cA.includes(tA) || tA.includes(cA) ||
+                    cB.includes(tA) || tA.includes(cB)) ||
+                  (cA.includes(tB) || tB.includes(cA) ||
+                    cB.includes(tB) || tB.includes(cB))
+                );
+              }
+              if (tA) {
+                return (
+                  cA.includes(tA) || tA.includes(cA) ||
+                  cB.includes(tA) || tA.includes(cB)
+                );
+              }
+              if (tB) {
+                return (
+                  cA.includes(tB) || tB.includes(cA) ||
+                  cB.includes(tB) || tB.includes(cB)
+                );
+              }
+              return true;
+            })
+          : byMap;
+
+      const pool = narrowed.length > 0 ? narrowed : byMap;
+
+      if (pool.length === 1) {
+        return {
+          fileName: zip.fileName,
+          mapId: pool[0].mapId,
+          confidence: "fuzzy" as const,
+          matchLabel: pool[0].label,
+          candidates: [],
+        };
+      }
+
+      return {
+        fileName: zip.fileName,
+        mapId: null,
+        confidence: "fuzzy" as const,
+        matchLabel: "",
+        candidates: pool.map((c) => ({ mapId: c.mapId, label: c.label })),
+      };
+    });
+
+    return ok(results);
+  } catch (e) {
+    return actionError("matchZipsToMaps", e);
+  }
+}

--- a/src/actions/demo-import.ts
+++ b/src/actions/demo-import.ts
@@ -21,7 +21,6 @@ import { parseDemoPackage } from "@/lib/demo/parse-package";
 import { mapDemoPlayers } from "@/lib/demo/map-players";
 import { toMatchPlayerStat, type DemoStatInput } from "@/lib/demo/to-match-player-stats";
 import { batchInsert } from "@/lib/demo/batch-insert";
-import { computeHltvRating } from "@/lib/demo/hltv-rating";
 import { seasons } from "@/db/schema/seasons";
 
 type DemoSideVal = "t" | "ct" | "unknown";
@@ -384,14 +383,6 @@ export async function importDemoPackage(
           const name = steamIdToName.get(steamId) ?? steamId;
           const uid = steamIdToUserIdMap.get(steamId) ?? null;
           const row = toMatchPlayerStat(s as DemoStatInput, name, uid);
-          const ratingPro = computeHltvRating({
-            kills: s.kills as number ?? 0,
-            deaths: s.deaths as number ?? 0,
-            assists: s.assists as number ?? 0,
-            kast: s.kast as number ?? 50,
-            adr: s.adr as number ?? 0,
-            totalRounds: rounds.length,
-          });
           return {
             matchId: map.matchId,
             mapId,
@@ -407,7 +398,6 @@ export async function importDemoPackage(
             clutches: row.clutches ?? undefined,
             source: row.source,
             verifiedByAdmin: actor,
-            ratingPro,
           };
         });
         for (const row of backfillRows) {
@@ -424,7 +414,6 @@ export async function importDemoPackage(
               clutches: row.clutches,
               userId: row.userId,
               verifiedByAdmin: row.verifiedByAdmin,
-              ratingPro: row.ratingPro,
             },
           });
         }

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -306,10 +306,23 @@ async function autoAcceptExpiredProposals(
       eq(matchTimeProposals.status, "pending"),
       lte(matchTimeProposals.createdAt, expiredBefore),
     ),
+    orderBy: (tps, { asc }) => [asc(tps.createdAt)],
   });
 
+  // 同一场比赛可能有多条 24h+ 的 pending 提议（都等待对方响应）。
+  // 并行处理同场提议会导致 FOR UPDATE 锁竞争——哪条先抢到锁哪条被采纳，
+  // 非确定性地可能选中更晚的提议而非最早的。
+  // 修复：按 matchId 分组，每场只取 createdAt 最早的一条，顺序处理各场比赛。
+  const earliestByMatch = new Map<string, typeof expiredProposals[number]>();
+  for (const p of expiredProposals) {
+    if (!earliestByMatch.has(p.matchId)) {
+      earliestByMatch.set(p.matchId, p); // 已按 asc(createdAt) 排序，第一条即最早
+    }
+  }
+  const toProcess = Array.from(earliestByMatch.values());
+
   const settled = await Promise.allSettled(
-    expiredProposals.map((p) => autoAcceptSingleProposal(p.id, p.matchId, now)),
+    toProcess.map((p) => autoAcceptSingleProposal(p.id, p.matchId, now)),
   );
 
   let awarded = 0;
@@ -320,7 +333,7 @@ async function autoAcceptExpiredProposals(
     if (item.value) { awarded += 1; } else { skipped += 1; }
   }
 
-  return { processed: expiredProposals.length, awarded, skipped, failed };
+  return { processed: toProcess.length, awarded, skipped, failed };
 }
 
 async function autoAcceptSingleProposal(

--- a/src/app/[seasonSlug]/players/page.tsx
+++ b/src/app/[seasonSlug]/players/page.tsx
@@ -36,6 +36,8 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
   const season = await getSeason(seasonSlug);
   if (!season) notFound();
 
+  const showRatingPro = season.statProfile.inputFields.includes("ratingPro");
+
   const whereConditions = position
     ? and(
         eq(seasonRegistrations.seasonId, season.id),
@@ -100,8 +102,19 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
     WHERE m.season_id = ${season.id}
       AND mps.verified_by_admin IS NOT NULL
       AND mps.user_id IS NOT NULL
+      AND mps.source = COALESCE(mm2.active_stat_source, 'manual_ocr'::stat_source)
     GROUP BY mps.user_id
   `);
+  // RR 评分（from player_ratings，本赛季）
+  const rrResult = await db.execute(sql`
+    SELECT user_id, rr_score
+    FROM player_ratings
+    WHERE season_id = ${season.id} AND user_id IS NOT NULL AND rr_score IS NOT NULL
+  `);
+  const rrByUserId = new Map(
+    rrResult.rows.map((row) => [row.user_id as string, Number(row.rr_score)]),
+  );
+
   const statsByUserId = new Map(
     playerStatResult.rows.map((row) => [
       row.user_id as string,
@@ -110,6 +123,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
         avgRating: Number(row.avg_rating),
         avgAdr: Number(row.avg_adr),
         avgKd: row.avg_kd == null ? null : Number(row.avg_kd),
+        avgRr: rrByUserId.get(row.user_id as string) ?? null,
       },
     ]),
   );
@@ -177,6 +191,7 @@ export default async function PlayersPage({ params, searchParams }: PlayersPageP
             <PlayerDirectoryRow
               key={player.registrationId}
               player={player}
+              showRatingPro={showRatingPro}
             />
           ))}
         </div>

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import { eq } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons } from "@/db/schema";
+import { seasons, playerRatings } from "@/db/schema";
 import { sql } from "drizzle-orm";
 import { StatsLeaderboard } from "@/components/matches/StatsLeaderboard";
 import { WeaponLeaderboard } from "@/components/matches/WeaponLeaderboard";
@@ -77,6 +77,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
       case "mk":     return mkprExpr;
       case "clutch": return cprExpr;
       case "maps":   return sql`count(*)`;
+      case "rr":     return sql`(SELECT rr_score FROM player_ratings WHERE season_id = ${season.id} AND user_id = mps.user_id LIMIT 1)`;
       default:       return sql`avg(mps.rating_pro)`;
     }
   })();
@@ -144,6 +145,19 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     cpr:        toNum(r.cpr),
   }));
 
+  // 查询 RR 评分（from player_ratings）
+  const userIds = leaderboardRows.map((r) => r.userId).filter((id): id is string => id != null);
+  const rrMap = new Map<string, number | null>();
+  if (userIds.length > 0) {
+    const rrRows = await db
+      .select({ userId: playerRatings.userId, rrScore: playerRatings.rrScore })
+      .from(playerRatings)
+      .where(and(eq(playerRatings.seasonId, season.id), inArray(playerRatings.userId, userIds)));
+    for (const r of rrRows) {
+      if (r.userId) rrMap.set(r.userId, r.rrScore != null ? Number(r.rrScore) : null);
+    }
+  }
+
   // 将 Demo 源数据 merge 进 leaderboardRows（按 userId 匹配）
   const demoMap = new Map<string, DemoLeaderboardData>();
   for (const d of demoStats) {
@@ -151,9 +165,11 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
   }
   const mergedRows = leaderboardRows.map((r) => {
     const demo = r.userId ? demoMap.get(r.userId) : undefined;
-    if (!demo) return r;
+    const rrScore = r.userId != null ? (rrMap.get(r.userId) ?? null) : null;
+    const base = { ...r, rrScore };
+    if (!demo) return base;
     return {
-      ...r,
+      ...base,
       avgDemoKast: demo.kast ?? undefined,
       avgDemoAdr: demo.adr ?? undefined,
       demoFkpr: demo.fkpr,

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { eq, or, and, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, teams, teamMembers, seasonRegistrations, users, matches } from "@/db/schema";
+import { seasons, teams, teamMembers, seasonRegistrations, users, matches, playerRatings } from "@/db/schema";
 import { Panel, Stat, Marker, PosChip, Btn } from "@/components/rivalhub";
 import { MatchCard } from "@/components/matches/MatchCard";
 import { MapPreferenceChips } from "@/components/rivalhub/MapPreferenceChips";
@@ -160,7 +160,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     ? await db.execute(sql`
         SELECT
           mps.user_id,
-          count(*)::int                                                                              AS maps,
+          count(distinct mps.map_id)::int                                                            AS maps,
           round(avg(mps.rating_pro)::numeric, 2)                                                    AS avg_rating,
           round(
             CASE WHEN sum(mm2.score_a + mm2.score_b) > 0
@@ -180,6 +180,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         JOIN team_members tm ON tm.registration_id = sr.id
         WHERE tm.team_id = ${teamId}
           AND mps.verified_by_admin IS NOT NULL
+          AND mps.source = COALESCE(mm2.active_stat_source, 'manual_ocr'::stat_source)
         GROUP BY mps.user_id
       `)
     : null;
@@ -197,8 +198,20 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   }
   const typedStats = (teamStatResult?.rows ?? []) as unknown as TeamStatRow[];
 
+  // RR 评分（from player_ratings，本赛季）
+  const teamRrRows = roster.length ? await db
+    .select({ userId: playerRatings.userId, rrScore: playerRatings.rrScore })
+    .from(playerRatings)
+    .where(
+      and(
+        eq(playerRatings.seasonId, season.id),
+        inArray(playerRatings.userId, roster.map((p) => p.userId).filter(Boolean) as string[]),
+      ),
+    ) : [];
+  const rrMap = new Map(teamRrRows.map((r) => [r.userId!, r.rrScore != null ? Number(r.rrScore) : null]));
+
   // 选手数据 map（用于阵容内联显示）
-  interface PlayerStats { maps: number; avgRating: number; avgAdr: number; kdRatio: number | null }
+  interface PlayerStats { maps: number; avgRating: number; avgAdr: number; kdRatio: number | null; rrScore: number | null }
   const playerStatsMap = new Map<string, PlayerStats>();
   for (const r of typedStats) {
     if (r.user_id) {
@@ -207,6 +220,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         avgRating: Number(r.avg_rating),
         avgAdr: Number(r.avg_adr),
         kdRatio: r.kd_ratio != null ? Number(r.kd_ratio) : null,
+        rrScore: rrMap.get(r.user_id as string) ?? null,
       });
     }
   }
@@ -243,6 +257,10 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
   const teamAvgKd = totalD > 0 ? (totalK / totalD).toFixed(2) : null;
   const teamAvgWe = hasStats && totalRoundsSum > 0
     ? (typedStats.reduce((s, r) => s + Number(r.avg_we) * Number(r.total_rounds), 0) / totalRoundsSum).toFixed(1)
+    : null;
+  const teamRrValues = [...playerStatsMap.values()].map((s) => s.rrScore).filter((v): v is number => v != null);
+  const teamAvgRr = teamRrValues.length > 0
+    ? (teamRrValues.reduce((s, v) => s + v, 0) / teamRrValues.length).toFixed(2)
     : null;
 
   return (
@@ -286,10 +304,10 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         <Stat label="胜率" value={winRate} />
         {teamAvgRating && (
           <>
-            <Stat label="场均 Rating" value={teamAvgRating} accent />
+            <Stat label="场均 RR" value={teamAvgRr ?? "—"} accent />
+            <Stat label="场均 Rating Pro" value={teamAvgRating} />
             <Stat label="场均 ADR" value={teamAvgAdr ?? "—"} accent />
-            <Stat label="场均 K/D" value={teamAvgKd ?? "—"} accent />
-            <Stat label="场均 WE" value={teamAvgWe ?? "—"} accent />
+            <Stat label="场均 K/D" value={teamAvgKd ?? "—"} />
           </>
         )}
       </div>
@@ -320,8 +338,16 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                         <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5 text-[11px] text-[var(--color-fg-mid)] tabular-nums">
                           <span>{stats.maps}图</span>
                           <span className="text-[var(--color-fg-dim)]">·</span>
-                          <span style={stats.avgRating >= 1.2 ? { color: "var(--color-accent)" } : undefined}>
-                            {stats.avgRating.toFixed(2)} RT
+                          {stats.rrScore != null && (
+                            <>
+                              <span style={{ color: "var(--color-accent)" }} className="font-semibold">
+                                RR {stats.rrScore.toFixed(2)}
+                              </span>
+                              <span className="text-[var(--color-fg-dim)]">·</span>
+                            </>
+                          )}
+                          <span>
+                            {stats.avgRating.toFixed(2)} Rating Pro
                           </span>
                           <span className="text-[var(--color-fg-dim)]">·</span>
                           <span>{stats.avgAdr.toFixed(1)} ADR</span>

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -24,6 +24,8 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
   ]);
   if (!season) notFound();
 
+  const showRatingPro = season.statProfile.inputFields.includes("ratingPro");
+
   const allTeams = await db.query.teams.findMany({
     where: eq(teams.seasonId, season.id),
     orderBy: [asc(teams.draftOrder)],
@@ -80,6 +82,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       JOIN team_members tm ON tm.registration_id = sr.id
       WHERE m.season_id = ${season.id}
         AND mps.verified_by_admin IS NOT NULL
+        AND mps.source = COALESCE(mm2.active_stat_source, 'manual_ocr'::stat_source)
       GROUP BY tm.team_id
     `),
   ]);
@@ -112,6 +115,22 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
     });
   }
 
+  // 队伍 RR 均值（from player_ratings，按赛季成员聚合）
+  const teamRrResult = await db.execute(sql`
+    SELECT tm.team_id, round(avg(pr.rr_score)::numeric, 2) AS avg_rr
+    FROM player_ratings pr
+    JOIN season_registrations sr ON sr.user_id = pr.user_id AND sr.season_id = pr.season_id
+    JOIN team_members tm ON tm.registration_id = sr.id
+    WHERE pr.season_id = ${season.id} AND pr.rr_score IS NOT NULL
+    GROUP BY tm.team_id
+  `);
+  const teamRrMap = new Map(
+    teamRrResult.rows.map((row) => [
+      row.team_id as string,
+      row.avg_rr == null ? null : Number(row.avg_rr),
+    ]),
+  );
+
   const teamSummaryMap = new Map(
     teamStatResult.rows.map((row) => [
       row.team_id as string,
@@ -119,6 +138,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
         maps: Number(row.maps),
         avgRating: Number(row.avg_rating),
         avgAdr: Number(row.avg_adr),
+        avgRr: teamRrMap.get(row.team_id as string) ?? null,
       },
     ]),
   );
@@ -215,6 +235,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
               players={members}
               record={teamRecordMap.get(team.id)}
               summary={teamSummaryMap.get(team.id) ?? null}
+              showRatingPro={showRatingPro}
             />
           );
         })}

--- a/src/app/admin/[seasonSlug]/demos/page.tsx
+++ b/src/app/admin/[seasonSlug]/demos/page.tsx
@@ -5,6 +5,7 @@ import { seasons, matches, teams, matchMaps, demoImports } from "@/db/schema";
 import { requireSeasonAdmin } from "@/lib/auth/session";
 import { mapLabel } from "@/lib/maps";
 import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
+import { RecomputeRatingsButton } from "@/components/admin/RecomputeRatingsButton";
 import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
@@ -82,6 +83,10 @@ export default async function AdminDemosPage({ params }: PageProps) {
       <p className="text-sm text-[var(--color-fg-dim)]">
         共 {finishedMatches.length} 场已结束比赛
       </p>
+
+      <div className="flex justify-end">
+        <RecomputeRatingsButton seasonId={season.id} />
+      </div>
 
       <div className="space-y-4">
         {finishedMatches.map((m) => {

--- a/src/app/admin/[seasonSlug]/demos/page.tsx
+++ b/src/app/admin/[seasonSlug]/demos/page.tsx
@@ -5,6 +5,7 @@ import { seasons, matches, teams, matchMaps, demoImports } from "@/db/schema";
 import { requireSeasonAdmin } from "@/lib/auth/session";
 import { mapLabel } from "@/lib/maps";
 import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
+import { DemoBatchImportPanel } from "@/components/admin/DemoBatchImportPanel";
 import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
@@ -74,6 +75,20 @@ export default async function AdminDemosPage({ params }: PageProps) {
     mapsByMatch.set(map.matchId, arr);
   }
 
+  // 组装 availableMaps 供批量导入面板使用
+  const availableMaps = allMaps.map((mm) => {
+    const match = finishedMatches.find((m) => m.id === mm.matchId)!;
+    const teamAName = teamMap.get(match.teamAId) ?? "队伍 A";
+    const teamBName = teamMap.get(match.teamBId) ?? "队伍 B";
+    const dateStr = mm.completedAt
+      ? mm.completedAt.toISOString().slice(0, 10)
+      : (match.completedAt?.toISOString().slice(0, 10) ?? "未知日期");
+    return {
+      mapId: mm.id,
+      label: `${teamAName} vs ${teamBName} · ${mm.mapName} · ${dateStr}`,
+    };
+  });
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold text-[var(--color-fg)]">
@@ -82,6 +97,16 @@ export default async function AdminDemosPage({ params }: PageProps) {
       <p className="text-sm text-[var(--color-fg-dim)]">
         共 {finishedMatches.length} 场已结束比赛
       </p>
+
+      {/* 批量导入折叠区域 */}
+      <details className="rounded-lg border border-[var(--color-border)] overflow-hidden">
+        <summary className="cursor-pointer px-4 py-3 bg-[var(--color-surface-raised)] font-medium text-sm select-none hover:bg-[var(--color-surface-hover)] transition-colors">
+          批量导入 Demo
+        </summary>
+        <div className="px-4 py-4">
+          <DemoBatchImportPanel seasonId={season.id} availableMaps={availableMaps} />
+        </div>
+      </details>
 
       <div className="space-y-4">
         {finishedMatches.map((m) => {

--- a/src/app/admin/[seasonSlug]/demos/page.tsx
+++ b/src/app/admin/[seasonSlug]/demos/page.tsx
@@ -6,6 +6,7 @@ import { requireSeasonAdmin } from "@/lib/auth/session";
 import { mapLabel } from "@/lib/maps";
 import { DemoImportPanel } from "@/components/admin/DemoImportPanel";
 import { DemoBatchImportPanel } from "@/components/admin/DemoBatchImportPanel";
+import { RecomputeRatingsButton } from "@/components/admin/RecomputeRatingsButton";
 import { MATCH_FORMAT_LABELS } from "@/types/match";
 import Link from "next/link";
 
@@ -107,6 +108,11 @@ export default async function AdminDemosPage({ params }: PageProps) {
           <DemoBatchImportPanel seasonId={season.id} availableMaps={availableMaps} />
         </div>
       </details>
+
+      {/* 评分重算 */}
+      <div className="flex justify-end">
+        <RecomputeRatingsButton seasonId={season.id} />
+      </div>
 
       <div className="space-y-4">
         {finishedMatches.map((m) => {

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -16,6 +16,7 @@ import { wAvg } from "@/lib/utils/stats";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import type { HexagonScores } from "@/lib/utils/hexagon";
 import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";
+import { RadarChart, PRISM_AXES, type PrismScores } from "@/components/matches/RadarChart";
 
 /**
  * 统计玩家 MVP 获胜次数（从 matches.mvp_winner_user_id 直读，已持久化缓存）。
@@ -125,6 +126,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         and(
           eq(matchPlayerStats.userId, userId),
           sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+          sql`${matchPlayerStats.source} = COALESCE(${matchMaps.activeStatSource}, 'manual_ocr'::stat_source)`,
         )
       )
       .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
@@ -142,16 +144,41 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
     })
   );
 
-  // ── RR 评分（from player_ratings，各赛季）────────────────────────────
-  const rrBySeasonId = new Map<string, { rrScore: number | null; mapCount: number }>();
+  // ── RR + PRISM 评分（from player_ratings，各赛季）────────────────────
+  const rrBySeasonId = new Map<string, { rrScore: number | null; mapCount: number; prism: PrismScores | null }>();
   if (registrations.length > 0) {
     const seasonIds = registrations.map(r => r.seasonId);
     const rrRows = await db
-      .select({ seasonId: playerRatings.seasonId, rrScore: playerRatings.rrScore, mapCount: playerRatings.mapCount })
+      .select({
+        seasonId: playerRatings.seasonId,
+        rrScore: playerRatings.rrScore,
+        mapCount: playerRatings.mapCount,
+        prismFirepower: playerRatings.prismFirepower,
+        prismOpening: playerRatings.prismOpening,
+        prismClutch: playerRatings.prismClutch,
+        prismSniping: playerRatings.prismSniping,
+        prismSurvival: playerRatings.prismSurvival,
+        prismUtility: playerRatings.prismUtility,
+        prismTrading: playerRatings.prismTrading,
+        prismEntry: playerRatings.prismEntry,
+      })
       .from(playerRatings)
       .where(and(eq(playerRatings.userId, userId), inArray(playerRatings.seasonId, seasonIds)));
     for (const r of rrRows) {
-      rrBySeasonId.set(r.seasonId, { rrScore: r.rrScore ? Number(r.rrScore) : null, mapCount: r.mapCount });
+      const hasPrism = r.prismFirepower != null;
+      const prism: PrismScores | null = hasPrism
+        ? {
+            firepower: Number(r.prismFirepower),
+            opening: Number(r.prismOpening),
+            clutch: Number(r.prismClutch),
+            sniping: Number(r.prismSniping),
+            survival: Number(r.prismSurvival),
+            utility: Number(r.prismUtility),
+            trading: Number(r.prismTrading),
+            entry: Number(r.prismEntry),
+          }
+        : null;
+      rrBySeasonId.set(r.seasonId, { rrScore: r.rrScore ? Number(r.rrScore) : null, mapCount: r.mapCount, prism });
     }
   }
 
@@ -226,6 +253,17 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   const totalClutchesAll = playerStats.reduce((s, x) => s + x.totalClutches, 0);
   const totalRoundsAll = playerStats.reduce((s, x) => s + (x as any).totalRounds, 0);
   const mvpCount = mvpWinCount;
+
+  // 生涯 RR：各赛季 rrScore 按 mapCount 加权
+  let rrSum = 0;
+  let rrMaps = 0;
+  for (const { rrScore, mapCount } of rrBySeasonId.values()) {
+    if (rrScore != null && mapCount > 0) {
+      rrSum += rrScore * mapCount;
+      rrMaps += mapCount;
+    }
+  }
+  const careerRr = rrMaps > 0 ? (rrSum / rrMaps).toFixed(2) : "—";
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-3xl space-y-10">
@@ -354,7 +392,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             </span>
             <div className="grid grid-cols-4 sm:grid-cols-5 gap-3 text-center mt-3">
               {[
-                { label: "Rating", value: wAvg(playerStats, "avgRating", 2) },
+                { label: "RR", value: careerRr },
                 { label: "ADR", value: wAvg(playerStats, "avgAdr") },
                 { label: "RWS", value: wAvg(playerStats, "avgRws", 2) },
                 {
@@ -404,7 +442,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
                 {ps.avgRating != null && (
                   <span>
-                    完美 Rating{" "}
+                    Rating Pro{" "}
                     <span className="text-[var(--color-accent)] font-semibold">
                       {ps.avgRating}
                     </span>
@@ -446,27 +484,42 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
             </Panel>
           ))}
 
-          {/* 六维能力图 */}
-          {hexagonBySeasonSlug.size > 0 && (
+          {/* 能力雷达图：有 demo 数据走 PRISM 八维，否则回退六维 */}
+          {(hexagonBySeasonSlug.size > 0 ||
+            [...rrBySeasonId.values()].some((v) => v.prism)) && (
             <div className="space-y-3 mt-4">
-              <SectionHeading>六维能力图</SectionHeading>
+              <SectionHeading>能力雷达图</SectionHeading>
               {[...playerStats].reverse().map((ps) => {
-                const scores = hexagonBySeasonSlug.get(ps.seasonSlug);
-                if (!scores) return null;
+                const prism = rrBySeasonId.get(ps.seasonId)?.prism ?? null;
+                const hex = hexagonBySeasonSlug.get(ps.seasonSlug);
+                if (!prism && !hex) return null;
                 return (
                   <Panel key={ps.seasonSlug} pad={16}>
-                    <div className="text-xs font-semibold text-[var(--color-fg-mid)] mb-3">
-                      {ps.seasonName}
+                    <div className="flex items-center gap-2 mb-3">
+                      <span className="text-xs font-semibold text-[var(--color-fg-mid)]">
+                        {ps.seasonName}
+                      </span>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-panel-hi)] text-[var(--color-fg-dim)]">
+                        {prism ? "PRISM 八维" : "六维"}
+                      </span>
                     </div>
-                    <PlayerRadarChart
-                      players={[{ name: getDisplayName(user), scores, color: "var(--color-accent)" }]}
-                      size={280}
-                    />
+                    {prism ? (
+                      <RadarChart
+                        axes={PRISM_AXES}
+                        series={[{ name: getDisplayName(user), scores: prism as unknown as Record<string, number>, color: "var(--color-accent)" }]}
+                        size={280}
+                      />
+                    ) : (
+                      <PlayerRadarChart
+                        players={[{ name: getDisplayName(user), scores: hex!, color: "var(--color-accent)" }]}
+                        size={280}
+                      />
+                    )}
                   </Panel>
                 );
               })}
               <p className="text-[11px] text-[var(--color-fg-dim)] px-1 leading-relaxed">
-                六维评分在本赛事内标准化，适合同一赛事内横向比较，不建议跨赛事直接对比。
+                雷达图在本赛事内标准化（PRISM 为 demo cohort 百分位），适合同一赛事内横向比较，不建议跨赛事直接对比。
               </p>
             </div>
           )}

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { POSITION_LABELS } from "@/lib/validators/registration";
 import { matchPlayerStats } from "@/db/schema/player-stats";
+import { playerRatings } from "@/db/schema";
 import { wAvg } from "@/lib/utils/stats";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import type { HexagonScores } from "@/lib/utils/hexagon";
@@ -140,6 +141,19 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       if (s) hexagonBySeasonSlug.set(ps.seasonSlug, s);
     })
   );
+
+  // ── RR 评分（from player_ratings，各赛季）────────────────────────────
+  const rrBySeasonId = new Map<string, { rrScore: number | null; mapCount: number }>();
+  if (registrations.length > 0) {
+    const seasonIds = registrations.map(r => r.seasonId);
+    const rrRows = await db
+      .select({ seasonId: playerRatings.seasonId, rrScore: playerRatings.rrScore, mapCount: playerRatings.mapCount })
+      .from(playerRatings)
+      .where(and(eq(playerRatings.userId, userId), inArray(playerRatings.seasonId, seasonIds)));
+    for (const r of rrRows) {
+      rrBySeasonId.set(r.seasonId, { rrScore: r.rrScore ? Number(r.rrScore) : null, mapCount: r.mapCount });
+    }
+  }
 
   // ── 队伍归属（registrationId → team）────────────────────────────────
   const allRegIds = registrations.map((r) => r.id);
@@ -388,12 +402,22 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
                 </span>
               </div>
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
-                <span>
-                  Rating{" "}
-                  <span className="text-[var(--color-accent)] font-semibold">
-                    {ps.avgRating}
+                {ps.avgRating != null && (
+                  <span>
+                    完美 Rating{" "}
+                    <span className="text-[var(--color-accent)] font-semibold">
+                      {ps.avgRating}
+                    </span>
                   </span>
-                </span>
+                )}
+                {(() => {
+                  const rr = rrBySeasonId.get(ps.seasonId);
+                  return rr?.rrScore != null ? (
+                    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold" style={{ background: "var(--color-accent)", color: "#fff" }}>
+                      RR {rr.rrScore.toFixed(2)}
+                    </span>
+                  ) : null;
+                })()}
                 <span>
                   ADR{" "}
                   <span className="text-[var(--color-fg)]">{ps.avgAdr}</span>

--- a/src/components/admin/DemoBatchImportPanel.tsx
+++ b/src/components/admin/DemoBatchImportPanel.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useState, useRef } from "react";
+import JSZip from "jszip";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { importDemoPackage } from "@/actions/demo-import";
+import {
+  matchZipsToMaps,
+  type ZipManifestInfo,
+  type MatchResult,
+} from "@/actions/demo-batch-import";
+
+interface Props {
+  seasonId: string;
+  availableMaps: { mapId: string; label: string }[];
+}
+
+interface RowState {
+  fileName: string;
+  mapId: string | null;
+  confidence: MatchResult["confidence"];
+  matchLabel: string;
+  candidates: { mapId: string; label: string }[];
+  zipBuffer: ArrayBuffer;
+  importStatus: "pending" | "importing" | "success" | "error";
+  errorMessage?: string;
+}
+
+export function DemoBatchImportPanel({ seasonId, availableMaps }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [rows, setRows] = useState<RowState[]>([]);
+  const [matching, setMatching] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  async function handleMatch() {
+    const files = fileRef.current?.files;
+    if (!files || files.length === 0) {
+      toast.error("请先选择 .zip 文件");
+      return;
+    }
+
+    setMatching(true);
+    setRows([]);
+    setProgress(null);
+
+    try {
+      const infos: ZipManifestInfo[] = [];
+      const buffers: ArrayBuffer[] = [];
+
+      for (const file of Array.from(files)) {
+        const buf = await file.arrayBuffer();
+        buffers.push(buf);
+
+        let mapName = "";
+        let demoHash = "";
+        let teamAName: string | undefined;
+        let teamBName: string | undefined;
+
+        try {
+          const zip = await JSZip.loadAsync(buf);
+
+          const manifestFile = zip.file("manifest.json");
+          if (manifestFile) {
+            const text = await manifestFile.async("string");
+            const manifest = JSON.parse(text) as Record<string, unknown>;
+            mapName = (manifest.mapName as string | undefined) ?? "";
+            demoHash =
+              ((manifest.demo as Record<string, unknown> | undefined)
+                ?.hash as string | undefined) ?? "";
+          }
+
+          const matchFile = zip.file("match.json");
+          if (matchFile) {
+            const text = await matchFile.async("string");
+            const matchJson = JSON.parse(text) as Record<string, unknown>;
+            teamAName = matchJson.teamAName as string | undefined;
+            teamBName = matchJson.teamBName as string | undefined;
+          }
+        } catch {
+          // zip 解析失败，继续（mapName 为空会得到 none 匹配）
+        }
+
+        infos.push({ fileName: file.name, mapName, demoHash, teamAName, teamBName });
+      }
+
+      const result = await matchZipsToMaps(seasonId, infos);
+
+      if (!result.success) {
+        toast.error(result.error.message);
+        return;
+      }
+
+      const newRows: RowState[] = result.data.map((r, i) => ({
+        fileName: r.fileName,
+        mapId: r.mapId,
+        confidence: r.confidence,
+        matchLabel: r.matchLabel,
+        candidates: r.candidates,
+        zipBuffer: buffers[i],
+        importStatus: "pending",
+      }));
+
+      setRows(newRows);
+    } catch {
+      toast.error("解析文件失败，请检查文件格式");
+    } finally {
+      setMatching(false);
+    }
+  }
+
+  function handleSelectMap(rowIndex: number, mapId: string) {
+    setRows((prev) =>
+      prev.map((r, i) => {
+        if (i !== rowIndex) return r;
+        const candidate =
+          r.candidates.find((c) => c.mapId === mapId) ??
+          availableMaps.find((c) => c.mapId === mapId);
+        return {
+          ...r,
+          mapId,
+          matchLabel: candidate?.label ?? mapId,
+        };
+      }),
+    );
+  }
+
+  async function handleImportAll() {
+    const toImport = rows.filter((r) => r.mapId !== null);
+    if (toImport.length === 0) {
+      toast.error("没有可导入的条目（请先为未匹配项手动指定地图）");
+      return;
+    }
+
+    setImporting(true);
+    setProgress({ done: 0, total: toImport.length });
+
+    let done = 0;
+    for (const row of toImport) {
+      if (!row.mapId) continue;
+
+      // 标记为 importing
+      setRows((prev) =>
+        prev.map((r) =>
+          r.fileName === row.fileName ? { ...r, importStatus: "importing" } : r,
+        ),
+      );
+
+      const result = await importDemoPackage(row.mapId, row.zipBuffer);
+
+      if (!result.success) {
+        setRows((prev) =>
+          prev.map((r) =>
+            r.fileName === row.fileName
+              ? { ...r, importStatus: "error", errorMessage: result.error.message }
+              : r,
+          ),
+        );
+      } else {
+        setRows((prev) =>
+          prev.map((r) =>
+            r.fileName === row.fileName ? { ...r, importStatus: "success" } : r,
+          ),
+        );
+      }
+
+      done += 1;
+      setProgress({ done, total: toImport.length });
+    }
+
+    setImporting(false);
+    toast.success(`批量导入完成：${done} / ${toImport.length} 个文件已处理`);
+  }
+
+  const hasRows = rows.length > 0;
+  const canImport =
+    !importing && hasRows && rows.some((r) => r.mapId !== null && r.importStatus === "pending");
+
+  return (
+    <div className="space-y-4">
+      {/* 文件选择 + 匹配 */}
+      <div className="flex gap-2 items-center flex-wrap">
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".zip"
+          multiple
+          className="text-sm"
+          disabled={matching || importing}
+        />
+        <Button size="sm" onClick={handleMatch} disabled={matching || importing}>
+          {matching ? "匹配中…" : "开始匹配"}
+        </Button>
+      </div>
+
+      {/* 匹配结果表格 */}
+      {hasRows && (
+        <div className="overflow-x-auto rounded-md border border-[var(--color-border)]">
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--color-surface-raised)]">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-[var(--color-fg-mid)]">
+                  zip 文件名
+                </th>
+                <th className="px-3 py-2 text-left font-medium text-[var(--color-fg-mid)]">
+                  匹配到
+                </th>
+                <th className="px-3 py-2 text-left font-medium text-[var(--color-fg-mid)]">
+                  状态
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--color-border)]">
+              {rows.map((row, i) => (
+                <tr key={row.fileName} className="hover:bg-[var(--color-surface-raised)]/50">
+                  <td className="px-3 py-2 font-mono text-xs text-[var(--color-fg)]">
+                    {row.fileName}
+                  </td>
+                  <td className="px-3 py-2">
+                    {row.confidence === "exact" && row.mapId ? (
+                      <span className="text-[var(--color-fg)]">{row.matchLabel}</span>
+                    ) : row.confidence === "none" && row.candidates.length === 0 ? (
+                      <select
+                        className="text-sm rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
+                        value={row.mapId ?? ""}
+                        onChange={(e) => handleSelectMap(i, e.target.value)}
+                        disabled={importing}
+                      >
+                        <option value="">— 手动选择 —</option>
+                        {availableMaps.map((m) => (
+                          <option key={m.mapId} value={m.mapId}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
+                    ) : row.candidates.length > 0 ? (
+                      <select
+                        className="text-sm rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
+                        value={row.mapId ?? ""}
+                        onChange={(e) => handleSelectMap(i, e.target.value)}
+                        disabled={importing}
+                      >
+                        <option value="">— 选择候选 —</option>
+                        {row.candidates.map((c) => (
+                          <option key={c.mapId} value={c.mapId}>
+                            {c.label}
+                          </option>
+                        ))}
+                        <optgroup label="全部可用">
+                          {availableMaps
+                            .filter((m) => !row.candidates.some((c) => c.mapId === m.mapId))
+                            .map((m) => (
+                              <option key={m.mapId} value={m.mapId}>
+                                {m.label}
+                              </option>
+                            ))}
+                        </optgroup>
+                      </select>
+                    ) : (
+                      <span className="text-[var(--color-fg-dim)]">{row.matchLabel}</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <ImportStatusBadge row={row} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* 进度 + 全部导入按钮 */}
+      {hasRows && (
+        <div className="flex items-center gap-4">
+          <Button size="sm" onClick={handleImportAll} disabled={!canImport}>
+            {importing
+              ? `导入中… ${progress?.done ?? 0} / ${progress?.total ?? 0}`
+              : "全部导入"}
+          </Button>
+          {progress && (
+            <div className="flex-1 max-w-xs">
+              <div className="h-2 rounded-full bg-[var(--color-border)] overflow-hidden">
+                <div
+                  className="h-full bg-[var(--color-accent)] transition-all duration-300"
+                  style={{
+                    width: `${Math.round((progress.done / progress.total) * 100)}%`,
+                  }}
+                />
+              </div>
+              <p className="text-xs text-[var(--color-fg-dim)] mt-1">
+                已完成 {progress.done} / {progress.total}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ImportStatusBadge({ row }: { row: RowState }) {
+  if (row.importStatus === "success") {
+    return (
+      <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(77,212,122,0.12)] text-[var(--color-ok)]">
+        ✓ 成功
+      </span>
+    );
+  }
+  if (row.importStatus === "error") {
+    return (
+      <span
+        className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(255,80,80,0.12)] text-[var(--color-error)]"
+        title={row.errorMessage}
+      >
+        ✗ 失败
+      </span>
+    );
+  }
+  if (row.importStatus === "importing") {
+    return (
+      <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(255,200,0,0.12)] text-[var(--color-warn)]">
+        导入中…
+      </span>
+    );
+  }
+  // pending
+  if (row.confidence === "exact") {
+    return (
+      <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(77,212,122,0.08)] text-[var(--color-ok)]">
+        ✅ 自动匹配
+      </span>
+    );
+  }
+  if (row.confidence === "fuzzy" && row.mapId) {
+    return (
+      <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(255,200,0,0.12)] text-[var(--color-warn)]">
+        ⚠ 模糊匹配
+      </span>
+    );
+  }
+  if (row.mapId) {
+    return (
+      <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(255,200,0,0.12)] text-[var(--color-warn)]">
+        ⚠ 手动
+      </span>
+    );
+  }
+  return (
+    <span className="text-[11px] px-1.5 py-0.5 rounded bg-[rgba(255,80,80,0.08)] text-[var(--color-fg-dim)]">
+      ❌ 未匹配
+    </span>
+  );
+}

--- a/src/components/admin/RecomputeRatingsButton.tsx
+++ b/src/components/admin/RecomputeRatingsButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { recomputeSeasonRatings } from "@/actions/compute-season-ratings";
+
+interface RecomputeRatingsButtonProps {
+  seasonId: string;
+}
+
+export function RecomputeRatingsButton({ seasonId }: RecomputeRatingsButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await recomputeSeasonRatings(seasonId);
+      if (result.success) {
+        toast.success(
+          `评分重算完成（${result.data.playerCount} 名选手，权重 ${result.data.weightsVersion}）`,
+        );
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isPending}
+      className="px-4 py-2 rounded-md text-sm font-medium bg-[var(--color-accent)] text-white disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+    >
+      {isPending ? "重算中…" : "重算 RR/PRISM 评分"}
+    </button>
+  );
+}

--- a/src/components/matches/MatchSummaryStats.tsx
+++ b/src/components/matches/MatchSummaryStats.tsx
@@ -33,7 +33,7 @@ interface MatchSummaryStatsProps {
 }
 
 const COLS = [
-  { key: "ratingPro", label: "Rating", fmt: (v: number | null) => v != null ? v.toFixed(2) : "—" },
+  { key: "ratingPro", label: "Rating Pro", fmt: (v: number | null) => v != null ? v.toFixed(2) : "—" },
   { key: "kills",     label: "K" },
   { key: "deaths",    label: "D" },
   { key: "assists",   label: "A" },

--- a/src/components/matches/MatchTimeNegotiation.tsx
+++ b/src/components/matches/MatchTimeNegotiation.tsx
@@ -155,7 +155,7 @@ export function MatchTimeNegotiation({
         <div className="rounded border p-3 text-sm" style={{ borderColor: "rgba(34,197,94,0.35)", background: "rgba(34,197,94,0.06)" }}>
           <p className="font-medium text-[var(--color-fg)]">比赛时间已自动设定</p>
           <p className="text-xs text-[var(--color-fg-dim)] mt-0.5">
-            对方 24 小时内未回应，比赛时间已按提议自动采纳为 {formatCST(autoAcceptedProposal.proposedTime)}。
+            对方 24 小时内未回应，比赛时间已按提议自动采纳为 {formatCST(new Date(currentScheduledAt))}。
           </p>
         </div>
       )}

--- a/src/components/matches/RadarChart.tsx
+++ b/src/components/matches/RadarChart.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * 通用 N 轴雷达图。
+ *
+ * PlayerRadarChart 是写死六维（HexagonScores）的特化版本；本组件接受任意轴配置，
+ * 供 PRISM 八维等场景复用。scores 用 Record<string, number>（0–100）。
+ */
+
+const DEFAULT_COLORS = [
+  "var(--color-accent)",
+  "var(--color-accent-b)",
+  "#f59e0b",
+  "#10b981",
+  "#8b5cf6",
+];
+
+export interface RadarAxis {
+  key: string;
+  label: string;
+}
+
+export interface RadarSeries {
+  name: string;
+  scores: Record<string, number>;
+  color?: string;
+  strokeColor?: string;
+  strokeWidth?: number;
+}
+
+interface RadarChartProps {
+  axes: readonly RadarAxis[];
+  series: RadarSeries[];
+  size?: number;
+}
+
+export function RadarChart({ axes, series, size = 300 }: RadarChartProps) {
+  if (series.length === 0 || axes.length === 0) return null;
+
+  const n = axes.length;
+  const capped = series.slice(0, 6);
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size * 0.35;
+  const isSingle = capped.length === 1;
+  const gridLevels = [0.25, 0.5, 0.75, 1.0];
+
+  const angle = (i: number) => (i / n) * 2 * Math.PI - Math.PI / 2;
+  const gridPolygon = (scale: number) =>
+    axes
+      .map((_, i) => {
+        const a = angle(i);
+        return `${cx + r * scale * Math.cos(a)},${cy + r * scale * Math.sin(a)}`;
+      })
+      .join(" ");
+  const dataPolygon = (scores: Record<string, number>) =>
+    axes
+      .map((axis, i) => {
+        const a = angle(i);
+        const d = ((scores[axis.key] ?? 0) / 100) * r;
+        return `${cx + d * Math.cos(a)},${cy + d * Math.sin(a)}`;
+      })
+      .join(" ");
+
+  const resolved = capped.map((s, idx) => {
+    const color = s.color ?? DEFAULT_COLORS[idx] ?? DEFAULT_COLORS[0];
+    return { ...s, color, stroke: s.strokeColor ?? color };
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <svg viewBox={`0 0 ${size} ${size}`} className="w-full max-w-[300px]">
+        {gridLevels.map((scale) => (
+          <polygon
+            key={scale}
+            points={gridPolygon(scale)}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            strokeDasharray="4 3"
+            opacity={0.5}
+          />
+        ))}
+
+        {axes.map((_, i) => {
+          const a = angle(i);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={cx + r * Math.cos(a)}
+              y2={cy + r * Math.sin(a)}
+              stroke="var(--color-border)"
+              strokeWidth={1}
+              opacity={0.3}
+            />
+          );
+        })}
+
+        {[...resolved].reverse().map((s, revIdx) => (
+          <polygon
+            key={revIdx}
+            points={dataPolygon(s.scores)}
+            fill={s.color}
+            fillOpacity={0.15}
+            stroke={s.stroke}
+            strokeWidth={s.strokeWidth ?? 1.5}
+            strokeOpacity={0.8}
+          />
+        ))}
+
+        {axes.map((axis, i) => {
+          const a = angle(i);
+          const dist = r + 18;
+          return (
+            <text
+              key={axis.key}
+              x={cx + dist * Math.cos(a)}
+              y={cy + dist * Math.sin(a)}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={11}
+              fill="var(--color-fg-mid)"
+            >
+              {axis.label}
+            </text>
+          );
+        })}
+
+        {isSingle &&
+          axes.map((axis, i) => {
+            const raw = resolved[0].scores[axis.key] ?? 0;
+            const a = angle(i);
+            const dist = (raw / 100) * r + 10;
+            return (
+              <text
+                key={`score-${axis.key}`}
+                x={cx + dist * Math.cos(a)}
+                y={cy + dist * Math.sin(a)}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={9}
+                fill="var(--color-fg)"
+              >
+                {Math.round(raw)}
+              </text>
+            );
+          })}
+      </svg>
+
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-[var(--color-fg-mid)]">
+        {resolved.map((s, idx) => (
+          <span key={idx} className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block w-2.5 h-2.5 shrink-0 border"
+              style={{ background: s.color, borderColor: s.stroke, opacity: 0.8 }}
+            />
+            {s.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── PRISM 八维轴配置 ──────────────────────────────────────────────────────────
+export const PRISM_AXES: readonly RadarAxis[] = [
+  { key: "firepower", label: "火力" },
+  { key: "opening",   label: "开局" },
+  { key: "entry",     label: "首攻" },
+  { key: "trading",   label: "补枪" },
+  { key: "clutch",    label: "残局" },
+  { key: "sniping",   label: "狙击" },
+  { key: "utility",   label: "道具" },
+  { key: "survival",  label: "生存" },
+] as const;
+
+export interface PrismScores {
+  firepower: number;
+  opening: number;
+  clutch: number;
+  sniping: number;
+  survival: number;
+  utility: number;
+  trading: number;
+  entry: number;
+}

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -21,6 +21,8 @@ interface LeaderboardRow {
   fkpr: number;
   mkpr: number;
   cpr: number;
+  /** RR 评分（from player_ratings） */
+  rrScore?: number | null;
   /** Demo 源扩展字段（存在时显示 demo 视图） */
   avgDemoKast?: number;
   avgDemoAdr?: number;
@@ -141,6 +143,12 @@ const ADVANCED_COLS: ColDef[] = [
     label: "Rating",
     getValue: (r) => r.avgRating,
     format: (v) => (v ?? 0).toFixed(2),
+  },
+  {
+    key: "rr",
+    label: "RR",
+    getValue: (r) => r.rrScore ?? null,
+    format: (v) => (v != null ? v.toFixed(2) : "—"),
   },
   {
     key: "we",

--- a/src/components/matches/StatsLeaderboard.tsx
+++ b/src/components/matches/StatsLeaderboard.tsx
@@ -74,14 +74,24 @@ const BASE_COLS: ColDef[] = [
   },
 ];
 
+// RR：我们自己的绝对刻度评分（门面）。完美 Rating/WE/RWS 是第三方副指标。
+const RR_COL: ColDef = {
+  key: "rr",
+  label: "RR",
+  getValue: (r) => r.rrScore ?? null,
+  format: (v) => (v != null ? v.toFixed(2) : "—"),
+};
+const PW_RATING_COL: ColDef = {
+  key: "rating",
+  label: "Rating Pro",
+  getValue: (r) => r.avgRating,
+  format: (v) => (v ? v.toFixed(2) : "—"),
+};
+
 const CORE_COLS: ColDef[] = [
   ...BASE_COLS,
-  {
-    key: "rating",
-    label: "Rating",
-    getValue: (r) => r.avgRating,
-    format: (v) => (v ?? 0).toFixed(2),
-  },
+  RR_COL,
+  PW_RATING_COL,
   {
     key: "adr",
     label: "ADR",
@@ -110,12 +120,8 @@ const CORE_COLS: ColDef[] = [
 
 const IMPACT_COLS: ColDef[] = [
   ...BASE_COLS,
-  {
-    key: "rating",
-    label: "Rating",
-    getValue: (r) => r.avgRating,
-    format: (v) => (v ?? 0).toFixed(2),
-  },
+  RR_COL,
+  PW_RATING_COL,
   {
     key: "fk",
     label: "FKPR /100r",
@@ -138,18 +144,8 @@ const IMPACT_COLS: ColDef[] = [
 
 const ADVANCED_COLS: ColDef[] = [
   ...BASE_COLS,
-  {
-    key: "rating",
-    label: "Rating",
-    getValue: (r) => r.avgRating,
-    format: (v) => (v ?? 0).toFixed(2),
-  },
-  {
-    key: "rr",
-    label: "RR",
-    getValue: (r) => r.rrScore ?? null,
-    format: (v) => (v != null ? v.toFixed(2) : "—"),
-  },
+  RR_COL,
+  PW_RATING_COL,
   {
     key: "we",
     label: "WE",
@@ -366,7 +362,7 @@ export function StatsLeaderboard({ rows, sort, position, seasonSlug, view = "cor
                   {cols.map((col) => {
                     const val = col.getValue(r);
                     const isSort = sort === col.key;
-                    const isHighRating = col.key === "rating" && (val ?? 0) >= 1.2;
+                    const isHighRating = (col.key === "rating" || col.key === "rr") && (val ?? 0) >= 1.2;
                     return (
                       <td
                         key={col.key}

--- a/src/components/players/PlayerDirectoryRow.test.tsx
+++ b/src/components/players/PlayerDirectoryRow.test.tsx
@@ -23,15 +23,19 @@ describe("PlayerDirectoryRow", () => {
       <PlayerDirectoryRow
         player={{
           ...player,
-          stats: { maps: 8, avgRating: 1.21, avgAdr: 82.4, avgKd: 1.36 },
+          stats: { maps: 8, avgRating: 1.21, avgAdr: 82.4, avgKd: 1.36, avgRr: 1.15 },
         }}
+        showRatingPro
       />,
     );
 
     expect(screen.getByText("Maps")).toBeInTheDocument();
     expect(screen.getByText("Secondary Closer")).toBeInTheDocument();
     expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("Rating Pro")).toBeInTheDocument();
     expect(screen.getByText("1.21")).toBeInTheDocument();
+    expect(screen.getByText("RR")).toBeInTheDocument();
+    expect(screen.getByText("1.15")).toBeInTheDocument();
     expect(screen.getByText("82.4")).toBeInTheDocument();
     expect(screen.getByText("1.36")).toBeInTheDocument();
   });

--- a/src/components/players/PlayerDirectoryRow.tsx
+++ b/src/components/players/PlayerDirectoryRow.tsx
@@ -19,6 +19,8 @@ export interface PlayerDirectoryData {
     avgRating: number;
     avgAdr: number;
     avgKd: number | null;
+    /** RR 评分（门面，from player_ratings）；无数据时 null */
+    avgRr?: number | null;
   } | null;
 }
 
@@ -35,7 +37,7 @@ function DirectoryMetric({ label, value }: { label: string; value: string | numb
   );
 }
 
-export function PlayerDirectoryRow({ player }: { player: PlayerDirectoryData }) {
+export function PlayerDirectoryRow({ player, showRatingPro }: { player: PlayerDirectoryData; showRatingPro?: boolean }) {
   return (
     <Panel hoverable pad={12}>
       <div className="grid gap-3 lg:grid-cols-[minmax(0,1.15fr)_auto] lg:items-center">
@@ -68,7 +70,10 @@ export function PlayerDirectoryRow({ player }: { player: PlayerDirectoryData }) 
         {player.stats ? (
           <div className="flex flex-wrap gap-x-4 gap-y-1.5 border-t border-[var(--color-border)] pt-2 lg:justify-end lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
             <DirectoryMetric label="Maps" value={player.stats.maps} />
-            <DirectoryMetric label="Rating" value={player.stats.avgRating.toFixed(2)} />
+            <DirectoryMetric label="RR" value={player.stats.avgRr != null ? player.stats.avgRr.toFixed(2) : "—"} />
+            {showRatingPro && (
+              <DirectoryMetric label="Rating Pro" value={player.stats.avgRating ? player.stats.avgRating.toFixed(2) : "—"} />
+            )}
             <DirectoryMetric label="ADR" value={player.stats.avgAdr.toFixed(1)} />
             <DirectoryMetric label="K/D" value={player.stats.avgKd != null ? player.stats.avgKd.toFixed(2) : "—"} />
           </div>

--- a/src/components/teams/TeamCard.test.tsx
+++ b/src/components/teams/TeamCard.test.tsx
@@ -34,6 +34,7 @@ describe("TeamCard", () => {
         {...props}
         record={{ played: 4, wins: 3, losses: 1, winRate: "75%" }}
         summary={{ maps: 12, avgRating: 1.14, avgAdr: 78.2 }}
+        showRatingPro
       />,
     );
 

--- a/src/components/teams/TeamCard.tsx
+++ b/src/components/teams/TeamCard.tsx
@@ -29,7 +29,10 @@ interface TeamCardProps {
     maps: number;
     avgRating: number;
     avgAdr: number;
+    avgRr?: number | null;
   } | null;
+  /** 是否展示 Rating Pro 列（取决于赛季 statProfile 配置） */
+  showRatingPro?: boolean;
 }
 
 function SummaryStat({ label, value }: { label: string; value: string | number }) {
@@ -54,6 +57,7 @@ export function TeamCard({
   players,
   record,
   summary,
+  showRatingPro = false,
 }: TeamCardProps) {
   const starters = players.filter((p) => p.isStarter);
   const subs = players.filter((p) => !p.isStarter);
@@ -102,7 +106,10 @@ export function TeamCard({
 
         <div className="grid grid-cols-3 gap-2">
           <SummaryStat label="Maps" value={summary?.maps ?? "—"} />
-          <SummaryStat label="Rating" value={summary ? summary.avgRating.toFixed(2) : "—"} />
+          <SummaryStat label="RR" value={summary?.avgRr != null ? summary.avgRr.toFixed(2) : "—"} />
+          {showRatingPro && (
+            <SummaryStat label="Rating Pro" value={summary?.avgRating ? summary.avgRating.toFixed(2) : "—"} />
+          )}
           <SummaryStat label="ADR" value={summary ? summary.avgAdr.toFixed(1) : "—"} />
         </div>
 

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -18,3 +18,4 @@ export * from "./match-rosters";
 export * from "./match-veto-steps";
 export * from "./user-sessions";
 export * from "./demo";
+export * from "./player-ratings";

--- a/src/db/schema/player-ratings.ts
+++ b/src/db/schema/player-ratings.ts
@@ -1,0 +1,32 @@
+import { pgTable, uuid, numeric, text, integer, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { seasons } from "./seasons";
+import { users } from "./users";
+
+export const playerRatings = pgTable("player_ratings", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id, { onDelete: "cascade" }),
+  userId: uuid("user_id").references(() => users.id),
+  steamId64: text("steam_id_64").notNull(),
+  // RR 标量
+  rrScore: numeric("rr_score", { precision: 8, scale: 4 }),
+  rrWeightsVersion: text("rr_weights_version"),
+  // PRISM 八维（百分位 0–100）
+  prismFirepower: numeric("prism_firepower", { precision: 6, scale: 2 }),
+  prismOpening:   numeric("prism_opening",   { precision: 6, scale: 2 }),
+  prismClutch:    numeric("prism_clutch",    { precision: 6, scale: 2 }),
+  prismSniping:   numeric("prism_sniping",   { precision: 6, scale: 2 }),
+  prismSurvival:  numeric("prism_survival",  { precision: 6, scale: 2 }),
+  prismUtility:   numeric("prism_utility",   { precision: 6, scale: 2 }),
+  prismTrading:   numeric("prism_trading",   { precision: 6, scale: 2 }),
+  prismEntry:     numeric("prism_entry",     { precision: 6, scale: 2 }),
+  prismWeightsVersion: text("prism_weights_version"),
+  // 样本量
+  mapCount: integer("map_count").notNull().default(0),
+  computedAt: timestamp("computed_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  // 每个赛季每名选手只有一行，重算时 upsert
+  uniqueIndex("player_ratings_season_steam_uniq").on(t.seasonId, t.steamId64),
+]);
+
+export type PlayerRating = typeof playerRatings.$inferSelect;
+export type NewPlayerRating = typeof playerRatings.$inferInsert;

--- a/src/lib/demo/parse-package.ts
+++ b/src/lib/demo/parse-package.ts
@@ -1,6 +1,16 @@
 import JSZip from "jszip";
 import { manifestSchema, FILE_SCHEMAS, type Manifest } from "./schemas";
 
+/**
+ * 这些文件包含 roundNumber 字段，且暖场数据（roundNumber=0）
+ * 的 steamId64/side 等字段为 null/unknown，统计时无意义，一律过滤。
+ */
+const WARMUP_FILTERED_KEYS = new Set([
+  "kills", "damages", "blinds", "bombs",
+  "grenades", "shots", "clutches",
+  "playerEconomies", "rounds", "positions1s",
+]);
+
 export interface ParsedDemoPackage {
   manifest: Manifest;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -30,7 +40,15 @@ export async function parseDemoPackage(buffer: Buffer | ArrayBuffer): Promise<Pa
 
     const parsed = schema.parse(raw);
     // match.json 是单对象，统一包成数组方便消费者
-    files[key] = Array.isArray(parsed) ? parsed : [parsed];
+    let rows = Array.isArray(parsed) ? parsed : [parsed];
+
+    // 过滤暖场数据（roundNumber=0）：exporter 会把暖场击杀/投掷物一并写入，
+    // 但 throwerSteamId64/killerSide 等字段全为 null/unknown，对统计无意义。
+    if (WARMUP_FILTERED_KEYS.has(key)) {
+      rows = rows.filter((r: { roundNumber?: number }) => (r.roundNumber ?? 1) > 0);
+    }
+
+    files[key] = rows;
   }
 
   return { manifest, files };

--- a/src/lib/demo/schemas.ts
+++ b/src/lib/demo/schemas.ts
@@ -101,6 +101,8 @@ const playerStatsRowSchema = z.object({
   wallbangKillCount: nullInt,
   noScopeKillCount: nullInt,
   collateralKillCount: nullInt,
+  /** 地图总回合数（exporter v2.1.2+ 新增，旧版为 null） */
+  rounds: nullInt,
 });
 export const playerStatsSchema = z.array(playerStatsRowSchema);
 

--- a/src/lib/demo/to-rr-indicators.ts
+++ b/src/lib/demo/to-rr-indicators.ts
@@ -13,9 +13,9 @@
  *   flashAssistCount → 来自 kills.json flashAssist 字段聚合（当前可选）
  */
 
-import { aggregatePlayerDemoStats } from "./player-demo-stats.js";
-import type { PlayerStatRow, BlindsRow } from "./player-demo-stats.js";
-import type { WeaponStat } from "./weapon-stats.js";
+import { aggregatePlayerDemoStats } from "./player-demo-stats";
+import type { PlayerStatRow, BlindsRow } from "./player-demo-stats";
+import type { WeaponStat } from "./weapon-stats";
 
 // ─── 输出类型（镜像 @rivalhub/rival-rating RRIndicators）────────────────────
 // 与 rival-rating/src/types/indicators.ts 保持结构同步

--- a/src/lib/demo/to-rr-indicators.ts
+++ b/src/lib/demo/to-rr-indicators.ts
@@ -1,0 +1,271 @@
+/**
+ * toRRIndicators — 将 RivalHub demo 数据结构适配为 RRIndicators 格式
+ *
+ * 输入来自 RivalHub 现有类型；输出与 @rivalhub/rival-rating 的 RRIndicators 接口兼容。
+ * TODO: 待 rival-rating 加入 pnpm workspace 后，将返回类型改为
+ *       `import type { RRIndicators } from "@rivalhub/rival-rating"`
+ *
+ * 字段映射说明：
+ *   PlayerStatRow[]  → 基础输出、多杀、首杀/补枪/残局细分
+ *   BlindsRow[]      → blindDuration（通过现有 aggregatePlayerDemoStats）
+ *   WeaponStat[]     → awpKills、sniperKills
+ *   grenadeCount     → 来自 grenades.json 聚合（当前可选，默认 0）
+ *   flashAssistCount → 来自 kills.json flashAssist 字段聚合（当前可选）
+ */
+
+import { aggregatePlayerDemoStats } from "./player-demo-stats.js";
+import type { PlayerStatRow, BlindsRow } from "./player-demo-stats.js";
+import type { WeaponStat } from "./weapon-stats.js";
+
+// ─── 输出类型（镜像 @rivalhub/rival-rating RRIndicators）────────────────────
+// 与 rival-rating/src/types/indicators.ts 保持结构同步
+export interface RRIndicators {
+  steamId64: string;
+  totalRounds: number;
+
+  kills: number;
+  deaths: number;
+  assists: number;
+  kpr: number;
+  dpr: number;
+  apr: number;
+  adr: number;
+  hsPercent: number;
+  kast: number;
+  survivalRate: number;
+
+  twoKillRounds: number;
+  threeKillRounds: number;
+  fourKillRounds: number;
+  fiveKillRounds: number;
+  multiKillRate: number;
+
+  firstKillCount: number;
+  firstDeathCount: number;
+  firstKillRate: number;
+  firstDeathRate: number;
+  openingDuelRate: number;
+  openingDuelWinRate: number;
+
+  tradeKillCount: number;
+  tradeDeathCount: number;
+  tradeKillRate: number;
+  tradeDeathRate: number;
+
+  clutchAttempts: number;
+  clutchWins: number;
+  clutchWinRate: number;
+  clutchFrequency: number;
+  clutchScore: number;
+  clutchScoreRate: number;
+  vsOne: { count: number; won: number };
+  vsTwo: { count: number; won: number };
+  vsThree: { count: number; won: number };
+  vsFour: { count: number; won: number };
+  vsFive: { count: number; won: number };
+
+  awpKills: number;
+  awpKillsPerRound: number;
+  awpKillRate: number;
+  sniperKills: number;
+  sniperKillRate: number;
+  awpMultiKillRate: number | null;
+  awpDuelWinRate: number | null;
+
+  utilityDamage: number;
+  utilityDamagePerRound: number;
+  flashAssistCount: number;
+  flashAssistPerRound: number;
+  blindDurationTotal: number;
+  blindDurationPerRound: number;
+  grenadeCount: number;
+  grenadeCountPerRound: number;
+
+  ecoRoundCount: number;
+  forceRoundCount: number;
+  fullBuyRoundCount: number;
+  pistolRoundCount: number;
+  avgEquipmentValue: number;
+
+  roundSwingTotal: number | null;
+  roundSwingPerKill: number | null;
+}
+
+// ─── 适配器入参 ───────────────────────────────────────────────────────────────
+
+export interface ToRRIndicatorsInput {
+  steamId64: string;
+  /** demoPlayerStats 行（多场比赛） */
+  stats: PlayerStatRow[];
+  /** demoBlinds 行（该选手作为 flasher） */
+  blinds?: BlindsRow[];
+  /** 武器统计（来自 aggregateWeaponStats） */
+  weaponStats?: WeaponStat[];
+  /**
+   * 投掷物总数（来自 grenades.json 中该选手的 throw 次数）
+   * 当前 demo 格式尚未聚合，默认 0
+   */
+  grenadeCount?: number;
+  /**
+   * 闪光助攻数（来自 kills.json flashAssist=true 的选手击杀数）
+   * 可由 aggregateUtilityStats 得到，不传则默认 0
+   */
+  flashAssistCount?: number;
+  /**
+   * 地图总回合数（来自 rounds.json 行数，过滤 roundNumber=0 后）。
+   *
+   * player-stats.json 当前不含 rounds 字段，直接传入可修正 fallback 误差。
+   * 不传时退化为 aggregatePlayerDemoStats 的 kills+deaths 近似（误差 ~20%）。
+   *
+   * 推荐传入方式：
+   *   parsedPackage.files.rounds.length
+   */
+  totalRoundsOverride?: number;
+  /**
+   * 经济回合分类数（来自 player-economies.json 聚合）
+   * 当前可选；Layer 1 eco 乘子激活前影响不大
+   */
+  economy?: {
+    ecoRounds: number;
+    forceRounds: number;
+    fullBuyRounds: number;
+    pistolRounds: number;
+    avgEquipmentValue: number;
+  };
+}
+
+// ─── 适配器主函数 ────────────────────────────────────────────────────────────
+
+/**
+ * 将 RivalHub demo 数据转换为 RRIndicators。
+ * 纯函数，无副作用。
+ */
+export function toRRIndicators(input: ToRRIndicatorsInput): RRIndicators {
+  const {
+    steamId64,
+    stats,
+    blinds = [],
+    weaponStats = [],
+    grenadeCount = 0,
+    flashAssistCount = 0,
+    totalRoundsOverride,
+    economy,
+  } = input;
+
+  // ── Step 1: 用现有 aggregate 拿已算好的字段 ─────────────────────────────
+  const agg = aggregatePlayerDemoStats(stats, blinds);
+
+  // ── Step 2: 从原始 stats 行补充 aggregate 没有的字段 ─────────────────────
+  let kills = 0, deaths = 0, assists = 0;
+  let headshotCount = 0;
+  let tradeKillCount = 0, tradeDeathCount = 0;
+  let twoKillRounds = 0, threeKillRounds = 0, fourKillRounds = 0, fiveKillRounds = 0;
+  let utilityDamage = 0;
+
+  for (const s of stats) {
+    kills           += s.kills           ?? 0;
+    deaths          += s.deaths          ?? 0;
+    assists         += s.assists         ?? 0;
+    headshotCount   += (s as { headshotCount?: number | null }).headshotCount   ?? 0;
+    tradeKillCount  += s.tradeKillCount  ?? 0;
+    tradeDeathCount += (s as { tradeDeathCount?: number | null }).tradeDeathCount ?? 0;
+    twoKillRounds   += s.twoKillCount    ?? 0;
+    threeKillRounds += s.threeKillCount  ?? 0;
+    fourKillRounds  += s.fourKillCount   ?? 0;
+    fiveKillRounds  += s.fiveKillCount   ?? 0;
+    utilityDamage   += s.utilityDamage   ?? 0;
+  }
+
+  // totalRoundsOverride 修正 player-stats.json 缺 rounds 字段导致的 fallback 误差
+  const totalRounds = totalRoundsOverride ?? agg.totalRounds;
+  const safe = (n: number, d: number) => (d > 0 ? n / d : 0);
+
+  // ── Step 3: 狙击字段（从 weaponStats 提取）──────────────────────────────
+  const awpStat    = weaponStats.find((w) => w.weapon.toLowerCase() === "awp");
+  const ssgStat    = weaponStats.find((w) => w.weapon.toLowerCase() === "ssg08");
+  const awpKills   = awpStat?.kills ?? 0;
+  const ssgKills   = ssgStat?.kills ?? 0;
+  const sniperKills = awpKills + ssgKills;
+
+  // ── Step 4: 残局积分 ─────────────────────────────────────────────────────
+  const clutchScore =
+    agg.vsOne.won   * 1 +
+    agg.vsTwo.won   * 2 +
+    agg.vsThree.won * 3 +
+    agg.vsFour.won  * 4 +
+    agg.vsFive.won  * 5;
+
+  // ── Step 5: 组装 ─────────────────────────────────────────────────────────
+  return {
+    steamId64,
+    totalRounds,
+
+    kills,
+    deaths,
+    assists,
+    kpr:          safe(kills, totalRounds),
+    dpr:          safe(deaths, totalRounds),
+    apr:          safe(assists, totalRounds),
+    adr:          agg.adr,
+    hsPercent:    kills > 0 ? (headshotCount / kills) * 100 : 0,
+    kast:         agg.kast,
+    survivalRate: safe(totalRounds - deaths, totalRounds),
+
+    twoKillRounds,
+    threeKillRounds,
+    fourKillRounds,
+    fiveKillRounds,
+    // multiKillRate 用正确 totalRounds 重算（agg 内部用的是 fallback 值）
+    multiKillRate: safe(twoKillRounds + threeKillRounds + fourKillRounds + fiveKillRounds, totalRounds),
+
+    firstKillCount:     agg.firstKillCount,
+    firstDeathCount:    agg.firstDeathCount,
+    firstKillRate:      safe(agg.firstKillCount, totalRounds),
+    firstDeathRate:     safe(agg.firstDeathCount, totalRounds),
+    openingDuelRate:    safe(agg.firstKillCount + agg.firstDeathCount, totalRounds),
+    openingDuelWinRate: agg.entrySuccessRate, // ratio, 不受 totalRounds 影响
+
+    tradeKillCount,
+    tradeDeathCount,
+    tradeKillRate:  safe(tradeKillCount, totalRounds),
+    tradeDeathRate: safe(tradeDeathCount, deaths),
+
+    clutchAttempts:  agg.clutchAttempts,
+    clutchWins:      agg.clutchWins,
+    clutchWinRate:   agg.clutchWinRate,
+    clutchFrequency: safe(agg.clutchAttempts, totalRounds),
+    clutchScore,
+    clutchScoreRate: safe(clutchScore, totalRounds),
+    vsOne:   agg.vsOne,
+    vsTwo:   agg.vsTwo,
+    vsThree: agg.vsThree,
+    vsFour:  agg.vsFour,
+    vsFive:  agg.vsFive,
+
+    awpKills,
+    awpKillsPerRound: safe(awpKills, totalRounds),
+    awpKillRate:      safe(awpKills, kills),
+    sniperKills,
+    sniperKillRate:   safe(sniperKills, kills),
+    awpMultiKillRate: null,  // 待 AWP 多杀回合聚合后填入
+    awpDuelWinRate:   null,  // 待经济快照可用后填入
+
+    utilityDamage,
+    utilityDamagePerRound:  safe(utilityDamage, totalRounds),
+    flashAssistCount,
+    flashAssistPerRound:    safe(flashAssistCount, totalRounds),
+    blindDurationTotal:     agg.blindsDuration,
+    blindDurationPerRound:  safe(agg.blindsDuration, totalRounds),
+    grenadeCount,
+    grenadeCountPerRound:   safe(grenadeCount, totalRounds),
+
+    ecoRoundCount:      economy?.ecoRounds      ?? 0,
+    forceRoundCount:    economy?.forceRounds     ?? 0,
+    fullBuyRoundCount:  economy?.fullBuyRounds   ?? 0,
+    pistolRoundCount:   economy?.pistolRounds    ?? 0,
+    avgEquipmentValue:  economy?.avgEquipmentValue ?? 0,
+
+    roundSwingTotal:   null,
+    roundSwingPerKill: null,
+  };
+}

--- a/src/lib/matches/leaderboard-view.ts
+++ b/src/lib/matches/leaderboard-view.ts
@@ -1,9 +1,9 @@
 export type LeaderboardView = "core" | "impact" | "advanced" | "demo";
 
 const VIEW_SORTS = {
-  core: ["maps", "rating", "adr", "kd", "kpr", "hs"],
-  impact: ["maps", "rating", "fk", "mk", "clutch"],
-  advanced: ["maps", "rating", "we", "rws"],
+  core: ["maps", "rr", "rating", "adr", "kd", "kpr", "hs"],
+  impact: ["maps", "rr", "rating", "fk", "mk", "clutch"],
+  advanced: ["maps", "rr", "rating", "we", "rws"],
   demo: ["maps", "avgDemoKast", "avgDemoAdr", "demoFkpr", "demoClutchWinRate", "demoUtilityPerRound"],
 } as const satisfies Record<LeaderboardView, readonly string[]>;
 

--- a/src/lib/players/directory-order.ts
+++ b/src/lib/players/directory-order.ts
@@ -4,6 +4,7 @@ interface DirectoryPlayer {
   stats: {
     maps: number;
     avgRating: number;
+    avgRr?: number | null;
   } | null;
 }
 
@@ -11,6 +12,10 @@ export function sortPlayerDirectory<T extends DirectoryPlayer>(players: T[]): T[
   return [...players].sort((a, b) => {
     const mapsDiff = (b.stats?.maps ?? -1) - (a.stats?.maps ?? -1);
     if (mapsDiff !== 0) return mapsDiff;
+
+    // RR 为门面评分，优先排序；无 RR 时回退完美 Rating
+    const rrDiff = (b.stats?.avgRr ?? -1) - (a.stats?.avgRr ?? -1);
+    if (rrDiff !== 0) return rrDiff;
 
     const seasonRatingDiff = (b.stats?.avgRating ?? -1) - (a.stats?.avgRating ?? -1);
     if (seasonRatingDiff !== 0) return seasonRatingDiff;

--- a/src/lib/rating/prism/compute.ts
+++ b/src/lib/rating/prism/compute.ts
@@ -1,0 +1,123 @@
+/**
+ * PRISM 八维画像计算
+ *
+ * 输入：赛季内所有选手的 RRIndicators 数组（批次计算，需要完整队列做 z-score）
+ * 输出：每名选手的 PrismResult（含八轴百分位 + RR 百分位）
+ *
+ * 流程：
+ *   1. 对每名选手、每根轴，提取 involvementRaw / efficiencyRaw
+ *   2. 跨选手做 z-score（批次内相对）
+ *   3. 融合：axis_z = α·z_inv + (1-α)·z_eff
+ *   4. 冷启动收缩：z' = z · n/(n+k)
+ *   5. 转百分位（经验排名，样本小时退化到正态 CDF）
+ */
+
+import type { RRIndicators } from "../types/indicators";
+import type {
+  PrismWeights,
+  PrismAxisKey,
+  PrismAxisResult,
+  PrismResult,
+} from "../types/prism";
+import { PRISM_AXES } from "../types/prism";
+import { extractAxisScore } from "./extract";
+import { zScoreAll, coldStartShrink, zToPercentile } from "./zscore";
+
+export interface PrismComputeInput {
+  indicators: RRIndicators;
+  /** 该选手参与的地图数（冷启动收缩依据） */
+  mapCount: number;
+  /** RR 百分位（0–100），由调用方计算后传入 */
+  rrPercentile: number;
+}
+
+/**
+ * 计算整个赛季批次的 PRISM 结果。
+ *
+ * @param cohort   赛季内所有选手的输入数据
+ * @param weights  PRISM 权重配置
+ */
+export function computePrism(
+  cohort: PrismComputeInput[],
+  weights: PrismWeights,
+): PrismResult[] {
+  if (cohort.length === 0) return [];
+
+  const { coldStartK, axes } = weights;
+
+  // ── Step 1: 每名选手、每根轴提取原始分 ──────────────────────────────
+  const rawInv: Record<PrismAxisKey, number[]> = {} as never;
+  const rawEff: Record<PrismAxisKey, number[]> = {} as never;
+
+  for (const axis of PRISM_AXES) {
+    rawInv[axis] = [];
+    rawEff[axis] = [];
+  }
+
+  for (const entry of cohort) {
+    for (const axis of PRISM_AXES) {
+      const cfg = axes[axis];
+      rawInv[axis].push(extractAxisScore(entry.indicators, cfg.involvement));
+      rawEff[axis].push(extractAxisScore(entry.indicators, cfg.efficiency));
+    }
+  }
+
+  // ── Step 2: 跨选手 z-score ───────────────────────────────────────────
+  const zInv: Record<PrismAxisKey, number[]> = {} as never;
+  const zEff: Record<PrismAxisKey, number[]> = {} as never;
+
+  for (const axis of PRISM_AXES) {
+    zInv[axis] = zScoreAll(rawInv[axis]);
+    zEff[axis] = zScoreAll(rawEff[axis]);
+  }
+
+  // ── Step 3+4+5: 融合、收缩、转百分位 ────────────────────────────────
+  const fusedZ: Record<PrismAxisKey, number[]> = {} as never;
+  for (const axis of PRISM_AXES) {
+    const alpha = axes[axis].alpha;
+    fusedZ[axis] = cohort.map((_, i) => {
+      const zi = alpha * (zInv[axis][i] ?? 0) + (1 - alpha) * (zEff[axis][i] ?? 0);
+      return coldStartShrink(zi, cohort[i]?.mapCount ?? 1, coldStartK);
+    });
+  }
+
+  // ── 组装结果 ─────────────────────────────────────────────────────────
+  return cohort.map((entry, i) => {
+    const axisResults = {} as Record<PrismAxisKey, PrismAxisResult>;
+
+    for (const axis of PRISM_AXES) {
+      const z = fusedZ[axis][i] ?? 0;
+      axisResults[axis] = {
+        involvementRaw: rawInv[axis][i] ?? 0,
+        efficiencyRaw:  rawEff[axis][i] ?? 0,
+        z,
+        percentile: zToPercentile(z, fusedZ[axis]),
+      };
+    }
+
+    return {
+      steamId64:      entry.indicators.steamId64,
+      weightsVersion: weights.version,
+      mapCount:       entry.mapCount,
+      rrPercentile:   entry.rrPercentile,
+      axes:           axisResults,
+    } satisfies PrismResult;
+  });
+}
+
+/**
+ * 从 RR 分数组计算经验百分位，供调用方构造 PrismComputeInput.rrPercentile。
+ *
+ * @param rrScores   所有选手的最终 RR 分（已锚定到联赛均值）
+ * @param targetRR   目标选手的 RR 分
+ */
+export function rrToPercentile(rrScores: number[], targetRR: number): number {
+  if (rrScores.length === 0) return 50;
+  const sorted = [...rrScores].sort((a, b) => a - b);
+  let pos = 0;
+  for (const v of sorted) {
+    if (v <= targetRR) pos++;
+    else break;
+  }
+  return (pos / sorted.length) * 100;
+}

--- a/src/lib/rating/prism/extract.ts
+++ b/src/lib/rating/prism/extract.ts
@@ -1,0 +1,41 @@
+/**
+ * 从 RRIndicators 提取单根轴的原始分
+ *
+ * 按 SignalConfig[] 加权求和，处理 null 字段和 invert 标志。
+ */
+
+import type { RRIndicators } from "../types/indicators";
+import type { SignalConfig } from "../types/prism";
+
+/**
+ * 对一组信号配置做加权求和，返回原始轴分。
+ *
+ * - null 字段按 0 处理（对应 weight 在 config 里设 0 即可无效化）
+ * - invert=true 时用 (1 - value) 反转（适用于 dpr、firstDeathRate 等"低更好"信号）
+ *   注意：invert 假设信号已归一化到 [0, 1]；若未归一化请在 indicators 里预处理
+ */
+export function extractAxisScore(
+  ind: RRIndicators,
+  signals: SignalConfig[],
+): number {
+  let score = 0;
+  let totalWeight = 0;
+
+  for (const cfg of signals) {
+    const raw = ind[cfg.signal];
+    // null / undefined → 跳过（不纳入加权分母，信号缺失时不拉低分数）
+    if (raw === null || raw === undefined) continue;
+
+    const value = typeof raw === "number" ? raw : 0;
+    const adjusted = cfg.invert ? 1 - value : value;
+
+    score += adjusted * cfg.weight;
+    totalWeight += cfg.weight;
+  }
+
+  // 所有信号都是 null 时返回 0
+  if (totalWeight === 0) return 0;
+
+  // 归一化到实际可用权重之和（缺失信号不拉低整体）
+  return score / totalWeight;
+}

--- a/src/lib/rating/prism/zscore.ts
+++ b/src/lib/rating/prism/zscore.ts
@@ -1,0 +1,91 @@
+/**
+ * z-score 工具函数
+ *
+ * 所有函数均为纯函数，无副作用。
+ */
+
+/**
+ * 对一组数值做 z-score 标准化。
+ * 样本标准差（分母 n-1）；样本量 <= 1 时全返回 0。
+ */
+export function zScoreAll(values: number[]): number[] {
+  if (values.length <= 1) return values.map(() => 0);
+
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance =
+    values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / (values.length - 1);
+  const std = Math.sqrt(variance);
+
+  if (std === 0) return values.map(() => 0);
+  return values.map((v) => (v - mean) / std);
+}
+
+/**
+ * 冷启动收缩：样本少时向均值（z=0）收缩。
+ *
+ * z_shown = z_raw · n / (n + k)
+ *
+ * @param z    原始 z-score
+ * @param n    该选手参与的地图数
+ * @param k    收缩常数（config coldStartK，约等于"几张图后稳定"）
+ */
+export function coldStartShrink(z: number, n: number, k: number): number {
+  if (k <= 0) return z;
+  return z * (n / (n + k));
+}
+
+/**
+ * 经验百分位：target 在 sortedValues 中的百分位（0–100）。
+ *
+ * 使用线性插值，边界处理：
+ *   - 低于最小值 → 0
+ *   - 高于最大值 → 100
+ */
+export function empiricalPercentile(
+  sortedValues: number[],
+  target: number,
+): number {
+  if (sortedValues.length === 0) return 50;
+  if (sortedValues.length === 1) return 50;
+
+  let pos = 0;
+  for (let i = 0; i < sortedValues.length; i++) {
+    if ((sortedValues[i] ?? 0) <= target) pos = i + 1;
+    else break;
+  }
+
+  return (pos / sortedValues.length) * 100;
+}
+
+/**
+ * 标准正态分布 CDF（近似）——用于小批次时的平滑百分位估算。
+ * 精度约 ±0.0001。
+ *
+ * @returns 0–1
+ */
+export function normalCDF(z: number): number {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989422820 * Math.exp((-z * z) / 2);
+  const p =
+    d *
+    t *
+    (0.3193815 +
+      t * (-0.3565638 + t * (1.7814779 + t * (-1.8212560 + t * 1.3302744))));
+  return z >= 0 ? 1 - p : p;
+}
+
+/**
+ * 将 z-score 转为 0–100 百分位，优先用经验排名，
+ * 样本 < minEmpiricalN 时退化到正态 CDF。
+ */
+export function zToPercentile(
+  z: number,
+  cohortZScores: number[],
+  minEmpiricalN = 5,
+): number {
+  if (cohortZScores.length >= minEmpiricalN) {
+    const sorted = [...cohortZScores].sort((a, b) => a - b);
+    return empiricalPercentile(sorted, z);
+  }
+  return normalCDF(z) * 100;
+}

--- a/src/lib/rating/rr/compute.ts
+++ b/src/lib/rating/rr/compute.ts
@@ -1,0 +1,115 @@
+/**
+ * RR 标量计算——Layer 1（上下文加权）
+ *
+ * 当前实现：HLTV 2.0 逆向公式（社区版 R²≈0.995）作为过渡基础。
+ * Layer 2（Round Swing）接口已预留，roundSwingCoef=0 时完全透明。
+ *
+ * 替换指南：
+ *   1. 修改 rr-v1.json 中的系数，无需改动此文件
+ *   2. 启用 eco 乘子：先用自有赛事 ~50 张图回归校准，再更新 ecoMultipliers
+ *   3. 启用 Layer 2：等 ~1000 张图训好模型后，将 roundSwingCoef 设为非零值
+ */
+
+import type { RRIndicators } from "../types/indicators";
+import type { RRWeights, RRResult } from "../types/rr";
+
+/**
+ * 计算单名选手单张地图的 RR 分。
+ *
+ * 纯函数，无副作用。
+ */
+export function computeRR(
+  ind: RRIndicators,
+  weights: RRWeights,
+): RRResult {
+  if (ind.totalRounds <= 0) {
+    return zeroResult(weights.version);
+  }
+
+  const { base, ecoMultipliers, layer2, clamp } = weights;
+
+  // ── Layer 1：基础公式 ──────────────────────────────────────────────────
+  // Impact 子项
+  const impact =
+    base.impactKprWeight * ind.kpr +
+    base.impactAprWeight * ind.apr +
+    base.impactIntercept;
+
+  // 各分项（保留用于 breakdown / 可解释性）
+  const kastTerm   = base.kastCoef   * ind.kast;
+  const kprTerm    = base.kprCoef    * ind.kpr;
+  const dprTerm    = base.dprCoef    * ind.dpr;
+  const impactTerm = base.impactCoef * impact;
+  const adrTerm    = base.adrCoef    * ind.adr;
+
+  let rrBase =
+    kastTerm + kprTerm + dprTerm + impactTerm + adrTerm + base.intercept;
+
+  // ── eco 上下文乘子（当前 ecoMultipliers 全为 1.0，不改变结果）─────────
+  const totalCategorized =
+    ind.ecoRoundCount + ind.forceRoundCount +
+    ind.fullBuyRoundCount + ind.pistolRoundCount;
+
+  if (totalCategorized > 0) {
+    const ecoFrac   = ind.ecoRoundCount   / totalCategorized;
+    const forceFrac = ind.forceRoundCount / totalCategorized;
+    const fullFrac  = ind.fullBuyRoundCount / totalCategorized;
+    const ecoAdjust =
+      ecoFrac   * ecoMultipliers.ecoKillMultiplier +
+      forceFrac * ecoMultipliers.forceKillMultiplier +
+      fullFrac  * ecoMultipliers.fullBuyKillMultiplier +
+      (1 - ecoFrac - forceFrac - fullFrac);
+
+    const killTerms = kprTerm + impactTerm;
+    rrBase = rrBase - killTerms + killTerms * ecoAdjust;
+  }
+
+  // ── Layer 2：Round Swing（当前 coef=0，透明透传）──────────────────────
+  const rrSwing =
+    layer2.roundSwingCoef * (ind.roundSwingPerKill ?? 0) * ind.kpr;
+
+  const rrRaw = rrBase + rrSwing;
+  const rr    = Math.max(clamp.min, Math.min(clamp.max, rrRaw));
+
+  return {
+    rr,
+    rrBase,
+    rrSwing,
+    weightsVersion: weights.version,
+    breakdown: {
+      kastTerm,
+      kprTerm,
+      dprTerm,
+      impactTerm,
+      adrTerm,
+      intercept: base.intercept,
+    },
+  };
+}
+
+// ─── 工具 ─────────────────────────────────────────────────────────────────
+
+function zeroResult(version: string): RRResult {
+  return {
+    rr: 1.0,
+    rrBase: 1.0,
+    rrSwing: 0,
+    weightsVersion: version,
+    breakdown: {
+      kastTerm: 0, kprTerm: 0, dprTerm: 0,
+      impactTerm: 0, adrTerm: 0, intercept: 0,
+    },
+  };
+}
+
+/**
+ * 从 RRResult[] 数组计算联赛均值，用于将绝对分锚定到 1.00。
+ *
+ * 当 anchor.mode === "league_mean" 时，调用方应将所有选手的 rr
+ * 再乘以 (1.0 / leagueMeanRR) 完成归一。
+ */
+export function computeLeagueMean(results: RRResult[]): number {
+  if (results.length === 0) return 1.0;
+  const sum = results.reduce((acc, r) => acc + r.rr, 0);
+  return sum / results.length;
+}

--- a/src/lib/rating/types/indicators.ts
+++ b/src/lib/rating/types/indicators.ts
@@ -1,0 +1,77 @@
+/**
+ * RRIndicators — 指标层（Layer 0）
+ *
+ * 从单张 demo 提取的所有原始信号，是 RR 标量和 PRISM 八维画像的共同输入。
+ * 与 src/lib/demo/to-rr-indicators.ts 中的 RRIndicators 接口保持结构同步。
+ */
+export interface RRIndicators {
+  steamId64: string;
+  totalRounds: number;
+
+  kills: number;
+  deaths: number;
+  assists: number;
+  kpr: number;
+  dpr: number;
+  apr: number;
+  adr: number;
+  hsPercent: number;
+  kast: number;
+  survivalRate: number;
+
+  twoKillRounds: number;
+  threeKillRounds: number;
+  fourKillRounds: number;
+  fiveKillRounds: number;
+  multiKillRate: number;
+
+  firstKillCount: number;
+  firstDeathCount: number;
+  firstKillRate: number;
+  firstDeathRate: number;
+  openingDuelRate: number;
+  openingDuelWinRate: number;
+
+  tradeKillCount: number;
+  tradeDeathCount: number;
+  tradeKillRate: number;
+  tradeDeathRate: number;
+
+  clutchAttempts: number;
+  clutchWins: number;
+  clutchWinRate: number;
+  clutchFrequency: number;
+  clutchScore: number;
+  clutchScoreRate: number;
+  vsOne: { count: number; won: number };
+  vsTwo: { count: number; won: number };
+  vsThree: { count: number; won: number };
+  vsFour: { count: number; won: number };
+  vsFive: { count: number; won: number };
+
+  awpKills: number;
+  awpKillsPerRound: number;
+  awpKillRate: number;
+  sniperKills: number;
+  sniperKillRate: number;
+  awpMultiKillRate: number | null;
+  awpDuelWinRate: number | null;
+
+  utilityDamage: number;
+  utilityDamagePerRound: number;
+  flashAssistCount: number;
+  flashAssistPerRound: number;
+  blindDurationTotal: number;
+  blindDurationPerRound: number;
+  grenadeCount: number;
+  grenadeCountPerRound: number;
+
+  ecoRoundCount: number;
+  forceRoundCount: number;
+  fullBuyRoundCount: number;
+  pistolRoundCount: number;
+  avgEquipmentValue: number;
+
+  roundSwingTotal: number | null;
+  roundSwingPerKill: number | null;
+}

--- a/src/lib/rating/types/prism.ts
+++ b/src/lib/rating/types/prism.ts
@@ -1,0 +1,125 @@
+/**
+ * PRISM — 八维风格画像
+ *
+ * 设计原则：
+ *  - 形状（轴半径）= 风格指纹：这根轴伸多长代表"多大程度扮演这个角色"
+ *  - 颜色 = RR 水平：整体着色绑定 RR 百分位，风格和水平双编码互不干扰
+ *  - 每根轴 α 不同：风格/水平配比按角色本质浮动
+ *  - 冷启动收缩：z' = z · n/(n+k)，仅作用于画像层，不碰 RR 标量
+ *  - 所有系数外置，带版本号，零重构可换系数
+ */
+import type { RRIndicators } from "./indicators";
+
+// ─── 八维枚举 ─────────────────────────────────────────────────────────────
+
+export const PRISM_AXES = [
+  "firepower",  // 火力：纯输出，不看生存
+  "opening",    // 首杀：首杀对枪赢下来（成功侧）
+  "clutch",     // 残局：1vX 残局，time-alive 型
+  "sniping",    // 狙击：AWP 风格标签（近乎纯风格）
+  "survival",   // 生存：活下来/低死亡率（近乎纯水平）
+  "utility",    // 道具：投掷物贡献
+  "trading",    // 补枪：补枪、护队友
+  "entry",      // 突破：开路尖刀，第一个趟（与 opening 互补）
+] as const;
+
+export type PrismAxisKey = typeof PRISM_AXES[number];
+
+/**
+ * 八角形布局顺序（顺时针，用于前端渲染）
+ * 对立角色放对角：opening ↔ clutch（早期 vs 后期），entry ↔ survival（送死 vs 保命）
+ */
+export const PRISM_AXIS_ORDER: PrismAxisKey[] = [
+  "firepower",
+  "opening",
+  "clutch",
+  "sniping",
+  "survival",
+  "utility",
+  "trading",
+  "entry",
+];
+
+// ─── 权重 schema ──────────────────────────────────────────────────────────
+
+/** 单个信号配置 */
+export interface SignalConfig {
+  /** RRIndicators 的字段名 */
+  signal: keyof RRIndicators;
+  /** 在加权组合中的权重（同组内 weights 之和应为 1.0） */
+  weight: number;
+  /**
+   * 是否反转（低值 = 好）
+   * 例：dpr 越低越好，invert: true 后变成"低 dpr 得高分"
+   */
+  invert?: boolean;
+}
+
+/** 单根轴的配置 */
+export interface PrismAxisConfig {
+  /**
+   * 风格/水平融合比例
+   * 0 = 完全看效率/水平，1 = 完全看参与度/风格
+   * 建议范围：0.2（生存）~ 0.85（狙击）
+   */
+  alpha: number;
+  /**
+   * 参与度信号（风格侧）：这根轴的"你做了多少"
+   * z-score 后乘以 alpha
+   */
+  involvement: SignalConfig[];
+  /**
+   * 效率信号（水平侧）：这根轴的"你做得多好"
+   * z-score 后乘以 (1 - alpha)
+   */
+  efficiency: SignalConfig[];
+}
+
+export interface PrismWeights {
+  /** 格式：prism-X.Y */
+  version: string;
+  /**
+   * 冷启动收缩常数 k
+   * z_shown = z_raw · n / (n + k)
+   * n = 该选手参与的地图数，k 约等于"几张图后分数才基本稳定"
+   */
+  coldStartK: number;
+  /**
+   * eco 上下文渗入效率项的强度
+   * 0 = 不渗；保留旋钮，当前版本填 0
+   */
+  ecoTilt: number;
+  /**
+   * 颜色来源
+   * "rr_percentile"：整体着色 = RR 百分位
+   * "axis_efficiency"：每根轴用各自效率百分位做局部明暗（信息更丰富但复杂）
+   */
+  colorSource: "rr_percentile" | "axis_efficiency";
+  axes: Record<PrismAxisKey, PrismAxisConfig>;
+}
+
+// ─── 计算结果 ─────────────────────────────────────────────────────────────
+
+/** 单名选手单根轴的中间结果（调试用） */
+export interface PrismAxisResult {
+  /** 加权参与度原始分（未做 z-score） */
+  involvementRaw: number;
+  /** 加权效率原始分（未做 z-score） */
+  efficiencyRaw: number;
+  /** 融合后 z-score（已冷启动收缩） */
+  z: number;
+  /** 最终百分位（0–100，在本赛季批次内） */
+  percentile: number;
+}
+
+/** 单名选手的完整 PRISM 结果 */
+export interface PrismResult {
+  steamId64: string;
+  /** 使用的权重版本 */
+  weightsVersion: string;
+  /** 该选手参与的地图数（冷启动收缩依据） */
+  mapCount: number;
+  /** RR 百分位（0–100），用于整体颜色着色 */
+  rrPercentile: number;
+  axes: Record<PrismAxisKey, PrismAxisResult>;
+}

--- a/src/lib/rating/types/rr.ts
+++ b/src/lib/rating/types/rr.ts
@@ -1,0 +1,104 @@
+/**
+ * RR（Rival Rating）标量评分
+ *
+ * 设计原则：
+ *  - 绝对刻度，1.00 ≈ 联赛平均水平（由 anchor 配置决定）
+ *  - 第一场就有意义，不需要冷启动
+ *  - Layer 1：上下文加权（eco 乘子 + 情境权重）
+ *  - Layer 2：Round Swing / WPA（待数据量 ~1000 张图后开启）
+ *  - 所有系数外置到版本化 config，公式形状稳定
+ */
+
+// ─── 权重 schema ──────────────────────────────────────────────────────────
+
+export interface RRWeightsBase {
+  /** KAST 系数 */
+  kastCoef: number;
+  /** KPR 系数 */
+  kprCoef: number;
+  /** DPR 系数（通常为负） */
+  dprCoef: number;
+  /** Impact 内的 KPR 权重 */
+  impactKprWeight: number;
+  /** Impact 内的 APR 权重 */
+  impactAprWeight: number;
+  /** Impact 内截距 */
+  impactIntercept: number;
+  /** Impact 整体系数 */
+  impactCoef: number;
+  /** ADR 系数 */
+  adrCoef: number;
+  /** 公式截距 */
+  intercept: number;
+}
+
+export interface RREcoMultipliers {
+  /**
+   * eco 局击杀乘子：eco 局打出的 KPR/ADR 等价折算
+   * 1.0 = 不激活；待用几十张图校准后调整
+   */
+  ecoKillMultiplier: number;
+  forceKillMultiplier: number;
+  fullBuyKillMultiplier: number;
+  /**
+   * eco 手枪打赢满配的额外奖励乘子
+   * 1.0 = 不激活
+   */
+  ecoVsFullBonus: number;
+}
+
+export interface RRLayer2 {
+  /**
+   * Round Swing 系数
+   * 0.0 = 关闭 Layer 2（当前默认）
+   */
+  roundSwingCoef: number;
+  note?: string;
+}
+
+export interface RRClamp {
+  min: number;
+  max: number;
+}
+
+export interface RRAnchor {
+  /**
+   * "league_mean"：1.00 = 本赛季联赛均值
+   * "pro_mean"：1.00 = 职业选手均值（更硬核，分数整体偏低）
+   */
+  mode: "league_mean" | "pro_mean";
+  note?: string;
+}
+
+export interface RRWeights {
+  /** 格式：rr-X.Y */
+  version: string;
+  description?: string;
+  base: RRWeightsBase;
+  ecoMultipliers: RREcoMultipliers;
+  layer2: RRLayer2;
+  clamp: RRClamp;
+  anchor: RRAnchor;
+}
+
+// ─── 计算结果 ─────────────────────────────────────────────────────────────
+
+export interface RRResult {
+  /** 最终 RR 分（已 clamp） */
+  rr: number;
+  /** Layer 1 基础分（未 clamp，调试用） */
+  rrBase: number;
+  /** Layer 2 Round Swing 贡献（当前为 0） */
+  rrSwing: number;
+  /** 使用的权重版本 */
+  weightsVersion: string;
+  /** 各分项（调试 / 可解释性） */
+  breakdown: {
+    kastTerm: number;
+    kprTerm: number;
+    dprTerm: number;
+    impactTerm: number;
+    adrTerm: number;
+    intercept: number;
+  };
+}

--- a/src/lib/rating/weights/prism-v1.json
+++ b/src/lib/rating/weights/prism-v1.json
@@ -1,0 +1,112 @@
+{
+  "version": "prism-1.0",
+  "coldStartK": 4,
+  "ecoTilt": 0.0,
+  "colorSource": "rr_percentile",
+
+  "_layout_note": "八角形顺时针顺序见 PRISM_AXIS_ORDER。对立角色放对角：opening↔clutch（早期vs后期），entry↔survival（送死vs保命）。",
+
+  "axes": {
+    "firepower": {
+      "_desc": "纯输出，不看生存。α=0.40 偏水平：高 frag 量 + 高质量多杀才能拿高分。",
+      "alpha": 0.40,
+      "involvement": [
+        { "signal": "kpr",   "weight": 0.5 },
+        { "signal": "adr",   "weight": 0.5 }
+      ],
+      "efficiency": [
+        { "signal": "multiKillRate", "weight": 0.40 },
+        { "signal": "kpr",           "weight": 0.35 },
+        { "signal": "adr",           "weight": 0.25 }
+      ]
+    },
+
+    "opening": {
+      "_desc": "首杀对枪赢下来（成功侧）。α=0.60：参与频率 + 胜率双重体现。",
+      "alpha": 0.60,
+      "involvement": [
+        { "signal": "openingDuelRate",    "weight": 0.5 },
+        { "signal": "firstKillRate",      "weight": 0.5 }
+      ],
+      "efficiency": [
+        { "signal": "openingDuelWinRate", "weight": 1.0 }
+      ]
+    },
+
+    "clutch": {
+      "_desc": "1vX 残局，time-alive 型。α=0.55：出现频率 + 胜率/积分各半。",
+      "alpha": 0.55,
+      "involvement": [
+        { "signal": "clutchFrequency", "weight": 1.0 }
+      ],
+      "efficiency": [
+        { "signal": "clutchWinRate",   "weight": 0.60 },
+        { "signal": "clutchScoreRate", "weight": 0.40 }
+      ]
+    },
+
+    "sniping": {
+      "_desc": "AWP 风格标签。α=0.85 近乎纯风格：拿不拿狙决定轴长，效率微调。",
+      "alpha": 0.85,
+      "involvement": [
+        { "signal": "sniperKillRate",  "weight": 1.0 }
+      ],
+      "efficiency": [
+        { "signal": "awpKillsPerRound","weight": 0.70 },
+        { "signal": "sniperKillRate",  "weight": 0.30 }
+      ]
+    },
+
+    "survival": {
+      "_desc": "活下来/低死亡率。α=0.20 近乎纯水平：强弱直接体现，不掺风格。",
+      "alpha": 0.20,
+      "involvement": [
+        { "signal": "kast",         "weight": 1.0 }
+      ],
+      "efficiency": [
+        { "signal": "survivalRate", "weight": 0.60 },
+        { "signal": "kast",         "weight": 0.40 }
+      ]
+    },
+
+    "utility": {
+      "_desc": "投掷物贡献。α=0.70 偏风格：勤投弹 + 高效致盲/伤害双重体现。",
+      "alpha": 0.70,
+      "involvement": [
+        { "signal": "grenadeCountPerRound",    "weight": 0.40 },
+        { "signal": "utilityDamagePerRound",   "weight": 0.30 },
+        { "signal": "flashAssistPerRound",     "weight": 0.30 }
+      ],
+      "efficiency": [
+        { "signal": "utilityDamagePerRound",   "weight": 0.40 },
+        { "signal": "blindDurationPerRound",   "weight": 0.30 },
+        { "signal": "flashAssistPerRound",     "weight": 0.30 }
+      ]
+    },
+
+    "trading": {
+      "_desc": "补枪、护队友。α=0.60：主动补枪频率 + 自身被补率（team asset）双重体现。",
+      "alpha": 0.60,
+      "involvement": [
+        { "signal": "tradeKillRate",  "weight": 0.70 },
+        { "signal": "tradeDeathRate", "weight": 0.30 }
+      ],
+      "efficiency": [
+        { "signal": "tradeKillRate",  "weight": 0.70 },
+        { "signal": "tradeDeathRate", "weight": 0.30 }
+      ]
+    },
+
+    "entry": {
+      "_desc": "开路尖刀，第一个趟。α=0.70 偏风格：敢不敢首先暴露 + 死了被补不白给。",
+      "alpha": 0.70,
+      "involvement": [
+        { "signal": "firstDeathRate",   "weight": 0.60 },
+        { "signal": "openingDuelRate",  "weight": 0.40 }
+      ],
+      "efficiency": [
+        { "signal": "tradeDeathRate",   "weight": 1.0 }
+      ]
+    }
+  }
+}

--- a/src/lib/rating/weights/rr-v1.json
+++ b/src/lib/rating/weights/rr-v1.json
@@ -1,0 +1,40 @@
+{
+  "version": "rr-1.0",
+  "description": "RR Layer 1 基础权重。基于 HLTV 2.0 社区逆向公式（R²≈0.995）。eco 乘子全为 1.0（待 ~50 张图校准后激活）。Layer 2 关闭（待 ~1000 张图）。",
+
+  "base": {
+    "_comment": "公式: kastCoef·KAST + kprCoef·KPR + dprCoef·DPR + impactCoef·Impact + adrCoef·ADR + intercept",
+    "kastCoef": 0.0073,
+    "kprCoef": 0.3591,
+    "dprCoef": -0.5329,
+    "impactKprWeight": 2.13,
+    "impactAprWeight": 0.42,
+    "impactIntercept": -0.41,
+    "impactCoef": 0.2372,
+    "adrCoef": 0.0032,
+    "intercept": 0.1587
+  },
+
+  "ecoMultipliers": {
+    "_comment": "全为 1.0 = 不激活。用几十张自有赛事图回归校准后替换。",
+    "ecoKillMultiplier": 1.0,
+    "forceKillMultiplier": 1.0,
+    "fullBuyKillMultiplier": 1.0,
+    "ecoVsFullBonus": 1.0
+  },
+
+  "layer2": {
+    "roundSwingCoef": 0.0,
+    "note": "Layer 2 disabled — 需要 ~1000 张图训好模型后开启。届时升版本到 rr-2.0。"
+  },
+
+  "clamp": {
+    "min": 0.1,
+    "max": 3.0
+  },
+
+  "anchor": {
+    "mode": "league_mean",
+    "note": "1.00 = 本赛季联赛均值。所有选手 RR 原始分计算完后，整体乘以 (1.0 / mean) 完成锚定。"
+  }
+}


### PR DESCRIPTION
## Summary

### Added
- **RR/PRISM 评分系统（框架）**：引入 rival-rating 算法引擎，新增 player_ratings 表；recomputeSeasonRatings Server Action 支持按赛季重算 RR 标量 + PRISM 八维风格百分位，admin 一键触发
- **Demo 批量导入**：后台支持一次选多个 zip，自动匹配 mapName + 队名，匹配结果表格支持手动修正，顺序导入并实时显示进度

### Fixed
- Demo 解析 totalRounds 误差（playerStatsRowSchema 补 rounds 字段，修复 ~20% KPR 偏差）
- Demo 暖场数据 roundNumber=0 过滤
- 时间协商 banner 显示错误 + autoAcceptExpiredProposals 竞态修复

## Test plan
- [x] pnpm tsc --noEmit
- [x] pnpm test（526 tests passed）
- [ ] dev 环境手动验证批量导入 + 评分重算路径