### PR TITLE
v1.27.1: demo batch import 匹配修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.27.0。
+部署：Vercel（`match.starfie1d.top`），当前 v1.27.1。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.1] - 2026-05-30
+
+### Fixed
+- **Demo 批量导入队名读取路径**：`match.json` 中 `teamAName`/`teamBName` 为嵌套字段 `teamA.name` / `teamB.name`，修正读取路径；新增文件名日期提取（`rivalhub-{map}-{YYYY-MM-DD}.zip`）与 `completedAt` 日期匹配 fallback，解决所有 demo ZIP 均显示"选择候选"无法自动匹配的问题
+
 ## [1.27.0] - 2026-05-29
 
 ### Added
@@ -930,6 +935,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.27.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.2...v1.27.0
 [1.26.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.1...v1.26.2
 [1.26.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.0...v1.26.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/demo-batch-import.ts
+++ b/src/actions/demo-batch-import.ts
@@ -16,9 +16,11 @@ export interface ZipManifestInfo {
   mapName: string;
   /** manifest.demo.hash */
   demoHash: string;
-  /** match.json 里的 teamAName / teamBName */
+  /** match.json 里的 teamAName / teamBName（cs2-demo-format v1.0 均为 "Team A"/"Team B"） */
   teamAName?: string;
   teamBName?: string;
+  /** 从文件名提取的比赛日期，如 "2026-05-18" */
+  zipDate?: string;
 }
 
 export interface MatchResult {
@@ -127,9 +129,31 @@ export async function matchZipsToMaps(
         };
       }
 
+      // 日期匹配：文件名提取的比赛日期与 completedAt 比较（cs2-demo-format v1.0 无实义队名）
+      let dateMatches: Candidate[];
+      if (zip.zipDate) {
+        dateMatches = byMap.filter((c) => {
+          if (!c.completedAt) return false;
+          const cd = new Date(c.completedAt).toISOString().slice(0, 10);
+          return cd === zip.zipDate;
+        });
+      } else {
+        dateMatches = [];
+      }
+
+      if (dateMatches.length === 1) {
+        return {
+          fileName: zip.fileName,
+          mapId: dateMatches[0].mapId,
+          confidence: "exact" as const,
+          matchLabel: dateMatches[0].label,
+          candidates: [],
+        };
+      }
+
       // 精确匹配：mapName 一致 + 队名 contains 匹配（不区分大小写）
       const exactMatches =
-        zip.teamAName && zip.teamBName
+        zip.teamAName && zip.teamBName && zip.teamAName !== "Team A" && zip.teamBName !== "Team B"
           ? byMap.filter((c) => {
               const tA = zip.teamAName!.toLowerCase();
               const tB = zip.teamBName!.toLowerCase();
@@ -197,7 +221,11 @@ export async function matchZipsToMaps(
             })
           : byMap;
 
-      const pool = narrowed.length > 0 ? narrowed : byMap;
+      // 队名匹配无帮助时用日期收窄（cs2-demo-format 队名均为 "Team A"/"Team B"）
+      const poolRaw = narrowed.length > 0 ? narrowed : byMap;
+      const pool = (poolRaw.length > 1 && dateMatches.length > 0 && dateMatches.length < poolRaw.length)
+        ? dateMatches
+        : poolRaw;
 
       if (pool.length === 1) {
         return {

--- a/src/components/admin/DemoBatchImportPanel.tsx
+++ b/src/components/admin/DemoBatchImportPanel.tsx
@@ -57,6 +57,7 @@ export function DemoBatchImportPanel({ seasonId, availableMaps }: Props) {
         let demoHash = "";
         let teamAName: string | undefined;
         let teamBName: string | undefined;
+        let zipDate: string | undefined;
 
         try {
           const zip = await JSZip.loadAsync(buf);
@@ -75,14 +76,21 @@ export function DemoBatchImportPanel({ seasonId, availableMaps }: Props) {
           if (matchFile) {
             const text = await matchFile.async("string");
             const matchJson = JSON.parse(text) as Record<string, unknown>;
-            teamAName = matchJson.teamAName as string | undefined;
-            teamBName = matchJson.teamBName as string | undefined;
+            // cs2-demo-format v1.0: teamA.name / teamB.name（都是 "Team A"/"Team B"）
+            const teamA = matchJson.teamA as { name?: string } | undefined;
+            const teamB = matchJson.teamB as { name?: string } | undefined;
+            teamAName = teamA?.name;
+            teamBName = teamB?.name;
           }
+
+          // 从文件名提取比赛日期：rivalhub-{map}-{YYYY-MM-DD}.zip
+          const dateMatch = file.name.match(/(\d{4}-\d{2}-\d{2})/);
+          if (dateMatch) zipDate = dateMatch[1];
         } catch {
           // zip 解析失败，继续（mapName 为空会得到 none 匹配）
         }
 
-        infos.push({ fileName: file.name, mapName, demoHash, teamAName, teamBName });
+        infos.push({ fileName: file.name, mapName, demoHash, teamAName, teamBName, zipDate });
       }
 
       const result = await matchZipsToMaps(seasonId, infos);


### PR DESCRIPTION
## Summary
- **fix(batch-import)**: 修正 `match.json` 队名读取路径（`teamAName` → `teamA?.name`）；新增文件名日期提取与 `completedAt` 日期匹配 fallback，解决所有 ZIP 均显示"选择候选"的问题
- **chore(release)**: bump version to v1.27.1

## Test plan
- [ ] 批量导入面板选择 43 个 demo zip，点击匹配 → 大部分应自动匹配（日期精确匹配）
- [ ] 未匹配项手动选择后全部导入
- [ ] 导入完成后点击重算评分 → 榜单 RR 列出现数据