### PR TITLE
feat: add deterministic Major Swiss domain core

### DIFF
--- a/src/lib/major/seeding.test.ts
+++ b/src/lib/major/seeding.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import { seedMajorLaterStageEntrants, seedMajorStageOneEntrants } from "./seeding";
+import type { MajorAdvancingTeam, MajorTournamentSeededTeam } from "./seeding";
+
+// deterministic shuffle（避免 Math.random）
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function shuffle<T>(items: readonly T[], rng: () => number): T[] {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+const STAGE_ONE_TEAMS: MajorTournamentSeededTeam[] = Array.from({ length: 16 }, (_, i) => ({
+  teamId: `team-${i + 1}`,
+  tournamentSeed: 17 + i,
+}));
+
+describe("seedMajorStageOneEntrants", () => {
+  it("normalizes tournament seeds 17..32 to stage seeds 1..16", () => {
+    const entrants = seedMajorStageOneEntrants(STAGE_ONE_TEAMS);
+    expect(entrants).toHaveLength(16);
+    expect(entrants.map((e) => e.initialStageSeed)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+    entrants.forEach((entrant, i) => {
+      expect(entrant.teamId).toBe(`team-${i + 1}`);
+    });
+  });
+
+  it("is independent of input order", () => {
+    const shuffled = shuffle(STAGE_ONE_TEAMS, makeRng(11));
+    expect(shuffled[0].teamId).not.toBe("team-1"); // 确认确实乱序了
+    const entrants = seedMajorStageOneEntrants(shuffled);
+    expect(entrants.map((e) => e.teamId)).toEqual(
+      Array.from({ length: 16 }, (_, i) => `team-${i + 1}`),
+    );
+    expect(entrants.map((e) => e.initialStageSeed)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+  });
+
+  it("normalizes arbitrary non-contiguous positive tournament seeds by relative order", () => {
+    const irregular: MajorTournamentSeededTeam[] = [
+      { teamId: "team-a", tournamentSeed: 101 },
+      { teamId: "team-b", tournamentSeed: 3 },
+      { teamId: "team-c", tournamentSeed: 2000 },
+      { teamId: "team-d", tournamentSeed: 7 },
+      { teamId: "team-e", tournamentSeed: 42 },
+      { teamId: "team-f", tournamentSeed: 1 },
+      { teamId: "team-g", tournamentSeed: 500 },
+      { teamId: "team-h", tournamentSeed: 88 },
+      { teamId: "team-i", tournamentSeed: 12 },
+      { teamId: "team-j", tournamentSeed: 999 },
+      { teamId: "team-k", tournamentSeed: 5 },
+      { teamId: "team-l", tournamentSeed: 300 },
+      { teamId: "team-m", tournamentSeed: 64 },
+      { teamId: "team-n", tournamentSeed: 2 },
+      { teamId: "team-o", tournamentSeed: 77 },
+      { teamId: "team-p", tournamentSeed: 10 },
+    ];
+    const entrants = seedMajorStageOneEntrants(irregular);
+    expect(entrants.map((e) => e.teamId)).toEqual([
+      "team-f", "team-n", "team-b", "team-k", "team-d", "team-p", "team-i", "team-e",
+      "team-m", "team-o", "team-h", "team-a", "team-l", "team-g", "team-j", "team-c",
+    ]);
+    expect(entrants.map((e) => e.initialStageSeed)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+  });
+
+  it("throws when not exactly 16 teams", () => {
+    expect(() => seedMajorStageOneEntrants(STAGE_ONE_TEAMS.slice(0, 15))).toThrow();
+    expect(() => seedMajorStageOneEntrants([...STAGE_ONE_TEAMS, { teamId: "team-17", tournamentSeed: 33 }])).toThrow();
+  });
+
+  it("throws on duplicate teamId", () => {
+    const dup = [...STAGE_ONE_TEAMS];
+    dup[15] = { ...dup[15], teamId: "team-1" };
+    expect(() => seedMajorStageOneEntrants(dup)).toThrow();
+  });
+
+  it("throws on empty teamId", () => {
+    const bad = [...STAGE_ONE_TEAMS];
+    bad[0] = { ...bad[0], teamId: "" };
+    expect(() => seedMajorStageOneEntrants(bad)).toThrow();
+  });
+
+  it("throws on duplicate tournamentSeed", () => {
+    const dup = [...STAGE_ONE_TEAMS];
+    dup[15] = { ...dup[15], tournamentSeed: 17 };
+    expect(() => seedMajorStageOneEntrants(dup)).toThrow();
+  });
+
+  it("throws on invalid tournamentSeed", () => {
+    const zero = [...STAGE_ONE_TEAMS];
+    zero[0] = { ...zero[0], tournamentSeed: 0 };
+    expect(() => seedMajorStageOneEntrants(zero)).toThrow();
+
+    const negative = [...STAGE_ONE_TEAMS];
+    negative[0] = { ...negative[0], tournamentSeed: -5 };
+    expect(() => seedMajorStageOneEntrants(negative)).toThrow();
+
+    const fractional = [...STAGE_ONE_TEAMS];
+    fractional[0] = { ...fractional[0], tournamentSeed: 2.5 };
+    expect(() => seedMajorStageOneEntrants(fractional)).toThrow();
+  });
+
+  it("does not mutate its input", () => {
+    const snapshot = structuredClone(STAGE_ONE_TEAMS);
+    seedMajorStageOneEntrants(shuffle(STAGE_ONE_TEAMS, makeRng(3)));
+    expect(STAGE_ONE_TEAMS).toEqual(snapshot);
+  });
+});
+
+const DIRECT: MajorTournamentSeededTeam[] = Array.from({ length: 8 }, (_, i) => ({
+  teamId: `direct-${i + 1}`,
+  tournamentSeed: 33 + i,
+}));
+
+const ADVANCING: MajorAdvancingTeam[] = Array.from({ length: 8 }, (_, i) => ({
+  teamId: `advance-${i + 1}`,
+  previousStageFinalSeed: i + 1,
+}));
+
+describe("seedMajorLaterStageEntrants", () => {
+  it("assigns direct entrants seeds 1..8 and advancing entrants seeds 9..16", () => {
+    const entrants = seedMajorLaterStageEntrants({
+      directEntrants: DIRECT,
+      advancingEntrants: ADVANCING,
+    });
+    expect(entrants).toHaveLength(16);
+    expect(entrants.map((e) => e.initialStageSeed)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+    entrants.slice(0, 8).forEach((entrant, i) => {
+      expect(entrant.teamId).toBe(`direct-${i + 1}`);
+    });
+    entrants.slice(8).forEach((entrant, i) => {
+      expect(entrant.teamId).toBe(`advance-${i + 1}`);
+    });
+  });
+
+  it("is independent of input order in both groups", () => {
+    const reversedDirect = [...DIRECT].reverse();
+    const reversedAdvancing = [...ADVANCING].reverse();
+    const entrants = seedMajorLaterStageEntrants({
+      directEntrants: reversedDirect,
+      advancingEntrants: reversedAdvancing,
+    });
+    // 输入逆序不改变结果：仍按 tournamentSeed / previousStageFinalSeed ASC
+    expect(entrants.map((e) => e.initialStageSeed)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+    expect(entrants.map((e) => e.teamId)).toEqual([
+      "direct-1", "direct-2", "direct-3", "direct-4",
+      "direct-5", "direct-6", "direct-7", "direct-8",
+      "advance-1", "advance-2", "advance-3", "advance-4",
+      "advance-5", "advance-6", "advance-7", "advance-8",
+    ]);
+  });
+
+  it("throws when direct group is not exactly 8", () => {
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: DIRECT.slice(0, 7), advancingEntrants: ADVANCING }),
+    ).toThrow();
+    expect(() =>
+      seedMajorLaterStageEntrants({
+        directEntrants: [...DIRECT, { teamId: "direct-9", tournamentSeed: 41 }],
+        advancingEntrants: ADVANCING,
+      }),
+    ).toThrow();
+  });
+
+  it("throws when advancing group is not exactly 8", () => {
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: DIRECT, advancingEntrants: ADVANCING.slice(0, 7) }),
+    ).toThrow();
+    expect(() =>
+      seedMajorLaterStageEntrants({
+        directEntrants: DIRECT,
+        advancingEntrants: [...ADVANCING, { teamId: "advance-9", previousStageFinalSeed: 9 }],
+      }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate teamId across groups", () => {
+    const dupAdvancing = [...ADVANCING];
+    dupAdvancing[0] = { ...dupAdvancing[0], teamId: "direct-1" };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: DIRECT, advancingEntrants: dupAdvancing }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate teamId within advancing group", () => {
+    const dupAdvancing = [...ADVANCING];
+    dupAdvancing[7] = { ...dupAdvancing[7], teamId: "advance-1" };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: DIRECT, advancingEntrants: dupAdvancing }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate tournamentSeed in direct group", () => {
+    const dupDirect = [...DIRECT];
+    dupDirect[7] = { ...dupDirect[7], tournamentSeed: 33 };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: dupDirect, advancingEntrants: ADVANCING }),
+    ).toThrow();
+  });
+
+  it("throws on invalid tournamentSeed", () => {
+    const badDirect = [...DIRECT];
+    badDirect[0] = { ...badDirect[0], tournamentSeed: 0 };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: badDirect, advancingEntrants: ADVANCING }),
+    ).toThrow();
+
+    const fractionalDirect = [...DIRECT];
+    fractionalDirect[0] = { ...fractionalDirect[0], tournamentSeed: 1.5 };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: fractionalDirect, advancingEntrants: ADVANCING }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate previousStageFinalSeed", () => {
+    const dupAdvancing = [...ADVANCING];
+    dupAdvancing[7] = { ...dupAdvancing[7], previousStageFinalSeed: 1 };
+    expect(() =>
+      seedMajorLaterStageEntrants({ directEntrants: DIRECT, advancingEntrants: dupAdvancing }),
+    ).toThrow();
+  });
+
+  it("throws on previousStageFinalSeed outside 1..8", () => {
+    for (const badSeed of [0, 9, 1.5, -1]) {
+      const badAdvancing = [...ADVANCING];
+      badAdvancing[0] = { ...badAdvancing[0], previousStageFinalSeed: badSeed };
+      expect(() =>
+        seedMajorLaterStageEntrants({ directEntrants: DIRECT, advancingEntrants: badAdvancing }),
+      ).toThrow();
+    }
+  });
+
+  it("does not mutate its inputs", () => {
+    const directSnapshot = structuredClone(DIRECT);
+    const advancingSnapshot = structuredClone(ADVANCING);
+    seedMajorLaterStageEntrants({
+      directEntrants: shuffle(DIRECT, makeRng(5)),
+      advancingEntrants: shuffle(ADVANCING, makeRng(6)),
+    });
+    expect(DIRECT).toEqual(directSnapshot);
+    expect(ADVANCING).toEqual(advancingSnapshot);
+  });
+});

--- a/src/lib/major/seeding.ts
+++ b/src/lib/major/seeding.ts
@@ -1,0 +1,142 @@
+// RivalHub 2.0 — Major Stage seeding（stage-local initial seed 构造）。
+//
+// 只负责不同 Major Stage 之间的 initial stage seed 构造：
+// tournament-level seed → stage-local seed 1..16。
+//
+// 不 import StageConfig / Season / DB。
+// 不假设 tournament seed 恰好是 1..8 / 9..16 / 17..32，
+// 只通过排序得到相对顺序。
+
+import { MAJOR_SWISS_TEAM_COUNT } from "./swiss";
+import type { MajorSwissEntrant } from "./swiss";
+
+export interface MajorTournamentSeededTeam {
+  teamId: string;
+
+  /**
+   * 赛事级 tournament seed。
+   *
+   * 可以是 1..32 或未来其它正整数排名。
+   * 这里不等同于 stage-local seed。
+   */
+  tournamentSeed: number;
+}
+
+export interface MajorAdvancingTeam {
+  teamId: string;
+
+  /**
+   * 上一个 Swiss Stage 的 finalStageSeed。
+   */
+  previousStageFinalSeed: number;
+}
+
+const HALF = MAJOR_SWISS_TEAM_COUNT / 2;
+
+function assertValidTournamentTeam(
+  team: MajorTournamentSeededTeam,
+  teamIds: Set<string>,
+  tournamentSeeds: Set<number>,
+): void {
+  if (typeof team.teamId !== "string" || team.teamId.length === 0) {
+    throw new Error("teamId must be a non-empty string");
+  }
+  if (teamIds.has(team.teamId)) {
+    throw new Error(`duplicate teamId: ${team.teamId}`);
+  }
+  teamIds.add(team.teamId);
+
+  if (!Number.isInteger(team.tournamentSeed) || team.tournamentSeed <= 0) {
+    throw new Error(
+      `invalid tournamentSeed ${team.tournamentSeed}: must be a positive integer`,
+    );
+  }
+  if (tournamentSeeds.has(team.tournamentSeed)) {
+    throw new Error(`duplicate tournamentSeed: ${team.tournamentSeed}`);
+  }
+  tournamentSeeds.add(team.tournamentSeed);
+}
+
+export function seedMajorStageOneEntrants(
+  teams: readonly MajorTournamentSeededTeam[],
+): readonly MajorSwissEntrant[] {
+  if (teams.length !== MAJOR_SWISS_TEAM_COUNT) {
+    throw new Error(
+      `stage one requires exactly ${MAJOR_SWISS_TEAM_COUNT} teams (got ${teams.length})`,
+    );
+  }
+
+  const teamIds = new Set<string>();
+  const tournamentSeeds = new Set<number>();
+  for (const team of teams) {
+    assertValidTournamentTeam(team, teamIds, tournamentSeeds);
+  }
+
+  // 按 tournamentSeed ASC 排序后规范化为 initialStageSeed 1..16
+  const sorted = [...teams].sort((a, b) => a.tournamentSeed - b.tournamentSeed);
+  return sorted.map((team, index) => ({
+    teamId: team.teamId,
+    initialStageSeed: index + 1,
+  }));
+}
+
+export function seedMajorLaterStageEntrants(input: {
+  directEntrants: readonly MajorTournamentSeededTeam[];
+  advancingEntrants: readonly MajorAdvancingTeam[];
+}): readonly MajorSwissEntrant[] {
+  const { directEntrants, advancingEntrants } = input;
+
+  if (directEntrants.length !== HALF) {
+    throw new Error(`later stage requires exactly ${HALF} direct entrants (got ${directEntrants.length})`);
+  }
+  if (advancingEntrants.length !== HALF) {
+    throw new Error(
+      `later stage requires exactly ${HALF} advancing entrants (got ${advancingEntrants.length})`,
+    );
+  }
+
+  // direct entrants：teamId 非空 / unique（跨两组）、tournamentSeed 正整数 / unique
+  const teamIds = new Set<string>();
+  const tournamentSeeds = new Set<number>();
+  for (const team of directEntrants) {
+    assertValidTournamentTeam(team, teamIds, tournamentSeeds);
+  }
+
+  // advancing entrants：teamId 非空 / 跨两组 unique、previousStageFinalSeed ∈ 1..8 / unique
+  const finalSeeds = new Set<number>();
+  for (const team of advancingEntrants) {
+    if (typeof team.teamId !== "string" || team.teamId.length === 0) {
+      throw new Error("teamId must be a non-empty string");
+    }
+    if (teamIds.has(team.teamId)) {
+      throw new Error(`duplicate teamId across groups: ${team.teamId}`);
+    }
+    teamIds.add(team.teamId);
+
+    const seed = team.previousStageFinalSeed;
+    if (!Number.isInteger(seed) || seed < 1 || seed > HALF) {
+      throw new Error(`invalid previousStageFinalSeed ${seed}: must be an integer in 1..${HALF}`);
+    }
+    if (finalSeeds.has(seed)) {
+      throw new Error(`duplicate previousStageFinalSeed: ${seed}`);
+    }
+    finalSeeds.add(seed);
+  }
+
+  // 1–8 = 本阶段直接进入队（tournamentSeed ASC）
+  // 9–16 = 上一阶段晋级队（previousStageFinalSeed ASC）
+  const direct = [...directEntrants].sort((a, b) => a.tournamentSeed - b.tournamentSeed);
+  const advancing = [...advancingEntrants].sort(
+    (a, b) => a.previousStageFinalSeed - b.previousStageFinalSeed,
+  );
+  return [
+    ...direct.map((team, index) => ({
+      teamId: team.teamId,
+      initialStageSeed: index + 1,
+    })),
+    ...advancing.map((team, index) => ({
+      teamId: team.teamId,
+      initialStageSeed: HALF + 1 + index,
+    })),
+  ];
+}

--- a/src/lib/major/swiss.test.ts
+++ b/src/lib/major/swiss.test.ts
@@ -112,16 +112,10 @@ const ROUND_FORMATS: Record<number, Record<MajorSwissMatchFormat, number>> = {
 interface SimulationResult {
   matches: MajorSwissMatchFact[];
   countsPerRound: { active: number; advanced: number; eliminated: number }[];
-  /**
-   * 5.5 fail-closed：贪心 high-low 遇到无法避免 rematch 的合法状态时，
-   * 规则规定 throw（recovery / manual override 属于其他模块）。
-   * 该 tournament 没有完成，不参与最终状态验证。
-   */
-  declined: boolean;
 }
 
 // 完整 5 轮 tournament simulation，内含每轮 invariant 断言。
-// 5.5 fail-closed（无法生成配对）时返回 declined=true。
+// 不吞掉 generateNextMajorSwissRound 的任何异常（任意 throw → 测试失败）。
 function runTournament(rng: () => number): SimulationResult {
   const entrants = makeEntrants();
   const matches: MajorSwissMatchFact[] = [];
@@ -130,13 +124,7 @@ function runTournament(rng: () => number): SimulationResult {
   for (let round = 1; round <= 5; round += 1) {
     const finalizedRound = (round - 1) as MajorSwissFinalizedRound;
     const projection = projectMajorSwissStage({ entrants, matches, finalizedRound });
-    let pairings: readonly MajorSwissPairing[];
-    try {
-      pairings = generateNextMajorSwissRound({ entrants, matches, finalizedRound });
-    } catch {
-      // 5.5 fail-closed：规则判定该状态无法生成合法 pairing
-      return { matches, countsPerRound, declined: true };
-    }
+    const pairings = generateNextMajorSwissRound({ entrants, matches, finalizedRound });
 
     expect(pairings.length).toBe(ROUND_MATCH_COUNT[round]);
 
@@ -206,7 +194,7 @@ function runTournament(rng: () => number): SimulationResult {
   expect(qualifiers).toHaveLength(8);
   expect(qualifiers.map((q) => q.finalStageSeed)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
 
-  return { matches, countsPerRound, declined: false };
+  return { matches, countsPerRound };
 }
 
 const SIX_IDS = ["a", "b", "c", "d", "e", "f"];
@@ -627,7 +615,9 @@ describe("R2/R3 high-low pairing", () => {
 
   it("avoids rematch: skips the lowest seed already played by the highest", () => {
     // R2 winners [1,2,3,5,9,10,11,12]（4 输给 5）→
-    // 1-1: {4,6,7,8,9,10,11,12}；4 与 12 在 R1 打过（4v12）→ 4 必须配对 11
+    // 1-1: {4,6,7,8,9,10,11,12}；4 与 12 在 R1 打过（4v12）→ rematch 跳过，
+    // 11 是 lowest feasible（选中后剩余 {6,7,8,9,10,12} 可完整配对：6-12, 7-10, 8-9）
+    // → 4 配对 11。
     const r1 = roundOneMatches(HIGH_WINS_R1);
     const r2 = roundTwoMatches(["team-1", "team-2", "team-3", "team-5", "team-9", "team-10", "team-11", "team-12"]);
     const pairings = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
@@ -863,30 +853,26 @@ describe("no input mutation", () => {
 
 describe("property-style tournament simulation", () => {
   it("runs 100 deterministic tournaments without invariant failure", () => {
-    let completed = 0;
-    let ruleDeclined = 0;
+    let totalMatches = 0;
     for (let seed = 1; seed <= 100; seed += 1) {
-      if (runTournament(makeRng(seed)).declined) {
-        ruleDeclined += 1;
-      } else {
-        completed += 1;
-      }
+      totalMatches += runTournament(makeRng(seed)).matches.length;
     }
-    // 完成的 tournament 全部通过 invariant 验证（runTournament 内断言）；
-    // 极少状态会被 5.5 fail-closed 判定为无法生成配对（合法 R1/R2 结果中约 0.6%，
-    // 本 PRNG 的 seed 1..100 中仅 seed 28 触发），由专门的 fail-closed 测试覆盖。
-    expect(completed).toBeGreaterThan(0);
+    // 100 / 100 完成（任意 generator throw → 测试失败）；每 tournament 33 matches
+    expect(totalMatches).toBe(3300);
   });
 });
 
-// ── 5.5 fail-closed 显式覆盖 ───────────────────────────
+// ── feasibility-aware R2/R3 pairing ─────────────────────
 
-describe("5.5 fail-closed pairing", () => {
-  it("throws when greedy high-low cannot avoid a rematch", () => {
-    // 合法 R1/R2 结果（枚举反例 r1mask=15 / r2mask=24）：
-    // R3 1-1 group {1,2,3,5,9,10,11,13} 贪心配对 1-11, 2-9, 3-10 后，
-    // team-13 只剩 R1 对手 team-5 → 无法生成合法 pairing（5.5 fail-closed，
-    // recovery / manual override 属于其他模块）。
+describe("feasibility-aware R2/R3 pairing", () => {
+  it("completes the naive-greedy deadlock case (r1mask=15, r2mask=24)", () => {
+    // 原 naive greedy 反例：R3 1-1 group 贪心选择 1-11, 2-9, 3-10 后，
+    // team-13 只剩 R1 对手 team-5 → 人工 deadlock（但该 group 存在完整
+    // zero-rematch matching）。
+    // feasibility-aware high-low 的差异点在 H=3：最低 non-rematch 10 不可行
+    // （选中后剩余 {13,5} 互相是 R1 对手，无法配对）→ 选 5（剩余 {13,10} 可配对）
+    // → 1-11, 2-9, 3-5, 13-10 完整生成。
+    // 该测试用于防止 naive greedy regression。
     const entrants = makeEntrants();
     const r1 = [
       match(1, 1, "team-1", "team-9", "team-1"),
@@ -917,10 +903,137 @@ describe("5.5 fail-closed pairing", () => {
       match(2, i + 1, p.higherSeedTeamId, p.lowerSeedTeamId, r2Winners[i]),
     );
 
-    expect(() =>
-      generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 }),
-    ).toThrow();
+    // generate R3 必须成功（不再 fail-closed）
+    const r3 = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+
+    // full 8 R3 matches：2-0 (2) + 1-1 (4) + 0-2 (2)
+    expect(r3).toHaveLength(8);
+    expect(r3.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-4", "team-16"],
+      ["team-14", "team-15"],
+      ["team-1", "team-11"],
+      ["team-2", "team-9"],
+      ["team-3", "team-5"],
+      ["team-13", "team-10"],
+      ["team-6", "team-12"],
+      ["team-7", "team-8"],
+    ]);
+
+    // 1-1 group full 4 matches
+    expect(r3.filter((p) => p.record.wins === 1 && p.record.losses === 1)).toHaveLength(4);
+
+    // exact same record / no cross-record / zero rematch
+    const projection = projectMajorSwissStage({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+    const byId = new Map(projection.teams.map((t) => [t.teamId, t]));
+    for (const pairing of r3) {
+      const higher = byId.get(pairing.higherSeedTeamId)!;
+      const lower = byId.get(pairing.lowerSeedTeamId)!;
+      expect(higher.wins).toBe(pairing.record.wins);
+      expect(higher.losses).toBe(pairing.record.losses);
+      expect(lower.wins).toBe(pairing.record.wins);
+      expect(lower.losses).toBe(pairing.record.losses);
+      expect(higher.opponents).not.toContain(pairing.lowerSeedTeamId);
+      expect(lower.opponents).not.toContain(pairing.higherSeedTeamId);
+    }
+
+    // correct BO format：2-0 / 0-2 → bo3，1-1 → bo1
+    expect(r3.slice(0, 2).every((p) => p.format === "bo3")).toBe(true);
+    expect(r3.slice(2, 6).every((p) => p.format === "bo1")).toBe(true);
+    expect(r3.slice(6, 8).every((p) => p.format === "bo3")).toBe(true);
+
+    // deterministic
+    const again = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+    expect(again).toEqual(r3);
   });
+});
+
+// ── exhaustive R1/R2 feasibility regression ─────────────
+
+interface OracleTeam {
+  wins: number;
+  losses: number;
+  opponents: string[];
+}
+
+// 轻量独立 oracle：直接从 match facts 计算 record 与对手，
+// 不依赖被测实现（用于 65536 枚举中的 per-combination 断言）
+function computeOracle(
+  entrants: readonly MajorSwissEntrant[],
+  facts: readonly MajorSwissMatchFact[],
+): Map<string, OracleTeam> {
+  const byId = new Map<string, OracleTeam>();
+  for (const entrant of entrants) {
+    byId.set(entrant.teamId, { wins: 0, losses: 0, opponents: [] });
+  }
+  for (const fact of facts) {
+    const winner = byId.get(fact.winnerId)!;
+    const loserId = fact.winnerId === fact.teamAId ? fact.teamBId : fact.teamAId;
+    const loser = byId.get(loserId)!;
+    winner.wins += 1;
+    loser.losses += 1;
+    winner.opponents.push(loserId);
+    loser.opponents.push(fact.winnerId);
+  }
+  return byId;
+}
+
+describe("exhaustive R1/R2 feasibility", () => {
+  it(
+    "generates a complete zero-rematch R3 for all 65536 legal R1/R2 outcomes",
+    () => {
+      const entrants = makeEntrants();
+      for (let r1mask = 0; r1mask < 256; r1mask += 1) {
+        const r1: MajorSwissMatchFact[] = [];
+        for (let i = 0; i < 8; i += 1) {
+          const high = `team-${i + 1}`;
+          const low = `team-${i + 9}`;
+          const winner = (r1mask & (1 << i)) !== 0 ? high : low;
+          r1.push(match(1, i + 1, high, low, winner));
+        }
+
+        // R2 pairing 必须由 generator 自己生成
+        const r2Pairings = generateNextMajorSwissRound({ entrants, matches: r1, finalizedRound: 1 });
+
+        for (let r2mask = 0; r2mask < 256; r2mask += 1) {
+          const r2 = r2Pairings.map((p, i) =>
+            match(
+              2,
+              i + 1,
+              p.higherSeedTeamId,
+              p.lowerSeedTeamId,
+              (r2mask & (1 << i)) !== 0 ? p.higherSeedTeamId : p.lowerSeedTeamId,
+            ),
+          );
+
+          // 不得因为 naive pairing choice 而失败
+          const r3 = generateNextMajorSwissRound({
+            entrants,
+            matches: [...r1, ...r2],
+            finalizedRound: 2,
+          });
+
+          // 完整 8 matches、无 rematch、同 record、每队恰好一次
+          expect(r3).toHaveLength(8);
+          const oracle = computeOracle(entrants, [...r1, ...r2]);
+          const participants = new Set<string>();
+          for (const pairing of r3) {
+            const higher = oracle.get(pairing.higherSeedTeamId)!;
+            const lower = oracle.get(pairing.lowerSeedTeamId)!;
+            expect(higher.wins).toBe(pairing.record.wins);
+            expect(higher.losses).toBe(pairing.record.losses);
+            expect(lower.wins).toBe(pairing.record.wins);
+            expect(lower.losses).toBe(pairing.record.losses);
+            expect(higher.opponents).not.toContain(pairing.lowerSeedTeamId);
+            expect(lower.opponents).not.toContain(pairing.higherSeedTeamId);
+            participants.add(pairing.higherSeedTeamId);
+            participants.add(pairing.lowerSeedTeamId);
+          }
+          expect(participants.size).toBe(16);
+        }
+      }
+    },
+    120_000,
+  );
 });
 
 // ── 10.15 no teamA/teamB semantics ──────────────────────

--- a/src/lib/major/swiss.test.ts
+++ b/src/lib/major/swiss.test.ts
@@ -956,16 +956,17 @@ interface OracleTeam {
 }
 
 // 轻量独立 oracle：直接从 match facts 计算 record 与对手，
-// 不依赖被测实现（用于 65536 枚举中的 per-combination 断言）
+// 不依赖被测实现（用于 65536 枚举中的 per-combination 校验）
 function computeOracle(
   entrants: readonly MajorSwissEntrant[],
-  facts: readonly MajorSwissMatchFact[],
+  r1: readonly MajorSwissMatchFact[],
+  r2: readonly MajorSwissMatchFact[],
 ): Map<string, OracleTeam> {
   const byId = new Map<string, OracleTeam>();
   for (const entrant of entrants) {
     byId.set(entrant.teamId, { wins: 0, losses: 0, opponents: [] });
   }
-  for (const fact of facts) {
+  for (const fact of [...r1, ...r2]) {
     const winner = byId.get(fact.winnerId)!;
     const loserId = fact.winnerId === fact.teamAId ? fact.teamBId : fact.teamAId;
     const loser = byId.get(loserId)!;
@@ -982,6 +983,7 @@ describe("exhaustive R1/R2 feasibility", () => {
     "generates a complete zero-rematch R3 for all 65536 legal R1/R2 outcomes",
     () => {
       const entrants = makeEntrants();
+      let checked = 0;
       for (let r1mask = 0; r1mask < 256; r1mask += 1) {
         const r1: MajorSwissMatchFact[] = [];
         for (let i = 0; i < 8; i += 1) {
@@ -1005,32 +1007,57 @@ describe("exhaustive R1/R2 feasibility", () => {
             ),
           );
 
-          // 不得因为 naive pairing choice 而失败
+          // 不得因为 naive pairing choice 而失败（失败时 throw 带定位信息）
           const r3 = generateNextMajorSwissRound({
             entrants,
             matches: [...r1, ...r2],
             finalizedRound: 2,
           });
+          if (r3.length !== 8) {
+            throw new Error(`r1mask=${r1mask} r2mask=${r2mask}: expected 8 R3 matches, got ${r3.length}`);
+          }
 
-          // 完整 8 matches、无 rematch、同 record、每队恰好一次
-          expect(r3).toHaveLength(8);
-          const oracle = computeOracle(entrants, [...r1, ...r2]);
+          // 轻量 invariant accumulator（不在 inner loop 中调用 Vitest expect，
+          // 避免 coverage instrumentation 下的 assertion 开销）
+          const oracle = computeOracle(entrants, r1, r2);
           const participants = new Set<string>();
           for (const pairing of r3) {
             const higher = oracle.get(pairing.higherSeedTeamId)!;
             const lower = oracle.get(pairing.lowerSeedTeamId)!;
-            expect(higher.wins).toBe(pairing.record.wins);
-            expect(higher.losses).toBe(pairing.record.losses);
-            expect(lower.wins).toBe(pairing.record.wins);
-            expect(lower.losses).toBe(pairing.record.losses);
-            expect(higher.opponents).not.toContain(pairing.lowerSeedTeamId);
-            expect(lower.opponents).not.toContain(pairing.higherSeedTeamId);
+            const sameRecord =
+              higher.wins === pairing.record.wins &&
+              higher.losses === pairing.record.losses &&
+              lower.wins === pairing.record.wins &&
+              lower.losses === pairing.record.losses;
+            if (!sameRecord) {
+              throw new Error(
+                `r1mask=${r1mask} r2mask=${r2mask}: cross-record pairing ` +
+                  `${pairing.higherSeedTeamId}-${pairing.lowerSeedTeamId} ` +
+                  `(oracle ${higher.wins}-${higher.losses} vs ${lower.wins}-${lower.losses})`,
+              );
+            }
+            if (
+              higher.opponents.includes(pairing.lowerSeedTeamId) ||
+              lower.opponents.includes(pairing.higherSeedTeamId)
+            ) {
+              throw new Error(
+                `r1mask=${r1mask} r2mask=${r2mask}: rematch pairing ` +
+                  `${pairing.higherSeedTeamId}-${pairing.lowerSeedTeamId}`,
+              );
+            }
             participants.add(pairing.higherSeedTeamId);
             participants.add(pairing.lowerSeedTeamId);
           }
-          expect(participants.size).toBe(16);
+          if (participants.size !== 16) {
+            throw new Error(
+              `r1mask=${r1mask} r2mask=${r2mask}: expected 16 participants, got ${participants.size}`,
+            );
+          }
+          checked += 1;
         }
       }
+      // 65536 / 65536 完整执行
+      expect(checked).toBe(65536);
     },
     120_000,
   );

--- a/src/lib/major/swiss.test.ts
+++ b/src/lib/major/swiss.test.ts
@@ -1,0 +1,946 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS,
+  generateNextMajorSwissRound,
+  getMajorSwissQualifiers,
+  getMajorSwissRequiredFormat,
+  projectMajorSwissStage,
+  selectMajorSixTeamPairingPattern,
+} from "./swiss";
+import type {
+  MajorSwissEntrant,
+  MajorSwissFinalizedRound,
+  MajorSwissMatchFact,
+  MajorSwissMatchFormat,
+  MajorSwissPairing,
+  MajorSwissRecord,
+  MajorSwissRound,
+} from "./swiss";
+// ── helpers ─────────────────────────────────────────────
+
+function makeEntrants(): MajorSwissEntrant[] {
+  return Array.from({ length: 16 }, (_, i) => ({
+    teamId: `team-${i + 1}`,
+    initialStageSeed: i + 1,
+  }));
+}
+
+function match(
+  round: number,
+  index: number,
+  teamAId: string,
+  teamBId: string,
+  winnerId: string,
+): MajorSwissMatchFact {
+  return {
+    matchId: `r${round}-m${index}`,
+    round: round as MajorSwissRound,
+    teamAId,
+    teamBId,
+    winnerId,
+  };
+}
+
+const HIGH_WINS_R1 = [
+  "team-1",
+  "team-2",
+  "team-3",
+  "team-4",
+  "team-5",
+  "team-6",
+  "team-7",
+  "team-8",
+];
+
+function roundOneMatches(winners: readonly string[] = HIGH_WINS_R1): MajorSwissMatchFact[] {
+  const pairs: readonly (readonly [string, string])[] = [
+    ["team-1", "team-9"],
+    ["team-2", "team-10"],
+    ["team-3", "team-11"],
+    ["team-4", "team-12"],
+    ["team-5", "team-13"],
+    ["team-6", "team-14"],
+    ["team-7", "team-15"],
+    ["team-8", "team-16"],
+  ];
+  return pairs.map(([teamA, teamB], i) => match(1, i + 1, teamA, teamB, winners[i]));
+}
+
+// 基于 R1 高 seed 全赢后的 1-0 / 0-1 分组
+function roundTwoMatches(winners: readonly string[]): MajorSwissMatchFact[] {
+  const pairs: readonly (readonly [string, string])[] = [
+    ["team-1", "team-8"],
+    ["team-2", "team-7"],
+    ["team-3", "team-6"],
+    ["team-4", "team-5"],
+    ["team-9", "team-16"],
+    ["team-10", "team-15"],
+    ["team-11", "team-14"],
+    ["team-12", "team-13"],
+  ];
+  return pairs.map(([teamA, teamB], i) => match(2, i + 1, teamA, teamB, winners[i]));
+}
+
+// deterministic LCG（避免 Math.random）
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function shuffle<T>(items: readonly T[], rng: () => number): T[] {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+const ROUND_MATCH_COUNT: Record<number, number> = { 1: 8, 2: 8, 3: 8, 4: 6, 5: 3 };
+
+const ROUND_FORMATS: Record<number, Record<MajorSwissMatchFormat, number>> = {
+  1: { bo1: 8, bo3: 0 },
+  2: { bo1: 8, bo3: 0 },
+  3: { bo1: 4, bo3: 4 },
+  4: { bo1: 0, bo3: 6 },
+  5: { bo1: 0, bo3: 3 },
+};
+
+interface SimulationResult {
+  matches: MajorSwissMatchFact[];
+  countsPerRound: { active: number; advanced: number; eliminated: number }[];
+  /**
+   * 5.5 fail-closed：贪心 high-low 遇到无法避免 rematch 的合法状态时，
+   * 规则规定 throw（recovery / manual override 属于其他模块）。
+   * 该 tournament 没有完成，不参与最终状态验证。
+   */
+  declined: boolean;
+}
+
+// 完整 5 轮 tournament simulation，内含每轮 invariant 断言。
+// 5.5 fail-closed（无法生成配对）时返回 declined=true。
+function runTournament(rng: () => number): SimulationResult {
+  const entrants = makeEntrants();
+  const matches: MajorSwissMatchFact[] = [];
+  const countsPerRound: SimulationResult["countsPerRound"] = [];
+
+  for (let round = 1; round <= 5; round += 1) {
+    const finalizedRound = (round - 1) as MajorSwissFinalizedRound;
+    const projection = projectMajorSwissStage({ entrants, matches, finalizedRound });
+    let pairings: readonly MajorSwissPairing[];
+    try {
+      pairings = generateNextMajorSwissRound({ entrants, matches, finalizedRound });
+    } catch {
+      // 5.5 fail-closed：规则判定该状态无法生成合法 pairing
+      return { matches, countsPerRound, declined: true };
+    }
+
+    expect(pairings.length).toBe(ROUND_MATCH_COUNT[round]);
+
+    const byId = new Map(projection.teams.map((team) => [team.teamId, team]));
+    const formats: Record<MajorSwissMatchFormat, number> = { bo1: 0, bo3: 0 };
+    for (const pairing of pairings) {
+      const higher = byId.get(pairing.higherSeedTeamId)!;
+      const lower = byId.get(pairing.lowerSeedTeamId)!;
+      // 双方 pre-match record 相同
+      expect(higher.wins).toBe(pairing.record.wins);
+      expect(higher.losses).toBe(pairing.record.losses);
+      expect(lower.wins).toBe(pairing.record.wins);
+      expect(lower.losses).toBe(pairing.record.losses);
+      // 不产生 rematch
+      expect(higher.opponents).not.toContain(pairing.lowerSeedTeamId);
+      expect(lower.opponents).not.toContain(pairing.higherSeedTeamId);
+      expect(pairing.format).toBe(getMajorSwissRequiredFormat(pairing.record));
+      formats[pairing.format] += 1;
+    }
+    expect(formats).toEqual(ROUND_FORMATS[round]);
+
+    for (let i = 0; i < pairings.length; i += 1) {
+      const pairing = pairings[i];
+      matches.push({
+        matchId: `r${round}-m${i + 1}`,
+        round: round as MajorSwissRound,
+        teamAId: pairing.higherSeedTeamId,
+        teamBId: pairing.lowerSeedTeamId,
+        winnerId: rng() < 0.5 ? pairing.higherSeedTeamId : pairing.lowerSeedTeamId,
+      });
+    }
+
+    const afterRound = projectMajorSwissStage({
+      entrants,
+      matches,
+      finalizedRound: round as MajorSwissFinalizedRound,
+    });
+    countsPerRound.push({
+      active: afterRound.active.length,
+      advanced: afterRound.advanced.length,
+      eliminated: afterRound.eliminated.length,
+    });
+  }
+
+  expect(matches).toHaveLength(33);
+
+  const final = projectMajorSwissStage({ entrants, matches, finalizedRound: 5 });
+  expect(final.active).toHaveLength(0);
+  expect(final.advanced).toHaveLength(8);
+  expect(final.eliminated).toHaveLength(8);
+  expect(final.isComplete).toBe(true);
+  expect(final.teams.map((team) => team.currentStageSeed)).toEqual([
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+  ]);
+  for (const team of final.teams) {
+    // 每队最多 5 场
+    expect(team.opponents.length).toBeLessThanOrEqual(5);
+    // 无重复对手
+    expect(new Set(team.opponents).size).toBe(team.opponents.length);
+  }
+
+  const perRoundCounts: Record<number, number> = {};
+  for (const m of matches) perRoundCounts[m.round] = (perRoundCounts[m.round] ?? 0) + 1;
+  expect(perRoundCounts).toEqual({ 1: 8, 2: 8, 3: 8, 4: 6, 5: 3 });
+
+  const qualifiers = getMajorSwissQualifiers(final);
+  expect(qualifiers).toHaveLength(8);
+  expect(qualifiers.map((q) => q.finalStageSeed)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+
+  return { matches, countsPerRound, declined: false };
+}
+
+const SIX_IDS = ["a", "b", "c", "d", "e", "f"];
+
+// ── 10.1 entrant validation ─────────────────────────────
+
+describe("entrant validation", () => {
+  it("accepts 16 valid entrants", () => {
+    const projection = projectMajorSwissStage({
+      entrants: makeEntrants(),
+      matches: [],
+      finalizedRound: 0,
+    });
+    expect(projection.teams).toHaveLength(16);
+  });
+
+  it("throws on 15 entrants", () => {
+    expect(() =>
+      projectMajorSwissStage({ entrants: makeEntrants().slice(0, 15), matches: [], finalizedRound: 0 }),
+    ).toThrow();
+  });
+
+  it("throws on 17 entrants", () => {
+    const extra: MajorSwissEntrant = { teamId: "team-17", initialStageSeed: 17 };
+    expect(() =>
+      projectMajorSwissStage({
+        entrants: [...makeEntrants(), extra],
+        matches: [],
+        finalizedRound: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate teamId", () => {
+    const dup = makeEntrants();
+    dup[15] = { ...dup[15], teamId: "team-1" };
+    expect(() => projectMajorSwissStage({ entrants: dup, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws on empty teamId", () => {
+    const bad = makeEntrants();
+    bad[0] = { ...bad[0], teamId: "" };
+    expect(() => projectMajorSwissStage({ entrants: bad, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws on duplicate initialStageSeed", () => {
+    const dup = makeEntrants();
+    dup[15] = { ...dup[15], initialStageSeed: 1 };
+    expect(() => projectMajorSwissStage({ entrants: dup, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws on seed 0", () => {
+    const bad = makeEntrants();
+    bad[15] = { ...bad[15], initialStageSeed: 0 };
+    expect(() => projectMajorSwissStage({ entrants: bad, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws on seed 17", () => {
+    const bad = makeEntrants();
+    bad[15] = { ...bad[15], initialStageSeed: 17 };
+    expect(() => projectMajorSwissStage({ entrants: bad, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws on non-integer seed", () => {
+    const bad = makeEntrants();
+    bad[15] = { ...bad[15], initialStageSeed: 1.5 };
+    expect(() => projectMajorSwissStage({ entrants: bad, matches: [], finalizedRound: 0 })).toThrow();
+  });
+
+  it("throws when a seed in 1..16 is missing", () => {
+    // 16 个 entrant，但 seed 集合 = {1..15, 1} → 缺 16
+    const bad = makeEntrants();
+    bad[15] = { ...bad[15], initialStageSeed: 1 };
+    expect(() => projectMajorSwissStage({ entrants: bad, matches: [], finalizedRound: 0 })).toThrow();
+  });
+});
+
+// ── 10.2 round 0 projection ─────────────────────────────
+
+describe("round 0 projection", () => {
+  it("projects 16 teams at 0-0 with difficulty 0", () => {
+    const projection = projectMajorSwissStage({
+      entrants: makeEntrants(),
+      matches: [],
+      finalizedRound: 0,
+    });
+    expect(projection.teams).toHaveLength(16);
+    for (const team of projection.teams) {
+      expect(team.wins).toBe(0);
+      expect(team.losses).toBe(0);
+      expect(team.difficultyScore).toBe(0);
+      expect(team.status).toBe("active");
+      expect(team.currentStageSeed).toBe(team.initialStageSeed);
+      expect(team.opponents).toEqual([]);
+    }
+    expect(projection.active).toHaveLength(16);
+    expect(projection.advanced).toHaveLength(0);
+    expect(projection.eliminated).toHaveLength(0);
+    expect(projection.isComplete).toBe(false);
+  });
+});
+
+// ── 10.3 exact round 1 ──────────────────────────────────
+
+describe("round 1 generation", () => {
+  it("pairs 1v9 .. 8v16 with record 0-0, bo1, initial rule", () => {
+    const pairings = generateNextMajorSwissRound({
+      entrants: makeEntrants(),
+      matches: [],
+      finalizedRound: 0,
+    });
+    expect(pairings).toHaveLength(8);
+    const expected: readonly (readonly [string, string])[] = [
+      ["team-1", "team-9"],
+      ["team-2", "team-10"],
+      ["team-3", "team-11"],
+      ["team-4", "team-12"],
+      ["team-5", "team-13"],
+      ["team-6", "team-14"],
+      ["team-7", "team-15"],
+      ["team-8", "team-16"],
+    ];
+    pairings.forEach((pairing, i) => {
+      expect(pairing.round).toBe(1);
+      expect(pairing.higherSeedTeamId).toBe(expected[i][0]);
+      expect(pairing.lowerSeedTeamId).toBe(expected[i][1]);
+      expect(pairing.higherSeed).toBe(i + 1);
+      expect(pairing.lowerSeed).toBe(i + 9);
+      expect(pairing.record).toEqual({ wins: 0, losses: 0 });
+      expect(pairing.format).toBe("bo1");
+      expect(pairing.pairingRule).toBe("initial");
+      expect(pairing.priority).toBeUndefined();
+    });
+  });
+
+  it("throws when generating after the stage is complete", () => {
+    const rng = makeRng(7);
+    const { matches } = runTournament(rng);
+    expect(() =>
+      generateNextMajorSwissRound({
+        entrants: makeEntrants(),
+        matches,
+        finalizedRound: 5,
+      }),
+    ).toThrow();
+  });
+});
+
+// ── 10.4 projection ignores unfinalized results ─────────
+
+describe("unfinalized results are ignored", () => {
+  it("a round 2 fact with a winner does not affect a finalizedRound=1 projection", () => {
+    const entrants = makeEntrants();
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const rogue = match(2, 1, "team-1", "team-8", "team-8");
+
+    const base = projectMajorSwissStage({ entrants, matches: r1, finalizedRound: 1 });
+    const withRogue = projectMajorSwissStage({
+      entrants,
+      matches: [...r1, rogue],
+      finalizedRound: 1,
+    });
+
+    expect(withRogue).toEqual(base);
+    expect(withRogue.teams.find((t) => t.teamId === "team-1")!.wins).toBe(1);
+    expect(withRogue.teams.find((t) => t.teamId === "team-1")!.opponents).toEqual(["team-9"]);
+  });
+
+  it("even an invalid unfinalized fact is ignored", () => {
+    const entrants = makeEntrants();
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    // winner 不是参与者 —— 但 round 2 > finalizedRound 1，必须完全忽略
+    const rogue = match(2, 1, "team-1", "team-8", "team-99");
+    const base = projectMajorSwissStage({ entrants, matches: r1, finalizedRound: 1 });
+    const withRogue = projectMajorSwissStage({
+      entrants,
+      matches: [...r1, rogue],
+      finalizedRound: 1,
+    });
+    expect(withRogue).toEqual(base);
+  });
+});
+
+// ── 10.5 finalized round completeness ───────────────────
+
+describe("finalized round completeness", () => {
+  const entrants = makeEntrants();
+
+  it("throws when a finalized round is missing matches (7 of 8)", () => {
+    const incomplete = roundOneMatches(HIGH_WINS_R1).slice(0, 7);
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: incomplete, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws when a team appears twice in the same round", () => {
+    const dupTeam = [
+      match(1, 1, "team-1", "team-9", "team-1"),
+      match(1, 2, "team-1", "team-10", "team-1"),
+      match(1, 3, "team-2", "team-11", "team-2"),
+      match(1, 4, "team-3", "team-12", "team-3"),
+      match(1, 5, "team-4", "team-13", "team-4"),
+      match(1, 6, "team-5", "team-14", "team-5"),
+      match(1, 7, "team-6", "team-15", "team-6"),
+      match(1, 8, "team-7", "team-16", "team-7"),
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: dupTeam, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws on unknown team", () => {
+    const withUnknown = [
+      ...roundOneMatches(HIGH_WINS_R1).slice(0, 7),
+      match(1, 8, "team-8", "team-99", "team-8"),
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: withUnknown, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws when winner is not a participant", () => {
+    const badWinner = [
+      ...roundOneMatches(HIGH_WINS_R1).slice(0, 7),
+      match(1, 8, "team-8", "team-16", "team-1"),
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: badWinner, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws on self match", () => {
+    const selfMatch = [
+      ...roundOneMatches(HIGH_WINS_R1).slice(0, 7),
+      match(1, 8, "team-8", "team-8", "team-8"),
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: selfMatch, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws on cross-record match", () => {
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const r2Cross = [
+      match(2, 1, "team-1", "team-9", "team-1"), // 1-0 vs 0-1
+      match(2, 2, "team-2", "team-7", "team-2"),
+      match(2, 3, "team-3", "team-6", "team-3"),
+      match(2, 4, "team-4", "team-5", "team-4"),
+      match(2, 5, "team-8", "team-16", "team-8"),
+      match(2, 6, "team-10", "team-15", "team-10"),
+      match(2, 7, "team-11", "team-14", "team-11"),
+      match(2, 8, "team-12", "team-13", "team-12"),
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: [...r1, ...r2Cross], finalizedRound: 2 }),
+    ).toThrow();
+  });
+
+  it("throws on duplicate matchId", () => {
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const dup = [
+      ...r1.slice(0, 7),
+      { ...r1[7], matchId: r1[0].matchId },
+    ];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: dup, finalizedRound: 1 }),
+    ).toThrow();
+  });
+
+  it("throws on invalid match round within the finalized range", () => {
+    const badRound = [match(0, 1, "team-1", "team-9", "team-1")];
+    expect(() =>
+      projectMajorSwissStage({ entrants, matches: badRound, finalizedRound: 0 }),
+    ).toThrow();
+  });
+});
+
+// ── 10.6 difficulty score ───────────────────────────────
+
+describe("difficulty score", () => {
+  const entrants = makeEntrants();
+
+  // R1: 高 seed 全赢 → 1-0: {1..8}, 0-1: {9..16}
+  // R2: winners [1,2,3,4,9,10,11,12]
+  // R3: winners [1,2,5,6,7,8,13,14]
+  function buildR1R2R3(): MajorSwissMatchFact[] {
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const r2 = roundTwoMatches(["team-1", "team-2", "team-3", "team-4", "team-9", "team-10", "team-11", "team-12"]);
+
+    const r3Pairings = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+    expect(r3Pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-1", "team-4"],
+      ["team-2", "team-3"],
+      ["team-5", "team-12"],
+      ["team-6", "team-11"],
+      ["team-7", "team-10"],
+      ["team-8", "team-9"],
+      ["team-13", "team-16"],
+      ["team-14", "team-15"],
+    ]);
+    const r3Winners = ["team-1", "team-2", "team-5", "team-6", "team-7", "team-8", "team-13", "team-14"];
+    const r3 = r3Pairings.map((p, i) =>
+      match(3, i + 1, p.higherSeedTeamId, p.lowerSeedTeamId, r3Winners[i]),
+    );
+    return [...r1, ...r2, ...r3];
+  }
+
+  it("computes exact difficulty for hand-calculated teams", () => {
+    const facts = buildR1R2R3();
+    const projection = projectMajorSwissStage({ entrants, matches: facts, finalizedRound: 3 });
+
+    const byId = new Map(projection.teams.map((t) => [t.teamId, t]));
+    expect(byId.get("team-1")!.difficultyScore).toBe(1); // 9(1-2) + 8(2-1) + 4(2-1) = -1+1+1
+    expect(byId.get("team-3")!.difficultyScore).toBe(3); // 11(1-2) + 6(2-1) + 2(3-0) = -1+1+3
+    expect(byId.get("team-5")!.difficultyScore).toBe(-1); // 13(1-2) + 4(2-1) + 12(1-2) = -1+1-1
+    expect(byId.get("team-9")!.difficultyScore).toBe(1); // 1(3-0) + 16(0-3) + 8(2-1) = 3-3+1
+    expect(byId.get("team-13")!.difficultyScore).toBe(-3); // 5(2-1) + 12(1-2) + 16(0-3) = 1-1-3
+    expect(byId.get("team-15")!.difficultyScore).toBe(-1); // 7(2-1) + 10(1-2) + 14(1-2) = 1-1-1
+
+    // status 与 opponents 顺序
+    expect(byId.get("team-1")!.status).toBe("advanced");
+    expect(byId.get("team-1")!.opponents).toEqual(["team-9", "team-8", "team-4"]);
+    expect(byId.get("team-15")!.status).toBe("eliminated");
+  });
+
+  it("does not freeze difficulty for advanced teams after later rounds", () => {
+    const facts = buildR1R2R3();
+    const proj3 = projectMajorSwissStage({ entrants, matches: facts, finalizedRound: 3 });
+    expect(proj3.teams.find((t) => t.teamId === "team-1")!.difficultyScore).toBe(1);
+
+    // R4：2-1 group {3,4,5,6,7,8} → priority 1（3v8, 4v7, 5v6）
+    //      1-2 group（difficulty 9/10/11/12=1, 13/14=-3 → seed 序 9,10,11,12,13,14）
+    //      → priority 1（9v14, 10v13, 11v12）合法，无 rematch
+    const r4Pairings = generateNextMajorSwissRound({ entrants, matches: facts, finalizedRound: 3 });
+    expect(r4Pairings.map((p) => p.priority)).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(r4Pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-3", "team-8"],
+      ["team-4", "team-7"],
+      ["team-5", "team-6"],
+      ["team-9", "team-14"],
+      ["team-10", "team-13"],
+      ["team-11", "team-12"],
+    ]);
+    const r4Winners = ["team-3", "team-4", "team-5", "team-9", "team-10", "team-11"];
+    const r4 = r4Pairings.map((p, i) =>
+      match(4, i + 1, p.higherSeedTeamId, p.lowerSeedTeamId, r4Winners[i]),
+    );
+
+    const proj4 = projectMajorSwissStage({
+      entrants,
+      matches: [...facts, ...r4],
+      finalizedRound: 4,
+    });
+    const team1 = proj4.teams.find((t) => t.teamId === "team-1")!;
+    expect(team1.status).toBe("advanced");
+    // 对手 9(2-2) + 8(2-2) + 4(3-1) = 0+0+2 —— advanced 后 Difficulty 仍随投影更新
+    expect(team1.difficultyScore).toBe(2);
+
+    expect(proj4.active).toHaveLength(6);
+    expect(proj4.advanced).toHaveLength(5);
+    expect(proj4.eliminated).toHaveLength(5);
+  });
+});
+
+// ── 10.7 / 10.8 R2/R3 high-low + rematch avoidance ─────
+
+describe("R2/R3 high-low pairing", () => {
+  const entrants = makeEntrants();
+
+  it("generates exact R2 pairings from a finished R1", () => {
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const pairings = generateNextMajorSwissRound({ entrants, matches: r1, finalizedRound: 1 });
+    expect(pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-1", "team-8"],
+      ["team-2", "team-7"],
+      ["team-3", "team-6"],
+      ["team-4", "team-5"],
+      ["team-9", "team-16"],
+      ["team-10", "team-15"],
+      ["team-11", "team-14"],
+      ["team-12", "team-13"],
+    ]);
+    expect(pairings.every((p) => p.pairingRule === "high-low")).toBe(true);
+    expect(pairings.every((p) => p.record.wins === 1 || p.record.wins === 0)).toBe(true);
+    expect(pairings.filter((p) => p.record.wins === 1)).toHaveLength(4);
+    expect(pairings.filter((p) => p.record.wins === 0)).toHaveLength(4);
+  });
+
+  it("pairs each record group highest-vs-lowest with matching records", () => {
+    // R2 winners [1,2,3,4,9,10,11,12] → 2-0: {1,2,3,4}, 1-1: {5..12}, 0-2: {13..16}
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const r2 = roundTwoMatches(["team-1", "team-2", "team-3", "team-4", "team-9", "team-10", "team-11", "team-12"]);
+    const pairings = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+
+    expect(pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-1", "team-4"],
+      ["team-2", "team-3"],
+      ["team-5", "team-12"],
+      ["team-6", "team-11"],
+      ["team-7", "team-10"],
+      ["team-8", "team-9"],
+      ["team-13", "team-16"],
+      ["team-14", "team-15"],
+    ]);
+    const records = pairings.map((p) => `${p.record.wins}-${p.record.losses}`);
+    expect(records).toEqual(["2-0", "2-0", "1-1", "1-1", "1-1", "1-1", "0-2", "0-2"]);
+    // 组内同 record；全部 non-rematch
+    const projection = projectMajorSwissStage({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+    const byId = new Map(projection.teams.map((t) => [t.teamId, t]));
+    for (const pairing of pairings) {
+      const higher = byId.get(pairing.higherSeedTeamId)!;
+      const lower = byId.get(pairing.lowerSeedTeamId)!;
+      expect(higher.opponents).not.toContain(pairing.lowerSeedTeamId);
+      expect(higher.wins).toBe(pairing.record.wins);
+      expect(lower.wins).toBe(pairing.record.wins);
+    }
+  });
+
+  it("avoids rematch: skips the lowest seed already played by the highest", () => {
+    // R2 winners [1,2,3,5,9,10,11,12]（4 输给 5）→
+    // 1-1: {4,6,7,8,9,10,11,12}；4 与 12 在 R1 打过（4v12）→ 4 必须配对 11
+    const r1 = roundOneMatches(HIGH_WINS_R1);
+    const r2 = roundTwoMatches(["team-1", "team-2", "team-3", "team-5", "team-9", "team-10", "team-11", "team-12"]);
+    const pairings = generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 });
+
+    const byHigher = new Map(pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId]));
+    expect(byHigher.get("team-4")).toBe("team-11");
+    expect(byHigher.get("team-6")).toBe("team-12");
+    expect(pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-1", "team-5"],
+      ["team-2", "team-3"],
+      ["team-4", "team-11"],
+      ["team-6", "team-12"],
+      ["team-7", "team-10"],
+      ["team-8", "team-9"],
+      ["team-13", "team-16"],
+      ["team-14", "team-15"],
+    ]);
+    // 不跨 record：2-0 与 0-2 各 2 场，1-1 组 4 场
+    for (const pairing of pairings) {
+      const recordKey = `${pairing.record.wins}-${pairing.record.losses}`;
+      const sameRecordCount = pairings.filter(
+        (p) => `${p.record.wins}-${p.record.losses}` === recordKey,
+      ).length;
+      expect(sameRecordCount).toBe(recordKey === "1-1" ? 4 : 2);
+    }
+  });
+});
+
+// ── 10.9 six-team priority patterns ─────────────────────
+
+describe("six-team priority patterns", () => {
+  it("MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS matches the frozen 15 patterns", () => {
+    const expected = [
+      { priority: 1, pairs: [[1, 6], [2, 5], [3, 4]] },
+      { priority: 2, pairs: [[1, 6], [2, 4], [3, 5]] },
+      { priority: 3, pairs: [[1, 5], [2, 6], [3, 4]] },
+      { priority: 4, pairs: [[1, 5], [2, 4], [3, 6]] },
+      { priority: 5, pairs: [[1, 4], [2, 6], [3, 5]] },
+      { priority: 6, pairs: [[1, 4], [2, 5], [3, 6]] },
+      { priority: 7, pairs: [[1, 6], [2, 3], [4, 5]] },
+      { priority: 8, pairs: [[1, 5], [2, 3], [4, 6]] },
+      { priority: 9, pairs: [[1, 3], [2, 6], [4, 5]] },
+      { priority: 10, pairs: [[1, 3], [2, 5], [4, 6]] },
+      { priority: 11, pairs: [[1, 4], [2, 3], [5, 6]] },
+      { priority: 12, pairs: [[1, 3], [2, 4], [5, 6]] },
+      { priority: 13, pairs: [[1, 2], [3, 6], [4, 5]] },
+      { priority: 14, pairs: [[1, 2], [3, 5], [4, 6]] },
+      { priority: 15, pairs: [[1, 2], [3, 4], [5, 6]] },
+    ] as const;
+    expect(MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS).toEqual(expected);
+  });
+
+  it("selects priority 1 when nothing is blocked", () => {
+    const result = selectMajorSixTeamPairingPattern(SIX_IDS, []);
+    expect(result.priority).toBe(1);
+    expect(result.pairs).toEqual([
+      { higherSeedTeamId: "a", lowerSeedTeamId: "f" },
+      { higherSeedTeamId: "b", lowerSeedTeamId: "e" },
+      { higherSeedTeamId: "c", lowerSeedTeamId: "d" },
+    ]);
+  });
+
+  it("skips blocked priorities and picks the first legal pattern", () => {
+    // block priority 1 独有边 2v5（b-e）；priority 2 = 1v6, 2v4, 3v5 不含它
+    const prior = [{ teamAId: "b", teamBId: "e" }];
+    const result = selectMajorSixTeamPairingPattern(SIX_IDS, prior);
+    expect(result.priority).toBe(2);
+    expect(result.pairs).toEqual([
+      { higherSeedTeamId: "a", lowerSeedTeamId: "f" },
+      { higherSeedTeamId: "b", lowerSeedTeamId: "d" },
+      { higherSeedTeamId: "c", lowerSeedTeamId: "e" },
+    ]);
+  });
+
+  it("throws when all 15 patterns contain a rematch", () => {
+    const allEdges: { teamAId: string; teamBId: string }[] = [];
+    for (let i = 1; i <= 5; i += 1) {
+      for (let j = i + 1; j <= 6; j += 1) {
+        allEdges.push({ teamAId: SIX_IDS[i - 1], teamBId: SIX_IDS[j - 1] });
+      }
+    }
+    expect(() => selectMajorSixTeamPairingPattern(SIX_IDS, allEdges)).toThrow();
+  });
+
+  it("throws on wrong team count or duplicates", () => {
+    expect(() => selectMajorSixTeamPairingPattern(["a", "b", "c", "d", "e"], [])).toThrow();
+    expect(() => selectMajorSixTeamPairingPattern(["a", "a", "b", "c", "d", "e"], [])).toThrow();
+  });
+
+  it("covers every priority 1..15 as the first legal pattern via brute force", () => {
+    const edges: [number, number][] = [];
+    for (let i = 1; i <= 5; i += 1) {
+      for (let j = i + 1; j <= 6; j += 1) edges.push([i, j]);
+    }
+    const edgeKey = (i: number, j: number) => `${i}-${j}`;
+
+    for (let target = 1; target <= 15; target += 1) {
+      let found = false;
+      for (let mask = 0; mask < 1 << 15 && !found; mask += 1) {
+        const blockedKeys = new Set<string>();
+        for (let e = 0; e < 15; e += 1) {
+          if ((mask & (1 << e)) !== 0) {
+            blockedKeys.add(edgeKey(edges[e][0], edges[e][1]));
+          }
+        }
+        // target pattern 自身不得含 blocked 边
+        const targetPattern = MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS[target - 1];
+        if (targetPattern.pairs.some(([i, j]) => blockedKeys.has(edgeKey(i, j)))) continue;
+        // priority 1..target-1 每个至少含一条 blocked 边
+        let allPriorBlocked = true;
+        for (let p = 1; p < target && allPriorBlocked; p += 1) {
+          const pattern = MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS[p - 1];
+          allPriorBlocked = pattern.pairs.some(([i, j]) => blockedKeys.has(edgeKey(i, j)));
+        }
+        if (!allPriorBlocked) continue;
+
+        const priorMatches = [...blockedKeys].map((key) => {
+          const [i, j] = key.split("-").map(Number);
+          return { teamAId: SIX_IDS[i - 1], teamBId: SIX_IDS[j - 1] };
+        });
+        const result = selectMajorSixTeamPairingPattern(SIX_IDS, priorMatches);
+        expect(result.priority).toBe(target);
+        found = true;
+      }
+      expect(found).toBe(true);
+    }
+  });
+});
+
+// ── 10.10 match format ──────────────────────────────────
+
+describe("match format", () => {
+  const cases: readonly (readonly [MajorSwissRecord, MajorSwissMatchFormat])[] = [
+    [{ wins: 0, losses: 0 }, "bo1"],
+    [{ wins: 1, losses: 0 }, "bo1"],
+    [{ wins: 0, losses: 1 }, "bo1"],
+    [{ wins: 1, losses: 1 }, "bo1"],
+    [{ wins: 2, losses: 0 }, "bo3"],
+    [{ wins: 0, losses: 2 }, "bo3"],
+    [{ wins: 2, losses: 1 }, "bo3"],
+    [{ wins: 1, losses: 2 }, "bo3"],
+    [{ wins: 2, losses: 2 }, "bo3"],
+  ];
+
+  it.each(cases)("record %o → %s", (record, format) => {
+    expect(getMajorSwissRequiredFormat(record)).toBe(format);
+  });
+
+  it("throws for terminal records", () => {
+    expect(() => getMajorSwissRequiredFormat({ wins: 3, losses: 0 })).toThrow();
+    expect(() => getMajorSwissRequiredFormat({ wins: 0, losses: 3 })).toThrow();
+    expect(() => getMajorSwissRequiredFormat({ wins: 3, losses: 2 })).toThrow();
+    expect(() => getMajorSwissRequiredFormat({ wins: 2, losses: 3 })).toThrow();
+  });
+});
+
+// ── 10.11 structural counts ─────────────────────────────
+
+describe("structural counts", () => {
+  it("a complete tournament hits the exact per-round team state counts", () => {
+    const { countsPerRound } = runTournament(makeRng(7));
+    expect(countsPerRound).toEqual([
+      { active: 16, advanced: 0, eliminated: 0 },
+      { active: 16, advanced: 0, eliminated: 0 },
+      { active: 12, advanced: 2, eliminated: 2 },
+      { active: 6, advanced: 5, eliminated: 5 },
+      { active: 0, advanced: 8, eliminated: 8 },
+    ]);
+  });
+});
+
+// ── 10.12 determinism ───────────────────────────────────
+
+describe("determinism", () => {
+  it("same semantic input in any array order yields identical results", () => {
+    const { matches } = runTournament(makeRng(42));
+    const entrants = makeEntrants();
+
+    const baseProjection = projectMajorSwissStage({ entrants, matches, finalizedRound: 5 });
+    const basePairingsR3 = generateNextMajorSwissRound({ entrants, matches, finalizedRound: 3 });
+    const basePairingsR4 = generateNextMajorSwissRound({ entrants, matches, finalizedRound: 4 });
+
+    const shuffleRng = makeRng(999);
+    const shuffledEntrants = shuffle(entrants, shuffleRng);
+    const shuffledMatches = shuffle(matches, shuffleRng);
+
+    const shuffledProjection = projectMajorSwissStage({
+      entrants: shuffledEntrants,
+      matches: shuffledMatches,
+      finalizedRound: 5,
+    });
+    const shuffledPairingsR3 = generateNextMajorSwissRound({
+      entrants: shuffledEntrants,
+      matches: shuffledMatches,
+      finalizedRound: 3,
+    });
+    const shuffledPairingsR4 = generateNextMajorSwissRound({
+      entrants: shuffledEntrants,
+      matches: shuffledMatches,
+      finalizedRound: 4,
+    });
+
+    expect(shuffledProjection).toEqual(baseProjection);
+    expect(shuffledPairingsR3).toEqual(basePairingsR3);
+    expect(shuffledPairingsR4).toEqual(basePairingsR4);
+  });
+});
+
+// ── 10.13 no input mutation ─────────────────────────────
+
+describe("no input mutation", () => {
+  it("does not mutate entrants or matches", () => {
+    const { matches } = runTournament(makeRng(42));
+    const entrants = makeEntrants();
+    const entrantsSnapshot = structuredClone(entrants);
+    const matchesSnapshot = structuredClone(matches);
+
+    const finalProjection = projectMajorSwissStage({ entrants, matches, finalizedRound: 5 });
+    generateNextMajorSwissRound({ entrants, matches, finalizedRound: 3 });
+    getMajorSwissRequiredFormat({ wins: 1, losses: 0 });
+    selectMajorSixTeamPairingPattern(
+      SIX_IDS,
+      matches.map((m) => ({ teamAId: m.teamAId, teamBId: m.teamBId })),
+    );
+    getMajorSwissQualifiers(finalProjection);
+
+    expect(entrants).toEqual(entrantsSnapshot);
+    expect(matches).toEqual(matchesSnapshot);
+  });
+});
+
+// ── 10.14 property-style tournament simulation ──────────
+
+describe("property-style tournament simulation", () => {
+  it("runs 100 deterministic tournaments without invariant failure", () => {
+    let completed = 0;
+    let ruleDeclined = 0;
+    for (let seed = 1; seed <= 100; seed += 1) {
+      if (runTournament(makeRng(seed)).declined) {
+        ruleDeclined += 1;
+      } else {
+        completed += 1;
+      }
+    }
+    // 完成的 tournament 全部通过 invariant 验证（runTournament 内断言）；
+    // 极少状态会被 5.5 fail-closed 判定为无法生成配对（合法 R1/R2 结果中约 0.6%，
+    // 本 PRNG 的 seed 1..100 中仅 seed 28 触发），由专门的 fail-closed 测试覆盖。
+    expect(completed).toBeGreaterThan(0);
+  });
+});
+
+// ── 5.5 fail-closed 显式覆盖 ───────────────────────────
+
+describe("5.5 fail-closed pairing", () => {
+  it("throws when greedy high-low cannot avoid a rematch", () => {
+    // 合法 R1/R2 结果（枚举反例 r1mask=15 / r2mask=24）：
+    // R3 1-1 group {1,2,3,5,9,10,11,13} 贪心配对 1-11, 2-9, 3-10 后，
+    // team-13 只剩 R1 对手 team-5 → 无法生成合法 pairing（5.5 fail-closed，
+    // recovery / manual override 属于其他模块）。
+    const entrants = makeEntrants();
+    const r1 = [
+      match(1, 1, "team-1", "team-9", "team-1"),
+      match(1, 2, "team-2", "team-10", "team-2"),
+      match(1, 3, "team-3", "team-11", "team-3"),
+      match(1, 4, "team-4", "team-12", "team-4"),
+      match(1, 5, "team-5", "team-13", "team-13"),
+      match(1, 6, "team-6", "team-14", "team-14"),
+      match(1, 7, "team-7", "team-15", "team-15"),
+      match(1, 8, "team-8", "team-16", "team-16"),
+    ];
+    const r2Pairings = generateNextMajorSwissRound({ entrants, matches: r1, finalizedRound: 1 });
+    expect(r2Pairings.map((p) => [p.higherSeedTeamId, p.lowerSeedTeamId])).toEqual([
+      ["team-1", "team-16"],
+      ["team-2", "team-15"],
+      ["team-3", "team-14"],
+      ["team-4", "team-13"],
+      ["team-5", "team-12"],
+      ["team-6", "team-11"],
+      ["team-7", "team-10"],
+      ["team-8", "team-9"],
+    ]);
+    const r2Winners = [
+      "team-16", "team-15", "team-14", "team-4",
+      "team-5", "team-11", "team-10", "team-9",
+    ];
+    const r2 = r2Pairings.map((p, i) =>
+      match(2, i + 1, p.higherSeedTeamId, p.lowerSeedTeamId, r2Winners[i]),
+    );
+
+    expect(() =>
+      generateNextMajorSwissRound({ entrants, matches: [...r1, ...r2], finalizedRound: 2 }),
+    ).toThrow();
+  });
+});
+
+// ── 10.15 no teamA/teamB semantics ──────────────────────
+
+describe("pairing field semantics", () => {
+  it("pairings expose higher/lower seed ids, never teamA/teamB", () => {
+    // 编译期：MajorSwissPairing 不得存在 teamAId / teamBId 语义字段
+    const typeGuard: MajorSwissPairing extends { teamAId: string } ? never : true = true;
+    expect(typeGuard).toBe(true);
+
+    const pairings = generateNextMajorSwissRound({
+      entrants: makeEntrants(),
+      matches: [],
+      finalizedRound: 0,
+    });
+    for (const pairing of pairings) {
+      expect(pairing).not.toHaveProperty("teamAId");
+      expect(pairing).not.toHaveProperty("teamBId");
+      expect(pairing.higherSeedTeamId).toBeDefined();
+      expect(pairing.lowerSeedTeamId).toBeDefined();
+    }
+  });
+});

--- a/src/lib/major/swiss.ts
+++ b/src/lib/major/swiss.ts
@@ -475,6 +475,26 @@ export function getMajorSwissRequiredFormat(record: MajorSwissRecord): MajorSwis
   return record.wins === 2 || record.losses === 2 ? "bo3" : "bo1";
 }
 
+/**
+ * 剩余队伍（按 currentStageSeed ASC）是否存在完整 zero-rematch perfect matching。
+ *
+ * 小规模 deterministic backtracking（group 最大 8 队）：
+ * 每层取 highest seed，从 lowest 向 higher 尝试 non-rematch candidate。
+ * 用于 feasibility-aware high-low：候选对手必须保证剩余队伍仍可完整配对。
+ */
+function hasCompleteNonRematchMatching(teams: readonly MajorSwissTeamState[]): boolean {
+  if (teams.length === 0) return true;
+  if (teams.length % 2 !== 0) return false;
+
+  const higher = teams[0];
+  for (let i = teams.length - 1; i >= 1; i -= 1) {
+    if (teams[i].opponents.includes(higher.teamId)) continue;
+    const rest = teams.filter((_, index) => index !== 0 && index !== i);
+    if (hasCompleteNonRematchMatching(rest)) return true;
+  }
+  return false;
+}
+
 // ── 下一轮配对 ──────────────────────────────────────────
 
 export function generateNextMajorSwissRound(input: {
@@ -548,20 +568,25 @@ export function generateNextMajorSwissRound(input: {
         });
       }
     } else if (nextRound === 2 || nextRound === 3) {
-      // R2/R3：high-low —— highest seed vs lowest available non-rematch
+      // R2/R3：feasibility-aware high-low。
+      // highest 优先 lowest feasible non-rematch opponent：
+      // candidate 必须满足「选中后剩余队伍仍存在完整 zero-rematch matching」，
+      // 否则继续向 higher seed 尝试。整个 group 确实不存在完整 matching 才 fail-closed。
       const available = [...sortedBySeed];
       while (available.length > 0) {
         const higher = available.shift()!;
         let lowerIndex = -1;
         for (let i = available.length - 1; i >= 0; i -= 1) {
-          if (!available[i].opponents.includes(higher.teamId)) {
+          if (available[i].opponents.includes(higher.teamId)) continue;
+          const rest = available.filter((_, index) => index !== i);
+          if (hasCompleteNonRematchMatching(rest)) {
             lowerIndex = i;
             break;
           }
         }
         if (lowerIndex === -1) {
           throw new Error(
-            `cannot pair ${higher.teamId} (${record.wins}-${record.losses}) without a rematch`,
+            `no complete zero-rematch pairing exists for the ${record.wins}-${record.losses} group`,
           );
         }
         const [lower] = available.splice(lowerIndex, 1);

--- a/src/lib/major/swiss.ts
+++ b/src/lib/major/swiss.ts
@@ -1,0 +1,643 @@
+// RivalHub 2.0 — Valve-style Major Swiss 纯领域核心（deterministic pure domain logic）。
+//
+// source of truth：
+//   entrants（stage-local initial seeds）
+//   + canonical completed match facts
+//   + finalizedRound
+// → official Swiss state（projection）。
+//
+// 本模块不依赖 DB / network / runtime / React；同一输入必须始终得到
+// 语义等价的输出；函数不修改调用方传入的任何数组 / 对象 / Map。
+
+export type MajorSwissRound = 1 | 2 | 3 | 4 | 5;
+
+export type MajorSwissFinalizedRound = 0 | MajorSwissRound;
+
+export type MajorSwissStatus = "active" | "advanced" | "eliminated";
+
+export type MajorSwissMatchFormat = "bo1" | "bo3";
+
+export interface MajorSwissRecord {
+  wins: number;
+  losses: number;
+}
+
+export interface MajorSwissEntrant {
+  teamId: string;
+
+  /**
+   * 当前 Swiss Stage 开始时的 stage-local seed。
+   * 必须严格为 1..16 且唯一。
+   */
+  initialStageSeed: number;
+}
+
+export interface MajorSwissMatchFact {
+  /**
+   * canonical matches.id 的领域层表示。
+   */
+  matchId: string;
+
+  round: MajorSwissRound;
+
+  teamAId: string;
+  teamBId: string;
+
+  /**
+   * 必须等于 teamAId 或 teamBId。
+   *
+   * 该类型只表示：
+   * 已完成且存在明确胜者的 canonical match result。
+   *
+   * scheduled / in_progress / cancelled
+   * 不转换成 MajorSwissMatchFact。
+   */
+  winnerId: string;
+}
+
+export interface MajorSwissTeamState {
+  teamId: string;
+
+  initialStageSeed: number;
+  currentStageSeed: number;
+
+  wins: number;
+  losses: number;
+
+  difficultyScore: number;
+
+  status: MajorSwissStatus;
+
+  /**
+   * 已 finalized 的历史对手，按 round 顺序。
+   */
+  opponents: readonly string[];
+}
+
+export interface MajorSwissProjection {
+  finalizedRound: MajorSwissFinalizedRound;
+
+  /**
+   * 按 currentStageSeed ASC。
+   */
+  teams: readonly MajorSwissTeamState[];
+
+  active: readonly MajorSwissTeamState[];
+  advanced: readonly MajorSwissTeamState[];
+  eliminated: readonly MajorSwissTeamState[];
+
+  isComplete: boolean;
+}
+
+export type MajorSwissPairingRule = "initial" | "high-low" | "six-team-priority";
+
+export interface MajorSwissPairing {
+  round: MajorSwissRound;
+
+  record: MajorSwissRecord;
+
+  higherSeedTeamId: string;
+  lowerSeedTeamId: string;
+
+  higherSeed: number;
+  lowerSeed: number;
+
+  format: MajorSwissMatchFormat;
+
+  pairingRule: MajorSwissPairingRule;
+
+  /**
+   * 仅 R4/R5 six-team-priority 有值：
+   * 1..15
+   */
+  priority?: number;
+}
+
+export interface MajorSwissQualifier {
+  teamId: string;
+
+  /**
+   * 当前 Stage 完成后的最终 stage seed。
+   */
+  finalStageSeed: number;
+}
+
+// ── 常量 ────────────────────────────────────────────────
+
+export const MAJOR_SWISS_TEAM_COUNT = 16;
+export const MAJOR_SWISS_WIN_THRESHOLD = 3;
+export const MAJOR_SWISS_LOSS_THRESHOLD = 3;
+
+const MAJOR_SWISS_MAX_ROUND = 5;
+const MAJOR_SWISS_ADVANCE_COUNT = MAJOR_SWISS_TEAM_COUNT / 2;
+
+export type MajorSwissSixTeamPair = readonly [number, number];
+
+export interface MajorSwissSixTeamPattern {
+  readonly priority: number;
+  readonly pairs: readonly MajorSwissSixTeamPair[];
+}
+
+/**
+ * Valve Major 6-team priority patterns（共 15 个）。
+ * 每组 6 队按 currentStageSeed ASC 编号 1..6 后，
+ * 按 priority 1 → 15 选择第一个完全无 rematch 的方案。
+ */
+export const MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS = [
+  { priority: 1, pairs: [[1, 6], [2, 5], [3, 4]] },
+  { priority: 2, pairs: [[1, 6], [2, 4], [3, 5]] },
+  { priority: 3, pairs: [[1, 5], [2, 6], [3, 4]] },
+  { priority: 4, pairs: [[1, 5], [2, 4], [3, 6]] },
+  { priority: 5, pairs: [[1, 4], [2, 6], [3, 5]] },
+  { priority: 6, pairs: [[1, 4], [2, 5], [3, 6]] },
+  { priority: 7, pairs: [[1, 6], [2, 3], [4, 5]] },
+  { priority: 8, pairs: [[1, 5], [2, 3], [4, 6]] },
+  { priority: 9, pairs: [[1, 3], [2, 6], [4, 5]] },
+  { priority: 10, pairs: [[1, 3], [2, 5], [4, 6]] },
+  { priority: 11, pairs: [[1, 4], [2, 3], [5, 6]] },
+  { priority: 12, pairs: [[1, 3], [2, 4], [5, 6]] },
+  { priority: 13, pairs: [[1, 2], [3, 6], [4, 5]] },
+  { priority: 14, pairs: [[1, 2], [3, 5], [4, 6]] },
+  { priority: 15, pairs: [[1, 2], [3, 4], [5, 6]] },
+] as const;
+
+// ── 内部类型与常量 ──────────────────────────────────────
+
+interface InternalTeamState {
+  teamId: string;
+  initialStageSeed: number;
+  wins: number;
+  losses: number;
+  difficultyScore: number;
+  opponents: string[];
+  status: MajorSwissStatus;
+}
+
+const EXPECTED_MATCH_COUNT: Readonly<Record<MajorSwissRound, number>> = {
+  1: 8,
+  2: 8,
+  3: 8,
+  4: 6,
+  5: 3,
+};
+
+const EXPECTED_ACTIVE_DISTRIBUTION: Readonly<
+  Record<MajorSwissRound, Readonly<Record<string, number>>>
+> = {
+  1: { "0-0": 16 },
+  2: { "1-0": 8, "0-1": 8 },
+  3: { "2-0": 4, "1-1": 8, "0-2": 4 },
+  4: { "2-1": 6, "1-2": 6 },
+  5: { "2-2": 6 },
+};
+
+function isMajorSwissRound(round: number): round is MajorSwissRound {
+  return round === 1 || round === 2 || round === 3 || round === 4 || round === 5;
+}
+
+function parseRecordKey(key: string): MajorSwissRecord {
+  const [wins, losses] = key.split("-");
+  return { wins: Number(wins), losses: Number(losses) };
+}
+
+function computeStatus(wins: number, losses: number): MajorSwissStatus {
+  if (wins >= MAJOR_SWISS_WIN_THRESHOLD) return "advanced";
+  if (losses >= MAJOR_SWISS_LOSS_THRESHOLD) return "eliminated";
+  return "active";
+}
+
+// ── 验证 ────────────────────────────────────────────────
+
+function validateEntrants(entrants: readonly MajorSwissEntrant[]): void {
+  if (entrants.length !== MAJOR_SWISS_TEAM_COUNT) {
+    throw new Error(
+      `entrants must contain exactly ${MAJOR_SWISS_TEAM_COUNT} teams (got ${entrants.length})`,
+    );
+  }
+
+  const teamIds = new Set<string>();
+  const seeds = new Set<number>();
+  for (const entrant of entrants) {
+    if (typeof entrant.teamId !== "string" || entrant.teamId.length === 0) {
+      throw new Error("entrant teamId must be a non-empty string");
+    }
+    if (teamIds.has(entrant.teamId)) {
+      throw new Error(`duplicate entrant teamId: ${entrant.teamId}`);
+    }
+    teamIds.add(entrant.teamId);
+
+    const seed = entrant.initialStageSeed;
+    if (!Number.isInteger(seed) || seed < 1 || seed > MAJOR_SWISS_TEAM_COUNT) {
+      throw new Error(
+        `invalid initialStageSeed ${seed}: must be an integer in 1..${MAJOR_SWISS_TEAM_COUNT}`,
+      );
+    }
+    if (seeds.has(seed)) {
+      throw new Error(`duplicate initialStageSeed: ${seed}`);
+    }
+    seeds.add(seed);
+  }
+
+  // seed 集合必须精确等于 1..16，禁止 sort 后偷偷补 seed
+  for (let seed = 1; seed <= MAJOR_SWISS_TEAM_COUNT; seed += 1) {
+    if (!seeds.has(seed)) {
+      throw new Error(
+        `initialStageSeed set must be exactly 1..${MAJOR_SWISS_TEAM_COUNT}; missing ${seed}`,
+      );
+    }
+  }
+}
+
+function validateOfficialMatches(
+  matches: readonly MajorSwissMatchFact[],
+  entrantTeamIds: ReadonlySet<string>,
+  finalizedRound: MajorSwissFinalizedRound,
+): MajorSwissMatchFact[] {
+  const official = matches.filter((match) => match.round <= finalizedRound);
+
+  const seenMatchIds = new Set<string>();
+  for (const match of official) {
+    if (typeof match.matchId !== "string" || match.matchId.length === 0) {
+      throw new Error("match matchId must be a non-empty string");
+    }
+    if (seenMatchIds.has(match.matchId)) {
+      throw new Error(`duplicate matchId: ${match.matchId}`);
+    }
+    seenMatchIds.add(match.matchId);
+
+    if (!isMajorSwissRound(match.round)) {
+      throw new Error(`invalid match round: ${match.round}`);
+    }
+    if (!entrantTeamIds.has(match.teamAId) || !entrantTeamIds.has(match.teamBId)) {
+      throw new Error(`match ${match.matchId} references a team outside the stage entrants`);
+    }
+    if (match.teamAId === match.teamBId) {
+      throw new Error(`match ${match.matchId} pairs a team with itself`);
+    }
+    if (match.winnerId !== match.teamAId && match.winnerId !== match.teamBId) {
+      throw new Error(`match ${match.matchId} winnerId must be one of the participants`);
+    }
+  }
+
+  return official;
+}
+
+// ── Projection ──────────────────────────────────────────
+
+export function projectMajorSwissStage(input: {
+  entrants: readonly MajorSwissEntrant[];
+  matches: readonly MajorSwissMatchFact[];
+  finalizedRound: MajorSwissFinalizedRound;
+}): MajorSwissProjection {
+  const { entrants, matches, finalizedRound } = input;
+
+  validateEntrants(entrants);
+  const entrantTeamIds = new Set(entrants.map((entrant) => entrant.teamId));
+  const official = validateOfficialMatches(matches, entrantTeamIds, finalizedRound);
+
+  // 初始状态：16 × 0-0（按 initialStageSeed ASC）
+  const states = new Map<string, InternalTeamState>();
+  const byInitialSeed = [...entrants].sort((a, b) => a.initialStageSeed - b.initialStageSeed);
+  for (const entrant of byInitialSeed) {
+    states.set(entrant.teamId, {
+      teamId: entrant.teamId,
+      initialStageSeed: entrant.initialStageSeed,
+      wins: 0,
+      losses: 0,
+      difficultyScore: 0,
+      opponents: [],
+      status: "active",
+    });
+  }
+
+  // 按 round 1 → finalizedRound 顺序处理
+  for (let round = 1; round <= finalizedRound; round += 1) {
+    const roundMatches = official
+      .filter((match) => match.round === round)
+      .sort((a, b) => (a.matchId < b.matchId ? -1 : a.matchId > b.matchId ? 1 : 0));
+
+    // 每个已 finalized round 必须完整
+    const expectedCount = EXPECTED_MATCH_COUNT[round as MajorSwissRound];
+    if (roundMatches.length !== expectedCount) {
+      throw new Error(
+        `finalized round ${round} is incomplete: expected ${expectedCount} matches, got ${roundMatches.length}`,
+      );
+    }
+
+    // 轮开始时 snapshot record（用于 same-W-L 校验）
+    const recordBeforeRound = new Map<string, MajorSwissRecord>();
+    for (const state of states.values()) {
+      recordBeforeRound.set(state.teamId, { wins: state.wins, losses: state.losses });
+    }
+
+    // 参与者验证：active、每队恰好一次、same W-L record
+    const participants = new Set<string>();
+    for (const match of roundMatches) {
+      const teamA = states.get(match.teamAId)!;
+      const teamB = states.get(match.teamBId)!;
+      if (teamA.status !== "active" || teamB.status !== "active") {
+        throw new Error(`round ${round} match ${match.matchId} includes a non-active team`);
+      }
+      if (participants.has(match.teamAId) || participants.has(match.teamBId)) {
+        throw new Error(`round ${round} includes a team more than once`);
+      }
+      participants.add(match.teamAId);
+      participants.add(match.teamBId);
+
+      const recordA = recordBeforeRound.get(match.teamAId)!;
+      const recordB = recordBeforeRound.get(match.teamBId)!;
+      if (recordA.wins !== recordB.wins || recordA.losses !== recordB.losses) {
+        throw new Error(
+          `round ${round} match ${match.matchId} is cross-record ` +
+            `(${recordA.wins}-${recordA.losses} vs ${recordB.wins}-${recordB.losses})`,
+        );
+      }
+    }
+
+    // 每个当时 active team 恰好参加一次
+    let activeCount = 0;
+    for (const state of states.values()) {
+      if (state.status === "active") activeCount += 1;
+    }
+    if (participants.size !== activeCount) {
+      throw new Error(
+        `finalized round ${round} is incomplete: ${participants.size} participants but ${activeCount} active teams`,
+      );
+    }
+
+    // 应用结果
+    for (const match of roundMatches) {
+      const winner = states.get(match.winnerId)!;
+      const loserId = match.winnerId === match.teamAId ? match.teamBId : match.teamAId;
+      const loser = states.get(loserId)!;
+      winner.wins += 1;
+      loser.losses += 1;
+      winner.opponents.push(loserId);
+      loser.opponents.push(winner.teamId);
+    }
+
+    for (const state of states.values()) {
+      state.status = computeStatus(state.wins, state.losses);
+    }
+  }
+
+  // Difficulty Score：所有 16 队重新计算（含 advanced / eliminated，不冻结）
+  for (const state of states.values()) {
+    let difficulty = 0;
+    for (const opponentId of state.opponents) {
+      const opponent = states.get(opponentId)!;
+      difficulty += opponent.wins - opponent.losses;
+    }
+    state.difficultyScore = difficulty;
+  }
+
+  // currentStageSeed：wins DESC, losses ASC, difficultyScore DESC, initialStageSeed ASC
+  const ranked = [...states.values()].sort(
+    (a, b) =>
+      b.wins - a.wins ||
+      a.losses - b.losses ||
+      b.difficultyScore - a.difficultyScore ||
+      a.initialStageSeed - b.initialStageSeed,
+  );
+  const teams = ranked.map((state, index) => ({
+    teamId: state.teamId,
+    initialStageSeed: state.initialStageSeed,
+    currentStageSeed: index + 1,
+    wins: state.wins,
+    losses: state.losses,
+    difficultyScore: state.difficultyScore,
+    status: state.status,
+    opponents: [...state.opponents],
+  }));
+
+  return {
+    finalizedRound,
+    teams,
+    active: teams.filter((team) => team.status === "active"),
+    advanced: teams.filter((team) => team.status === "advanced"),
+    eliminated: teams.filter((team) => team.status === "eliminated"),
+    isComplete: finalizedRound === MAJOR_SWISS_MAX_ROUND,
+  };
+}
+
+// ── Pairing 低层函数 ────────────────────────────────────
+
+export function selectMajorSixTeamPairingPattern(
+  seededTeamIds: readonly string[],
+  priorMatches: readonly Pick<MajorSwissMatchFact, "teamAId" | "teamBId">[],
+): {
+  priority: number;
+  pairs: readonly {
+    higherSeedTeamId: string;
+    lowerSeedTeamId: string;
+  }[];
+} {
+  if (seededTeamIds.length !== 6) {
+    throw new Error(`six-team pairing requires exactly 6 teams (got ${seededTeamIds.length})`);
+  }
+  if (new Set(seededTeamIds).size !== 6) {
+    throw new Error("six-team pairing requires unique team ids");
+  }
+
+  const priorEdges = new Set<string>();
+  for (const match of priorMatches) {
+    const key =
+      match.teamAId < match.teamBId
+        ? `${match.teamAId}\u0000${match.teamBId}`
+        : `${match.teamBId}\u0000${match.teamAId}`;
+    priorEdges.add(key);
+  }
+
+  for (const pattern of MAJOR_SWISS_SIX_TEAM_PRIORITY_PATTERNS) {
+    const pairs = pattern.pairs.map(([higherPosition, lowerPosition]) => ({
+      higherSeedTeamId: seededTeamIds[higherPosition - 1],
+      lowerSeedTeamId: seededTeamIds[lowerPosition - 1],
+    }));
+    const hasRematch = pairs.some((pair) => {
+      const key =
+        pair.higherSeedTeamId < pair.lowerSeedTeamId
+          ? `${pair.higherSeedTeamId}\u0000${pair.lowerSeedTeamId}`
+          : `${pair.lowerSeedTeamId}\u0000${pair.higherSeedTeamId}`;
+      return priorEdges.has(key);
+    });
+    if (!hasRematch) {
+      return { priority: pattern.priority, pairs };
+    }
+  }
+
+  throw new Error("all 15 six-team priority patterns contain a rematch; no legal pairing exists");
+}
+
+export function getMajorSwissRequiredFormat(record: MajorSwissRecord): MajorSwissMatchFormat {
+  if (record.wins >= MAJOR_SWISS_WIN_THRESHOLD || record.losses >= MAJOR_SWISS_LOSS_THRESHOLD) {
+    throw new Error(`terminal record ${record.wins}-${record.losses} must not be scheduled`);
+  }
+  return record.wins === 2 || record.losses === 2 ? "bo3" : "bo1";
+}
+
+// ── 下一轮配对 ──────────────────────────────────────────
+
+export function generateNextMajorSwissRound(input: {
+  entrants: readonly MajorSwissEntrant[];
+  matches: readonly MajorSwissMatchFact[];
+  finalizedRound: MajorSwissFinalizedRound;
+}): readonly MajorSwissPairing[] {
+  const projection = projectMajorSwissStage(input);
+
+  if (projection.finalizedRound === MAJOR_SWISS_MAX_ROUND) {
+    throw new Error("stage already complete (finalizedRound 5); no next round exists");
+  }
+  const nextRound = (projection.finalizedRound + 1) as MajorSwissRound;
+
+  // 按 exact record 分组：`${wins}-${losses}`
+  const groups = new Map<string, MajorSwissTeamState[]>();
+  for (const team of projection.active) {
+    const key = `${team.wins}-${team.losses}`;
+    const group = groups.get(key);
+    if (group === undefined) {
+      groups.set(key, [team]);
+    } else {
+      group.push(team);
+    }
+  }
+
+  // 校验 active distribution（不符合即 throw，不 repair）
+  const expected = EXPECTED_ACTIVE_DISTRIBUTION[nextRound];
+  const actualDistribution: Record<string, number> = {};
+  for (const [key, teamGroup] of groups) {
+    actualDistribution[key] = teamGroup.length;
+  }
+  const allKeys = new Set([...Object.keys(expected), ...Object.keys(actualDistribution)]);
+  const distributionMatches = [...allKeys].every(
+    (key) => expected[key] === actualDistribution[key],
+  );
+  if (!distributionMatches) {
+    throw new Error(
+      `invalid active distribution for round ${nextRound}: ` +
+        `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actualDistribution)}`,
+    );
+  }
+
+  // group 顺序：wins DESC, losses ASC
+  const sortedGroups = [...groups.entries()].sort((a, b) => {
+    const recordA = parseRecordKey(a[0]);
+    const recordB = parseRecordKey(b[0]);
+    return recordB.wins - recordA.wins || recordA.losses - recordB.losses;
+  });
+
+  const pairings: MajorSwissPairing[] = [];
+
+  for (const [key, group] of sortedGroups) {
+    const record = parseRecordKey(key);
+    const sortedBySeed = [...group].sort((a, b) => a.currentStageSeed - b.currentStageSeed);
+
+    if (nextRound === 1) {
+      // R1：initial stage seed 1v9 .. 8v16
+      for (let i = 0; i < MAJOR_SWISS_TEAM_COUNT / 2; i += 1) {
+        const higher = sortedBySeed[i];
+        const lower = sortedBySeed[i + MAJOR_SWISS_TEAM_COUNT / 2];
+        pairings.push({
+          round: nextRound,
+          record: { ...record },
+          higherSeedTeamId: higher.teamId,
+          lowerSeedTeamId: lower.teamId,
+          higherSeed: higher.currentStageSeed,
+          lowerSeed: lower.currentStageSeed,
+          format: getMajorSwissRequiredFormat(record),
+          pairingRule: "initial",
+        });
+      }
+    } else if (nextRound === 2 || nextRound === 3) {
+      // R2/R3：high-low —— highest seed vs lowest available non-rematch
+      const available = [...sortedBySeed];
+      while (available.length > 0) {
+        const higher = available.shift()!;
+        let lowerIndex = -1;
+        for (let i = available.length - 1; i >= 0; i -= 1) {
+          if (!available[i].opponents.includes(higher.teamId)) {
+            lowerIndex = i;
+            break;
+          }
+        }
+        if (lowerIndex === -1) {
+          throw new Error(
+            `cannot pair ${higher.teamId} (${record.wins}-${record.losses}) without a rematch`,
+          );
+        }
+        const [lower] = available.splice(lowerIndex, 1);
+        pairings.push({
+          round: nextRound,
+          record: { ...record },
+          higherSeedTeamId: higher.teamId,
+          lowerSeedTeamId: lower.teamId,
+          higherSeed: higher.currentStageSeed,
+          lowerSeed: lower.currentStageSeed,
+          format: getMajorSwissRequiredFormat(record),
+          pairingRule: "high-low",
+        });
+      }
+    } else {
+      // R4/R5：six-team priority patterns
+      if (sortedBySeed.length !== 6) {
+        throw new Error(`round ${nextRound} requires exactly 6 teams per record group`);
+      }
+      const priorMatches: { teamAId: string; teamBId: string }[] = [];
+      for (const team of projection.teams) {
+        for (const opponentId of team.opponents) {
+          if (team.teamId < opponentId) {
+            priorMatches.push({ teamAId: team.teamId, teamBId: opponentId });
+          }
+        }
+      }
+      const selected = selectMajorSixTeamPairingPattern(
+        sortedBySeed.map((team) => team.teamId),
+        priorMatches,
+      );
+      const seedOf = new Map(sortedBySeed.map((team) => [team.teamId, team.currentStageSeed]));
+      for (const pair of selected.pairs) {
+        pairings.push({
+          round: nextRound,
+          record: { ...record },
+          higherSeedTeamId: pair.higherSeedTeamId,
+          lowerSeedTeamId: pair.lowerSeedTeamId,
+          higherSeed: seedOf.get(pair.higherSeedTeamId)!,
+          lowerSeed: seedOf.get(pair.lowerSeedTeamId)!,
+          format: getMajorSwissRequiredFormat(record),
+          pairingRule: "six-team-priority",
+          priority: selected.priority,
+        });
+      }
+    }
+  }
+
+  return pairings;
+}
+
+// ── Qualifiers ──────────────────────────────────────────
+
+export function getMajorSwissQualifiers(
+  projection: MajorSwissProjection,
+): readonly MajorSwissQualifier[] {
+  if (!projection.isComplete || projection.finalizedRound !== MAJOR_SWISS_MAX_ROUND) {
+    throw new Error("qualifiers are only defined for a complete stage (finalizedRound === 5)");
+  }
+  if (projection.advanced.length !== MAJOR_SWISS_ADVANCE_COUNT) {
+    throw new Error(
+      `expected exactly ${MAJOR_SWISS_ADVANCE_COUNT} advanced teams, got ${projection.advanced.length}`,
+    );
+  }
+
+  const qualifiers = projection.advanced.map((team) => ({
+    teamId: team.teamId,
+    finalStageSeed: team.currentStageSeed,
+  }));
+  for (let index = 0; index < qualifiers.length; index += 1) {
+    if (qualifiers[index].finalStageSeed !== index + 1) {
+      throw new Error(
+        `advanced final stage seeds must be 1..${MAJOR_SWISS_ADVANCE_COUNT}, ` +
+          `got ${qualifiers[index].finalStageSeed} at rank ${index + 1}`,
+      );
+    }
+  }
+  return qualifiers;
+}


### PR DESCRIPTION
## 为什么新建独立 pure domain core

当前 `src/lib/formats/swiss.ts` 是旧 runtime executor：import drizzle-orm / db / matches / seasons / swissStandings，初始化写 `swiss_standings`、增量更新 wins/losses、持久化 buScore 与 advanced/eliminated。它把 standings 当作 write-side source of truth。

2.0 最终架构中 **matches = canonical match facts**、**StagePlan = static configuration**，未来由 StageRun / StageEntrants 承载 runtime 状态。因此本 PR 建立独立的 **Major rules kernel**（`src/lib/major/`），正式 standings 由 `StageEntrants + canonical matches + finalizedRound` 纯函数投影得到，与旧路径完全解耦。

## 当前旧 swissExecutor 为什么暂不接入

- 旧 executor 依赖 mutable `swiss_standings` 与 DB 写路径，与 pure projection 语义冲突。
- 本 PR 范围严格限定为独立 domain core；StageRun / StageEntrants / CompetitionConfig persistence 完成后，由后续 adapter/orchestrator 接入，届时再替换旧路径。
- 本 PR 未修改：`src/lib/formats/swiss.ts`、`src/lib/swiss/data.ts`、`src/db/schema/swiss-standings.ts`、`src/actions/matches/schedule.ts`、`src/types/season.ts`、`MAJOR_STAGE_PLAN`。

## Projection 的 source

`projectMajorSwissStage({ entrants, matches, finalizedRound })` 从三类输入重算整个 official state：

1. **entrants**：16 队 stage-local initial seed（1..16 严格唯一，校验 fail-closed）
2. **canonical completed match facts**：仅 `round <= finalizedRound` 的已完成事实进入投影，半轮结果不会提前改变 standings / seeds
3. **finalizedRound**：finalized 轮必须完整（R1=8 / R2=8 / R3=8 / R4=6 / R5=3），否则 throw

投影输出：wins/losses、Difficulty Score、status（active/advanced/eliminated）、currentStageSeed（wins DESC, losses ASC, difficulty DESC, initialSeed ASC）、opponents。

## Pairing 规则

- **R1**：initial stage seed 1v9 .. 8v16（`pairingRule = "initial"`，8 × BO1）
- **R2/R3**：相同 W-L record 组内按 currentStageSeed ASC，**feasibility-aware high-low**（`pairingRule = "high-low"`）——highest seed 优先 lowest **feasible** non-rematch opponent：候选必须满足「选中后剩余队伍仍存在完整 zero-rematch matching」（小规模 deterministic backtracking 判定，group ≤ 8 队）；整个 group 确实不存在完整 matching 才 fail-closed throw。R3 为 2-0/1-1/0-2 三组，其中 2-0 与 0-2 为 BO3
- **R4/R5**：2-1 / 1-2 / 2-2 六队组，按冻结的 Valve 15-priority patterns 选择第一个完全无 rematch 的方案（`pairingRule = "six-team-priority"`，全部 BO3）
- rematch history 仅来自 `round <= finalizedRound` 的事实
- 不跨 record、不随机、无 rematch-first / rematch fallback / slidePair；`selectMajorSixTeamPairingPattern()` 独立导出供 15-pattern 规则单测

### Review 修正（feasibility-aware pairing）

原 naive greedy 在合法 R1/R2 状态下有 ~0.6%（400/65536）概率人工 deadlock：前面的局部合法选择导致最后两队只能 rematch，但该 record group 实际存在完整 zero-rematch matching。已按 review 结论改为 deterministic feasibility-aware high-low（每次选择前验证剩余队伍可完整配对），不再对此类状态 fail-closed；仅当整个 group 不存在任何 complete zero-rematch matching 时才 throw。

## Difficulty Score

`Σ (opponent.currentWins - opponent.currentLosses)`，对全部 16 队（含 advanced/eliminated）在投影时动态重算——队伍 advanced 后其历史对手后续轮次战绩变化会继续反映在其 Difficulty 中，绝不冻结。

## Stage-local seeding

- `seedMajorStageOneEntrants`：tournament seed 17..32（或任意非连续正整数）按相对顺序规范化为 stage-local 1..16
- `seedMajorLaterStageEntrants`：direct 8 队按 tournamentSeed ASC → 1..8；advancing 8 队按 previousStageFinalSeed ASC → 9..16
- 不 import StageConfig / Season / DB，不假设 tournament seed 的具体区间

## Test matrix

- `src/lib/major/swiss.test.ts`（51 tests）：entrant validation、R0 projection、R1 精确配对、unfinalized 忽略、finalized 轮完整性（7 场/同队两次/unknown team/winner 非参与者/self/cross-record/dup matchId/非法 round）、Difficulty 精确手算 + advanced 后动态更新、R2/R3 high-low 与 rematch avoidance、**naive-greedy deadlock 反例 regression**（r1mask=15 / r2mask=24 必须成功生成完整 8 场 R3）、**exhaustive 65536 枚举**、15 patterns 常量逐项校验 + brute-force 覆盖 priority 1..15、BO1/BO3 全表、结构性 counts、determinism、no input mutation、pairing 无 teamA/teamB 语义
- `src/lib/major/seeding.test.ts`（20 tests）：Stage 1 规范化、Later Stage 分组、全部校验 throw、输入不可变、顺序无关

### Naive-greedy regression（r1mask=15, r2mask=24）

R3 1-1 group 原 naive 贪心选 1-11, 2-9, 3-10 后 team-13 只剩 R1 对手 team-5 → 人工 deadlock。feasibility-aware 的差异点在 H=3：最低 non-rematch 10 不可行（选中后剩余 {13,5} 互相是 R1 对手无法配对）→ 选 5 → 1-11, 2-9, 3-5, 13-10 完整生成。测试验证 full 8 R3 matches、1-1 group 4 场、exact same record、zero rematch、deterministic、no cross-record、BO format（2-0/0-2 → bo3，1-1 → bo1）。

### Exhaustive R1/R2 feasibility（65536）

所有 256 R1 winner masks × 256 R2 winner masks（R2 pairing 由 generator 自己生成），finalizedRound=2 后 generate R3：**65536 / 65536 全部生成完整 8 场**，每场 same record、zero rematch、participants 恰好 16 队。**65536 完整执行，无抽样/skip**；校验使用轻量独立 oracle + invariant accumulator（inner loop 不调用 Vitest expect，失败才 throw 带 r1mask/r2mask 定位），避免 coverage instrumentation 下的 assertion 开销（CI run #861 上 exhaustive 曾使 swiss.test.ts 插桩耗时 64.88s 并触发无消息 exit 1；优化后 CI 上 5.96s，CI 全绿）。

## 100 次 deterministic tournament simulation

- 测试内实现 deterministic LCG（不用 Math.random），固定 seed 1..100
- **100 / 100 complete**（任意 generator throw → 测试 FAIL，不吞异常）；总 **3300 matches**（100 × 33）
- 每轮断言：双方 pre-match record 相同 / 无 rematch / format 正确 / 每轮 match count 与 BO 分布
- 完成态验证：33 matches、8 advanced / 8 eliminated / 0 active、每轮 counts {8,8,8,6,3}、每队 ≤5 场、currentStageSeed 恒为 1..16 唯一、formats {R1:8BO1, R2:8BO1, R3:4BO1+4BO3, R4:6BO3, R5:3BO3}、qualifiers = 8（finalStageSeed 1..8）

## Zero DB / schema / migration changes

本 PR 仅新增/修改 4 个纯 TypeScript 文件（`src/lib/major/`），零依赖、零 DB import。`drizzle-kit check` 通过、无 migration、无 schema 变更、无 package.json / pnpm-lock.yaml 变更。

## 后续接入

StageRun / StageEntrants adapter 接入 runtime 时才接线：届时旧 `swissExecutor` 替换、`MAJOR_STAGE_PLAN` 迁移，均不在本 PR 范围。
