### PR TITLE
v1.27.2: demo batch import steamId 模糊匹配 fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.27.1。
+部署：Vercel（`match.starfie1d.top`），当前 v1.27.2。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.2] - 2026-05-30
+
+### Fixed
+- **Demo 批量导入 steamId 模糊匹配 fallback**：新增 `players.json` 选手 steamId64 → 队伍归属查询，作为日期、队名匹配都失败后的最终收窄手段；只要任一选手匹配候选比赛的某支队伍即保留，大幅减少需手动选择的情况
+
 ## [1.27.1] - 2026-05-30
 
 ### Fixed
@@ -935,6 +940,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.27.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.1...v1.27.2
 [1.27.1]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.2...v1.27.0
 [1.26.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.26.1...v1.26.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/demo-batch-import.ts
+++ b/src/actions/demo-batch-import.ts
@@ -1,10 +1,11 @@
 "use server";
 
-import { eq, and, inArray, asc } from "drizzle-orm";
+import { eq, and, inArray, asc, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchMaps } from "@/db/schema/match-maps";
 import { matches } from "@/db/schema/matches";
 import { teams } from "@/db/schema/teams";
+import { users, seasonRegistrations, teamMembers } from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
 import { actionError } from "@/lib/action-utils";
 import { requireAdmin } from "@/lib/auth/session";
@@ -21,6 +22,8 @@ export interface ZipManifestInfo {
   teamBName?: string;
   /** 从文件名提取的比赛日期，如 "2026-05-18" */
   zipDate?: string;
+  /** players.json 中的 steamId64 列表（用于模糊匹配） */
+  steamId64s?: string[];
 }
 
 export interface MatchResult {
@@ -88,10 +91,13 @@ export async function matchZipsToMaps(
 
     interface Candidate {
       mapId: string;
+      matchId: string;
       mapName: string;
       completedAt: Date | null;
       teamAName: string;
       teamBName: string;
+      teamAId: string;
+      teamBId: string;
       label: string;
     }
 
@@ -105,15 +111,18 @@ export async function matchZipsToMaps(
       const label = `${teamAName} vs ${teamBName} · ${mm.mapName} · ${dateStr}`;
       return {
         mapId: mm.id,
+        matchId: mm.matchId,
         mapName: mm.mapName,
         completedAt: mm.completedAt ?? match.completedAt ?? null,
         teamAName,
         teamBName,
+        teamAId: match.teamAId,
+        teamBId: match.teamBId,
         label,
       };
     });
 
-    const results: MatchResult[] = zips.map((zip) => {
+    const results: MatchResult[] = await Promise.all(zips.map(async (zip) => {
       // 先按 mapName 过滤
       const byMap = candidates.filter(
         (c) => c.mapName.toLowerCase() === zip.mapName.toLowerCase(),
@@ -227,12 +236,39 @@ export async function matchZipsToMaps(
         ? dateMatches
         : poolRaw;
 
-      if (pool.length === 1) {
+      // steamId 模糊匹配：通过 ZIP 玩家查询队伍归属，缩小候选范围
+      let playerMatchPool: Candidate[] | null = null;
+      if (pool.length > 1 && zip.steamId64s && zip.steamId64s.length > 0) {
+        try {
+          const teamRows = await db.execute(sql`
+            SELECT DISTINCT tm.team_id
+            FROM ${users} u
+            JOIN ${seasonRegistrations} sr ON sr.user_id = u.id AND sr.season_id = ${seasonId}
+            JOIN ${teamMembers} tm ON tm.registration_id = sr.id
+            WHERE u.steam_id64 = ANY(ARRAY[${sql.join(zip.steamId64s.map((s) => sql`${s}`), sql`, `)}])
+          `);
+          const zipTeamIds = new Set(teamRows.rows.map((r) => (r as Record<string, unknown>).team_id as string));
+          if (zipTeamIds.size > 0) {
+            const filtered = pool.filter((c) =>
+              zipTeamIds.has(c.teamAId) || zipTeamIds.has(c.teamBId),
+            );
+            if (filtered.length > 0 && filtered.length < pool.length) {
+              playerMatchPool = filtered;
+            }
+          }
+        } catch {
+          // steamId 匹配失败时忽略，继续使用原 pool
+        }
+      }
+
+      const finalPool = playerMatchPool ?? pool;
+
+      if (finalPool.length === 1) {
         return {
           fileName: zip.fileName,
-          mapId: pool[0].mapId,
+          mapId: finalPool[0].mapId,
           confidence: "fuzzy" as const,
-          matchLabel: pool[0].label,
+          matchLabel: finalPool[0].label,
           candidates: [],
         };
       }
@@ -242,9 +278,9 @@ export async function matchZipsToMaps(
         mapId: null,
         confidence: "fuzzy" as const,
         matchLabel: "",
-        candidates: pool.map((c) => ({ mapId: c.mapId, label: c.label })),
+        candidates: finalPool.map((c) => ({ mapId: c.mapId, label: c.label })),
       };
-    });
+    }));
 
     return ok(results);
   } catch (e) {

--- a/src/components/admin/DemoBatchImportPanel.tsx
+++ b/src/components/admin/DemoBatchImportPanel.tsx
@@ -58,6 +58,7 @@ export function DemoBatchImportPanel({ seasonId, availableMaps }: Props) {
         let teamAName: string | undefined;
         let teamBName: string | undefined;
         let zipDate: string | undefined;
+        let steamId64s: string[] = [];
 
         try {
           const zip = await JSZip.loadAsync(buf);
@@ -86,11 +87,19 @@ export function DemoBatchImportPanel({ seasonId, availableMaps }: Props) {
           // 从文件名提取比赛日期：rivalhub-{map}-{YYYY-MM-DD}.zip
           const dateMatch = file.name.match(/(\d{4}-\d{2}-\d{2})/);
           if (dateMatch) zipDate = dateMatch[1];
+
+          // 读取玩家信息用于模糊匹配
+          const playersFile = zip.file("players.json");
+          if (playersFile) {
+            const text = await playersFile.async("string");
+            const players = JSON.parse(text) as { steamId64: string }[];
+            steamId64s = players.map((p) => p.steamId64).filter(Boolean);
+          }
         } catch {
           // zip 解析失败，继续（mapName 为空会得到 none 匹配）
         }
 
-        infos.push({ fileName: file.name, mapName, demoHash, teamAName, teamBName, zipDate });
+        infos.push({ fileName: file.name, mapName, demoHash, teamAName, teamBName, zipDate, steamId64s });
       }
 
       const result = await matchZipsToMaps(seasonId, infos);


### PR DESCRIPTION
## Summary
- fix(batch-import): 新增 players.json 选手 steamId64 -> 队伍归属匹配作为最终 fallback
- chore(release): bump version to v1.27.2

匹配流水线：日期精确 -> 队名包含 -> 日期收窄 -> steamId 队伍匹配
- 只要任一选手的 steamId64 匹配候选比赛的某支队伍即保留
- 日期+地图名无法区分的同图多场比赛（如 5-18 三场 de_ancient）靠选手关系收窄