### PR TITLE
test: reduce Vitest runtime overhead

### DIFF
--- a/src/components/layout/SeasonNav.test.tsx
+++ b/src/components/layout/SeasonNav.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";

--- a/src/components/matches/StatsLeaderboard.test.tsx
+++ b/src/components/matches/StatsLeaderboard.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/src/components/players/PlayerDirectoryRow.test.tsx
+++ b/src/components/players/PlayerDirectoryRow.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/src/components/teams/TeamCard.test.tsx
+++ b/src/components/teams/TeamCard.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/tests/unit/components/draft/CaptainDraftPanel.test.tsx
+++ b/tests/unit/components/draft/CaptainDraftPanel.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/tests/unit/components/draft/PlayerPool.test.tsx
+++ b/tests/unit/components/draft/PlayerPool.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/tests/unit/components/matches/BracketView.test.tsx
+++ b/tests/unit/components/matches/BracketView.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { useEffect } from "react";

--- a/tests/unit/components/matches/PlayerStatsTable.test.tsx
+++ b/tests/unit/components/matches/PlayerStatsTable.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 

--- a/tests/unit/components/matches/StatsLeaderboard.test.tsx
+++ b/tests/unit/components/matches/StatsLeaderboard.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";

--- a/tests/unit/components/register/RegistrationForm.test.tsx
+++ b/tests/unit/components/register/RegistrationForm.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
+    environment: "node",
     setupFiles: ["./tests/setup.ts"],
     globals: true,
     include: ["tests/unit/**/*.test.ts", "tests/unit/**/*.test.tsx", "tests/integration/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],


### PR DESCRIPTION
## 背景

Vitest 全局使用 `jsdom` 环境运行全部 70 个测试文件，其中 60 个是纯逻辑单测（libs / actions / validators / db），并不需要 DOM。本 PR 将默认环境改为 `node`，仅对真实依赖 DOM 的 10 个组件测试文件添加 file-level `@vitest-environment jsdom` 注释。不改测试逻辑、不删测试、不升级依赖。

## Baseline methodology

- 机器：macOS（16GB），Node v22.22.3，pnpm 11.0.8
- 命令：`pnpm test` 与 `CI=true pnpm test:coverage`（模拟 CI 无 remote secret 条件，`DATABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `NEXT_PUBLIC_SUPABASE_URL` 均不可用）
- 每项 1 次 warm-up + 多次 measured，取 median；本机存在周期性内存压力（swap）导致 wall-clock 抖动，按协议触发 STOP condition #11 的 remedy：采用 5-run median + baseline/candidate 交错（interleaved）配对测量抵消漂移
- 每次命令 exit 0

## Baseline（dev @ 68807ba）

- pnpm test median：**10.30s**（5-run）
- CI=true pnpm test:coverage median：**10.76s**（5-run）
- 70 test files / 508 tests，0 skipped / 0 todo
- coverage：lines 32.5 / functions 64.72 / branches 74.02（阈值 28 / 60 / 50 全部 PASS）

## Candidate（本 PR：node 默认 + 10 个 jsdom 注释）

- baseline median（交错窗口）：**9.71s**
- candidate median：**7.34s**
- improvement：**+24.4%**（>= 20% 门槛），且 4/4 交错配对全部更快
- `pnpm test` median：baseline 10.30s → candidate 7.04s（+31.7%，无回归，<= 5% 门槛满足）

## 需要 jsdom 的测试文件（10 个）

- src/components/layout/SeasonNav.test.tsx
- src/components/matches/StatsLeaderboard.test.tsx
- src/components/players/PlayerDirectoryRow.test.tsx
- src/components/teams/TeamCard.test.tsx
- tests/unit/components/draft/CaptainDraftPanel.test.tsx
- tests/unit/components/draft/PlayerPool.test.tsx
- tests/unit/components/matches/BracketView.test.tsx
- tests/unit/components/matches/PlayerStatsTable.test.tsx
- tests/unit/components/matches/StatsLeaderboard.test.tsx
- tests/unit/components/register/RegistrationForm.test.tsx

判定依据：import `@testing-library/react` / `user-event` 并使用 `render()` / `screen.*` / `document` / `window` / `HTMLElement`。其余 60 个文件（含 `.tsx` 后缀但纯逻辑的 `registration-form-utils.test.tsx`）无任何 DOM 依赖。该分类已通过实际执行验证：node 环境下恰好这 10 个文件失败、其余 60 个通过。

## 未变更项

- 测试数量不变：70 files / 508 tests，0 skipped / 0 todo，无 skip、无删除、无 assertion 修改
- coverage 无实质下降：lines 32.5 / functions 64.72 / branches 74.43（baseline 74.02，+0.41pp 波动），阈值全部 PASS
- 未访问任何 DB / Supabase / Vercel；测试路径无 remote secret；supabase client 全部 vi.mock
- package.json、pnpm-lock.yaml、drizzle/、src/db/、业务源码均未改动

## Verification（全部本机执行）

- pnpm type-check：PASS
- pnpm exec drizzle-kit check：PASS（纯静态，不连 DB）
- pnpm test：70 passed (70) / 508 passed (508)
- CI=true pnpm test:coverage：PASS，thresholds 全绿
- pnpm build：PASS
- git diff --check：clean
