### PR TITLE
feat: add canonical team identity bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
 
       - run: pnpm type-check
 
+      # migration integrity gate：纯静态 snapshot 链校验，无需 DATABASE_URL / secrets
+      # （本地已验证：移除 .env.local 后 drizzle-kit check 仍正常通过）
+      - run: pnpm exec drizzle-kit check
+
       - run: pnpm test:coverage
 
       - run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ pnpm lint              # ESLint
 pnpm test              # Vitest 单元 + 集成测试
 pnpm test:e2e          # Playwright E2E
 pnpm db:generate       # drizzle-kit generate（生成迁移 SQL）
-pnpm db:push           # drizzle-kit push（推送到 Supabase）
+pnpm db:push           # 直接 schema sync；远程使用限制见 docs/deployment.md
 pnpm db:studio         # Drizzle Studio
 pnpm seed              # 种子数据
 ```
@@ -57,6 +57,7 @@ pnpm seed              # 种子数据
 7. **禁止 Server Action 外写 DB** — 页面只读（RSC fetch），写操作必须是 Server Action。
 8. **shadcn 组件按需 add** — `pnpm dlx shadcn@latest add button`，不手写。
 9. **组件 PascalCase 命名** — 文件名与 export 一致（`ui/` 目录除外）。代码结构查询统一用 CodeGraph（如 `codegraph_files src/components/`），`docs/code-map.md` 仅作业务域入口参考、不再强制同步。
+10. **数据库迁移安全** — 包含 custom SQL / data backfill / fail-closed validation 的 migration 禁止用 `db:push` 应用；任何远程 migration 前必须先确认 staging 隔离与 migration baseline。详见 `docs/deployment.md`。
 
 ## 6. 缓存策略
 
@@ -127,17 +128,3 @@ src/
 - **版本号与 CHANGELOG 由 changeset 管理**：日常 `pnpm changeset`，发版 `pnpm changeset version`；CHANGELOG 必须在打 tag 之前提交，否则 release workflow 找不到版本条目。详见 `.claude/skills/release.md`。
 - **push 必须带 tag**：`git push origin <分支> --follow-tags`，否则 GitHub Release 不会触发。
 - **Demo 与评分外部包属 2.0 线**：v1.30.0 起 1.x 移除 Demo 导入及评分外部包（`@cs2dak/core` / `@rivalhub/rival-rating`），旧 Demo/DAK 历史已归档至 `archive/legacy-demo-dak` / `archive/legacy-original-lineage`（含 `archive/worktree-*` tags），不再有长期 `release/2.0.0` 分支；2.0 开发从 `dev` 开分支；生产库 demo 相关表保留空置、不删除。
-
-## 11. Generated/custom migration safety
-
-从 0020 canonical team identity migration 开始：
-
-- `pnpm db:push` **不得**用于应用 0020——它按 TypeScript schema 与远端 DB 直接 diff 同步，不执行 migration SQL 里的 custom backfill / fail-closed RAISE 逻辑；
-- 0020 的 backfill 与 fail-closed checks 存在于 migration SQL 中，必须通过能够实际执行该 SQL 的 migration workflow 应用；
-- 当前 staging DB isolation 尚未验证；
-- 在独立 staging Supabase 建立之前，**不得应用 0020 到任何 remote DB**；
-- 建立 staging 后必须先检查：1) actual database schema；2) Drizzle migration history table / baseline state；3) 0000–0019 的实际应用状态；
-- 然后再决定一次性的 migration baseline/adoption 方案；
-- 不允许盲目运行 `drizzle-kit migrate` 去假设历史 migration log 已完整。
-
-保留现有 staging data gate（第 7 节）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,17 @@ src/
 - **版本号与 CHANGELOG 由 changeset 管理**：日常 `pnpm changeset`，发版 `pnpm changeset version`；CHANGELOG 必须在打 tag 之前提交，否则 release workflow 找不到版本条目。详见 `.claude/skills/release.md`。
 - **push 必须带 tag**：`git push origin <分支> --follow-tags`，否则 GitHub Release 不会触发。
 - **Demo 与评分外部包属 2.0 线**：v1.30.0 起 1.x 移除 Demo 导入及评分外部包（`@cs2dak/core` / `@rivalhub/rival-rating`），旧 Demo/DAK 历史已归档至 `archive/legacy-demo-dak` / `archive/legacy-original-lineage`（含 `archive/worktree-*` tags），不再有长期 `release/2.0.0` 分支；2.0 开发从 `dev` 开分支；生产库 demo 相关表保留空置、不删除。
+
+## 11. Generated/custom migration safety
+
+从 0020 canonical team identity migration 开始：
+
+- `pnpm db:push` **不得**用于应用 0020——它按 TypeScript schema 与远端 DB 直接 diff 同步，不执行 migration SQL 里的 custom backfill / fail-closed RAISE 逻辑；
+- 0020 的 backfill 与 fail-closed checks 存在于 migration SQL 中，必须通过能够实际执行该 SQL 的 migration workflow 应用；
+- 当前 staging DB isolation 尚未验证；
+- 在独立 staging Supabase 建立之前，**不得应用 0020 到任何 remote DB**；
+- 建立 staging 后必须先检查：1) actual database schema；2) Drizzle migration history table / baseline state；3) 0000–0019 的实际应用状态；
+- 然后再决定一次性的 migration baseline/adoption 方案；
+- 不允许盲目运行 `drizzle-kit migrate` 去假设历史 migration log 已完整。
+
+保留现有 staging data gate（第 7 节）。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -112,6 +112,20 @@ const pgConfig = {
 pnpm db:push    # 将 Drizzle schema 推送到 Supabase 生产数据库
 ```
 
+### Generated/custom migration safety
+
+从 0020 canonical team identity migration 开始：
+
+- `pnpm db:push` **不得**用于应用 0020——它按 TypeScript schema 与远端 DB 直接 diff 同步，不执行 migration SQL 里的 custom backfill / fail-closed RAISE 逻辑；
+- 0020 的 backfill 与 fail-closed checks（7 类校验：NULL / duplicate / season 一致性 / legacy provenance season 一致性）存在于 migration SQL 中，必须通过能够实际执行该 SQL 的 migration workflow 应用；
+- 当前 staging DB isolation 尚未验证；
+- 在独立 staging Supabase 建立之前，**不得应用 0020 到任何 remote DB**；
+- 建立 staging 后必须先检查：1) actual database schema；2) Drizzle migration history table / baseline state；3) 0000–0019 的实际应用状态；
+- 然后再决定一次性的 migration baseline/adoption 方案；
+- 不允许盲目运行 `drizzle-kit migrate` 去假设历史 migration log 已完整。
+
+保留现有 staging data gate（见「环境分层」）。
+
 ### Drizzle 关系查询已知陷阱
 
 `matchRosterPlayers` 是全库唯一没有 `primaryKey()` 的表（用 `unique()` 复合约束）。任何 `db.query.matchRosters.findMany/findFirst({ with: { players: true } })` 都会触发 Drizzle 的 `buildRelationalQueryWithoutPK` 路径。若引用表解析失败会抛 `Cannot read properties of undefined (reading 'referencedTable')`。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -106,25 +106,15 @@ const pgConfig = {
 
 ### 数据库迁移
 
-新增表/列后，Schema 定义只在代码中，**生产数据库不会自动同步**：
+Schema 定义只在代码中，远程数据库不会自动同步。**不要默认使用 `db:push` 更新远程数据库**：
 
-```bash
-pnpm db:push    # 将 Drizzle schema 推送到 Supabase 生产数据库
-```
+- `db:push` 按 TypeScript schema 与远端 DB 直接 diff 同步，**不执行** migration SQL 中的 custom SQL / data backfill / fail-closed validation 逻辑，无法替代包含这些内容的 migration；
+- 0020 canonical team identity migration 是当前第一个明确需要实际执行 migration SQL（backfill + fail-closed checks）的例子；
+- 当前 migration baseline / adoption 尚未完成：staging isolation、actual database schema、migration history 状态均未确认；
+- 在 staging 隔离与 migration baseline 确认之前，**禁止任何远程 migration**（包括盲目运行 `drizzle-kit migrate`——不得假设历史 migration log 已完整）；
+- adoption 完成后，将在此文档定义正式 migration workflow。
 
-### Generated/custom migration safety
-
-从 0020 canonical team identity migration 开始：
-
-- `pnpm db:push` **不得**用于应用 0020——它按 TypeScript schema 与远端 DB 直接 diff 同步，不执行 migration SQL 里的 custom backfill / fail-closed RAISE 逻辑；
-- 0020 的 backfill 与 fail-closed checks（7 类校验：NULL / duplicate / season 一致性 / legacy provenance season 一致性）存在于 migration SQL 中，必须通过能够实际执行该 SQL 的 migration workflow 应用；
-- 当前 staging DB isolation 尚未验证；
-- 在独立 staging Supabase 建立之前，**不得应用 0020 到任何 remote DB**；
-- 建立 staging 后必须先检查：1) actual database schema；2) Drizzle migration history table / baseline state；3) 0000–0019 的实际应用状态；
-- 然后再决定一次性的 migration baseline/adoption 方案；
-- 不允许盲目运行 `drizzle-kit migrate` 去假设历史 migration log 已完整。
-
-保留现有 staging data gate（见「环境分层」）。
+（migration 的校验实现以对应 migration SQL 与测试为 source of truth。）
 
 ### Drizzle 关系查询已知陷阱
 

--- a/drizzle/migrations/0020_black_marvex.sql
+++ b/drizzle/migrations/0020_black_marvex.sql
@@ -46,6 +46,23 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'team_members.season_id does not match parent teams.season_id; migration aborted';
   END IF;
+  -- legacy provenance season consistency：canonical backfill 从 registration 提取 userId，
+  -- 不得把跨 season 的历史错误 provenance 静默升级为 canonical truth
+  IF EXISTS (
+    SELECT 1 FROM "teams" t
+    JOIN "season_registrations" sr ON sr."id" = t."captain_registration_id"
+    WHERE sr."season_id" IS DISTINCT FROM t."season_id"
+  ) THEN
+    RAISE EXCEPTION 'teams.captain_registration_id registration season does not match teams.season_id; migration aborted';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM "team_members" tm
+    JOIN "teams" t ON t."id" = tm."team_id"
+    JOIN "season_registrations" sr ON sr."id" = tm."registration_id"
+    WHERE sr."season_id" IS DISTINCT FROM t."season_id"
+  ) THEN
+    RAISE EXCEPTION 'team_members.registration_id registration season does not match parent teams.season_id; migration aborted';
+  END IF;
 END $$;--> statement-breakpoint
 ALTER TABLE "teams" ALTER COLUMN "captain_user_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "team_members" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint

--- a/drizzle/migrations/0020_black_marvex.sql
+++ b/drizzle/migrations/0020_black_marvex.sql
@@ -1,0 +1,59 @@
+-- PR1: Canonical Team Identity Bridge
+-- teams.captain_user_id / team_members.user_id / team_members.season_id
+-- 安全顺序：nullable ADD → backfill → fail-closed validation → NOT NULL → constraints
+-- 最终 schema 与 0020_snapshot.json 等价（NOT NULL + FK + UNIQUE）
+ALTER TABLE "team_members" ADD COLUMN "season_id" uuid;--> statement-breakpoint
+ALTER TABLE "team_members" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+ALTER TABLE "teams" ADD COLUMN "captain_user_id" uuid;--> statement-breakpoint
+-- backfill teams.captain_user_id ← season_registrations.user_id
+UPDATE "teams" AS t
+SET "captain_user_id" = sr."user_id"
+FROM "season_registrations" AS sr
+WHERE t."captain_registration_id" = sr."id";--> statement-breakpoint
+-- backfill team_members.user_id ← season_registrations.user_id
+UPDATE "team_members" AS tm
+SET "user_id" = sr."user_id"
+FROM "season_registrations" AS sr
+WHERE tm."registration_id" = sr."id";--> statement-breakpoint
+-- backfill team_members.season_id ← teams.season_id
+UPDATE "team_members" AS tm
+SET "season_id" = t."season_id"
+FROM "teams" AS t
+WHERE tm."team_id" = t."id";--> statement-breakpoint
+-- fail-closed validation：任何异常直接中止迁移
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "teams" WHERE "captain_user_id" IS NULL) THEN
+    RAISE EXCEPTION 'teams.captain_user_id has NULL rows; backfill failed';
+  END IF;
+  IF EXISTS (SELECT 1 FROM "team_members" WHERE "user_id" IS NULL) THEN
+    RAISE EXCEPTION 'team_members.user_id has NULL rows; backfill failed';
+  END IF;
+  IF EXISTS (SELECT 1 FROM "team_members" WHERE "season_id" IS NULL) THEN
+    RAISE EXCEPTION 'team_members.season_id has NULL rows; backfill failed';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM "team_members"
+    GROUP BY "season_id", "user_id"
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'duplicate team_members(season_id, user_id) found; migration aborted';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM "team_members" tm
+    JOIN "teams" t ON t."id" = tm."team_id"
+    WHERE tm."season_id" IS DISTINCT FROM t."season_id"
+  ) THEN
+    RAISE EXCEPTION 'team_members.season_id does not match parent teams.season_id; migration aborted';
+  END IF;
+END $$;--> statement-breakpoint
+ALTER TABLE "teams" ALTER COLUMN "captain_user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "team_members" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "team_members" ALTER COLUMN "season_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_season_id_user_id_unique" UNIQUE("season_id","user_id");--> statement-breakpoint
+-- composite FK 目标必须先建立 teams(id, season_id) unique
+ALTER TABLE "teams" ADD CONSTRAINT "teams_id_season_id_unique" UNIQUE("id","season_id");--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_team_season_fk" FOREIGN KEY ("team_id","season_id") REFERENCES "public"."teams"("id","season_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "teams" ADD CONSTRAINT "teams_captain_user_id_users_id_fk" FOREIGN KEY ("captain_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/migrations/meta/0019_snapshot.json
+++ b/drizzle/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2524 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "1d275277-55ef-41c6-b493-18ee2112728f",
+  "prevId": "ff2fdf06-01f3-4e4a-ac81-a1001ad34b68"
+}

--- a/drizzle/migrations/meta/0020_snapshot.json
+++ b/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,2612 @@
+{
+  "id": "1e6de41c-630c-4df3-88be-9b8c6d8c793f",
+  "prevId": "1d275277-55ef-41c6-b493-18ee2112728f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1748044800000,
       "tag": "0019_is_forfeit",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1786412927678,
+      "tag": "0020_black_marvex",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -232,6 +232,7 @@ export async function confirmCaptains(
       const candidates = await tx
         .select({
           registrationId: seasonRegistrations.id,
+          userId: users.id,
           peakRating: seasonRegistrations.peakRating,
           createdAt: seasonRegistrations.createdAt,
           steamName: users.steamName,
@@ -240,7 +241,7 @@ export async function confirmCaptains(
           email: users.email,
         })
         .from(seasonRegistrations)
-        .leftJoin(users, eq(seasonRegistrations.userId, users.id))
+        .innerJoin(users, eq(seasonRegistrations.userId, users.id))
         .where(
           and(
             eq(seasonRegistrations.seasonId, season.id),
@@ -284,6 +285,7 @@ export async function confirmCaptains(
             seasonId: season.id,
             name: `${captainName} 队`,
             captainRegistrationId: captain.registrationId,
+            captainUserId: captain.userId,
             draftOrder: index + 1,
           })
           .returning({ id: teams.id });
@@ -292,6 +294,8 @@ export async function confirmCaptains(
         await tx.insert(teamMembers).values({
           teamId: team.id,
           registrationId: captain.registrationId,
+          userId: captain.userId,
+          seasonId: season.id,
           isStarter: true,
         });
       }

--- a/src/actions/draft/picks.ts
+++ b/src/actions/draft/picks.ts
@@ -484,6 +484,8 @@ async function executeDraftPick(
   await tx.insert(teamMembers).values({
     teamId: input.teamId,
     registrationId: input.registrationId,
+    userId: targetRegistration.userId,
+    seasonId: input.seasonId,
     isStarter: isStarterRound(ds.currentRound),
   });
 

--- a/src/actions/matches/_shared.ts
+++ b/src/actions/matches/_shared.ts
@@ -1,33 +1,22 @@
 import { eq, and, or } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasonRegistrations, teams } from "@/db/schema";
+import { teams } from "@/db/schema";
 import { getMatchOrThrow } from "@/lib/action-utils";
 
 /**
  * 获取队长所属的队伍 ID（用于 roster 提交和 scheduling 的队长身份校验）。
- * 链路：userId → seasonRegistrations.id → teams.captainRegistrationId。
+ * 链路：userId → teams.captainUserId（canonical identity bridge）。
  */
 export async function getTeamIdForCaptain(
   userId: string,
   match: Awaited<ReturnType<typeof getMatchOrThrow>>,
 ): Promise<string | null> {
-  const [reg] = await db
-    .select({ id: seasonRegistrations.id })
-    .from(seasonRegistrations)
-    .where(
-      and(
-        eq(seasonRegistrations.userId, userId),
-        eq(seasonRegistrations.seasonId, match.seasonId),
-      ),
-    );
-  if (!reg) return null;
-
   const [team] = await db
     .select({ id: teams.id })
     .from(teams)
     .where(
       and(
-        eq(teams.captainRegistrationId, reg.id),
+        eq(teams.captainUserId, userId),
         or(eq(teams.id, match.teamAId), eq(teams.id, match.teamBId)),
       ),
     );

--- a/src/actions/matches/_shared.ts
+++ b/src/actions/matches/_shared.ts
@@ -6,6 +6,7 @@ import { getMatchOrThrow } from "@/lib/action-utils";
 /**
  * 获取队长所属的队伍 ID（用于 roster 提交和 scheduling 的队长身份校验）。
  * 链路：userId → teams.captainUserId（canonical identity bridge）。
+ * 必须同时满足：captain identity + match participant + same season（defense-in-depth）。
  */
 export async function getTeamIdForCaptain(
   userId: string,
@@ -17,6 +18,7 @@ export async function getTeamIdForCaptain(
     .where(
       and(
         eq(teams.captainUserId, userId),
+        eq(teams.seasonId, match.seasonId),
         or(eq(teams.id, match.teamAId), eq(teams.id, match.teamBId)),
       ),
     );

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -8,7 +8,6 @@ import { matchPlayerStats } from "@/db/schema/player-stats";
 import { matchMvpVotes } from "@/db/schema/mvp-votes";
 import { auditLogs } from "@/db/schema/audit";
 import { users } from "@/db/schema/users";
-import { seasonRegistrations } from "@/db/schema/registrations";
 import { teamMembers } from "@/db/schema/teams";
 import { ok, fail, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
@@ -56,21 +55,20 @@ export async function extractStatsFromScreenshot(
 
     // 仅查询本场比赛两队队员（用于昵称匹配 + 下拉选择）
     const teamMemberRows = await db
-      .select({ registrationId: teamMembers.registrationId })
+      .select({ userId: teamMembers.userId })
       .from(teamMembers)
       .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId]));
 
-    const teamRegistrationIds = teamMemberRows.map((r) => r.registrationId);
+    const teamUserIds = teamMemberRows.map((r) => r.userId);
 
-    const seasonPlayers = teamRegistrationIds.length
+    const seasonPlayers = teamUserIds.length
       ? await db
           .select({
             userId: users.id,
             perfectName: users.perfectName,
           })
           .from(users)
-          .innerJoin(seasonRegistrations, eq(seasonRegistrations.userId, users.id))
-          .where(inArray(seasonRegistrations.id, teamRegistrationIds))
+          .where(inArray(users.id, teamUserIds))
       : [];
 
     const nameToUserId = new Map<string, string>();
@@ -221,18 +219,17 @@ export async function getMatchPlayerOptions(mapId: string): Promise<PlayerOption
     if (!match) return [];
 
     const teamMemberRows = await db
-      .select({ registrationId: teamMembers.registrationId })
+      .select({ userId: teamMembers.userId })
       .from(teamMembers)
       .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId]));
 
-    const teamRegistrationIds = teamMemberRows.map((r) => r.registrationId);
-    if (!teamRegistrationIds.length) return [];
+    const teamUserIds = teamMemberRows.map((r) => r.userId);
+    if (!teamUserIds.length) return [];
 
     const seasonPlayers = await db
       .select({ userId: users.id, perfectName: users.perfectName })
       .from(users)
-      .innerJoin(seasonRegistrations, eq(seasonRegistrations.userId, users.id))
-      .where(inArray(seasonRegistrations.id, teamRegistrationIds));
+      .where(inArray(users.id, teamUserIds));
 
     return seasonPlayers.map((p) => ({
       userId: p.userId,

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -1,9 +1,9 @@
 "use server";
 
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "@/db/client";
-import { auditLogs, seasonRegistrations, seasons, teams } from "@/db/schema";
+import { auditLogs, seasons, teams } from "@/db/schema";
 import { actionError, failValidation } from "@/lib/action-utils";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { auditActorId, requireAuth } from "@/lib/auth/session";
@@ -38,22 +38,14 @@ export async function uploadTeamLogo(
   try {
     const session = await requireAuth();
 
-    // 并行读取：team 先取，registration + season 依赖 team.seasonId 再并行
+    // 并行读取：team 先取，season 依赖 team.seasonId
     const team = await db.query.teams.findFirst({ where: eq(teams.id, teamId) });
     if (!team) throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
 
-    const [registration, season] = await Promise.all([
-      db.query.seasonRegistrations.findFirst({
-        where: and(
-          eq(seasonRegistrations.seasonId, team.seasonId),
-          eq(seasonRegistrations.userId, session.userId),
-        ),
-      }),
-      db.query.seasons.findFirst({ where: eq(seasons.id, team.seasonId) }),
-    ]);
-    if (!registration || registration.id !== team.captainRegistrationId) {
+    if (team.captainUserId !== session.userId) {
       throw new AppError(ErrorCode.FORBIDDEN, "只有队长可以上传队伍图标");
     }
+    const season = await db.query.seasons.findFirst({ where: eq(seasons.id, team.seasonId) });
     if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
 
     const ext = EXT_MAP[file.type] ?? "jpg";
@@ -108,13 +100,7 @@ export async function updateTeamName(
         throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在");
       }
 
-      const registration = await tx.query.seasonRegistrations.findFirst({
-        where: and(
-          eq(seasonRegistrations.seasonId, team.seasonId),
-          eq(seasonRegistrations.userId, session.userId),
-        ),
-      });
-      if (!registration || registration.id !== team.captainRegistrationId) {
+      if (team.captainUserId !== session.userId) {
         throw new AppError(ErrorCode.FORBIDDEN, "只有队长可以修改队伍名称");
       }
 

--- a/src/app/[seasonSlug]/draft/captain/page.tsx
+++ b/src/app/[seasonSlug]/draft/captain/page.tsx
@@ -4,7 +4,7 @@ import type { Route } from "next";
 import type { Metadata } from "next";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasonRegistrations, seasons, teams } from "@/db/schema";
+import { seasons, teams } from "@/db/schema";
 import { CaptainDraftPanel } from "@/components/draft/CaptainDraftPanel";
 import { Panel, Btn } from "@/components/rivalhub";
 import { getUserSession } from "@/lib/auth/session";
@@ -61,15 +61,10 @@ export default async function DraftCaptainPage({ params }: DraftCaptainPageProps
       teamName: teams.name,
     })
     .from(teams)
-    .innerJoin(
-      seasonRegistrations,
-      eq(teams.captainRegistrationId, seasonRegistrations.id),
-    )
     .where(
       and(
         eq(teams.seasonId, season.id),
-        eq(seasonRegistrations.seasonId, season.id),
-        eq(seasonRegistrations.userId, session.userId),
+        eq(teams.captainUserId, session.userId),
       ),
     )
     .limit(1);

--- a/src/app/[seasonSlug]/matches/[matchId]/page.tsx
+++ b/src/app/[seasonSlug]/matches/[matchId]/page.tsx
@@ -90,8 +90,8 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
           userId: users.id,
         })
         .from(teamMembers)
+        .innerJoin(users, eq(teamMembers.userId, users.id))
         .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
-        .innerJoin(users, eq(seasonRegistrations.userId, users.id))
         .where(inArray(teamMembers.teamId, [match.teamAId, match.teamBId])),
       getSeasonFinishedMatches(season.id, match.teamAId),
       getSeasonFinishedMatches(season.id, match.teamBId),
@@ -263,27 +263,19 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
       userSession.role === "super_admin" ||
       (userSession.role === "season_admin" && userSession.adminSeasonIds.includes(season.id));
 
-    const reg = await db.query.seasonRegistrations.findFirst({
-      where: and(
-        eq(seasonRegistrations.userId, userSession.userId),
-        eq(seasonRegistrations.seasonId, season.id),
-      ),
-    });
-    if (reg) {
-      isCaptainA = teamA?.captainRegistrationId === reg.id;
-      isCaptainB = teamB?.captainRegistrationId === reg.id;
-      if (isCaptainA || isCaptainB) {
-        const captainTeamId = isCaptainA ? match.teamAId : match.teamBId;
-        captainTeamMembers = allTeamMembers
-          .filter((m) => m.teamId === captainTeamId)
-          .map((r) => ({
-            id: r.id,
-            steamName: r.steamName ?? "未知",
-            displayName: r.displayName ?? null,
-            perfectName: r.perfectName ?? null,
-            primaryPosition: r.primaryPosition,
-          }));
-      }
+    isCaptainA = teamA?.captainUserId === userSession.userId;
+    isCaptainB = teamB?.captainUserId === userSession.userId;
+    if (isCaptainA || isCaptainB) {
+      const captainTeamId = isCaptainA ? match.teamAId : match.teamBId;
+      captainTeamMembers = allTeamMembers
+        .filter((m) => m.teamId === captainTeamId)
+        .map((r) => ({
+          id: r.id,
+          steamName: r.steamName ?? "未知",
+          displayName: r.displayName ?? null,
+          perfectName: r.perfectName ?? null,
+          primaryPosition: r.primaryPosition,
+        }));
     }
   }
 

--- a/src/app/[seasonSlug]/stats/page.tsx
+++ b/src/app/[seasonSlug]/stats/page.tsx
@@ -93,7 +93,8 @@ export default async function StatsPage({ params, searchParams }: StatsPageProps
     LEFT JOIN users u ON u.id = mps.user_id
     LEFT JOIN season_registrations sr
       ON sr.user_id = mps.user_id AND sr.season_id = m.season_id
-    LEFT JOIN team_members tm ON tm.registration_id = sr.id
+    LEFT JOIN team_members tm
+      ON tm.user_id = mps.user_id AND tm.season_id = m.season_id
     LEFT JOIN teams t ON t.id = tm.team_id
     WHERE m.season_id = ${season.id}
       AND mps.verified_by_admin IS NOT NULL

--- a/src/app/[seasonSlug]/teams/[teamId]/page.tsx
+++ b/src/app/[seasonSlug]/teams/[teamId]/page.tsx
@@ -45,15 +45,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
 
   const session = await getUserSession();
   const isAdmin = session ? session.role !== "user" : !!(await checkAdminSession());
-  const currentUserRegistration = session
-    ? await db.query.seasonRegistrations.findFirst({
-        where: and(
-          eq(seasonRegistrations.seasonId, season.id),
-          eq(seasonRegistrations.userId, session.userId),
-        ),
-      })
-    : null;
-  const canEditTeamName = currentUserRegistration?.id === team.captainRegistrationId;
+  const canEditTeamName = session?.userId === team.captainUserId;
 
   // ── 阵容 + 赛果 + 即将进行的比赛（并行） ─────────────────────────────────
   const [roster, teamMatches, upcomingMatches] = await Promise.all([
@@ -70,8 +62,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
         userId: users.id,
       })
       .from(teamMembers)
+      .innerJoin(users, eq(teamMembers.userId, users.id))
       .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
-      .innerJoin(users, eq(seasonRegistrations.userId, users.id))
       .where(eq(teamMembers.teamId, teamId)),
     db.query.matches.findMany({
       where: and(
@@ -89,8 +81,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
     }),
   ]);
 
-  const isTeamMember = currentUserRegistration
-    ? roster.some((r) => r.registrationId === currentUserRegistration.id)
+  const isTeamMember = session
+    ? roster.some((r) => r.userId === session.userId)
     : false;
 
   const starters = roster
@@ -176,8 +168,8 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
             ELSE NULL END                                                                            AS kd_ratio
         FROM match_player_stats mps
         JOIN match_maps mm2 ON mm2.id = mps.map_id
-        JOIN season_registrations sr ON sr.user_id = mps.user_id AND sr.season_id = ${season.id}
-        JOIN team_members tm ON tm.registration_id = sr.id
+        JOIN team_members tm
+          ON tm.user_id = mps.user_id AND tm.season_id = ${season.id}
         WHERE tm.team_id = ${teamId}
           AND mps.verified_by_admin IS NOT NULL
           AND mps.source = 'manual_ocr'
@@ -306,7 +298,7 @@ export default async function TeamDetailPage({ params }: TeamDetailPageProps) {
                   <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-1.5 sm:gap-3">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
-                        {p.registrationId === team.captainRegistrationId && <PosChip pos="C" small />}
+                        {p.userId === team.captainUserId && <PosChip pos="C" small />}
                         {p.userId ? (
                           <Link href={`/players/${p.userId}`} className="font-medium text-sm sm:text-base text-[var(--color-fg)] truncate hover:text-[var(--color-accent)] transition-colors">
                             {getDisplayName(p)}

--- a/src/app/[seasonSlug]/teams/page.tsx
+++ b/src/app/[seasonSlug]/teams/page.tsx
@@ -42,7 +42,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       .select({
         teamId: teamMembers.teamId,
         registrationId: teamMembers.registrationId,
-        captainRegId: teams.captainRegistrationId,
+        captainUserId: teams.captainUserId,
         isStarter: teamMembers.isStarter,
         primaryPosition: seasonRegistrations.primaryPosition,
         steamName: users.steamName,
@@ -52,8 +52,8 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       })
       .from(teamMembers)
       .innerJoin(teams, eq(teamMembers.teamId, teams.id))
+      .innerJoin(users, eq(teamMembers.userId, users.id))
       .innerJoin(seasonRegistrations, eq(teamMembers.registrationId, seasonRegistrations.id))
-      .innerJoin(users, eq(seasonRegistrations.userId, users.id))
       .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id))),
     db.query.matches.findMany({
       where: eq(matches.seasonId, season.id),
@@ -75,9 +75,8 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
       FROM match_player_stats mps
       JOIN matches m ON m.id = mps.match_id
       JOIN match_maps mm2 ON mm2.id = mps.map_id
-      JOIN season_registrations sr
-        ON sr.user_id = mps.user_id AND sr.season_id = m.season_id
-      JOIN team_members tm ON tm.registration_id = sr.id
+      JOIN team_members tm
+        ON tm.user_id = mps.user_id AND tm.season_id = m.season_id
       WHERE m.season_id = ${season.id}
         AND mps.verified_by_admin IS NOT NULL
       GROUP BY tm.team_id
@@ -194,7 +193,7 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
               name: getDisplayName(m),
               primaryPosition: m.primaryPosition,
               isStarter: m.isStarter,
-              isCaptain: m.registrationId === m.captainRegId,
+              isCaptain: m.userId === m.captainUserId,
               userId: m.userId,
             }))
             .sort((a, b) => {

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -249,11 +249,11 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
           primaryPosition: seasonRegistrations.primaryPosition,
         })
         .from(teamMembers)
+        .innerJoin(users, eq(teamMembers.userId, users.id))
         .innerJoin(
           seasonRegistrations,
           eq(teamMembers.registrationId, seasonRegistrations.id),
         )
-        .innerJoin(users, eq(seasonRegistrations.userId, users.id))
         .where(inArray(teamMembers.teamId, allTeams.map((t) => t.id))),
       displayedMatchIds.length > 0
         ? (async () => {

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -142,23 +142,20 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
     })
   );
 
-  // ── 队伍归属（registrationId → team）────────────────────────────────
-  const allRegIds = registrations.map((r) => r.id);
-  const teamMemberRows = allRegIds.length
-    ? await db
-        .select({
-          registrationId: teamMembers.registrationId,
-          teamId: teamMembers.teamId,
-          teamName: teams.name,
-          seasonSlug: seasons.slug,
-        })
-        .from(teamMembers)
-        .innerJoin(teams, eq(teamMembers.teamId, teams.id))
-        .innerJoin(seasons, eq(teams.seasonId, seasons.id))
-        .where(inArray(teamMembers.registrationId, allRegIds))
-    : [];
+  // ── 队伍归属（canonical userId → team）────────────────────────────────
+  const teamMemberRows = await db
+    .select({
+      seasonId: teams.seasonId,
+      teamId: teamMembers.teamId,
+      teamName: teams.name,
+      seasonSlug: seasons.slug,
+    })
+    .from(teamMembers)
+    .innerJoin(teams, eq(teamMembers.teamId, teams.id))
+    .innerJoin(seasons, eq(teams.seasonId, seasons.id))
+    .where(eq(teamMembers.userId, userId));
 
-  const regIdToTeam = new Map(teamMemberRows.map((r) => [r.registrationId, r]));
+  const teamBySeasonId = new Map(teamMemberRows.map((r) => [r.seasonId, r]));
 
   // ── 跨赛季比赛战绩（以个人 OCR 出场记录为准）───────────────────────
   const teamIds = [...new Set(teamMemberRows.map((r) => r.teamId).filter(Boolean))];
@@ -457,7 +454,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
           <SectionHeading>参赛记录</SectionHeading>
           <div className="space-y-2">
             {[...registrations].reverse().map((reg) => {
-              const teamInfo = regIdToTeam.get(reg.id);
+              const teamInfo = teamBySeasonId.get(reg.seasonId);
               const posLabel = POSITION_LABELS[reg.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? reg.primaryPosition;
               const peakParts = [`${reg.peakRank} (${reg.peakRankSeason})`, `Rating ${reg.peakRating.toFixed(2)}`];
               if (reg.peakWe != null) peakParts.push(`WE ${reg.peakWe.toFixed(1)}`);

--- a/src/components/matches/PlayerStatsTable.tsx
+++ b/src/components/matches/PlayerStatsTable.tsx
@@ -30,30 +30,18 @@ async function getStatsGroupedByTeam(
   if (stats.length === 0) return { teamA: [] as SummaryPlayer[], teamB: [] as SummaryPlayer[] };
 
   const userIds = stats.map((s) => s.userId).filter(Boolean) as string[];
-  const registrations = userIds.length
-    ? await db.query.seasonRegistrations.findMany({
-        where: (t, { inArray: inArr, and, eq: eqFn }) =>
-          and(inArr(t.userId, userIds), eqFn(t.seasonId, seasonId)),
-        columns: { id: true, userId: true },
-      })
-    : [];
-  const regIds = registrations.map((r) => r.id);
-  const memberships = regIds.length
+  const memberships = userIds.length
     ? await db.query.teamMembers.findMany({
         where: (t, { inArray: inArr, and, eq: eqFn, or: orFn }) =>
           and(
-            inArr(t.registrationId, regIds),
+            inArr(t.userId, userIds),
             orFn(eqFn(t.teamId, teamAId), eqFn(t.teamId, teamBId)),
           ),
-        columns: { registrationId: true, teamId: true },
+        columns: { userId: true, teamId: true },
       })
     : [];
 
-  const userIdToTeam = new Map<string, string>();
-  for (const reg of registrations) {
-    const mship = memberships.find((m) => m.registrationId === reg.id);
-    if (mship) userIdToTeam.set(reg.userId, mship.teamId);
-  }
+  const userIdToTeam = new Map(memberships.map((m) => [m.userId, m.teamId]));
 
   const teamARows = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === teamAId);
   const teamBRows = stats.filter((s) => s.userId && userIdToTeam.get(s.userId) === teamBId);

--- a/src/db/schema/teams.ts
+++ b/src/db/schema/teams.ts
@@ -1,5 +1,6 @@
-import { pgTable, uuid, text, integer, boolean, timestamp, unique } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, integer, boolean, timestamp, unique, foreignKey } from "drizzle-orm/pg-core";
 import { seasons } from "./seasons";
+import { users } from "./users";
 import { seasonRegistrations } from "./registrations";
 
 // TODO: add team status enum if needed
@@ -11,20 +12,35 @@ export const teams = pgTable("teams", {
   captainRegistrationId: uuid("captain_registration_id")
     .notNull()
     .references(() => seasonRegistrations.id),
+  // canonical captain identity（Rivals provenance 保留在 captainRegistrationId）
+  captainUserId: uuid("captain_user_id").notNull().references(() => users.id),
   draftOrder: integer("draft_order").notNull(), // 1-based snake draft order
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({
   uniqueSeasonDraftOrder: unique().on(t.seasonId, t.draftOrder),
+  // composite FK 目标（teams.id, teams.season_id）要求唯一约束
+  uniqueIdSeason: unique().on(t.id, t.seasonId),
 }));
 
 export const teamMembers = pgTable("team_members", {
   id: uuid("id").primaryKey().defaultRandom(),
   teamId: uuid("team_id").notNull().references(() => teams.id),
   registrationId: uuid("registration_id").notNull().references(() => seasonRegistrations.id),
+  // canonical member identity（Rivals provenance 保留在 registrationId）
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  userId: uuid("user_id").notNull().references(() => users.id),
   isStarter: boolean("is_starter").notNull().default(false),
   joinedAt: timestamp("joined_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({
   uniqueRegistration: unique().on(t.registrationId),
+  // 同 season 同 user 只能属于一个正式队伍
+  uniqueSeasonUser: unique().on(t.seasonId, t.userId),
+  // DB 层保证 teamMember.seasonId == parent team.seasonId
+  teamSeasonFk: foreignKey({
+    columns: [t.teamId, t.seasonId],
+    foreignColumns: [teams.id, teams.seasonId],
+    name: "team_members_team_season_fk",
+  }),
 }));
 
 export type Team = typeof teams.$inferSelect;

--- a/tests/unit/actions/captain-identity.test.ts
+++ b/tests/unit/actions/captain-identity.test.ts
@@ -48,15 +48,17 @@ vi.mock("@/lib/revalidation", () => ({
 }));
 
 vi.mock("@/db/schema", () => {
-  const mk = (name: string) => ({ __name: name });
+  // 列对象带 name 属性，便于对 where predicate 做 SQL chunk 检查
+  const col = (name: string) => ({ name });
+  const mk = (name: string, cols: Record<string, unknown> = {}) => ({ __name: name, ...cols });
   return {
-    teams: mk("teams"),
-    teamMembers: mk("teamMembers"),
-    seasons: mk("seasons"),
-    seasonRegistrations: mk("seasonRegistrations"),
-    captainVotes: mk("captainVotes"),
-    auditLogs: mk("auditLogs"),
-    users: mk("users"),
+    teams: mk("teams", { id: col("id"), seasonId: col("season_id"), captainUserId: col("captain_user_id") }),
+    teamMembers: mk("teamMembers", { id: col("id"), teamId: col("team_id"), seasonId: col("season_id"), userId: col("user_id") }),
+    seasons: mk("seasons", {}),
+    seasonRegistrations: mk("seasonRegistrations", {}),
+    captainVotes: mk("captainVotes", {}),
+    auditLogs: mk("auditLogs", {}),
+    users: mk("users", {}),
   };
 });
 
@@ -250,24 +252,56 @@ describe("getTeamIdForCaptain() — canonical captain authorization", () => {
     status: "scheduled",
   } as unknown as Parameters<typeof getTeamIdForCaptain>[1];
 
-  function mockTeamRows(rows: { id: string }[]) {
+  let lastWhere: unknown;
+
+  function mockTeamRows(rows: { id: string }[], capture = false) {
     dbSelectMock.mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(rows),
+        where: vi.fn((cond: unknown) => {
+          if (capture) lastWhere = cond;
+          return Promise.resolve(rows);
+        }),
       }),
     });
   }
 
-  it("captainUserId match → allowed (returns own team id)", async () => {
-    mockTeamRows([{ id: TEAM_A_ID }]);
+  /** 递归检查 drizzle SQL chunk 树中是否包含指定列名 */
+  function sqlContains(chunk: unknown, needle: string): boolean {
+    if (!chunk || typeof chunk !== "object") return false;
+    if (Array.isArray(chunk)) return chunk.some((c) => sqlContains(c, needle));
+    const obj = chunk as { name?: unknown; queryChunks?: unknown };
+    if (typeof obj.name === "string" && obj.name === needle) return true;
+    if (Array.isArray(obj.queryChunks)) return sqlContains(obj.queryChunks, needle);
+    return false;
+  }
+
+  beforeEach(() => {
+    lastWhere = undefined;
+  });
+
+  it("captainUserId match + match participant + same season → allowed", async () => {
+    mockTeamRows([{ id: TEAM_A_ID }], true);
     const teamId = await getTeamIdForCaptain(USER_ID_1, match);
     expect(teamId).toBe(TEAM_A_ID);
+    // query predicate 必须包含 season scope（defense-in-depth）
+    expect(sqlContains(lastWhere, "season_id")).toBe(true);
+    expect(sqlContains(lastWhere, "captain_user_id")).toBe(true);
+    expect(sqlContains(lastWhere, "id")).toBe(true);
   });
 
   it("captain of teamB → returns teamB id", async () => {
-    mockTeamRows([{ id: TEAM_B_ID }]);
+    mockTeamRows([{ id: TEAM_B_ID }], true);
     const teamId = await getTeamIdForCaptain(USER_ID_2, match);
     expect(teamId).toBe(TEAM_B_ID);
+    expect(sqlContains(lastWhere, "season_id")).toBe(true);
+  });
+
+  it("same captainUserId but team season != match season → denied (no matching row)", async () => {
+    // 谓词含 season scope：跨赛季队伍不会命中（mock 返回空行即等价于被谓词排除）
+    mockTeamRows([], true);
+    const teamId = await getTeamIdForCaptain(USER_ID_1, match);
+    expect(teamId).toBeNull();
+    expect(sqlContains(lastWhere, "season_id")).toBe(true);
   });
 
   it("non-captain → denied (null)", async () => {

--- a/tests/unit/actions/captain-identity.test.ts
+++ b/tests/unit/actions/captain-identity.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+// ── 合法 UUID 常量 ─────────────────────────────────────────────────────────────
+const SEASON_ID = "11111111-1111-1111-1111-111111111111";
+const USER_ID_1 = "22222222-2222-2222-2222-222222222222";
+const USER_ID_2 = "33333333-3333-3333-3333-333333333333";
+const REG_ID_1 = "44444444-4444-4444-4444-444444444444";
+const REG_ID_2 = "55555555-5555-5555-5555-555555555555";
+const TEAM_A_ID = "66666666-6666-6666-6666-666666666666";
+const TEAM_B_ID = "77777777-7777-7777-7777-777777777777";
+
+// ── hoisted mock refs ──────────────────────────────────────────────────────────
+const {
+  requireSeasonAdminMock,
+  txSeasonFindFirstMock,
+  txSelectMock,
+  txInsertMock,
+  txUpdateMock,
+  revalidateSeasonPathsMock,
+  // 外部 db.select（getTeamIdForCaptain）
+  dbSelectMock,
+  // 捕获 insert values
+  insertValuesCalls,
+} = vi.hoisted(() => {
+  const insertValuesCalls: { table: string; values: unknown }[] = [];
+  return {
+    requireSeasonAdminMock: vi.fn(),
+    txSeasonFindFirstMock: vi.fn(),
+    txSelectMock: vi.fn(),
+    txInsertMock: vi.fn(),
+    txUpdateMock: vi.fn(),
+    revalidateSeasonPathsMock: vi.fn(),
+    dbSelectMock: vi.fn(),
+    insertValuesCalls,
+  };
+});
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("@/lib/auth/session", () => ({
+  requireAuth: vi.fn(),
+  requireSeasonAdmin: requireSeasonAdminMock,
+  auditActorId: vi.fn((admin: { email?: string; userId?: string }) => admin?.email ?? admin?.userId ?? "system"),
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateSeasonPaths: revalidateSeasonPathsMock,
+}));
+
+vi.mock("@/db/schema", () => {
+  const mk = (name: string) => ({ __name: name });
+  return {
+    teams: mk("teams"),
+    teamMembers: mk("teamMembers"),
+    seasons: mk("seasons"),
+    seasonRegistrations: mk("seasonRegistrations"),
+    captainVotes: mk("captainVotes"),
+    auditLogs: mk("auditLogs"),
+    users: mk("users"),
+  };
+});
+
+vi.mock("@/lib/action-utils", () => ({
+  getMatchOrThrow: vi.fn(),
+  isPgUniqueViolation: vi.fn(() => false),
+  failValidation: vi.fn(),
+  actionError: vi.fn((_scope: string, e: unknown) => ({
+    success: false,
+    error: { code: ErrorCode.INTERNAL_ERROR, message: String(e) },
+  })),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(TX)),
+    select: dbSelectMock,
+  },
+}));
+
+const TX = {
+  query: {
+    seasons: { findFirst: txSeasonFindFirstMock },
+  },
+  select: txSelectMock,
+  insert: txInsertMock,
+  update: txUpdateMock,
+};
+
+// ── import after mocks ─────────────────────────────────────────────────────────
+import { confirmCaptains } from "@/actions/captains";
+import { getTeamIdForCaptain } from "@/actions/matches/_shared";
+
+// ── 公共测试数据 ──────────────────────────────────────────────────────────────
+const SEASON = {
+  id: SEASON_ID,
+  slug: "spring-2026",
+  status: "voting",
+  hasCaptainVoting: true,
+  hasDraft: true,
+  bracketData: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// CAPTAIN_TEAM_COUNT = 8，必须提供 8 名候选人
+const CANDIDATES = Array.from({ length: 8 }, (_, i) => ({
+  registrationId: `10000000-0000-4000-8000-00000000000${i}`,
+  userId: `20000000-0000-4000-8000-00000000000${i}`,
+  peakRating: 2.5 - i * 0.1,
+  createdAt: new Date(`2026-01-0${i + 1}`),
+  steamName: `c${i + 1}`,
+  displayName: null,
+  perfectName: `队长${i + 1}`,
+  email: `c${i + 1}@test.com`,
+}));
+
+const VOTE_ROWS = CANDIDATES.map((c) => ({ candidateRegistrationId: c.registrationId }));
+
+// tx.select 按 from 的表分派返回链
+function setupTxSelect() {
+  txSelectMock.mockImplementation(() => ({
+    from: vi.fn((table: { __name?: string }) => {
+      const name = table.__name ?? "?";
+      if (name === "teams") {
+        // existingTeamCount
+        return { where: vi.fn().mockResolvedValue([{ count: 0 }]) };
+      }
+      if (name === "captainVotes") {
+        return {
+          // totalVotes（带 innerJoin）
+          innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 3 }]) }),
+          // voteRows（无 innerJoin）
+          where: vi.fn().mockResolvedValue(VOTE_ROWS),
+        };
+      }
+      if (name === "seasonRegistrations") {
+        // candidates
+        return { innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(CANDIDATES) }) };
+      }
+      return { where: vi.fn().mockResolvedValue([]) };
+    }),
+  }));
+}
+
+function setupTxInsert() {
+  let teamSeq = 0;
+  txInsertMock.mockImplementation((table: { __name?: string }) => {
+    const name = table.__name ?? "?";
+    if (name === "teams") {
+      return {
+        values: vi.fn((values: unknown) => {
+          insertValuesCalls.push({ table: name, values });
+          teamSeq += 1;
+          return { returning: vi.fn().mockResolvedValue([{ id: teamSeq === 1 ? TEAM_A_ID : TEAM_B_ID }]) };
+        }),
+      };
+    }
+    return {
+      values: vi.fn((values: unknown) => {
+        insertValuesCalls.push({ table: name, values });
+        return Promise.resolve();
+      }),
+    };
+  });
+}
+
+function setupTxUpdate() {
+  txUpdateMock.mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertValuesCalls.length = 0;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("confirmCaptains() — Rivals team creation dual-write", () => {
+  beforeEach(() => {
+    requireSeasonAdminMock.mockResolvedValue({ email: "admin@test.com" });
+    txSeasonFindFirstMock.mockResolvedValue(SEASON);
+    setupTxSelect();
+    setupTxInsert();
+    setupTxUpdate();
+  });
+
+  it("writes captainRegistrationId AND captainUserId on team insert", async () => {
+    const result = await confirmCaptains({ seasonId: SEASON_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teamInserts = insertValuesCalls.filter((c) => c.table === "teams");
+    expect(teamInserts).toHaveLength(8);
+    for (const t of teamInserts) {
+      const values = t.values as Record<string, unknown>;
+      expect(values.captainRegistrationId).toBeTypeOf("string");
+      expect(values.captainUserId).toBeTypeOf("string");
+    }
+    // captainRegistrationId 与 captainUserId 必须来自同一条 registration
+    const byReg = new Map(CANDIDATES.map((c) => [c.registrationId, c.userId]));
+    for (const t of teamInserts) {
+      const values = t.values as Record<string, string>;
+      expect(byReg.get(values.captainRegistrationId)).toBe(values.captainUserId);
+    }
+  });
+
+  it("writes registrationId + userId + seasonId on captain teamMember insert", async () => {
+    const result = await confirmCaptains({ seasonId: SEASON_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const memberInserts = insertValuesCalls.filter((c) => c.table === "teamMembers");
+    expect(memberInserts).toHaveLength(8);
+    for (const m of memberInserts) {
+      const values = m.values as Record<string, string>;
+      expect(values.registrationId).toBeTypeOf("string");
+      expect(values.userId).toBeTypeOf("string");
+      expect(values.seasonId).toBe(SEASON_ID);
+    }
+    // userId 必须等于 registration 的 userId（canonical identity）
+    const byReg = new Map(CANDIDATES.map((c) => [c.registrationId, c.userId]));
+    for (const m of memberInserts) {
+      const values = m.values as Record<string, string>;
+      expect(byReg.get(values.registrationId)).toBe(values.userId);
+    }
+  });
+
+  it("keeps draftOrder provenance (1-based) on team insert", async () => {
+    const result = await confirmCaptains({ seasonId: SEASON_ID });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teamInserts = insertValuesCalls.filter((c) => c.table === "teams");
+    const orders = teamInserts.map((t) => (t.values as Record<string, number>).draftOrder).sort();
+    expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("getTeamIdForCaptain() — canonical captain authorization", () => {
+  const match = {
+    id: "m1",
+    seasonId: SEASON_ID,
+    teamAId: TEAM_A_ID,
+    teamBId: TEAM_B_ID,
+    status: "scheduled",
+  } as unknown as Parameters<typeof getTeamIdForCaptain>[1];
+
+  function mockTeamRows(rows: { id: string }[]) {
+    dbSelectMock.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+    });
+  }
+
+  it("captainUserId match → allowed (returns own team id)", async () => {
+    mockTeamRows([{ id: TEAM_A_ID }]);
+    const teamId = await getTeamIdForCaptain(USER_ID_1, match);
+    expect(teamId).toBe(TEAM_A_ID);
+  });
+
+  it("captain of teamB → returns teamB id", async () => {
+    mockTeamRows([{ id: TEAM_B_ID }]);
+    const teamId = await getTeamIdForCaptain(USER_ID_2, match);
+    expect(teamId).toBe(TEAM_B_ID);
+  });
+
+  it("non-captain → denied (null)", async () => {
+    mockTeamRows([]);
+    const teamId = await getTeamIdForCaptain("99999999-9999-9999-9999-999999999999", match);
+    expect(teamId).toBeNull();
+  });
+});

--- a/tests/unit/actions/draft-picks-identity.test.ts
+++ b/tests/unit/actions/draft-picks-identity.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── 合法 UUID 常量 ─────────────────────────────────────────────────────────────
+const SEASON_ID = "11111111-1111-1111-1111-111111111111";
+const CAPTAIN_USER_ID = "22222222-2222-2222-2222-222222222222";
+const TARGET_USER_ID = "33333333-3333-3333-3333-333333333333";
+const CAPTAIN_REG_ID = "44444444-4444-4444-4444-444444444444";
+const TARGET_REG_ID = "55555555-5555-5555-5555-555555555555";
+const TEAM_ID = "66666666-6666-6666-6666-666666666666";
+const TEAM_B_ID = "77777777-7777-7777-7777-777777777777";
+const PICK_ID = "88888888-8888-8888-8888-888888888888";
+const CLIENT_REQUEST_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+// ── hoisted mock refs ──────────────────────────────────────────────────────────
+const {
+  requireAuthMock,
+  txSeasonFindFirstMock,
+  txDraftPickFindFirstMock,
+  txTeamFindFirstMock,
+  txRegFindFirstMock,
+  txSelectMock,
+  txInsertMock,
+  txUpdateMock,
+  revalidateSeasonPathsMock,
+  insertValuesCalls,
+} = vi.hoisted(() => {
+  const insertValuesCalls: { table: string; values: unknown }[] = [];
+  return {
+    requireAuthMock: vi.fn(),
+    txSeasonFindFirstMock: vi.fn(),
+    txDraftPickFindFirstMock: vi.fn(),
+    txTeamFindFirstMock: vi.fn(),
+    txRegFindFirstMock: vi.fn(),
+    txSelectMock: vi.fn(),
+    txInsertMock: vi.fn(),
+    txUpdateMock: vi.fn(),
+    revalidateSeasonPathsMock: vi.fn(),
+    insertValuesCalls,
+  };
+});
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+vi.mock("@/lib/auth/session", () => ({
+  requireAuth: requireAuthMock,
+  requireSeasonAdmin: vi.fn(),
+  auditActorId: vi.fn((session: { userId?: string }) => session?.userId ?? "system"),
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateSeasonPaths: revalidateSeasonPathsMock,
+}));
+
+vi.mock("@/db/schema", () => {
+  const mk = (name: string) => ({ __name: name });
+  return {
+    teams: mk("teams"),
+    teamMembers: mk("teamMembers"),
+    seasons: mk("seasons"),
+    seasonRegistrations: mk("seasonRegistrations"),
+    draftState: mk("draftState"),
+    draftPicks: mk("draftPicks"),
+    auditLogs: mk("auditLogs"),
+    users: mk("users"),
+  };
+});
+
+vi.mock("@/db/client", () => ({
+  db: {
+    transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(TX)),
+  },
+}));
+
+const TX = {
+  query: {
+    seasons: { findFirst: txSeasonFindFirstMock },
+    draftPicks: { findFirst: txDraftPickFindFirstMock },
+    teams: { findFirst: txTeamFindFirstMock },
+    seasonRegistrations: { findFirst: txRegFindFirstMock },
+  },
+  select: txSelectMock,
+  insert: txInsertMock,
+  update: txUpdateMock,
+};
+
+// ── import after mocks ─────────────────────────────────────────────────────────
+import { pickPlayer } from "@/actions/draft/picks";
+
+// ── 公共测试数据 ──────────────────────────────────────────────────────────────
+const SEASON = {
+  id: SEASON_ID,
+  slug: "spring-2026",
+  status: "drafting",
+  hasDraft: true,
+  bracketData: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const DS = {
+  id: "ds1",
+  seasonId: SEASON_ID,
+  currentTeamId: TEAM_ID,
+  currentRound: 1,
+  roundDeadline: new Date(Date.now() + 60_000),
+  isActive: true,
+  updatedAt: new Date(),
+};
+
+const TEAM = {
+  id: TEAM_ID,
+  seasonId: SEASON_ID,
+  name: "A 队",
+  captainRegistrationId: CAPTAIN_REG_ID,
+  captainUserId: CAPTAIN_USER_ID,
+  draftOrder: 2,
+  logoUrl: null,
+  createdAt: new Date(),
+};
+
+const CAPTAIN_REG = {
+  id: CAPTAIN_REG_ID,
+  userId: CAPTAIN_USER_ID,
+  seasonId: SEASON_ID,
+  status: "approved",
+};
+
+const TARGET_REG = {
+  id: TARGET_REG_ID,
+  userId: TARGET_USER_ID,
+  seasonId: SEASON_ID,
+  status: "approved",
+  primaryPosition: "opener",
+};
+
+const SEASON_TEAMS = [
+  { id: TEAM_B_ID, draftOrder: 1 },
+  { id: TEAM_ID, draftOrder: 2 },
+];
+
+// tx.select 按 from 的表分派返回链
+function setupTxSelect() {
+  txSelectMock.mockImplementation(() => ({
+    from: vi.fn((table: { __name?: string }) => {
+      const name = table.__name ?? "?";
+      if (name === "draftState") {
+        return { where: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue([DS]) }) };
+      }
+      if (name === "teamMembers") {
+        // 位置统计：无同位置冲突
+        return { innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) };
+      }
+      if (name === "draftPicks") {
+        // pickNumber 计数
+        return { where: vi.fn().mockResolvedValue([{ count: 0 }]) };
+      }
+      if (name === "teams") {
+        // 选秀顺序（getNextTeamId）
+        return { where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue(SEASON_TEAMS) }) };
+      }
+      return { where: vi.fn().mockResolvedValue([]) };
+    }),
+  }));
+}
+
+function setupTxInsert() {
+  txInsertMock.mockImplementation((table: { __name?: string }) => {
+    const name = table.__name ?? "?";
+    if (name === "draftPicks") {
+      return {
+        values: vi.fn((values: unknown) => {
+          insertValuesCalls.push({ table: name, values });
+          return { returning: vi.fn().mockResolvedValue([{ id: PICK_ID }]) };
+        }),
+      };
+    }
+    return {
+      values: vi.fn((values: unknown) => {
+        insertValuesCalls.push({ table: name, values });
+        return Promise.resolve();
+      }),
+    };
+  });
+}
+
+function setupTxUpdate() {
+  txUpdateMock.mockImplementation(() => ({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertValuesCalls.length = 0;
+  requireAuthMock.mockResolvedValue({ userId: CAPTAIN_USER_ID, email: "captain@test.com" });
+  txSeasonFindFirstMock.mockResolvedValue(SEASON);
+  txDraftPickFindFirstMock.mockResolvedValue(null);
+  txTeamFindFirstMock.mockResolvedValue(TEAM);
+  txRegFindFirstMock.mockResolvedValueOnce(CAPTAIN_REG).mockResolvedValueOnce(TARGET_REG);
+  setupTxSelect();
+  setupTxInsert();
+  setupTxUpdate();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("pickPlayer() — Rivals draft pick dual-write", () => {
+  it("teamMember insert writes registrationId + userId + seasonId", async () => {
+    const result = await pickPlayer({
+      seasonId: SEASON_ID,
+      teamId: TEAM_ID,
+      registrationId: TARGET_REG_ID,
+      clientRequestId: CLIENT_REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+
+    const memberInserts = insertValuesCalls.filter((c) => c.table === "teamMembers");
+    expect(memberInserts).toHaveLength(1);
+    const values = memberInserts[0].values as Record<string, string>;
+    expect(values.registrationId).toBe(TARGET_REG_ID);
+    expect(values.userId).toBe(TARGET_USER_ID);
+    expect(values.seasonId).toBe(SEASON_ID);
+  });
+
+  it("draft regression: draftPick insert keeps registrationId provenance", async () => {
+    const result = await pickPlayer({
+      seasonId: SEASON_ID,
+      teamId: TEAM_ID,
+      registrationId: TARGET_REG_ID,
+      clientRequestId: CLIENT_REQUEST_ID,
+    });
+
+    expect(result.success).toBe(true);
+
+    const pickInserts = insertValuesCalls.filter((c) => c.table === "draftPicks");
+    expect(pickInserts).toHaveLength(1);
+    const values = pickInserts[0].values as Record<string, string>;
+    expect(values.registrationId).toBe(TARGET_REG_ID);
+    expect(values.seasonId).toBe(SEASON_ID);
+    expect(values.teamId).toBe(TEAM_ID);
+  });
+});

--- a/tests/unit/actions/team-profile.test.ts
+++ b/tests/unit/actions/team-profile.test.ts
@@ -91,8 +91,8 @@ describe("updateTeamName", () => {
       seasonId: "season-1",
       name: "Old Name",
       captainRegistrationId: "reg-1",
+      captainUserId: "user-1",
     });
-    registrationFindFirstMock.mockResolvedValue({ id: "reg-1" });
     seasonFindFirstMock.mockResolvedValue({ slug: "spring" });
 
     const result = await updateTeamName("team-1", "  New Name  ");
@@ -119,8 +119,8 @@ describe("updateTeamName", () => {
       seasonId: "season-1",
       name: "Old Name",
       captainRegistrationId: "reg-1",
+      captainUserId: "other-user",
     });
-    registrationFindFirstMock.mockResolvedValue({ id: "reg-other" });
 
     const result = await updateTeamName("team-1", "New Name");
 

--- a/tests/unit/actions/teams.test.ts
+++ b/tests/unit/actions/teams.test.ts
@@ -6,11 +6,9 @@ import { mockUserSession, expectAuditLog, resetAuditTracking } from "tests/helpe
 const {
   // outside-tx query mocks (used by uploadTeamLogo)
   teamFindFirstMock,
-  registrationFindFirstMock,
   seasonFindFirstMock,
   // inside-tx mocks (used by both uploadTeamLogo and updateTeamName)
   txTeamFindFirstMock,
-  txRegistrationFindFirstMock,
   txSeasonFindFirstMock,
   txUpdateMock,
   txInsertMock,
@@ -29,10 +27,8 @@ const {
   const txInsertValuesCalls: unknown[] = [];
   return {
     teamFindFirstMock: vi.fn(),
-    registrationFindFirstMock: vi.fn(),
     seasonFindFirstMock: vi.fn(),
     txTeamFindFirstMock: vi.fn(),
-    txRegistrationFindFirstMock: vi.fn(),
     txSeasonFindFirstMock: vi.fn(),
     txUpdateMock: vi.fn(),
     txInsertMock: vi.fn(),
@@ -75,7 +71,6 @@ vi.mock("@/db/client", () => {
   const tx = {
     query: {
       teams: { findFirst: txTeamFindFirstMock },
-      seasonRegistrations: { findFirst: txRegistrationFindFirstMock },
       seasons: { findFirst: txSeasonFindFirstMock },
     },
     update: txUpdateMock,
@@ -86,7 +81,6 @@ vi.mock("@/db/client", () => {
     db: {
       query: {
         teams: { findFirst: teamFindFirstMock },
-        seasonRegistrations: { findFirst: registrationFindFirstMock },
         seasons: { findFirst: seasonFindFirstMock },
       },
       transaction: transactionMock.mockImplementation(
@@ -120,16 +114,8 @@ function setupOutsideTxTeam(overrides?: Record<string, unknown>) {
     seasonId: SEASON_ID,
     name: "Test Team",
     captainRegistrationId: CAPTAIN_REG_ID,
+    captainUserId: USER_ID,
     logoUrl: null,
-    ...overrides,
-  });
-}
-
-function setupOutsideTxRegistration(overrides?: Record<string, unknown>) {
-  registrationFindFirstMock.mockResolvedValue({
-    id: CAPTAIN_REG_ID,
-    userId: USER_ID,
-    seasonId: SEASON_ID,
     ...overrides,
   });
 }
@@ -148,16 +134,8 @@ function setupTxTeam(overrides?: Record<string, unknown>) {
     seasonId: SEASON_ID,
     name: "Test Team",
     captainRegistrationId: CAPTAIN_REG_ID,
+    captainUserId: USER_ID,
     logoUrl: null,
-    ...overrides,
-  });
-}
-
-function setupTxRegistration(overrides?: Record<string, unknown>) {
-  txRegistrationFindFirstMock.mockResolvedValue({
-    id: CAPTAIN_REG_ID,
-    userId: USER_ID,
-    seasonId: SEASON_ID,
     ...overrides,
   });
 }
@@ -239,9 +217,7 @@ describe("uploadTeamLogo", () => {
   });
 
   it("not captain → fail", async () => {
-    setupOutsideTxTeam();
-    registrationFindFirstMock.mockResolvedValue(null); // not registered
-    setupOutsideTxSeason();
+    setupOutsideTxTeam({ captainUserId: "other-user" }); // canonical captain mismatch
 
     const fd = new FormData();
     fd.append("file", new File(["test"], "test.png", { type: "image/png" }));
@@ -255,7 +231,6 @@ describe("uploadTeamLogo", () => {
 
   it("success → ok + audit", async () => {
     setupOutsideTxTeam();
-    setupOutsideTxRegistration();
     setupOutsideTxSeason();
     setupSupabaseSuccess();
 
@@ -281,7 +256,6 @@ describe("uploadTeamLogo", () => {
 
   it("season has bracketData → logo upload unaffected", async () => {
     setupOutsideTxTeam();
-    setupOutsideTxRegistration();
     setupOutsideTxSeason({ bracketData: { participant: [], stage: [] } });
     setupSupabaseSuccess();
 
@@ -334,8 +308,7 @@ describe("updateTeamName", () => {
   });
 
   it("not captain → fail", async () => {
-    setupTxTeam();
-    txRegistrationFindFirstMock.mockResolvedValue({ id: "reg-other" });
+    setupTxTeam({ captainUserId: "other-user" }); // canonical captain mismatch
 
     const result = await updateTeamName(TEAM_ID, "New Name");
 
@@ -349,7 +322,6 @@ describe("updateTeamName", () => {
 
   it("success → ok + audit", async () => {
     setupTxTeam({ name: "Old Name" });
-    setupTxRegistration();
     setupTxSeason();
 
     const result = await updateTeamName(TEAM_ID, "  New Name  ");
@@ -373,7 +345,6 @@ describe("updateTeamName", () => {
 
   it("same name → ok no-op", async () => {
     setupTxTeam({ name: "Same Name" });
-    setupTxRegistration();
     setupTxSeason();
 
     const result = await updateTeamName(TEAM_ID, "Same Name");
@@ -385,7 +356,6 @@ describe("updateTeamName", () => {
 
   it("bracketData null → rename ok", async () => {
     setupTxTeam({ name: "Old Name" });
-    setupTxRegistration();
     setupTxSeason({ bracketData: null });
 
     const result = await updateTeamName(TEAM_ID, "New Name");
@@ -396,7 +366,6 @@ describe("updateTeamName", () => {
 
   it("bracketData exists → rename rejected without writes", async () => {
     setupTxTeam({ name: "Old Name" });
-    setupTxRegistration();
     setupTxSeason({ bracketData: { participant: [], stage: [] } });
 
     const result = await updateTeamName(TEAM_ID, "New Name");

--- a/tests/unit/components/matches/PlayerStatsTable.test.tsx
+++ b/tests/unit/components/matches/PlayerStatsTable.test.tsx
@@ -1,14 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
-const { mockFindMany } = vi.hoisted(() => ({ mockFindMany: vi.fn() }));
+const { mockFindMany, mockMembershipFindMany } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockMembershipFindMany: vi.fn(),
+}));
 
 vi.mock("@/db/client", () => ({
   db: {
     query: {
       matchPlayerStats: { findMany: mockFindMany },
-      seasonRegistrations: { findMany: vi.fn().mockResolvedValue([]) },
-      teamMembers: { findMany: vi.fn().mockResolvedValue([]) },
+      // canonical member identity：只暴露 teamMembers.findMany（按 userId 查）
+      teamMembers: { findMany: mockMembershipFindMany },
     },
   },
 }));
@@ -23,7 +26,7 @@ vi.mock("@/db/schema/player-stats", () => ({
 }));
 
 vi.mock("@/db/schema/teams", () => ({
-  teamMembers: { registrationId: {}, teamId: {} },
+  teamMembers: { userId: {}, teamId: {} },
 }));
 
 vi.mock("@/db/schema/registrations", () => ({
@@ -43,6 +46,12 @@ const baseProps = {
 };
 
 describe("PlayerStatsTable", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockMembershipFindMany.mockReset();
+    mockMembershipFindMany.mockResolvedValue([]);
+  });
+
   it("renders empty state when no stats", async () => {
     mockFindMany.mockResolvedValue([]);
     const jsx = await PlayerStatsTable(baseProps);
@@ -70,5 +79,23 @@ describe("PlayerStatsTable", () => {
     const jsx = await PlayerStatsTable(baseProps);
     render(jsx);
     expect(screen.getByText("1.35")).toBeDefined();
+  });
+
+  it("assigns players to teams via canonical teamMembers.userId (no seasonRegistration chain)", async () => {
+    mockFindMany.mockResolvedValue([
+      { id: "p1", userId: "u-a", perfectName: "A队选手", kills: 10, deaths: 5, assists: 3, adr: 80, ratingPro: 1.1, hsPercent: 50, firstKills: 2, multiKills: 1, clutches: 0, rws: 12, we: 1.5 },
+      { id: "p2", userId: "u-b", perfectName: "B队选手", kills: 5, deaths: 10, assists: 1, adr: 50, ratingPro: 0.8, hsPercent: 40, firstKills: 0, multiKills: 0, clutches: 0, rws: 8, we: 0.8 },
+    ]);
+    // canonical membership：userId → teamId
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: "u-a", teamId: "ta" },
+      { userId: "u-b", teamId: "tb" },
+    ]);
+    const jsx = await PlayerStatsTable(baseProps);
+    render(jsx);
+    // 两队都能正确归属渲染
+    expect(screen.getByText("A队选手")).toBeDefined();
+    expect(screen.getByText("B队选手")).toBeDefined();
+    expect(mockMembershipFindMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/db/migration-0020.test.ts
+++ b/tests/unit/db/migration-0020.test.ts
@@ -43,14 +43,17 @@ describe("0020 canonical team identity migration — fail-closed coverage", () =
     expect(idx).toBeGreaterThan(-1);
   });
 
-  it("fail-closed validation：5 类异常全部 RAISE EXCEPTION", () => {
+  it("fail-closed validation：7 类异常全部 RAISE EXCEPTION", () => {
     const checks = [
       "teams.captain_user_id has NULL rows",
       "team_members.user_id has NULL rows",
       "team_members.season_id has NULL rows",
       "duplicate team_members(season_id, user_id)",
       "team_members.season_id does not match parent teams.season_id",
+      "teams.captain_registration_id registration season does not match teams.season_id",
+      "team_members.registration_id registration season does not match parent teams.season_id",
     ];
+    expect(checks).toHaveLength(7);
     for (const c of checks) {
       expect(sql).toContain(`RAISE EXCEPTION '${c}`);
     }
@@ -76,6 +79,23 @@ describe("0020 canonical team identity migration — fail-closed coverage", () =
     expect(sql).toContain('"team_members_season_id_user_id_unique" UNIQUE("season_id","user_id")');
     expect(sql).toContain('"team_members_team_season_fk"');
     expect(sql).toContain('"teams_id_season_id_unique" UNIQUE("id","season_id")');
+  });
+
+  it("provenance season consistency checks 使用 registration-season 而非猜测修复", () => {
+    // 从 provenance 校验块起点（注释锚点）开始切片，覆盖 JOIN + RAISE 全部语句
+    const block = sql.slice(sql.indexOf("legacy provenance season consistency"));
+    // A. captain provenance：registration season != team season → RAISE
+    expect(block).toContain("JOIN \"season_registrations\" sr ON sr.\"id\" = t.\"captain_registration_id\"");
+    expect(block).toContain("sr.\"season_id\" IS DISTINCT FROM t.\"season_id\"");
+    expect(block).toContain("RAISE EXCEPTION 'teams.captain_registration_id registration season does not match teams.season_id");
+    // B. member provenance：registration season != parent team season → RAISE
+    expect(block).toContain("JOIN \"teams\" t ON t.\"id\" = tm.\"team_id\"");
+    expect(block).toContain("JOIN \"season_registrations\" sr ON sr.\"id\" = tm.\"registration_id\"");
+    expect(block).toContain("sr.\"season_id\" IS DISTINCT FROM t.\"season_id\"");
+    expect(block).toContain("RAISE EXCEPTION 'team_members.registration_id registration season does not match parent teams.season_id");
+    // fail closed：无自动 UPDATE 修复 / 无 DELETE
+    expect(sql).not.toMatch(/UPDATE\s+("teams"|"team_members")\s+SET\s+"season_id"/);
+    expect(sql).not.toMatch(/DELETE FROM/i);
   });
 
   it("provenance 列保持 NOT NULL（Rivals registration provenance 未放宽）", () => {

--- a/tests/unit/db/migration-0020.test.ts
+++ b/tests/unit/db/migration-0020.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATIONS_DIR = join(process.cwd(), "drizzle/migrations");
+
+const sql = readFileSync(join(MIGRATIONS_DIR, "0020_black_marvex.sql"), "utf-8");
+const snap0020 = JSON.parse(
+  readFileSync(join(MIGRATIONS_DIR, "meta/0020_snapshot.json"), "utf-8"),
+) as { id: string; prevId: string; tables: Record<string, { columns: Record<string, { notNull: boolean }> }> };
+const snap0019 = JSON.parse(
+  readFileSync(join(MIGRATIONS_DIR, "meta/0019_snapshot.json"), "utf-8"),
+) as { id: string };
+const journal = JSON.parse(
+  readFileSync(join(MIGRATIONS_DIR, "meta/_journal.json"), "utf-8"),
+) as { entries: { idx: number; tag: string }[] };
+
+describe("0020 canonical team identity migration — fail-closed coverage", () => {
+  it("adds canonical columns nullable first（存量行安全）", () => {
+    expect(sql).toContain('ADD COLUMN "season_id" uuid;');
+    expect(sql).toContain('ADD COLUMN "user_id" uuid;');
+    expect(sql).toContain('ADD COLUMN "captain_user_id" uuid;');
+    // 初始 ADD 不得直接 NOT NULL，否则已有 rows 的表必然失败
+    expect(sql.match(/ADD COLUMN "[^"]+" uuid NOT NULL/g)).toBeNull();
+  });
+
+  it("backfill 顺序正确：teams.captain_user_id ← season_registrations.user_id", () => {
+    const idx = sql.indexOf('UPDATE "teams"');
+    expect(idx).toBeGreaterThan(-1);
+    expect(sql.slice(idx, idx + 400)).toContain("captain_registration_id");
+    expect(sql.slice(idx, idx + 400)).toContain("season_registrations");
+  });
+
+  it("backfill team_members.user_id ← season_registrations.user_id", () => {
+    const idx = sql.indexOf('UPDATE "team_members"');
+    expect(idx).toBeGreaterThan(-1);
+    expect(sql.slice(idx, idx + 400)).toContain("registration_id");
+    expect(sql.slice(idx, idx + 400)).toContain("season_registrations");
+  });
+
+  it("backfill team_members.season_id ← teams.season_id", () => {
+    const idx = sql.indexOf('SET "season_id" = t."season_id"');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("fail-closed validation：5 类异常全部 RAISE EXCEPTION", () => {
+    const checks = [
+      "teams.captain_user_id has NULL rows",
+      "team_members.user_id has NULL rows",
+      "team_members.season_id has NULL rows",
+      "duplicate team_members(season_id, user_id)",
+      "team_members.season_id does not match parent teams.season_id",
+    ];
+    for (const c of checks) {
+      expect(sql).toContain(`RAISE EXCEPTION '${c}`);
+    }
+  });
+
+  it("禁止自动删除/猜测/静默忽略（无 DELETE 兜底）", () => {
+    expect(sql).not.toMatch(/DELETE FROM/i);
+  });
+
+  it("validation 通过后才 SET NOT NULL，且顺序在 backfill 之后", () => {
+    const backfillPos = sql.indexOf('SET "season_id" = t."season_id"');
+    const validatePos = sql.indexOf("RAISE EXCEPTION");
+    const notNullPos = sql.indexOf('SET NOT NULL');
+    expect(backfillPos).toBeGreaterThan(-1);
+    expect(validatePos).toBeGreaterThan(backfillPos);
+    expect(notNullPos).toBeGreaterThan(validatePos);
+  });
+
+  it("最终 NOT NULL + UNIQUE(season_id, user_id) + composite FK + teams(id, season_id) unique", () => {
+    expect(sql).toContain('ALTER TABLE "teams" ALTER COLUMN "captain_user_id" SET NOT NULL');
+    expect(sql).toContain('ALTER TABLE "team_members" ALTER COLUMN "user_id" SET NOT NULL');
+    expect(sql).toContain('ALTER TABLE "team_members" ALTER COLUMN "season_id" SET NOT NULL');
+    expect(sql).toContain('"team_members_season_id_user_id_unique" UNIQUE("season_id","user_id")');
+    expect(sql).toContain('"team_members_team_season_fk"');
+    expect(sql).toContain('"teams_id_season_id_unique" UNIQUE("id","season_id")');
+  });
+
+  it("provenance 列保持 NOT NULL（Rivals registration provenance 未放宽）", () => {
+    const teamsCols = snap0020.tables["public.teams"].columns;
+    const membersCols = snap0020.tables["public.team_members"].columns;
+    expect(teamsCols["captain_registration_id"].notNull).toBe(true);
+    expect(teamsCols["draft_order"].notNull).toBe(true);
+    expect(membersCols["registration_id"].notNull).toBe(true);
+  });
+
+  it("snapshot 链：0020.prevId == 0019.id，journal 最后 idx 20，无 0021", () => {
+    expect(snap0020.prevId).toBe(snap0019.id);
+    expect(journal.entries[journal.entries.length - 1]).toMatchObject({ idx: 20, tag: "0020_black_marvex" });
+    expect(journal.entries.some((e) => e.idx === 21)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Goal

为正式 Team 建立 canonical user identity bridge（PR1）：新增 `teams.captain_user_id`、`team_members.season_id`、`team_members.user_id`，逐步解除通用 Team domain 对 `season_registrations` 作为身份主键的强依赖。先架新桥，不拆旧桥：全部 Rivals registration provenance 原样保留。

## Schema

- `teams.captain_user_id` uuid NOT NULL → `users.id`（canonical captain identity）
- `team_members.season_id` uuid NOT NULL → `seasons.id`
- `team_members.user_id` uuid NOT NULL → `users.id`（canonical member identity）
- `UNIQUE(team_members.season_id, team_members.user_id)`：同赛季同用户只能属于一个正式队伍
- composite FK `team_members(team_id, season_id) → teams(id, season_id)` + `UNIQUE(teams.id, season_id)`：DB 层保证成员赛季与父队伍赛季一致
- 未新增：tournamentSeed / entryStageKey / teamRegistrationMemberId / position

## Migration and backfill

`0020_black_marvex.sql`（生成后人工调整安全顺序）：

1. ADD canonical columns **nullable**
2. backfill：`teams.captain_user_id ← season_registrations.user_id`（经 captain_registration_id）；`team_members.user_id ← season_registrations.user_id`（经 registration_id）；`team_members.season_id ← teams.season_id`
3. fail-closed DO 校验（**7 类**，见 Validation）
4. `SET NOT NULL`
5. FK / UNIQUE（composite FK 在 teams unique 之后建立）

backfill 确定性：`captain_registration_id` / `registration_id` 均为 FK 指向 `season_registrations.id`（PK），`season_registrations` 有 `UNIQUE(user_id, season_id)`，映射 1:1。

## Snapshot baseline repair

- previous latest snapshot: `0006_snapshot.json`
- journal latest before repair: idx 19 / `0019_is_forfeit`
- reconstructed baseline snapshot: `meta/0019_snapshot.json`（id `1d275277-…`，prevId=0006.id），从 `origin/dev`（`78f051d`）schema 生成，不含任何 PR1 字段
- baseline consistency：修复后对相同 schema 再 generate → **No schema changes**，无历史 drift
- generated migration: `0020_black_marvex.sql`，generated unrelated diff: **无**
- 0019 snapshot hash 在 0020 generate 前后不变；`0020.prevId == 0019.id`；snapshot 链无 fork/collision（`drizzle-kit check` 通过）
- 未创建 0007–0018 snapshot、未重写任何已有 migration SQL；review-fix 只改 0020 SQL 的 DO 块内容，**未重建任何 snapshot**（0019/0020 hash 均未变化）

## Generic identity migration

- 队长授权：`getTeamIdForCaptain`（roster 提交 / scheduling）、队徽上传、队名修改、match 详情页 isCaptainA/B、draft captain 页门禁 → `teams.captainUserId == user.id`
- **Captain authorization season scope（review fix）**：`getTeamIdForCaptain` 增加 `teams.seasonId == match.seasonId`，canonical 授权必须同时满足 captain identity + match participant + same season（defense-in-depth，不恢复 seasonRegistration lookup）；测试断言 where predicate 含 `season_id`
- 成员身份展示/查询：teams 列表/详情页、admin matches、match 详情、OCR 选手下拉（extractStatsFromScreenshot / getMatchPlayerOptions）、PlayerStatsTable、玩家主页队伍归属、三处 raw SQL 统计 join → `teamMembers.userId`
- 仅当查询需要 position / mapPreferences 等 registration snapshot 时才保留 registration join（身份本身来自 canonical userId）

## Rivals compatibility

- `captainRegistrationId` / `teamMembers.registrationId` / `draftOrder` **均保持 NOT NULL**，语义未变
- draft picks / draft state / captain voting / standings / schedule / bracket 读路径零改动
- 现有 Rivals 创建路径 dual-write：`confirmCaptains` 同时写 `captainRegistrationId + captainUserId`、`registrationId + userId + seasonId`；`executeDraftPick` 写 `registrationId + userId + seasonId`
- Draft 内部队长校验（executeDraftPick）仍走 registration chain——按设计保留（Phase 9：不改 Draft-specific provenance）

## Validation

0020 migration fail-closed DO 块（**7 类**，任一命中即中止）：

1. `teams.captain_user_id IS NULL` → fail
2. `team_members.user_id IS NULL` → fail
3. `team_members.season_id IS NULL` → fail
4. 重复 `team_members(season_id, user_id)` → fail
5. `team_members.season_id != parent teams.season_id` → fail
6. **（review fix）`teams.captain_registration_id` 对应 registration 的 `season_id != teams.season_id` → fail**
7. **（review fix）`team_members.registration_id` 对应 registration 的 `season_id != parent team.season_id` → fail**

第 6/7 类防止把跨 season 的历史错误 provenance 静默升级为 canonical truth。自动修复：**无**（不 UPDATE 修复、不 DELETE、不猜正确 season）。`tests/unit/db/migration-0020.test.ts` 对 7 类校验做静态覆盖，并断言无自动修复语句。

## Staging data gate

- remote DB migration executed: **no**
- seed executed: **no**
- E2E executed: **no**
- isolation status: **NOT YET VERIFIED**
- 仅执行：`db:generate`（纯本地 diff）、`drizzle-kit check`（纯静态 snapshot 链校验，本地已验证移除 `.env.local` 后仍正常通过）
- Migration deployment guard（documentation cleanup）：AGENTS.md 含**简洁 invariant**（硬性禁令「数据库迁移安全」一条 + `db:push` 命令注释修正）；docs/deployment.md 为**详细 migration policy source of truth**（db:push 限制、0020 为需实际执行 migration SQL 的首例、baseline/adoption 未完成、远程 migration 禁令）；`db:migrate` 未新增
- actual DB migration remains **NOT EXECUTED**

## CI migration check

- added: **yes**（`.github/workflows/ci.yml` 在 type-check 后增加 `pnpm exec drizzle-kit check`）
- reason: 已验证该命令为纯静态 migration metadata 校验——本地移除 `.env.local`（0 env injected）后仍正常通过、无需任何 secrets；作为 migration integrity gate（snapshot 链 / journal 一致性）

## Tests

新增/更新（共 70 files / **508 tests** 全绿，coverage lines 32.5 / funcs 74.02 / branches 64.72 均超阈值）：

- `captain-identity.test.ts`：confirmCaptains dual-write（captainRegistrationId+captainUserId 同源、member registrationId+userId+seasonId、draftOrder 1-based）；getTeamIdForCaptain canonical 授权（identity+participant+**season scope** match/denied，SQL chunk 检查谓词含 `season_id`）
- `draft-picks-identity.test.ts`：pickPlayer 写 userId+seasonId；draftPick insert 保留 registrationId provenance（draft regression）
- `PlayerStatsTable.test.tsx`：经 `teamMembers.userId` 归属，无 seasonRegistration chain
- `migration-0020.test.ts`：fail-closed 静态覆盖（**7 类** RAISE、nullable→backfill→validation→NOT NULL 顺序、UNIQUE、composite FK、provenance NOT NULL、snapshot 链、无自动修复语句）

## Out of scope

本 PR 不实现：team_registrations、team_registration_members、self-service Team Registration、preparing、tournamentSeed、entryStageKey、CompetitionConfig、StageRun、StageEntrants、Swiss、Major、bracket identity migration、recovery、2.0 UI、DAK、Demo、RR、PRISM。未修改 package version。

## 验证命令（真实执行结果）

- `pnpm type-check` → exit 0
- `pnpm test:coverage` → 70 files / 508 tests passed；thresholds met
- `pnpm build` → exit 0
- `pnpm exec drizzle-kit check` → Everything's fine
- `git diff --check` → clean
- 0019_snapshot hash 未变化（`91914875…`）；0020_snapshot 无 diff；journal 无 0021
- rg 分类扫描：剩余 `captainRegistrationId`/`registrationId` 引用均为 Rivals provenance / Draft / migration / tests / fixtures，无 generic authorization 依赖 registration identity
- review-fix 后 remote DB 未访问

