### PR TITLE
v1.27.6: Stats 页 SQL 修复 + CI 测试修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 RivalHub 是开源电竞赛事管理平台，通过 capability 驱动多赛事模型支持选秀联赛、公开赛、杯赛等全流程运营。
 技术栈：Next.js 15 App Router + TypeScript strict + Tailwind CSS v4 + shadcn/ui + Supabase + Drizzle ORM。
-部署：Vercel（`match.starfie1d.top`），当前 v1.27.5。
+部署：Vercel（`match.starfie1d.top`），当前 v1.27.6。
 
 ## 2. 常用命令
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to RivalHub are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.6] - 2026-05-30
+
+### Fixed
+- **Stats 页 GROUP BY SQL 错误**：OCR fallback CTE 引用 `ocr.avg_rating_ocr` 未用聚合函数包裹，PostgreSQL 拒绝运行；改用 `min()` 包裹解决
+- **CI 测试失败**：PlayerStatsTable 测试 mock 补全 `statSourceEnum`、`matchMaps` 和 `db.query.matchMaps`
+
+### Added
+- **weapon-names 别名映射测试**：新增 `src/lib/demo/weapon-names.test.ts` 覆盖 13 个映射和 fallthrough 场景
+
 ## [1.27.5] - 2026-05-30
 
 ### Added
@@ -978,6 +987,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[1.27.6]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.5...v1.27.6
 [1.27.5]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.4...v1.27.5
 [1.27.4]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.3...v1.27.4
 [1.27.3]: https://github.com/Starfie1d1272/RivalHub/compare/v1.27.2...v1.27.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "1.27.5",
+  "version": "1.27.6",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -107,10 +107,10 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
       t.name  AS team_name,
       t.id    AS team_id,
       count(*)::int                                                          AS maps,
-      COALESCE(round(avg(mps.rating_pro)::numeric, 2), ocr.avg_rating_ocr)  AS avg_rating,
+      COALESCE(round(avg(mps.rating_pro)::numeric, 2), min(ocr.avg_rating_ocr))  AS avg_rating,
       round(${adrExpr}::numeric, 1)                                         AS avg_adr,
-      COALESCE(round(avg(mps.rws)::numeric, 2), ocr.avg_rws_ocr)           AS avg_rws,
-      COALESCE(round(avg(mps.we)::numeric, 1), ocr.avg_we_ocr)             AS avg_we,
+      COALESCE(round(avg(mps.rws)::numeric, 2), min(ocr.avg_rws_ocr))           AS avg_rws,
+      COALESCE(round(avg(mps.we)::numeric, 1), min(ocr.avg_we_ocr))             AS avg_we,
       round(${hsExpr}::numeric, 1)                                          AS avg_hs,
       CASE WHEN sum(mps.deaths) > 0
         THEN round(sum(mps.kills)::numeric / sum(mps.deaths), 2)


### PR DESCRIPTION
## Summary
- **Stats 页 GROUP BY SQL 错误修复**: OCR fallback CTE 用 min() 包裹通过 PG 约束
- **CI 测试修复**: PlayerStatsTable mock 补全 statSourceEnum、matchMaps
- **测试新增**: weapon-names 别名映射覆盖

## Test plan
- [ ] pnpm tsc --noEmit
- [ ] pnpm test
- [ ] /stats 页面正常加载