### PR TITLE
docs: clarify external pilot readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # RivalHub
 
-RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，用于支撑从报名、审核、队长投票、选秀、队伍展示、赛程管理、比分录入到数据统计的完整赛事运营流程。
+RivalHub 是一个面向高校电竞赛事的开源赛事管理平台。当前生产验证重点是 NJU 选秀联赛流程：个人报名、审核、队长投票、选秀、排位赛、双败淘汰赛、基础比分和数据录入。
 
 项目采用 capability 驱动的多赛事模型。赛季能力由配置决定，公开路由以 `seasonSlug` 区分，避免把具体赛事、赛制或阶段硬编码进业务逻辑。
 
 生产站点：[match.starfie1d.top](https://match.starfie1d.top)
 
-## 核心能力
+## 当前能力状态
 
-| 模块 | 能力 |
+不要把 capability 预设或设计文档等同于生产可用能力。外部试点前请先阅读 [docs/external-pilot-readiness.md](./docs/external-pilot-readiness.md)。
+
+| 状态 | 模块 | 能力 |
 |---|---|
-| 赛季 | 多赛季路由、能力开关、阶段状态机、赛季发布与归档 |
-| 报名 | 邮箱账号、表单校验、草稿恢复、位置与人数限制、截图链接 |
-| 审核 | 管理员审核、候补名单、邀请码提权、操作审计 |
-| 队长投票 | 候选人确认、限票规则、票数展示与实时更新 |
-| 选秀 | 蛇形选秀、事务行锁、幂等 pick、超时自动递补 |
-| 队伍 | 阵容展示、队长标识、队名与队徽管理、队员联系方式可见性 |
-| 比赛 | 赛程、Bracket、BP / 地图结果、阵容提交、比分录入、MVP 投票 |
-| 协商 | 比赛时间提议、接受/拒绝、管理员强制设定、截止自动裁定 |
-| Demo | CS2 demo 解析与可视化：回合时间线、击杀回放、经济曲线、残局统计、热力图、武器偏好与首杀倾向 |
-| 数据 | OCR 录入、选手/队伍统计、排行榜、审计日志 |
-| 运维 | Vercel 部署、Supabase 数据库、GitHub Actions Cron |
+| 已实战验证 | 赛季 | 多赛季路由、能力开关、阶段状态机、赛季发布与归档 |
+| 已实战验证 | 个人报名 | 邮箱账号、表单校验、草稿恢复、位置与人数限制、截图链接 |
+| 已实战验证 | 审核 | 管理员审核、候补名单、邀请码提权、操作审计 |
+| 已实战验证 | 队长投票 | 候选人确认、限票规则、票数展示与实时更新 |
+| 已实战验证 | 选秀 | 蛇形选秀、事务行锁、幂等 pick、超时自动递补 |
+| 已实战验证 | 队伍 | 选秀生成队伍后的阵容展示、队长标识、队名与队徽管理 |
+| 已实战验证 | 比赛 | 排位赛、双败淘汰、BP / 地图结果、阵容提交、比分录入、MVP 投票 |
+| 已实战验证 | 协商 | 比赛时间提议、接受/拒绝、管理员强制设定、截止自动裁定 |
+| 已实战验证 | 数据 | OCR 录入、选手/队伍基础统计、排行榜、审计日志 |
+| 已实现待验收 | Demo | demo ZIP 导入、批量匹配、OCR 冲突确认、覆盖导入、Steam alias 绑定、部分详情展示 |
+| 已实现待验收 | 评分 | `@rivalhub/rival-rating` 接入、RR / PRISM 重算入口 |
+| 设计/配置中 | Major / Swiss | Major preset、Swiss executor 和展示基础；完整三段 Swiss 运营闭环仍需 staging 验收和 UI 补强 |
+| 尚未实现 | 队伍报名 | 外部队伍自助报名、审核、生成队伍流程 |
+| 尚未实现 | Broadcast | public broadcast API、OBS / vMix overlay、MVP 转播卡 |
 
 ## 技术栈
 
@@ -28,7 +33,7 @@ RivalHub 是一个面向高校电竞赛事的开源赛事管理平台，用于�
 |---|---|
 | Web | Next.js App Router, React, TypeScript strict |
 | UI | Tailwind CSS, shadcn/ui, 自定义 Tactical Grid 组件 |
-| Demo 解析 | CS2 demo parser (node), canvas 热力图 (Canvas API), SVG 经济曲线 |
+| Demo 解析 | `cs2-demo-format` ZIP 导入；完整分析展示仍在建设 |
 | 数据 | Supabase Postgres, Auth, Realtime, Storage |
 | ORM | Drizzle ORM |
 | 表单 | React Hook Form, Zod |
@@ -87,6 +92,8 @@ password: RivalHub_password
 
 Cron 由 GitHub Actions 调用，端点与频率见 [.github/workflows/cron.yml](./.github/workflows/cron.yml)。部署细节见 [docs/deployment.md](./docs/deployment.md)。
 
+外部试点必须使用独立 staging 环境：独立 Vercel environment / preview deployment + 独立 Supabase 项目。不要把试点 seed、E2E 或 demo 导入压测指向生产数据库。
+
 ## 安全边界
 
 - 业务写操作走 Server Actions；Cron 触发才使用 API Route。
@@ -135,6 +142,7 @@ pnpm build
 | [docs/state-machines.md](./docs/state-machines.md) | 关键业务状态机 |
 | [docs/deployment.md](./docs/deployment.md) | Vercel / Supabase 部署手册 |
 | [docs/testing.md](./docs/testing.md) | 测试策略 |
+| [docs/external-pilot-readiness.md](./docs/external-pilot-readiness.md) | 外部试点前能力边界、staging 和整改清单 |
 | [CHANGELOG.md](./CHANGELOG.md) | 版本发布记录 |
 
 历史设计稿、一次性计划和过程材料已归档到 [docs/archive](./docs/archive)，不作为当前实现的事实来源。

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,9 +24,10 @@
 | 文档 | 读它当你要… |
 |---|---|
 | [`auth-and-permissions.md`](./auth-and-permissions.md) | 改登录、鉴权、权限分级 |
-| [`registration-flow.md`](./registration-flow.md) | 改报名流程（个人/队伍） |
+| [`registration-flow.md`](./registration-flow.md) | 改个人报名流程；队伍报名仍是待实现分支 |
 | [`draft-flow.md`](./draft-flow.md) | 改选秀流程（事务、并发、超时） |
 | [`code-map.md`](./code-map.md) | 快速找到业务域对应的代码入口 |
+| [`external-pilot-readiness.md`](./external-pilot-readiness.md) | 判断外部试点前哪些能力可承诺、哪些必须声明限制 |
 
 ## 运维 & 测试
 
@@ -49,4 +50,5 @@
 - 顶层文档只记录当前有效的架构、流程、约束和运维信息。
 - 临时计划、调研、设计稿放入 `docs/archive/`。
 - 修改状态机、数据库约束、权限或部署流程时，同步更新对应文档。
+- 对外能力描述必须区分已实战验证、已实现待验收、设计/配置基础和新增开发。
 - 两个文档冲突时，以更贴近代码入口的专题文档为准，并顺手修正旧描述。

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -7,7 +7,7 @@
 
 | 修改目标 | 主要入口 | 规则 / 辅助 |
 |---|---|---|
-| 报名 | `src/app/[seasonSlug]/register/`、`src/components/register/RegistrationForm.tsx`、`src/actions/register.ts` | `src/lib/validators/registration.ts`、`src/lib/registration/window.ts` |
+| 个人报名 | `src/app/[seasonSlug]/register/`、`src/components/register/RegistrationForm.tsx`、`src/actions/register.ts` | `src/lib/validators/registration.ts`、`src/lib/registration/window.ts`；队伍报名闭环尚未实现 |
 | 队长投票 | `src/app/[seasonSlug]/captains/`、`src/components/captains/`、`src/actions/captains.ts` | `src/lib/captains/rules.ts`、`src/lib/captains/data.ts` |
 | 选秀 | `src/app/[seasonSlug]/draft/`、`src/components/draft/`、`src/actions/draft/` | `src/lib/draft/rules.ts`、`src/lib/draft/auto-pick.ts`、`src/lib/draft/data.ts` |
 | 队伍 | `src/app/[seasonSlug]/teams/`、`src/components/teams/`、`src/actions/teams.ts` | `src/lib/teams/data.ts` |
@@ -15,10 +15,10 @@
 | 比赛详情 | `src/app/[seasonSlug]/matches/[matchId]/page.tsx` | `src/lib/matches/detail-data.ts`、`src/lib/matches/detail-stats.ts` |
 | 比赛结果 / BP / 阵容 | `src/actions/matches/`、`src/components/matches/` | `src/lib/match-transitions.ts`、`src/lib/validators/match.ts` |
 | 玩家数据 / OCR | `src/actions/player-stats.ts`、`src/components/matches/StatsOCRPanel.tsx` | `src/lib/ocr/`、`src/lib/stats/mvp.ts`、`src/lib/config/stat-profile.ts` |
-| Demo 导入与解析 | `src/actions/demo-import.ts`、`src/actions/demo-detail.ts`、`src/lib/demo/` | `src/lib/demo/map-calibration.ts`、`src/lib/demo/economy-series.ts` |
-| Demo 比赛页展现 | `src/components/matches/DemoPlayerStatsTable.tsx`、`src/components/matches/DemoHeatmap.tsx`、`src/components/matches/DemoRoundTimeline.tsx`、`src/components/matches/DemoKillFeed.tsx`、`src/components/matches/DemoEconomyChart.tsx`、`src/components/matches/DemoClutchList.tsx`、`src/components/matches/PlayerKillHeatmap.tsx`、`src/components/matches/PlayerWeaponBreakdown.tsx`、`src/components/matches/PlayerEntryStats.tsx`、`src/components/matches/PlayerClutchStats.tsx`、`src/components/matches/PlayerUtilityStats.tsx`、`src/components/matches/EconomyConversionPanel.tsx`、`src/components/matches/HighlightLeaderboard.tsx`、`src/components/teams/TeamStyleProfile.tsx`、`src/components/teams/TeamHalfSideStats.tsx` | `src/lib/demo/map-calibration.ts`、`src/lib/demo/utility-stats.ts`、`src/actions/season-demo-stats.ts` |
-| 数据统计排行榜 | `src/app/[seasonSlug]/stats/page.tsx`、`src/components/matches/StatsLeaderboard.tsx` | `src/lib/stats/` |
-| 评分系统 (RR / PRISM / 六维) | `src/actions/compute-season-ratings.ts`（重算入口）、`src/lib/rating/index.ts`（统一适配层） | 外部仓库 `@rivalhub/rival-rating`（权重 JSON + 计算逻辑），适配器 `src/lib/demo/to-rr-indicators.ts`，六维 `src/lib/utils/hexagon.ts` |
+| Demo 导入与解析 | `src/actions/demo-import.ts`、`src/actions/demo-batch-import.ts`、`src/actions/demo-detail.ts`、`src/lib/demo/` | `src/lib/demo/map-calibration.ts`、`src/lib/demo/economy-series.ts`；导入链路可进 staging 验收 |
+| Demo 比赛页展现 | `src/components/matches/DemoPlayerStatsTable.tsx`、`src/components/matches/DemoHeatmap.tsx`、`src/components/matches/DemoRoundTimeline.tsx`、`src/components/matches/DemoKillFeed.tsx`、`src/components/matches/DemoEconomyChart.tsx`、`src/components/matches/DemoClutchList.tsx`、`src/components/matches/PlayerKillHeatmap.tsx`、`src/components/matches/PlayerWeaponBreakdown.tsx`、`src/components/matches/PlayerEntryStats.tsx`、`src/components/matches/PlayerClutchStats.tsx`、`src/components/matches/PlayerUtilityStats.tsx`、`src/components/matches/EconomyConversionPanel.tsx`、`src/components/matches/HighlightLeaderboard.tsx`、`src/components/teams/TeamStyleProfile.tsx`、`src/components/teams/TeamHalfSideStats.tsx` | 当前为建设中能力；完整分析展示待 `cs2-demo-analysis-kit` 接入后再对外承诺 |
+| 数据统计排行榜 | `src/app/[seasonSlug]/stats/page.tsx`、`src/components/matches/StatsLeaderboard.tsx` | `src/lib/stats/`；当前可承诺基础统计 |
+| 评分系统 (RR / PRISM / 六维) | `src/actions/compute-season-ratings.ts`（重算入口）、`src/lib/rating/index.ts`（统一适配层） | 外部仓库 `@rivalhub/rival-rating`（权重 JSON + 计算逻辑），适配器 `src/lib/demo/to-rr-indicators.ts`，六维 `src/lib/utils/hexagon.ts`；完整调权和分析仍在外部仓库推进 |
 | 赛季管理 | `src/app/admin/seasons/`、`src/components/admin/SeasonForm.tsx`、`src/actions/seasons.ts` | `src/types/season.ts`、`src/lib/utils/season.ts` |
 | 权限 / 会话 | `src/actions/auth.ts`、`src/actions/account.ts`、`src/middleware.ts` | `src/lib/auth/session.ts`、`src/lib/auth/supabase.ts` |
 | Cron | `src/app/api/cron/` | `src/actions/draft/picks.ts`、`src/actions/transitions.ts`、`src/actions/matches/scheduling.ts` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,32 @@
 
 生产域名：`https://match.starfie1d.top`。
 
+## 环境分层
+
+| 环境 | 用途 | 数据库 |
+|---|---|---|
+| production | 当前 NJU 赛事和正式站点 | 生产 Supabase 项目 |
+| staging / preview | 外部试点、seed、E2E、demo 导入压测 | 独立 Supabase 项目 |
+| local | 本地开发 | 本地 `.env.local` 指向的开发或 staging 数据库 |
+
+外部试点必须使用独立 staging：独立 Vercel environment / preview deployment + 独立 Supabase 项目。不要在生产数据库上运行 seed、Playwright E2E、demo 批量导入压测或权限越权测试。
+
+staging 与 production 必须分离的变量：
+
+| 变量 | 分离要求 |
+|---|---|
+| `DATABASE_URL` | 指向 staging Supabase Pooler |
+| `NEXT_PUBLIC_SUPABASE_URL` | 指向 staging Supabase 项目 |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 使用 staging anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | 使用 staging service role key |
+| `ADMIN_SESSION_SECRET` | staging 独立生成 |
+| `CRON_SECRET` | staging 独立生成；不要复用 GitHub Actions production secret |
+| `NEXT_PUBLIC_APP_URL` | 指向 staging 域名 |
+| `SILICONFLOW_API_KEY` | 可复用服务商账号，但建议用独立限额 key |
+| `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | 如启用 Turnstile，使用 staging 对应配置 |
+
+---
+
 ## 数据库连接
 
 ### 为什么 Vercel 连不上 Supabase

--- a/docs/external-pilot-readiness.md
+++ b/docs/external-pilot-readiness.md
@@ -1,0 +1,79 @@
+# 外部试点 Readiness
+
+本文档用于外部高校赛事方试点前判断 RivalHub 的真实可用边界。它不替代 `README.md`，也不把设计预设视为已生产可用能力。
+
+## 总体判断
+
+RivalHub 当前适合作为 NJU 选秀联赛流程的二开基础，也适合作为外部赛事方的受控试点基础。试点前必须先搭建独立 staging 环境，并把权限、seed 和文档边界处理清楚。
+
+当前不适合直接承诺为完整商业 SaaS。队伍报名、Major 三段 Swiss、broadcast overlay、俱乐部体系、广告系统仍属于新增开发或未验收能力。
+
+## 能力分层
+
+| 分层 | 能力 | 状态 |
+|---|---|---|
+| 已实战验证 | 个人报名、审核、队长投票、选秀、排位赛、双败淘汰、基础比分录入、OCR 数据录入、公开赛程和基础统计 | 可作为 NJU 当前流程继续使用 |
+| 已实现待验收 | demo ZIP 导入、批量匹配、OCR 冲突确认、覆盖导入、Steam alias、RR / PRISM 重算入口 | 可进 staging 验收，不直接承诺生产稳定 |
+| 配置/代码基础存在 | Major preset、Swiss executor、single elimination handoff | 需要补多阶段运营 UI 和 staging 验收 |
+| 尚未实现 | 队伍自助报名、队伍报名审核、自动生成队伍、broadcast API、OBS/vMix overlay、俱乐部体系、广告系统 | 需要单独立项 |
+
+## 外部试点前必须完成
+
+1. **文档事实化**
+   - README 和 docs 只描述当前真实能力。
+   - demo 展示、Major、队伍报名、broadcast 统一标注为待验收或新增。
+
+2. **独立 staging**
+   - Vercel staging / preview deployment。
+   - 独立 Supabase 项目。
+   - 独立 `DATABASE_URL`、Supabase URL、anon key、service role key、`ADMIN_SESSION_SECRET`、`CRON_SECRET`、OCR key。
+   - staging 的 seed、E2E、demo 导入压测不得指向生产数据库。
+
+3. **权限收敛**
+   - map/match 级 demo、OCR、经济回填 action 应按 `match.seasonId` 调用 `requireSeasonAdmin(seasonId)`。
+   - 外部 `season_admin` 只能操作授权赛季。
+
+4. **试点 seed**
+   - `seed:rivals`：个人报名、审核、队长投票、选秀、排位赛、双败。
+   - `seed:permissions`：guest、user、season_admin、super_admin、root。
+   - 后续再补 `seed:major`、`seed:broadcast`、`seed:demo`。
+
+5. **最小 E2E**
+   - 登录。
+   - 个人报名。
+   - 审核通过。
+   - 确认队长。
+   - 选秀 smoke。
+   - 生成赛程。
+   - 比分录入。
+   - 权限越权 smoke。
+
+## 暂不做但必须声明
+
+| 能力 | 当前处理 |
+|---|---|
+| 队伍报名 | 暂不承诺；外部试点若需要队伍制，先由管理员手工建队或等待后续实现 |
+| Major 三段 Swiss | 暂不承诺完整运营；当前仅有 preset 和 executor 基础 |
+| Broadcast / OBS / vMix | 新增模块；需要另立 broadcast MVP |
+| demo 高级展示 | 当前仓库保留导入和部分展示基础；完整分析展示由 `cs2-demo-analysis-kit` 完成后接入 |
+| rival-rating 体系 | 当前保留接入和重算入口；权重、分析和发布流程由 `rival-rating` 仓库推进 |
+| 俱乐部/广告系统 | 不属于试点前最小范围 |
+
+## 建议整改顺序
+
+1. 文档事实化。
+2. 建 staging 环境文档和 seed 入口。
+3. 修 demo/OCR/经济回填权限。
+4. 补权限单测。
+5. 补 staging smoke E2E。
+6. 再评估是否进入队伍报名或 Major UI 实现。
+
+## 试点验收口径
+
+一次外部试点只能承诺以下结果：
+
+- staging 环境可独立访问，不读写生产库。
+- seed 数据可复现 NJU 选秀联赛核心路径。
+- `season_admin` 无法跨赛季执行管理操作。
+- README/docs 不再过度声明未验收能力。
+- 当前 NJU 赛事线上流程不受影响。

--- a/docs/registration-flow.md
+++ b/docs/registration-flow.md
@@ -1,5 +1,13 @@
 # 报名流程
 
+## 当前实现范围
+
+当前生产验证的是个人报名流程：登录用户在 `/[seasonSlug]/register` 提交个人资料，管理员在 `/admin/[seasonSlug]/registrations` 审核 `season_registrations`。
+
+`registrationMode=team`、队伍自助报名、队员名单提交、队伍报名审核、审核后自动生成 `teams` / `team_members` 仍未形成闭环。外部公开赛或 Major 试点如需队伍制，试点前需要单独实现；在实现前只能由管理员手工建队或使用现有选秀生成队伍流程。
+
+---
+
 ## 完整流程图
 
 ```

--- a/docs/season-abstraction.md
+++ b/docs/season-abstraction.md
@@ -6,18 +6,32 @@
 
 ---
 
+## 当前实现边界
+
+Capability 字段和 preset 是配置层基础，不等于生产已验收流程。当前真实跑通的是 NJU 选秀联赛路径：`registrationMode=solo`、队长投票、选秀、排位赛、双败淘汰、基础比分和数据录入。
+
+以下能力仍需谨慎标注：
+
+| 能力 | 当前状态 |
+|---|---|
+| `registrationMode=team` | schema/types/season form 中已有配置基础，但公开报名页和 `submitRegistration` 仍是个人报名流程 |
+| `open-tournament` | preset 存在；队伍自助报名、审核、生成队伍闭环未完成 |
+| `major` | preset 存在；Swiss executor 有基础，但三段 Swiss 到单败的后台运营闭环未完整验收 |
+| broadcast / overlay | 不属于当前 capability preset，需新增模块 |
+
+---
+
 ## Capability 驱动（核心）
 
 多赛事的功能差异不通过 `season.kind` 判断，而是通过 `seasons` 表上的 capability 字段控制：
 
-| 字段 | 类型 | 选秀联赛预设 | 公开赛预设 | 说明 |
+| 字段 | 类型 | 选秀联赛预设 | 公开赛预设 | 当前实现说明 |
 |---|---|---|---|---|
-| `registrationMode` | `solo \| team` | `solo` | `team` | 个人报名 vs 队伍报名 |
+| `registrationMode` | `solo \| team` | `solo` | `team` | `solo` 已跑通；`team` 仍需队伍报名流程实现 |
 | `hasCaptainVoting` | `boolean` | `true` | `false` | 是否有队长投票环节 |
 | `hasDraft` | `boolean` | `true` | `false` | 是否有蛇形选秀 |
-| `stagePlan` | `StagePlan` | `round_robin -> double_elim` | `round_robin -> double_elim` | 多阶段赛制计划，`matches.stage` 存阶段 `key` |
+| `stagePlan` | `StagePlan` | `round_robin -> double_elim` | `round_robin -> double_elim` | 多阶段赛制计划，`matches.stage` 存阶段 `key`；多段 Swiss 仍需 UI 验收 |
 | `registrationConfig` | `RegistrationConfig` | Rivals 默认（含 maxTotal: 56） | Rivals 默认 | 身份类型、段位门槛、位置上限、截图链接数量、总人数上限 |
-
 | `minTeamSize` | `integer` | `7` | `5` | 每队最少人数 |
 | `maxTeamSize` | `integer` | `7` | `9` | 每队最多人数 |
 | `starterCount` | `integer` | `5` | `5` | 首发人数 |
@@ -26,7 +40,7 @@
 
 **为什么使用 stagePlan**：有些赛事可能仅有排位赛、仅有正赛，或有多个 Swiss / Playoff 阶段。用 `stagePlan` 的阶段数组统一描述，业务代码读取稳定的 `stage.key`，展示使用可变的 `stage.name`。
 
-**这意味着**：新增娱乐赛、All-Star 赛、1v1 赛等，只需在数据库里配置一行不同的 capability，不需要修改任何业务代码。
+**这意味着**：已实现的功能分支应优先读 capability。它不意味着任意新赛事只改数据库配置就能投入生产；队伍报名、Major 多段 Swiss、broadcast 等仍需要对应业务流程和验收。
 
 ```typescript
 // ❌ 禁止
@@ -76,13 +90,13 @@ if (season.hasDraft) { showDraftPage() }
 
 ## Capability 决定的功能差异
 
-| 功能点 | capability 判断 | 选秀联赛 | 公开赛 |
-|---|---|---|---|
-| 报名表单类型 | `registrationMode` | `solo`（个人） | `team`（队伍） |
-| 队长投票入口 | `hasCaptainVoting` | `true` | `false` |
-| 蛇形选秀入口 | `hasDraft` | `true` | `false` |
-| 排位赛展示 | `showQualifier(season)` | `round_robin` | `round_robin` |
-| Bracket 视图 | `showPlayoffBracket(season)` | `double_elim` | `double_elim` |
+| 功能点 | capability 判断 | 选秀联赛 | 公开赛 | 当前状态 |
+|---|---|---|---|---|
+| 报名表单类型 | `registrationMode` | `solo`（个人） | `team`（队伍） | `solo` 已实现；`team` 待实现 |
+| 队长投票入口 | `hasCaptainVoting` | `true` | `false` | 已实现 |
+| 蛇形选秀入口 | `hasDraft` | `true` | `false` | 已实现 |
+| 排位赛展示 | `showQualifier(season)` | `round_robin` | `round_robin` | round-robin 已实战；Swiss 需 staging 验收 |
+| Bracket 视图 | `showPlayoffBracket(season)` | `double_elim` | `double_elim` | 双败已实战；单败需 Major 场景验收 |
 
 **代码中 capability 检查的位置**（统一用 `lib/utils/season.ts` 的工具函数）：
 - `[seasonSlug]/draft/page.tsx`：`if (!showDraft(season)) return <ComingSoon />`
@@ -136,8 +150,8 @@ return (
 | 预设名 | 说明 |
 |---|---|
 | `draft-league` | 选秀联赛（个人报名 → 投票 → 选秀 → 循环赛 + 双败） |
-| `open-tournament` | 公开赛（队伍报名 → 循环赛 + 双败） |
-| `major` | Major 公开赛（32 队 3 轮 Swiss + 单败淘汰） |
+| `open-tournament` | 公开赛配置基础（队伍报名闭环未完成） |
+| `major` | Major 配置基础（32 队 3 轮 Swiss + 单败淘汰仍需 staging 验收） |
 
 部署者可以基于预设创建赛季，也可以完全自定义每个 capability 字段。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,6 +67,34 @@ tests/e2e/
     └── home.spec.ts           # 当前已有首页 smoke
 ```
 
+### Staging 验收
+
+外部试点前需要一套独立 staging 数据库和可复现 seed。当前 `pnpm seed` 只创建 Root 管理员，不足以验收外部试点。
+
+建议新增场景 seed：
+
+| 脚本 | 内容 |
+|---|---|
+| `seed:rivals` | 个人报名、审核、队长投票、选秀、排位赛、双败淘汰 |
+| `seed:permissions` | guest、user、season_admin、super_admin、root 权限矩阵 |
+| `seed:major` | 32 队队伍报名、Swiss、单败；当前需等队伍报名和 Major UI 补齐后再做 |
+| `seed:demo` | demo 导入 fixture；当前可用于导入链路验收，完整展示等外部分析仓库接入 |
+| `seed:broadcast` | broadcast fixture；当前需等 broadcast 模块新增后再做 |
+
+外部试点前最小 staging smoke：
+
+1. 登录。
+2. 个人报名。
+3. 管理员审核。
+4. 队长确认。
+5. 选秀 smoke。
+6. 生成赛程。
+7. 比分录入。
+8. demo 管理页可打开。
+9. `season_admin` 不能跨赛季操作管理 action。
+
+这些验收不得指向 production `DATABASE_URL`。
+
 ---
 
 ## Vitest 配置要点


### PR DESCRIPTION
## Summary
- 将 README 的能力描述改为当前事实状态，区分已实战验证、待验收和未实现能力
- 新增外部试点 readiness 文档，明确 staging、权限、seed 和暂不承诺范围
- 同步更新 season abstraction、registration、deployment、testing 和 code-map 文档

## Test Plan
- pnpm type-check
- git diff --check HEAD~1..HEAD