### PR TITLE
feat(matches): support multi-stage tournament views

### DIFF
--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -11,7 +11,13 @@ import { MatchTeamFilter } from "@/components/matches/MatchTeamFilter";
 import { StandingsTable } from "@/components/matches/StandingsTable";
 import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
-import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
+import {
+  buildStageViews,
+  filterLegacyBracketByStageName,
+  getTeamsReferencedByMatches,
+  resolveDefaultStageKey,
+} from "@/lib/matches/stage-views";
+import { normalizeStagePlan } from "@/types/season";
 import { MatchTabsSection } from "@/components/matches/MatchTabsSection";
 import { checkAdminSession } from "@/lib/auth/session";
 import { AdminShortcut } from "@/components/layout/AdminShortcut";
@@ -28,11 +34,10 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   const { seasonSlug } = await params;
   const { team: filterTeamId } = await searchParams;
 
-  const [seasonResult, adminSession] = await Promise.all([
+  const [season, adminSession] = await Promise.all([
     db.query.seasons.findFirst({ where: eq(seasons.slug, seasonSlug) }),
     checkAdminSession(),
   ]);
-  const season = seasonResult;
   if (!season) notFound();
 
   const [allTeams, allMatches] = await Promise.all([
@@ -46,108 +51,47 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
     }),
   ]);
 
-  const teamMap = new Map(allTeams.map((t) => [t.id, t.name]));
+  const teamMap = new Map(allTeams.map((team) => [team.id, team.name]));
   const stagePlan = normalizeStagePlan(season.stagePlan);
-  const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
-  const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
-  const qualifierKey = qualifierStage?.key ?? "qualifier";
-  const playoffKey = playoffStage?.key ?? "playoff";
+  const { views: stageViews, unconfiguredMatches } = buildStageViews(stagePlan, allMatches);
+  const matchFilter = (match: { teamAId: string; teamBId: string }) =>
+    !filterTeamId || match.teamAId === filterTeamId || match.teamBId === filterTeamId;
 
-  const qualifierMatchesAll = allMatches.filter((m) => m.stage === qualifierKey);
-  const playoffMatchesAll = allMatches.filter((m) => m.stage === playoffKey);
-
-  // 按队伍筛选
-  const matchFilter = (m: { teamAId: string; teamBId: string }) =>
-    !filterTeamId || m.teamAId === filterTeamId || m.teamBId === filterTeamId;
-  const qualifierMatches = qualifierMatchesAll.filter(matchFilter);
-  const playoffMatches = playoffMatchesAll.filter(matchFilter);
-
-  // 待进行：已排期（由近及远）→ 未排期
-  const sortActiveMatches = (list: typeof allMatches) =>
-    [...list].sort((a, b) => {
-      const aTime = a.scheduledAt?.getTime() ?? Infinity;
-      const bTime = b.scheduledAt?.getTime() ?? Infinity;
-      if (aTime !== bTime) return aTime - bTime;
-      return a.createdAt.getTime() - b.createdAt.getTime();
+  const sortActiveMatches = (stageMatches: typeof allMatches) =>
+    [...stageMatches].sort((a, b) => {
+      const timeDifference = (a.scheduledAt?.getTime() ?? Infinity) - (b.scheduledAt?.getTime() ?? Infinity);
+      return timeDifference || a.createdAt.getTime() - b.createdAt.getTime();
     });
-
-  // 已结束：按结束时间从近到远
-  const sortDoneMatches = (list: typeof allMatches) =>
-    [...list].sort((a, b) => {
-      const aTime = (a.completedAt ?? a.scheduledAt)?.getTime() ?? 0;
-      const bTime = (b.completedAt ?? b.scheduledAt)?.getTime() ?? 0;
-      if (aTime !== bTime) return bTime - aTime;
-      return b.createdAt.getTime() - a.createdAt.getTime();
+  const sortDoneMatches = (stageMatches: typeof allMatches) =>
+    [...stageMatches].sort((a, b) => {
+      const timeDifference = (b.completedAt ?? b.scheduledAt)?.getTime() ?? 0;
+      const otherTime = (a.completedAt ?? a.scheduledAt)?.getTime() ?? 0;
+      return timeDifference - otherTime || b.createdAt.getTime() - a.createdAt.getTime();
     });
-
-  const splitMatches = (list: typeof allMatches) => ({
-    active: sortActiveMatches(list.filter((m) => m.status !== "finished" && m.status !== "cancelled")),
-    done: sortDoneMatches(list.filter((m) => m.status === "finished" || m.status === "cancelled")),
+  const splitMatches = (stageMatches: typeof allMatches) => ({
+    active: sortActiveMatches(
+      stageMatches.filter((match) => match.status !== "finished" && match.status !== "cancelled"),
+    ),
+    done: sortDoneMatches(
+      stageMatches.filter((match) => match.status === "finished" || match.status === "cancelled"),
+    ),
   });
 
-  const { active: qualifierActive, done: qualifierDone } = splitMatches(qualifierMatches);
-  const { active: playoffActive, done: playoffDone } = splitMatches(playoffMatches);
-
-  // 积分榜（仅当有 round_robin 排位赛时计算，使用未筛选的全部排位赛）
-  const finishedQualifierMatches = qualifierMatchesAll.filter((m) => m.status === "finished");
-  const standings = qualifierStage && qualifierStage.type !== "swiss"
-    ? calculateStandings(allTeams, finishedQualifierMatches)
-    : [];
-
-  // 瑞士轮视图数据（仅当有 swiss 排位赛时查询）
-  const swissData = qualifierStage?.type === "swiss"
-    ? await getSwissViewData(season.id, qualifierKey, qualifierStage.name)
-    : null;
-
-  const allQualifierFinished =
-    qualifierMatchesAll.length > 0 &&
-    qualifierMatchesAll.every((m) => m.status === "finished" || m.status === "cancelled");
-
-  // Bracket 数据（用于正赛 bracket 视图）
+  const swissDataByStage = new Map(
+    await Promise.all(
+      stageViews
+        .filter(({ stage, matches: stageMatches }) => stage.type === "swiss" && stageMatches.length > 0)
+        .map(async ({ stage }) => [
+          stage.key,
+          await getSwissViewData(season.id, stage.key, stage.name),
+        ] as const),
+    ),
+  );
   const fullBracketData = serializeBracket(
     (season.bracketData as Database | null) ?? null,
-    allTeams
+    allTeams,
   );
-
-  // 正赛 stage 的 bracket 数据；brackets-viewer 需要 stage 和 match 同步过滤。
-  const playoffBracketStageIds = new Set(
-    fullBracketData.stage
-      .filter((s) => s.name === playoffStage?.name)
-      .map((s) => s.id),
-  );
-  const playoffBracketMatchIds = new Set(
-    fullBracketData.match
-      .filter((m) => playoffBracketStageIds.has(m.stage_id))
-      .map((m) => m.id),
-  );
-  const bracketData = {
-    ...fullBracketData,
-    stage: fullBracketData.stage.filter((s) => playoffBracketStageIds.has(s.id)),
-    match: fullBracketData.match.filter((m) => playoffBracketStageIds.has(m.stage_id)),
-    match_game: fullBracketData.match_game.filter((game) => {
-      const parentId = game.parent_id;
-      return typeof parentId === "number" && playoffBracketMatchIds.has(parentId);
-    }),
-    group: fullBracketData.group.filter((g) => playoffBracketStageIds.has(g.stage_id)),
-    round: fullBracketData.round.filter((r) => playoffBracketStageIds.has(r.stage_id)),
-  };
-
-  // bracketNodeId（字符串）→ matchId（UUID），用于 BracketView 点击跳转
-  const matchNodeMap = new Map<string, string>(
-    playoffMatches
-      .filter((m) => m.bracketNodeId !== null)
-      .map((m) => [m.bracketNodeId!, m.id])
-  );
-
-  const hasQualifier = !!qualifierStage;
-  const hasPlayoff = !!playoffStage;
-
-  // 默认显示 stagePlan 中最靠后且已有比赛记录的阶段，支持任意数量阶段
-  const stagesWithMatches = new Set(allMatches.map((m) => m.stage));
-  const defaultStageKey =
-    [...stagePlan].reverse().find((s) => stagesWithMatches.has(s.key))?.key ??
-    stagePlan[0]?.key ??
-    qualifierKey;
+  const defaultStageKey = resolveDefaultStageKey(stagePlan, allMatches);
 
   if (allMatches.length === 0 && allTeams.length === 0) {
     return (
@@ -161,119 +105,116 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
     <div className="container mx-auto px-4 py-12 max-w-5xl space-y-8">
       <div className="flex items-center justify-between">
         <Marker sub={season.name}>赛程总览</Marker>
-        {adminSession && (
-          <AdminShortcut href={`/admin/${seasonSlug}/matches`} />
-        )}
+        {adminSession && <AdminShortcut href={`/admin/${seasonSlug}/matches`} />}
       </div>
 
       {allTeams.length > 0 && (
-        <MatchTeamFilter teams={allTeams.map((t) => ({ id: t.id, name: t.name }))} />
+        <MatchTeamFilter teams={allTeams.map((team) => ({ id: team.id, name: team.name }))} />
       )}
 
-      <Panel pad={24}>
-      <Tabs
-        defaultValue={defaultStageKey}
-        className="w-full"
-      >
-        <TabsList className="mb-6 bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
-          {qualifierStage && <TabsTrigger value={qualifierKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{qualifierStage.name}</TabsTrigger>}
-          {playoffStage && <TabsTrigger value={playoffKey} className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]">{playoffStage.name}</TabsTrigger>}
-        </TabsList>
+      {unconfiguredMatches.length > 0 && (
+        <Panel pad={16} className="border-[rgba(255,196,77,0.3)] bg-[rgba(255,196,77,0.05)]">
+          <p className="text-sm text-[var(--color-warn)]">
+            部分赛程数据与当前阶段配置不一致。
+          </p>
+        </Panel>
+      )}
 
-        {/* ── 排位赛面板 ─────────────────────────────────────────── */}
-        {hasQualifier && (
-          <TabsContent value={qualifierKey} className="space-y-8">
-            {/* Swiss 视图 */}
-            {swissData ? (
-              <section className="space-y-3">
-                <h2 className="text-lg font-semibold text-[var(--color-fg)]">
-                  {qualifierStage?.name ?? "瑞士轮"}
-                </h2>
-                <SwissBracket data={swissData} seasonSlug={seasonSlug} />
-              </section>
-            ) : (
-              <>
-                {/* 积分榜 */}
-                {standings.length > 0 && (
-                  <section className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <h2 className="text-lg font-semibold text-[var(--color-fg)]">积分榜</h2>
-                      {allQualifierFinished && (
-                        <span className="text-xs text-[var(--color-ok)] font-medium">最终排名</span>
+      {defaultStageKey && (
+        <Panel pad={24}>
+          <Tabs defaultValue={defaultStageKey} className="w-full">
+            <TabsList className="mb-6 max-w-full justify-start overflow-x-auto bg-[var(--color-panel)] border border-[var(--color-border)] p-1">
+              {stageViews.map(({ stage }) => (
+                <TabsTrigger
+                  key={stage.key}
+                  value={stage.key}
+                  className="data-[state=active]:bg-[var(--color-accent)] data-[state=active]:text-[var(--color-accent-fg)]"
+                >
+                  {stage.name}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {stageViews.map(({ stage, matches: allStageMatches }) => {
+              const stageMatches = allStageMatches.filter(matchFilter);
+              const { active, done } = splitMatches(stageMatches);
+              const swissData = swissDataByStage.get(stage.key);
+              const standings = stage.type === "round_robin" && allStageMatches.length > 0
+                ? calculateStandings(
+                    getTeamsReferencedByMatches(allTeams, allStageMatches),
+                    allStageMatches.filter((match) => match.status === "finished"),
+                  )
+                : [];
+              const isPlayoff = stage.type === "double_elim" || stage.type === "single_elim";
+              const bracketData = isPlayoff
+                ? filterLegacyBracketByStageName(fullBracketData, stage.name)
+                : null;
+              const matchNodeMap = new Map<string, string>(
+                allStageMatches
+                  .filter((match) => match.bracketNodeId !== null)
+                  .map((match) => [match.bracketNodeId!, match.id]),
+              );
+
+              return (
+                <TabsContent key={stage.key} value={stage.key} className="space-y-8">
+                  {swissData ? (
+                    <section className="space-y-3">
+                      <h2 className="text-lg font-semibold text-[var(--color-fg)]">{stage.name}</h2>
+                      <SwissBracket data={swissData} seasonSlug={seasonSlug} />
+                    </section>
+                  ) : (
+                    <>
+                      {standings.length > 0 && (
+                        <section className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <h2 className="text-lg font-semibold text-[var(--color-fg)]">积分榜</h2>
+                          </div>
+                          <StandingsTable
+                            standings={standings}
+                            seasonSlug={seasonSlug}
+                            isFinal={false}
+                          />
+                        </section>
                       )}
-                    </div>
-                    <StandingsTable
-                      standings={standings}
-                      seasonSlug={seasonSlug}
-                      isFinal={allQualifierFinished}
-                    />
-                  </section>
-                )}
 
-                {/* 赛程列表 */}
-                {qualifierMatchesAll.length > 0 && (
-                  <section className="space-y-3">
-                    <MatchTabsSection
-                      activeMatches={qualifierActive}
-                      doneMatches={qualifierDone}
-                      stage={qualifierKey}
-                      seasonSlug={seasonSlug}
-                      teamMap={teamMap}
-                    />
-                  </section>
-                )}
+                      {bracketData && bracketData.stage.length > 0 && (
+                        <section className="space-y-3">
+                          <h2 className="text-lg font-semibold text-[var(--color-fg)]">对阵图</h2>
+                          <BracketView
+                            data={bracketData}
+                            themeColor={season.themeColor}
+                            matchNodeMap={matchNodeMap}
+                            seasonSlug={seasonSlug}
+                          />
+                        </section>
+                      )}
 
-                {qualifierMatchesAll.length === 0 && (
-                  <div className="text-center py-16 text-[var(--color-fg-mid)]">
-                    排位赛赛程尚未生成
-                  </div>
-                )}
-              </>
-            )}
-          </TabsContent>
-        )}
+                      {allStageMatches.length > 0 && (
+                        <section className="space-y-3">
+                          <MatchTabsSection
+                            activeMatches={active}
+                            doneMatches={done}
+                            stage={stage.key}
+                            seasonSlug={seasonSlug}
+                            teamMap={teamMap}
+                            unknownTeamName={isPlayoff ? "TBD" : "未知队伍"}
+                          />
+                        </section>
+                      )}
 
-        {/* ── 正赛面板 ───────────────────────────────────────────── */}
-        {hasPlayoff && (
-          <TabsContent value={playoffKey} className="space-y-8">
-            {/* Bracket 图 */}
-            {bracketData.stage.length > 0 && (
-              <section id="bracket" className="space-y-3">
-                <h2 className="text-lg font-semibold text-[var(--color-fg)]">对阵图</h2>
-                <BracketView
-                  data={bracketData}
-                  themeColor={season.themeColor}
-                  matchNodeMap={matchNodeMap}
-                  seasonSlug={seasonSlug}
-                />
-              </section>
-            )}
-
-            {/* 正赛赛程列表 */}
-            {playoffMatchesAll.length > 0 && (
-              <section className="space-y-3">
-                <MatchTabsSection
-                  activeMatches={playoffActive}
-                  doneMatches={playoffDone}
-                  stage={playoffKey}
-                  seasonSlug={seasonSlug}
-                  teamMap={teamMap}
-                  unknownTeamName="TBD"
-                />
-              </section>
-            )}
-
-            {playoffMatchesAll.length === 0 && (
-              <div className="text-center py-16 text-[var(--color-fg-mid)]">
-                {allQualifierFinished
-                  ? "正赛即将开始，敬请期待"
-                  : "正赛将在排位赛结束后生成"}
-              </div>
-            )}
-          </TabsContent>
-        )}
-      </Tabs>
-      </Panel>
+                      {allStageMatches.length === 0 && (
+                        <div className="text-center py-16 text-[var(--color-fg-mid)]">
+                          {stage.name}赛程尚未生成
+                        </div>
+                      )}
+                    </>
+                  )}
+                </TabsContent>
+              );
+            })}
+          </Tabs>
+        </Panel>
+      )}
     </div>
   );
 }

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -13,8 +13,9 @@ import { SwissBracket } from "@/components/matches/SwissBracket";
 import { getSwissViewData } from "@/lib/swiss/data";
 import {
   buildStageViews,
-  filterLegacyBracketByStageName,
+  canUseLegacySwissView,
   getTeamsReferencedByMatches,
+  projectLegacyBracketByStageName,
   resolveDefaultStageKey,
 } from "@/lib/matches/stage-views";
 import { normalizeStagePlan } from "@/types/season";
@@ -139,6 +140,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
               const stageMatches = allStageMatches.filter(matchFilter);
               const { active, done } = splitMatches(stageMatches);
               const swissData = swissDataByStage.get(stage.key);
+              const canShowSwissBracket = canUseLegacySwissView(stage, allStageMatches, swissData);
               const standings = stage.type === "round_robin" && allStageMatches.length > 0
                 ? calculateStandings(
                     getTeamsReferencedByMatches(allTeams, allStageMatches),
@@ -146,8 +148,8 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                   )
                 : [];
               const isPlayoff = stage.type === "double_elim" || stage.type === "single_elim";
-              const bracketData = isPlayoff
-                ? filterLegacyBracketByStageName(fullBracketData, stage.name)
+              const bracketProjection = isPlayoff
+                ? projectLegacyBracketByStageName(fullBracketData, stage.name)
                 : null;
               const matchNodeMap = new Map<string, string>(
                 allStageMatches
@@ -157,13 +159,25 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
 
               return (
                 <TabsContent key={stage.key} value={stage.key} className="space-y-8">
-                  {swissData ? (
+                  {canShowSwissBracket ? (
                     <section className="space-y-3">
                       <h2 className="text-lg font-semibold text-[var(--color-fg)]">{stage.name}</h2>
                       <SwissBracket data={swissData} seasonSlug={seasonSlug} />
                     </section>
                   ) : (
                     <>
+                      {stage.type === "swiss" && allStageMatches.length > 0 && (
+                        <p className="text-sm text-[var(--color-warn)]">
+                          瑞士轮统计投影暂不可用。
+                        </p>
+                      )}
+
+                      {bracketProjection?.status === "ambiguous" && (
+                        <p className="text-sm text-[var(--color-warn)]">
+                          对阵图映射异常。
+                        </p>
+                      )}
+
                       {standings.length > 0 && (
                         <section className="space-y-3">
                           <div className="flex items-center justify-between">
@@ -177,11 +191,11 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                         </section>
                       )}
 
-                      {bracketData && bracketData.stage.length > 0 && (
+                      {bracketProjection?.status === "ok" && (
                         <section className="space-y-3">
                           <h2 className="text-lg font-semibold text-[var(--color-fg)]">对阵图</h2>
                           <BracketView
-                            data={bracketData}
+                            data={bracketProjection.data}
                             themeColor={season.themeColor}
                             matchNodeMap={matchNodeMap}
                             seasonSlug={seasonSlug}

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -16,6 +16,12 @@ import { BatchDeadlineCard } from "@/components/matches/BatchDeadlineCard";
 import { SyncBracketButton } from "@/components/matches/SyncBracketButton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Panel } from "@/components/rivalhub";
+import {
+  buildStageViews,
+  getTeamsReferencedByMatches,
+  hasAdjacentLegacyQualifierPlayoff,
+  resolveDefaultStageKey,
+} from "@/lib/matches/stage-views";
 import { getFirstStageOfType, normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
 import Link from "next/link";
 
@@ -127,18 +133,15 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   const mapPool = normalizeRegistrationConfig(season.registrationConfig).mapPool;
   const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
   const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
-  const qualifierKey = qualifierStage?.key ?? "qualifier";
-  const playoffKey = playoffStage?.key ?? "playoff";
   const statusFilter = (m: { status: string }) =>
     !filterStatus || filterStatus === "all" || m.status === filterStatus;
   const teamFilter = (m: { teamAId: string; teamBId: string }) =>
     !filterTeam || filterTeam === "all" || m.teamAId === filterTeam || m.teamBId === filterTeam;
-  const qualifierMatches = sortMatches(
-    allMatches.filter((m) => m.stage === qualifierKey).filter(statusFilter).filter(teamFilter)
-  );
-  const playoffMatches = sortMatches(
-    allMatches.filter((m) => m.stage === playoffKey).filter(statusFilter).filter(teamFilter)
-  );
+  const { views: allStageViews, unconfiguredMatches } = buildStageViews(stagePlan, allMatches);
+  const stageViews = allStageViews.map((view) => ({
+    ...view,
+    matches: sortMatches(view.matches.filter(statusFilter).filter(teamFilter)),
+  }));
 
   // 已完成比赛的地图列表（用于 OCR 录入面板）
   const finishedMatchIds = allMatches
@@ -159,43 +162,40 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   }
 
   const matchCount = allMatches.length;
-  const qualifierCount = qualifierMatches.length;
-
-  // 不受界面筛选影响，用于判断正赛是否已生成
-  const allPlayoffCount = allMatches.filter((m) => m.stage === playoffKey).length;
-  // 不受界面筛选影响，用于判断排位赛是否全部结束
-  const allQualifierMatches = allMatches.filter((m) => m.stage === qualifierKey);
-
-  const canGenerate = season.status === "playing" && matchCount === 0 && allTeams.length >= 2;
-
-  // 是否所有排位赛已结束（基于全量数据，不受筛选影响）
-  const allQualifierFinished =
-    allQualifierMatches.length > 0 &&
-    allQualifierMatches.every((m) => m.status === "finished" || m.status === "cancelled");
-
-  // 是否可以生成正赛
+  const hasSwissStage = stagePlan.some((stage) => stage.type === "swiss");
+  const canGenerate =
+    season.status === "playing" && matchCount === 0 && allTeams.length >= 2 && !hasSwissStage;
+  const qualifierView = qualifierStage
+    ? allStageViews.find((view) => view.stage.key === qualifierStage.key)
+    : null;
+  const playoffView = playoffStage
+    ? allStageViews.find((view) => view.stage.key === playoffStage.key)
+    : null;
+  const hasLegacyAdjacentPlayoff = hasAdjacentLegacyQualifierPlayoff(stagePlan);
+  const hasTerminalLegacyQualifierMatches =
+    qualifierView != null &&
+    qualifierView.matches.length > 0 &&
+    qualifierView.matches.every((match) => match.status === "finished" || match.status === "cancelled");
   const canGeneratePlayoff =
     !!qualifierStage &&
     !!playoffStage &&
-    allQualifierFinished &&
-    allPlayoffCount === 0;
+    hasLegacyAdjacentPlayoff &&
+    hasTerminalLegacyQualifierMatches &&
+    playoffView?.matches.length === 0;
 
-  // 积分榜（有排位赛时计算）
-  const finishedQualifierMatches = qualifierMatches.filter((m) => m.status === "finished");
-  const standings =
-    qualifierStage && qualifierCount > 0
-      ? calculateStandings(allTeams, finishedQualifierMatches)
-      : [];
-
-  const hasQualifier = !!qualifierStage;
-  const hasPlayoff = !!playoffStage;
-
-  // 默认显示 stagePlan 中最靠后且已有比赛记录的阶段，支持任意数量阶段
-  const stagesWithMatches = new Set(allMatches.map((m) => m.stage));
-  const defaultStageKey =
-    [...stagePlan].reverse().find((s) => stagesWithMatches.has(s.key))?.key ??
-    stagePlan[0]?.key ??
-    qualifierKey;
+  const standingsByStage = new Map(
+    allStageViews
+      .filter((view) => view.stage.type === "round_robin" && view.matches.length > 0)
+      .map((view) => [
+        view.stage.key,
+        calculateStandings(
+          getTeamsReferencedByMatches(allTeams, view.matches),
+          view.matches.filter((match) => match.status === "finished"),
+        ),
+      ]),
+  );
+  const qualifierStandings = qualifierStage ? standingsByStage.get(qualifierStage.key) ?? [] : [];
+  const defaultStageKey = resolveDefaultStageKey(stagePlan, allMatches, filterStage);
 
   const batchDeadlineGroups: { label: string; stage: string; round?: number | null; entryRound?: string | null; matchCount: number }[] = [];
   if (matchCount > 0) {
@@ -234,9 +234,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
   const teamMembersByTeam = new Map<string, TeamMemberData[]>();
 
   if (matchCount > 0) {
-    const displayedMatchIds = qualifierMatches
-      .map((m) => m.id)
-      .concat(playoffMatches.map((m) => m.id));
+    const displayedMatchIds = stageViews.flatMap((view) => view.matches.map((match) => match.id));
 
     const [members, rosters] = await Promise.all([
       db
@@ -351,6 +349,17 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
         />
       )}
 
+      {unconfiguredMatches.length > 0 && (
+        <Panel pad={16} className="border-[rgba(255,196,77,0.3)] bg-[rgba(255,196,77,0.05)]">
+          <p className="text-sm text-[var(--color-warn)]">
+            检测到 {unconfiguredMatches.length} 场比赛引用了当前 StagePlan 中不存在的阶段，请检查赛制配置。
+          </p>
+          <p className="mt-1 text-xs text-[var(--color-fg-mid)]">
+            涉及阶段：{[...new Set(unconfiguredMatches.map((match) => match.stage))].join("、")}
+          </p>
+        </Panel>
+      )}
+
       {/* 赛季状态提示 */}
       {season.status !== "playing" && matchCount === 0 && (
         <Panel pad={16} className="border-[rgba(255,196,77,0.3)] bg-[rgba(255,196,77,0.05)]">
@@ -369,18 +378,26 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
         />
       )}
 
+      {season.status === "playing" && matchCount === 0 && allTeams.length >= 2 && hasSwissStage && (
+        <Panel pad={16} className="border-[rgba(255,196,77,0.3)] bg-[rgba(255,196,77,0.05)]">
+          <p className="text-sm text-[var(--color-warn)]">
+            该赛制的自动赛程运行尚未启用。
+          </p>
+        </Panel>
+      )}
+
       {/* 生成正赛（排位赛全部结束后） */}
-      {canGeneratePlayoff && standings.length > 0 && playoffStage && (
+      {canGeneratePlayoff && qualifierStandings.length > 0 && playoffStage && (
         <GeneratePlayoffCard
           seasonId={season.id}
           stageKey={playoffStage.key}
           stageName={playoffStage.name}
-          standings={standings}
+          standings={qualifierStandings}
         />
       )}
 
       {/* 修复 Bracket 缺失比赛（bracket 已初始化时显示） */}
-      {hasPlayoff && (
+      {playoffStage && hasLegacyAdjacentPlayoff && (
         <SyncBracketButton seasonId={season.id} />
       )}
 
@@ -390,17 +407,20 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
       )}
 
       {/* Tab 面板 */}
-      {matchCount > 0 && (
-        <Tabs defaultValue={filterStage && filterStage !== "all" ? filterStage : defaultStageKey}>
-          <TabsList>
-            {qualifierStage && <TabsTrigger value={qualifierKey}>{qualifierStage.name}</TabsTrigger>}
-            {playoffStage && <TabsTrigger value={playoffKey}>{playoffStage.name}</TabsTrigger>}
+      {matchCount > 0 && defaultStageKey && (
+        <Tabs defaultValue={defaultStageKey}>
+          <TabsList className="max-w-full justify-start overflow-x-auto">
+            {stageViews.map(({ stage }) => (
+              <TabsTrigger key={stage.key} value={stage.key}>{stage.name}</TabsTrigger>
+            ))}
           </TabsList>
 
-          {/* 排位赛面板 */}
-          {hasQualifier && (
-            <TabsContent value={qualifierKey} className="space-y-6 mt-4">
-              {/* 积分榜 */}
+          {stageViews.map(({ stage, matches: stageMatches }) => {
+            const standings = standingsByStage.get(stage.key) ?? [];
+            const isPlayoff = stage.type === "double_elim" || stage.type === "single_elim";
+
+            return (
+            <TabsContent key={stage.key} value={stage.key} className="space-y-6 mt-4">
               {standings.length > 0 && (
                 <section className="space-y-2">
                   <h2 className="text-base font-semibold text-[var(--color-fg)]">积分榜</h2>
@@ -408,19 +428,24 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                     <StandingsTable
                       standings={standings}
                       seasonSlug={seasonSlug}
-                      isFinal={allQualifierFinished}
+                      isFinal={false}
                     />
                   </Panel>
                 </section>
               )}
 
-              {/* 排位赛列表 */}
               <section className="space-y-3">
                 <h2 className="text-base font-semibold text-[var(--color-fg)]">赛程</h2>
-                <div className="space-y-3">
-                  {qualifierMatches.map((m) => {
-                    const teamAName = teamMap.get(m.teamAId) ?? "未知队伍";
-                    const teamBName = teamMap.get(m.teamBId) ?? "未知队伍";
+                {stageMatches.length === 0 ? (
+                  <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
+                    暂无比赛记录
+                  </Panel>
+                ) : (
+                  <div className="space-y-3">
+                  {stageMatches.map((m) => {
+                    const unknownTeamName = isPlayoff ? "TBD" : "未知队伍";
+                    const teamAName = teamMap.get(m.teamAId) ?? unknownTeamName;
+                    const teamBName = teamMap.get(m.teamBId) ?? unknownTeamName;
                     return (
                       <AdminMatchRow
                         key={m.id}
@@ -429,6 +454,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                         teamBName={teamBName}
                         seasonSlug={seasonSlug}
                         mapPool={mapPool}
+                        isPlayoff={isPlayoff}
                         teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
                         teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
                         teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
@@ -439,47 +465,12 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
                       />
                     );
                   })}
-                </div>
+                  </div>
+                )}
               </section>
             </TabsContent>
-          )}
-
-          {/* 正赛面板 */}
-          {hasPlayoff && (
-            <TabsContent value={playoffKey} className="space-y-3 mt-4">
-              <h2 className="text-base font-semibold text-[var(--color-fg)]">赛程</h2>
-              {playoffMatches.length === 0 ? (
-                <Panel pad={32} className="text-center text-[var(--color-fg-mid)]">
-                  {allQualifierFinished ? "点击上方「生成正赛」按钮" : "排位赛全部结束后可生成正赛"}
-                </Panel>
-              ) : (
-                <div className="space-y-3">
-                  {playoffMatches.map((m) => {
-                    const teamAName = teamMap.get(m.teamAId) ?? "TBD";
-                    const teamBName = teamMap.get(m.teamBId) ?? "TBD";
-                    return (
-                      <AdminMatchRow
-                        key={m.id}
-                        match={m}
-                        teamAName={teamAName}
-                        teamBName={teamBName}
-                        seasonSlug={seasonSlug}
-                        mapPool={mapPool}
-                        isPlayoff
-                        teamAMembers={teamMembersByTeam.get(m.teamAId) ?? []}
-                        teamBMembers={teamMembersByTeam.get(m.teamBId) ?? []}
-                        teamARoster={rosterByMatch.get(m.id)?.get(m.teamAId) ?? null}
-                        teamBRoster={rosterByMatch.get(m.id)?.get(m.teamBId) ?? null}
-                        completedMaps={mapCompletedMaps(mapsByMatchId.get(m.id) ?? [])}
-                        pendingMaps={mapPendingMaps(mapsByMatchId.get(m.id) ?? [])}
-                        finishedMaps={mapFinishedMaps(mapsByMatch.get(m.id) ?? [])}
-                      />
-                    );
-                  })}
-                </div>
-              )}
-            </TabsContent>
-          )}
+            );
+          })}
         </Tabs>
       )}
 

--- a/src/lib/matches/stage-views.test.ts
+++ b/src/lib/matches/stage-views.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { BracketData } from "@/lib/bracket";
+import type { SwissViewData } from "@/lib/swiss/data";
 import { MAJOR_STAGE_PLAN, RIVALS_STAGE_PLAN } from "@/types/season";
 import {
   buildStageViews,
-  filterLegacyBracketByStageName,
+  canUseLegacySwissView,
   getTeamsReferencedByMatches,
   hasAdjacentLegacyQualifierPlayoff,
+  projectLegacyBracketByStageName,
   resolveDefaultStageKey,
 } from "./stage-views";
 
@@ -93,7 +95,10 @@ describe("stage views", () => {
       ],
     } as BracketData;
 
-    const filtered = filterLegacyBracketByStageName(data, "Playoff B");
+    const projection = projectLegacyBracketByStageName(data, "Playoff B");
+    expect(projection.status).toBe("ok");
+    if (projection.status !== "ok") throw new Error("expected unique legacy bracket stage");
+    const { data: filtered } = projection;
 
     expect(filtered.stage.map(({ id }) => id)).toEqual([2]);
     expect(filtered.match.map(({ id }) => id)).toEqual([12]);
@@ -103,7 +108,7 @@ describe("stage views", () => {
     expect(filtered.participant).toEqual(data.participant);
   });
 
-  it("legacy bracket adapter 按同名 stage 保留所有匹配记录，名称缺失时返回空投影", () => {
+  it("legacy bracket adapter 对同名 stage fail closed，并报告缺失映射", () => {
     const data = {
       stage: [
         { id: 1, name: "同名", type: "single_elimination" },
@@ -112,7 +117,32 @@ describe("stage views", () => {
       match: [], match_game: [], participant: [], group: [], round: [],
     } as BracketData;
 
-    expect(filterLegacyBracketByStageName(data, "同名").stage.map(({ id }) => id)).toEqual([1, 2]);
-    expect(filterLegacyBracketByStageName(data, "不存在").stage).toEqual([]);
+    expect(projectLegacyBracketByStageName(data, "同名")).toEqual({ status: "ambiguous" });
+    expect(projectLegacyBracketByStageName(data, "不存在")).toEqual({ status: "missing" });
+  });
+
+  it("仅在 legacy Swiss standings 完整覆盖当前阶段时显示 SwissBracket", () => {
+    const stage = MAJOR_STAGE_PLAN[0];
+    const stageMatches = Array.from({ length: 8 }, (_, index) =>
+      match("stage1", "scheduled", `team-${index * 2}`, `team-${index * 2 + 1}`),
+    );
+    const swissData = (teamCount: number, teamIds = Array.from({ length: 16 }, (_, index) => `team-${index}`)) => ({
+      stageName: stage.name,
+      teamCount,
+      advanceCount: 0,
+      rounds: [],
+      teams: teamIds.map((teamId, index) => ({
+        teamId, teamName: teamId, seed: index + 1, wins: 0, losses: 0, status: "active", buScore: 0,
+      })),
+    }) as SwissViewData;
+
+    expect(canUseLegacySwissView(stage, stageMatches, swissData(16))).toBe(true);
+    expect(canUseLegacySwissView(stage, stageMatches, swissData(0, []))).toBe(false);
+    expect(canUseLegacySwissView(
+      stage,
+      stageMatches,
+      swissData(16, [...Array.from({ length: 15 }, (_, index) => `team-${index}`), "other-team"]),
+    )).toBe(false);
+    expect(canUseLegacySwissView(stage, stageMatches, swissData(15))).toBe(false);
   });
 });

--- a/src/lib/matches/stage-views.test.ts
+++ b/src/lib/matches/stage-views.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { BracketData } from "@/lib/bracket";
+import { MAJOR_STAGE_PLAN, RIVALS_STAGE_PLAN } from "@/types/season";
+import {
+  buildStageViews,
+  filterLegacyBracketByStageName,
+  getTeamsReferencedByMatches,
+  hasAdjacentLegacyQualifierPlayoff,
+  resolveDefaultStageKey,
+} from "./stage-views";
+
+const match = (stage: string, status = "scheduled", teamAId = `${stage}-a`, teamBId = `${stage}-b`) => ({
+  stage,
+  status,
+  teamAId,
+  teamBId,
+});
+
+describe("stage views", () => {
+  it("为 Major 的每个配置阶段建立独立视图", () => {
+    const matches = [
+      match("stage1", "finished"),
+      match("stage2", "scheduled"),
+      match("stage3", "cancelled"),
+      match("playoff", "finished"),
+      match("unknown", "finished"),
+    ];
+
+    const { views, unconfiguredMatches } = buildStageViews(MAJOR_STAGE_PLAN, matches);
+
+    expect(views.map(({ stage }) => stage.key)).toEqual(["stage1", "stage2", "stage3", "playoff"]);
+    expect(views.map(({ matches: stageMatches }) => stageMatches.map((item) => item.stage))).toEqual([
+      ["stage1"],
+      ["stage2"],
+      ["stage3"],
+      ["playoff"],
+    ]);
+    expect(views.every((view) => !("isComplete" in view))).toBe(true);
+    expect(unconfiguredMatches).toEqual([matches[4]]);
+
+    const onlyFirstStage = buildStageViews(MAJOR_STAGE_PLAN, [match("stage1")]);
+    expect(onlyFirstStage.views.find((view) => view.stage.key === "stage2")?.matches).toEqual([]);
+  });
+
+  it("默认阶段始终来自 stagePlan，并允许选择一个有效阶段", () => {
+    const matches = [match("stage1"), match("stage3"), match("unknown")];
+
+    expect(resolveDefaultStageKey(MAJOR_STAGE_PLAN, matches)).toBe("stage3");
+    expect(resolveDefaultStageKey(MAJOR_STAGE_PLAN, matches, "stage2")).toBe("stage2");
+    expect(resolveDefaultStageKey(MAJOR_STAGE_PLAN, matches, "unknown")).toBe("stage3");
+    expect(resolveDefaultStageKey(MAJOR_STAGE_PLAN, [match("unknown")])).toBe("stage1");
+    expect(resolveDefaultStageKey(MAJOR_STAGE_PLAN, [])).toBe("stage1");
+    expect(resolveDefaultStageKey([], matches)).toBeNull();
+  });
+
+  it("保留 Rivals 的排位赛和正赛两阶段合同", () => {
+    const { views } = buildStageViews(RIVALS_STAGE_PLAN, [match("qualifier"), match("playoff")]);
+
+    expect(views.map(({ stage }) => stage.key)).toEqual(["qualifier", "playoff"]);
+    expect(resolveDefaultStageKey(RIVALS_STAGE_PLAN, views.flatMap((view) => view.matches))).toBe("playoff");
+    expect(hasAdjacentLegacyQualifierPlayoff(RIVALS_STAGE_PLAN)).toBe(true);
+    expect(hasAdjacentLegacyQualifierPlayoff(MAJOR_STAGE_PLAN)).toBe(false);
+  });
+
+  it("积分榜参赛队只取当前阶段比赛涉及的队伍", () => {
+    const teams = [{ id: "a" }, { id: "b" }, { id: "other" }];
+
+    expect(getTeamsReferencedByMatches(teams, [
+      match("stage1", "finished", "b", "a"),
+      match("stage1", "finished", "a", "b"),
+    ])).toEqual([
+      { id: "a" },
+      { id: "b" },
+    ]);
+  });
+
+  it("淘汰赛视图只保留对应 bracket stage 的节点", () => {
+    const data = {
+      stage: [
+        { id: 1, name: "Playoff A", type: "single_elimination" },
+        { id: 2, name: "Playoff B", type: "single_elimination" },
+      ],
+      match: [
+        { id: 11, stage_id: 1, group_id: 101, round_id: 201 },
+        { id: 12, stage_id: 2, group_id: 102, round_id: 202 },
+      ],
+      match_game: [{ id: 21, parent_id: 11 }, { id: 22, parent_id: 12 }],
+      participant: [{ id: 1, name: "A" }],
+      group: [{ id: 101, stage_id: 1, number: 1 }, { id: 102, stage_id: 2, number: 1 }],
+      round: [
+        { id: 201, stage_id: 1, group_id: 101, number: 1 },
+        { id: 202, stage_id: 2, group_id: 102, number: 1 },
+      ],
+    } as BracketData;
+
+    const filtered = filterLegacyBracketByStageName(data, "Playoff B");
+
+    expect(filtered.stage.map(({ id }) => id)).toEqual([2]);
+    expect(filtered.match.map(({ id }) => id)).toEqual([12]);
+    expect(filtered.match_game.map(({ id }) => id)).toEqual([22]);
+    expect(filtered.group.map(({ id }) => id)).toEqual([102]);
+    expect(filtered.round.map(({ id }) => id)).toEqual([202]);
+    expect(filtered.participant).toEqual(data.participant);
+  });
+
+  it("legacy bracket adapter 按同名 stage 保留所有匹配记录，名称缺失时返回空投影", () => {
+    const data = {
+      stage: [
+        { id: 1, name: "同名", type: "single_elimination" },
+        { id: 2, name: "同名", type: "single_elimination" },
+      ],
+      match: [], match_game: [], participant: [], group: [], round: [],
+    } as BracketData;
+
+    expect(filterLegacyBracketByStageName(data, "同名").stage.map(({ id }) => id)).toEqual([1, 2]);
+    expect(filterLegacyBracketByStageName(data, "不存在").stage).toEqual([]);
+  });
+});

--- a/src/lib/matches/stage-views.ts
+++ b/src/lib/matches/stage-views.ts
@@ -1,4 +1,5 @@
 import type { BracketData } from "@/lib/bracket";
+import type { SwissViewData } from "@/lib/swiss/data";
 import { getFirstStageOfType, getPreviousStage, type StagePlan } from "@/types/season";
 
 interface StageMatch {
@@ -81,16 +82,49 @@ export function getTeamsReferencedByMatches<T extends { id: string }>(
  * Legacy presentation adapter：现有 brackets-manager 数据只能按 stage.name 筛选。
  * name 不是稳定领域 identity；不得将该行为扩展为新的 bracket/domain contract。
  */
-export function filterLegacyBracketByStageName(data: BracketData, stageName: string): BracketData {
-  const stageIds = new Set(data.stage.filter((stage) => stage.name === stageName).map((stage) => stage.id));
+export type LegacyBracketProjection =
+  | { status: "ok"; data: BracketData }
+  | { status: "missing" }
+  | { status: "ambiguous" };
+
+export function projectLegacyBracketByStageName(
+  data: BracketData,
+  stageName: string,
+): LegacyBracketProjection {
+  const bracketStages = data.stage.filter((stage) => stage.name === stageName);
+  if (bracketStages.length === 0) return { status: "missing" };
+  if (bracketStages.length > 1) return { status: "ambiguous" };
+
+  const stageIds = new Set(bracketStages.map((stage) => stage.id));
   const matchIds = new Set(data.match.filter((match) => stageIds.has(match.stage_id)).map((match) => match.id));
 
   return {
-    ...data,
-    stage: data.stage.filter((stage) => stageIds.has(stage.id)),
-    match: data.match.filter((match) => stageIds.has(match.stage_id)),
-    match_game: data.match_game.filter((game) => matchIds.has(game.parent_id)),
-    group: data.group.filter((group) => stageIds.has(group.stage_id)),
-    round: data.round.filter((round) => stageIds.has(round.stage_id)),
+    status: "ok",
+    data: {
+      ...data,
+      stage: bracketStages,
+      match: data.match.filter((match) => stageIds.has(match.stage_id)),
+      match_game: data.match_game.filter((game) => matchIds.has(game.parent_id)),
+      group: data.group.filter((group) => stageIds.has(group.stage_id)),
+      round: data.round.filter((round) => stageIds.has(round.stage_id)),
+    },
   };
+}
+
+/**
+ * Legacy Swiss projection 仅在 standings 能完整覆盖当前比赛队伍时展示。
+ * 它不是新的 Swiss truth source；不完整时调用方必须退回通用比赛列表。
+ */
+export function canUseLegacySwissView(
+  stage: StagePlan[number],
+  stageMatches: readonly Pick<StageMatch, "teamAId" | "teamBId">[],
+  swissData: SwissViewData | undefined,
+): swissData is SwissViewData {
+  if (stage.type !== "swiss" || stageMatches.length === 0 || !swissData) return false;
+  if (swissData.teamCount !== stage.teamCount || swissData.teams.length !== stage.teamCount) return false;
+
+  const standingTeamIds = new Set(swissData.teams.map((team) => team.teamId));
+  return stageMatches.every(
+    (match) => standingTeamIds.has(match.teamAId) && standingTeamIds.has(match.teamBId),
+  );
 }

--- a/src/lib/matches/stage-views.ts
+++ b/src/lib/matches/stage-views.ts
@@ -1,0 +1,96 @@
+import type { BracketData } from "@/lib/bracket";
+import { getFirstStageOfType, getPreviousStage, type StagePlan } from "@/types/season";
+
+interface StageMatch {
+  stage: string;
+  status: string;
+  teamAId: string;
+  teamBId: string;
+}
+
+export interface StageViewsResult<T extends StageMatch> {
+  /** 只包含当前 StagePlan 已配置的阶段，顺序与配置完全一致。 */
+  views: readonly { stage: StagePlan[number]; matches: readonly T[] }[];
+  /**
+   * 指向已不在当前 StagePlan 中的阶段的比赛。
+   * 这些记录不能被猜测归属，也不能在展示层静默丢弃。
+   */
+  unconfiguredMatches: readonly T[];
+}
+
+export function buildStageViews<T extends StageMatch>(
+  stagePlan: StagePlan,
+  matches: readonly T[],
+): StageViewsResult<T> {
+  const configuredStageKeys = new Set(stagePlan.map((stage) => stage.key));
+  const matchesByStage = new Map<string, T[]>();
+  for (const match of matches) {
+    if (!configuredStageKeys.has(match.stage)) continue;
+    const stageMatches = matchesByStage.get(match.stage) ?? [];
+    stageMatches.push(match);
+    matchesByStage.set(match.stage, stageMatches);
+  }
+
+  return {
+    views: stagePlan.map((stage) => ({
+      stage,
+      matches: matchesByStage.get(stage.key) ?? [],
+    })),
+    unconfiguredMatches: matches.filter((match) => !configuredStageKeys.has(match.stage)),
+  };
+}
+
+export function resolveDefaultStageKey<T extends Pick<StageMatch, "stage">>(
+  stagePlan: StagePlan,
+  matches: readonly T[],
+  requestedStage?: string,
+): string | null {
+  if (requestedStage && requestedStage !== "all" && stagePlan.some((stage) => stage.key === requestedStage)) {
+    return requestedStage;
+  }
+
+  const stagesWithMatches = new Set(matches.map((match) => match.stage));
+  return [...stagePlan].reverse().find((stage) => stagesWithMatches.has(stage.key))?.key
+    ?? stagePlan[0]?.key
+    ?? null;
+}
+
+/**
+ * Legacy GeneratePlayoff/SyncBracket controls only understand a direct
+ * qualifier → playoff flow. This is a UI safety gate, not tournament runtime state.
+ */
+export function hasAdjacentLegacyQualifierPlayoff(stagePlan: StagePlan): boolean {
+  const qualifierStage = getFirstStageOfType(stagePlan, ["round_robin", "swiss"]);
+  const playoffStage = getFirstStageOfType(stagePlan, ["double_elim", "single_elim"]);
+  return !!qualifierStage && getPreviousStage(stagePlan, playoffStage?.key ?? "")?.key === qualifierStage.key;
+}
+
+/**
+ * 仅供积分榜等展示投影使用：从当前已有比赛中提取出现过的队伍。
+ * 这不是 canonical StageEntrants；轮空、部分生成或未来阶段的队伍均可能不在其中。
+ */
+export function getTeamsReferencedByMatches<T extends { id: string }>(
+  teams: readonly T[],
+  stageMatches: readonly Pick<StageMatch, "teamAId" | "teamBId">[],
+): T[] {
+  const teamIds = new Set(stageMatches.flatMap((match) => [match.teamAId, match.teamBId]));
+  return teams.filter((team) => teamIds.has(team.id));
+}
+
+/**
+ * Legacy presentation adapter：现有 brackets-manager 数据只能按 stage.name 筛选。
+ * name 不是稳定领域 identity；不得将该行为扩展为新的 bracket/domain contract。
+ */
+export function filterLegacyBracketByStageName(data: BracketData, stageName: string): BracketData {
+  const stageIds = new Set(data.stage.filter((stage) => stage.name === stageName).map((stage) => stage.id));
+  const matchIds = new Set(data.match.filter((match) => stageIds.has(match.stage_id)).map((match) => match.id));
+
+  return {
+    ...data,
+    stage: data.stage.filter((stage) => stageIds.has(stage.id)),
+    match: data.match.filter((match) => stageIds.has(match.stage_id)),
+    match_game: data.match_game.filter((game) => matchIds.has(game.parent_id)),
+    group: data.group.filter((group) => stageIds.has(group.stage_id)),
+    round: data.round.filter((round) => stageIds.has(round.stage_id)),
+  };
+}


### PR DESCRIPTION
## What changed

- 从完整 StagePlan 渲染公开赛程与管理赛程，支持任意数量的已配置阶段。
- 为各阶段分别展示 Swiss、循环赛积分榜、淘汰赛 bracket 投影和比赛列表。
- 默认阶段按已存在 canonical match 的最靠后已配置阶段确定；无匹配时回退首阶段。
- 显式检测未配置阶段的比赛，公开页提示不一致，管理页显示数量与 stage key。
- 通用 StageView 不再推断 canonical completion state。
- legacy bracket name 映射在缺失或同名歧义时 fail closed；legacy Swiss standings 不完整时回退通用比赛列表。

## Safety

- 仅 presentation/admin view；未引入 StageRun、StageEntrants、数据库 schema 或持久化。
- 未启用 Major runtime，也未接入 final placement UI。
- 保留现有 unsupported flow 的 fail-closed 边界；含 Swiss 的自动赛程入口显示未启用。
- 按 bracket stage.name 的过滤仍只是 legacy presentation adapter，不是 stable identity contract。

## Validation

- `pnpm type-check`
- `pnpm exec drizzle-kit check`
- `pnpm test:coverage` — 77 files, 606 tests
- `pnpm build`