### PR TITLE
fix: filter source=manual_ocr，修复排行榜 OCR+demo 双重计算

### DIFF
--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -97,6 +97,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     LEFT JOIN teams t ON t.id = tm.team_id
     WHERE m.season_id = ${season.id}
       AND mps.verified_by_admin IS NOT NULL
+      AND mps.source = 'manual_ocr'
       ${positionFilter}
       ${stageFilter}
     GROUP BY mps.user_id, COALESCE(u.perfect_name, mps.perfect_name), sr.primary_position, t.name, t.id

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -124,6 +124,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         and(
           eq(matchPlayerStats.userId, userId),
           sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+          sql`"match_player_stats".source = 'manual_ocr'`,
         )
       )
       .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
@@ -169,6 +170,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       and(
         eq(matchPlayerStats.userId, userId),
         sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+        sql`"match_player_stats".source = 'manual_ocr'`,
       )
     );
   const ocrMatchIds = ocrMatchIdRows.map((r) => r.matchId);


### PR DESCRIPTION
## Problem

v1.30.0 移除 demo 系统时，`active_stat_source` 过滤被一并删除。数据库里每个有 demo 的 map 同时存有两行（`manual_ocr` + `demo_import`），导致：

- **排行榜**：`count(*)` 无 source 过滤 → 两行都算 → MAPS 显示 36（实际 22）
- **选手主页**：`count(distinct mapId)` 侥幸正确，但 avg_kills/ADR 等均值在混用两套数据

## Fix

3 处查询统一加上 `source = 'manual_ocr'` 过滤（1.x 不使用 demo，直接锁死 OCR 来源）：

1. `stats/page.tsx` 排行榜 WHERE
2. `players/[userId]/page.tsx` playerStats 查询（均值计算）
3. `players/[userId]/page.tsx` ocrMatchIdRows 查询（战绩统计）