### PR TITLE
fix: fail closed unsupported tournament flows

### DIFF
--- a/.changeset/fail-closed-team-registration.md
+++ b/.changeset/fail-closed-team-registration.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+Team 报名与含 Swiss 赛季在完整运营闭环落地前保持 fail closed，避免误用个人报名和自动状态迁移。

--- a/docs/registration-flow.md
+++ b/docs/registration-flow.md
@@ -4,7 +4,7 @@
 
 当前生产验证的是个人报名流程：登录用户在 `/[seasonSlug]/register` 提交个人资料，管理员在 `/admin/[seasonSlug]/registrations` 审核 `season_registrations`。
 
-`registrationMode=team`、队伍自助报名、队员名单提交、队伍报名审核、审核后自动生成 `teams` / `team_members` 仍未形成闭环。外部公开赛或 Major 试点如需队伍制，试点前需要单独实现；在实现前只能由管理员手工建队或使用现有选秀生成队伍流程。
+`registrationMode=team`、队伍自助报名、队员名单提交、队伍报名审核、审核后自动生成 `teams` / `team_members` 仍未形成闭环。为避免把个人报名误写为队伍报名，Team 模式的公开报名页和 `submitRegistration` 当前都会 fail closed；在实现完整闭环前只能由管理员手工建队。
 
 ---
 
@@ -13,6 +13,10 @@
 ```
 用户访问 /[seasonSlug]/register
   ↓
+检查 registrationMode
+  ├── team → 显示“队伍报名尚未开放”，不加载个人报名与 season_registrations 写链
+  └── solo → 继续
+        ↓
 检查赛季状态是否为 registration（Server Component fetch）
   ├── 否（已截止 / 未开放） → 显示"报名未开放"提示
   └── 是 → 检查用户登录状态

--- a/docs/season-abstraction.md
+++ b/docs/season-abstraction.md
@@ -14,9 +14,9 @@ Capability 字段和 preset 是配置层基础，不等于生产已验收流程�
 
 | 能力 | 当前状态 |
 |---|---|
-| `registrationMode=team` | schema/types/season form 中已有配置基础，但公开报名页和 `submitRegistration` 仍是个人报名流程 |
+| `registrationMode=team` | schema/types/season form 中已有配置基础；公开报名页与个人 `submitRegistration` 已 fail closed，队伍报名闭环待实现 |
 | `open-tournament` | preset 存在；队伍自助报名、审核、生成队伍闭环未完成 |
-| `major` | preset 存在；Swiss executor 有基础，但三段 Swiss 到单败的后台运营闭环未完整验收 |
+| `major` | preset 存在；Swiss executor 有基础，但三段 Swiss 到单败的后台运营闭环未完整验收，含 Swiss 的赛季不会自动完赛 |
 | broadcast / overlay | 不属于当前 capability preset，需新增模块 |
 
 ---

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -30,13 +30,13 @@ archived
 | 当前状态 | 可迁移至 | 触发方 | 备注 |
 |---|---|---|---|
 | `draft` | `registration` | admin | 发布赛季，开放报名 |
-| `registration` | `voting` | system | 自动触发（满员或截止），不再手动 |
-| `registration` | `playing` | system | 当 `hasCaptainVoting=false` 时跳过 voting+drafting，自动触发 |
+| `registration` | `voting` | system | 仅 `registrationMode=solo` 自动触发（满员或截止） |
+| `registration` | `playing` | system | 仅 `registrationMode=solo && hasCaptainVoting=false` 时自动触发 |
 | `draft` | `registration` | admin | 撤回至草稿（仅无报名时可用） |
 | `voting` | `registration` | admin | 撤回至报名阶段（清空投票记录） |
 | `voting` | `drafting` | admin | 确认 8 名队长，生成队伍和选秀顺位 |
 | `drafting` | `playing` | system | 所有 pick 完成时自动触发 |
-| `playing` | `finished` | system / admin | 自动（所有比赛结束）+ 手动 fallback |
+| `playing` | `finished` | system / admin | 无 Swiss 阶段时可自动（所有比赛结束）；含 Swiss 时由管理员显式结束，未来交给阶段 orchestrator |
 | `finished` | `archived` | admin | 管理员手动归档 |
 
 ### 禁止迁移

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -135,6 +135,12 @@ export async function submitRegistration(input: RegistrationFormData) {
     if (!season) {
       throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
     }
+    if (season.registrationMode !== "solo") {
+      throw new AppError(
+        ErrorCode.SEASON_CAPABILITY_DISABLED,
+        "队伍报名尚未开放，请联系赛事管理员",
+      );
+    }
     const windowState = getRegistrationWindowState(season);
     if (!windowState.canSubmit) {
       throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);

--- a/src/actions/transitions.ts
+++ b/src/actions/transitions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { eq, count, and, not, inArray } from "drizzle-orm";
 import type { TxDb } from "@/db/client";
 import { seasons, seasonRegistrations, auditLogs, matches } from "@/db/schema";
-import { normalizeRegistrationConfig } from "@/types/season";
+import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
 
 async function getApprovedCountInTx(tx: TxDb, seasonId: string): Promise<number> {
   const [row] = await tx
@@ -30,7 +30,11 @@ export async function maybeAdvanceFromRegistration(
   const season = await tx.query.seasons.findFirst({
     where: eq(seasons.id, seasonId),
   });
-  if (!season || season.status !== "registration") return;
+  if (
+    !season ||
+    season.status !== "registration" ||
+    season.registrationMode !== "solo"
+  ) return;
 
   const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
   const approvedCount = await getApprovedCountInTx(tx, seasonId);
@@ -81,7 +85,11 @@ export async function maybeFinishSeason(
   const season = await tx.query.seasons.findFirst({
     where: eq(seasons.id, seasonId),
   });
-  if (!season || season.status !== "playing") return;
+  if (
+    !season ||
+    season.status !== "playing" ||
+    normalizeStagePlan(season.stagePlan).some((stage) => stage.type === "swiss")
+  ) return;
 
   // 检查是否所有比赛都已结束（finished 或 cancelled）
   const [pendingMatch] = await tx

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -12,6 +12,7 @@ import { positionLabel } from "@/lib/validators/registration";
 import { getRegistrationWindowState, getWindowTone } from "@/lib/registration/window";
 import { formatCST } from "@/lib/utils/date";
 import { getUserSession } from "@/lib/auth/session";
+import { isSoloRegistration } from "@/lib/utils/season";
 
 export const dynamic = "force-dynamic";
 
@@ -56,6 +57,20 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           />
         </div>
       </Panel>
+      </div>
+    );
+  }
+
+  if (!isSoloRegistration(season)) {
+    return (
+      <div className="container mx-auto px-4 py-16 max-w-2xl">
+        <Panel pad={40}>
+          <StatusBanner
+            tone="info"
+            title={season.name}
+            sub="队伍报名尚未开放，请联系赛事管理员。"
+          />
+        </Panel>
       </div>
     );
   }

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -36,6 +36,20 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   });
   if (!season) notFound();
 
+  if (!isSoloRegistration(season)) {
+    return (
+      <div className="container mx-auto px-4 py-16 max-w-2xl">
+        <Panel pad={40}>
+          <StatusBanner
+            tone="info"
+            title={season.name}
+            sub="队伍报名尚未开放，请联系赛事管理员。"
+          />
+        </Panel>
+      </div>
+    );
+  }
+
   // 报名未开放时显示状态提示
   if (season.status !== "registration") {
     const statusMessages: Record<string, string> = {
@@ -57,20 +71,6 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           />
         </div>
       </Panel>
-      </div>
-    );
-  }
-
-  if (!isSoloRegistration(season)) {
-    return (
-      <div className="container mx-auto px-4 py-16 max-w-2xl">
-        <Panel pad={40}>
-          <StatusBanner
-            tone="info"
-            title={season.name}
-            sub="队伍报名尚未开放，请联系赛事管理员。"
-          />
-        </Panel>
       </div>
     );
   }

--- a/tests/unit/actions/register.test.ts
+++ b/tests/unit/actions/register.test.ts
@@ -205,6 +205,21 @@ describe("submitRegistration()", () => {
     }
   });
 
+  it("队伍报名未实现时 fail closed，不进入个人报名写链", async () => {
+    seasonFindFirstMock.mockResolvedValue({ ...SEASON, registrationMode: "team" });
+
+    const result = await submitRegistration(VALID_INPUT as never);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe(ErrorCode.SEASON_CAPABILITY_DISABLED);
+    }
+    expect(getRegistrationWindowStateMock).not.toHaveBeenCalled();
+    expect(getUserSessionMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
   it("报名窗口关闭（canSubmit=false）返回 REGISTRATION_CLOSED", async () => {
     seasonFindFirstMock.mockResolvedValue(SEASON);
     getRegistrationWindowStateMock.mockReturnValue({

--- a/tests/unit/actions/transitions.test.ts
+++ b/tests/unit/actions/transitions.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidatePathMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import { maybeAdvanceFromRegistration, maybeFinishSeason } from "@/actions/transitions";
+
+function createTx(season: Record<string, unknown>, count = 0) {
+  const selectMock = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue([{ count }]),
+    })),
+  }));
+  const updateSetMock = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+  const updateMock = vi.fn(() => ({ set: updateSetMock }));
+  const insertValuesMock = vi.fn().mockResolvedValue(undefined);
+  const insertMock = vi.fn(() => ({ values: insertValuesMock }));
+
+  return {
+    tx: {
+      query: { seasons: { findFirst: vi.fn().mockResolvedValue(season) } },
+      select: selectMock,
+      update: updateMock,
+      insert: insertMock,
+    },
+    selectMock,
+    updateMock,
+    updateSetMock,
+    insertMock,
+  };
+}
+
+describe("season automatic transitions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not advance team registration into the solo lifecycle", async () => {
+    const { tx, selectMock, updateMock, insertMock } = createTx({
+      id: "season-1",
+      slug: "major",
+      status: "registration",
+      registrationMode: "team",
+      hasCaptainVoting: false,
+      registrationConfig: { maxTotal: 1 },
+      registrationDeadline: new Date(0),
+    }, 1);
+
+    await maybeAdvanceFromRegistration(tx as never, "season-1");
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing solo auto-advance path", async () => {
+    const { tx, updateSetMock, insertMock } = createTx({
+      id: "season-1",
+      slug: "rivals",
+      status: "registration",
+      registrationMode: "solo",
+      hasCaptainVoting: false,
+      registrationConfig: { maxTotal: 1 },
+      registrationDeadline: null,
+    }, 1);
+
+    await maybeAdvanceFromRegistration(tx as never, "season-1");
+
+    expect(updateSetMock).toHaveBeenCalledWith(expect.objectContaining({ status: "playing" }));
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-finish a season whose stage plan contains Swiss", async () => {
+    const { tx, selectMock, updateMock, insertMock } = createTx({
+      id: "season-1",
+      slug: "major",
+      status: "playing",
+      stagePlan: [
+        { key: "opening", name: "Opening", type: "swiss", teamCount: 32, advanceTiers: [] },
+        { key: "playoff", name: "Playoff", type: "single_elim", teamCount: 8, advanceTiers: [] },
+      ],
+    });
+
+    await maybeFinishSeason(tx as never, "season-1");
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto-finish for non-Swiss stage plans with no pending matches", async () => {
+    const { tx, updateSetMock, insertMock } = createTx({
+      id: "season-1",
+      slug: "rivals",
+      status: "playing",
+      stagePlan: [
+        { key: "playoff", name: "Playoff", type: "double_elim", teamCount: 8, advanceTiers: [] },
+      ],
+    });
+
+    await maybeFinishSeason(tx as never, "season-1");
+
+    expect(updateSetMock).toHaveBeenCalledWith(expect.objectContaining({ status: "finished" }));
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/app/register-page.test.tsx
+++ b/tests/unit/app/register-page.test.tsx
@@ -1,0 +1,74 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  seasonFindFirstMock,
+  registrationFindFirstMock,
+  userFindFirstMock,
+  getPositionCountsMock,
+  getApprovedCountMock,
+  getUserSessionMock,
+  registrationFormMock,
+} = vi.hoisted(() => ({
+  seasonFindFirstMock: vi.fn(),
+  registrationFindFirstMock: vi.fn(),
+  userFindFirstMock: vi.fn(),
+  getPositionCountsMock: vi.fn(),
+  getApprovedCountMock: vi.fn(),
+  getUserSessionMock: vi.fn(),
+  registrationFormMock: vi.fn(() => null),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    query: {
+      seasons: { findFirst: seasonFindFirstMock },
+      seasonRegistrations: { findFirst: registrationFindFirstMock },
+      users: { findFirst: userFindFirstMock },
+    },
+  },
+}));
+
+vi.mock("@/actions/register", () => ({
+  getPositionCounts: getPositionCountsMock,
+  getApprovedCount: getApprovedCountMock,
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getUserSession: getUserSessionMock }));
+
+vi.mock("@/components/register/RegistrationForm", () => ({
+  RegistrationForm: registrationFormMock,
+}));
+
+import RegisterPage from "@/app/[seasonSlug]/register/page";
+
+describe("team registration page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("React", React);
+  });
+
+  it("renders an unavailable state without loading the solo registration flow", async () => {
+    seasonFindFirstMock.mockResolvedValue({
+      id: "season-1",
+      slug: "major",
+      name: "RivalHub Major",
+      status: "registration",
+      registrationMode: "team",
+    });
+
+    const page = await RegisterPage({
+      params: Promise.resolve({ seasonSlug: "major" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("队伍报名尚未开放");
+    expect(getUserSessionMock).not.toHaveBeenCalled();
+    expect(getPositionCountsMock).not.toHaveBeenCalled();
+    expect(getApprovedCountMock).not.toHaveBeenCalled();
+    expect(registrationFindFirstMock).not.toHaveBeenCalled();
+    expect(userFindFirstMock).not.toHaveBeenCalled();
+    expect(registrationFormMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/register-page.test.tsx
+++ b/tests/unit/app/register-page.test.tsx
@@ -49,12 +49,12 @@ describe("team registration page", () => {
     vi.stubGlobal("React", React);
   });
 
-  it("renders an unavailable state without loading the solo registration flow", async () => {
+  it("renders an unavailable state before season status or solo registration flow", async () => {
     seasonFindFirstMock.mockResolvedValue({
       id: "season-1",
       slug: "major",
       name: "RivalHub Major",
-      status: "registration",
+      status: "draft",
       registrationMode: "team",
     });
 


### PR DESCRIPTION
## What

- Team mode 的公开报名页 fail closed，不展示或进入个人报名流程。
- `submitRegistration` 在服务端对非 `solo` 报名模式 fail closed。
- Team mode 不再自动进入 solo lifecycle。
- 含 Swiss 的赛季不再由 legacy `maybeFinishSeason` 自动完赛。
- 非 Swiss 旧赛制保留原有自动完赛行为。

## Why

完整 Team Registration 和 Tournament Stage Orchestrator 尚未落地。本 PR 是临时安全护栏，防止旧 1.x lifecycle 对 2.0 tournament flow 做出错误状态迁移。

## Boundary

本 PR 不实现 Team Application、StageRun、StageEntrants、Major runtime orchestration 或任何数据库 schema。

## Validation

- `pnpm exec vitest run tests/unit/actions/register.test.ts tests/unit/actions/transitions.test.ts tests/unit/app/register-page.test.tsx`
- `pnpm type-check`
- `pnpm exec drizzle-kit check`
- `pnpm test`
- `CI=true pnpm test:coverage`
- `pnpm build`
- `git diff --check`