### PR TITLE
fix: maps 数双倍计数去重（OCR+Demo 双录）

### DIFF
--- a/.changeset/fix-ocr-dedup-leaderboard-player.md
+++ b/.changeset/fix-ocr-dedup-leaderboard-player.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复排行榜和个人页面因 OCR+Demo 双录导致的 maps 数双倍计数，过滤 source=manual_ocr

--- a/.changeset/fix-ocr-dedup-team-page.md
+++ b/.changeset/fix-ocr-dedup-team-page.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复队伍页面选手 maps 数双倍计数（同图 OCR+Demo 双录），补充 source=manual_ocr 过滤，与排行榜/个人页对齐

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -97,6 +97,7 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     LEFT JOIN teams t ON t.id = tm.team_id
     WHERE m.season_id = ${season.id}
       AND mps.verified_by_admin IS NOT NULL
+      AND mps.source = 'manual_ocr'
       ${positionFilter}
       ${stageFilter}
     GROUP BY mps.user_id, COALESCE(u.perfect_name, mps.perfect_name), sr.primary_position, t.name, t.id

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -180,6 +180,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         JOIN team_members tm ON tm.registration_id = sr.id
         WHERE tm.team_id = ${teamId}
           AND mps.verified_by_admin IS NOT NULL
+          AND mps.source = 'manual_ocr'
         GROUP BY mps.user_id
       `)
     : null;

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -124,6 +124,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         and(
           eq(matchPlayerStats.userId, userId),
           sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+          sql`"match_player_stats".source = 'manual_ocr'`,
         )
       )
       .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
@@ -169,6 +170,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       and(
         eq(matchPlayerStats.userId, userId),
         sql`${matchPlayerStats.verifiedByAdmin} IS NOT NULL`,
+        sql`"match_player_stats".source = 'manual_ocr'`,
       )
     );
   const ocrMatchIds = ocrMatchIdRows.map((r) => r.matchId);


### PR DESCRIPTION
## Summary

- **排行榜/个人页**（已在 1a800bd 修复）：补上对应 changeset
- **队伍页面**（本 PR 修复）：`team_stat` 查询漏加 `AND mps.source = 'manual_ocr'`，导致同一张图的 OCR+Demo 两行各被计一次，maps 数虚增为真实值的 2 倍

根因：每张真实出场图在 `match_player_stats` 中存在 `manual_ocr` 和 `demo_import` 两行，过滤 `source = 'manual_ocr'` 即可还原真实出场图数。

## Changes

- `src/app/[seasonSlug]/teams/[teamId]/page.tsx`：`team_stat` 查询加 `AND mps.source = 'manual_ocr'`
- `.changeset/fix-ocr-dedup-leaderboard-player.md`：补记 1a800bd 的 changeset
- `.changeset/fix-ocr-dedup-team-page.md`：本次修复的 changeset

## Test plan

- [ ] 队伍页面大肠教父显示 4 图（原来 8，现在 4）
- [ ] 排行榜/个人页与队伍页三端数字对齐