### PR TITLE
fix(major): unify standard Major preset

### DIFF
--- a/src/app/admin/seasons/new/page.tsx
+++ b/src/app/admin/seasons/new/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { requireSuperAdmin } from "@/lib/auth/session";
-import { RIVALS_REGISTRATION_CONFIG, MAJOR_STAGE_PLAN, CS2_POSITIONS } from "@/types/season";
+import { createMajorDefaultCapabilities } from "@/types/season";
 import { SeasonForm } from "@/components/admin/SeasonForm";
 
 export default async function NewSeasonPage() {
@@ -9,6 +9,8 @@ export default async function NewSeasonPage() {
   } catch {
     redirect("/admin/login");
   }
+
+  const major = createMajorDefaultCapabilities();
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
@@ -23,15 +25,7 @@ export default async function NewSeasonPage() {
           startAt: null,
           registrationDeadline: null,
           endAt: null,
-          registrationMode: "team",
-          hasCaptainVoting: false,
-          hasDraft: false,
-          maxTeamSize: 9,
-          minTeamSize: 5,
-          starterCount: 5,
-          positions: CS2_POSITIONS,
-          stagePlan: MAJOR_STAGE_PLAN,
-          registrationConfig: RIVALS_REGISTRATION_CONFIG,
+          ...major,
         }}
       />
     </div>

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -9,11 +9,11 @@ import {
   PLAYER_TYPE_LABELS,
   RIVALS_REGISTRATION_CONFIG,
   RIVALS_STAGE_PLAN,
-  MAJOR_STAGE_PLAN,
-  MAJOR_TEAM_CONFIG,
-  DEFAULT_CS2_MAP_POOL,
+  checkStandardMajorCapabilities,
+  createMajorDefaultCapabilities,
   type PlayerType,
   type RegistrationConfig,
+  type SeasonCapabilities,
   type TeamRegistrationConfig,
   type StagePlan,
 } from "@/types/season";
@@ -61,8 +61,10 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
-  const defaultConfig = initial?.registrationConfig ?? RIVALS_REGISTRATION_CONFIG;
-  const defaultTeamConfig = initial?.teamRegistrationConfig ?? MAJOR_TEAM_CONFIG;
+  const majorDefaults = createMajorDefaultCapabilities();
+
+  const defaultConfig = initial?.registrationConfig ?? majorDefaults.registrationConfig;
+  const defaultTeamConfig = initial?.teamRegistrationConfig ?? majorDefaults.teamRegistrationConfig;
 
   const [name, setName] = useState(initial?.name ?? "");
   const [slug, setSlug] = useState(initial?.slug ?? "");
@@ -74,16 +76,16 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [registrationMode, setRegistrationMode] = useState<"solo" | "team">(
     initial?.registrationMode ?? "team",
   );
-  const [hasCaptainVoting, setHasCaptainVoting] = useState(initial?.hasCaptainVoting ?? true);
-  const [hasDraft, setHasDraft] = useState(initial?.hasDraft ?? true);
-  const [maxTeamSize, setMaxTeamSize] = useState(initial?.maxTeamSize ?? 9);
-  const [minTeamSize, setMinTeamSize] = useState(initial?.minTeamSize ?? 5);
-  const [starterCount, setStarterCount] = useState(initial?.starterCount ?? 5);
+  const [hasCaptainVoting, setHasCaptainVoting] = useState(initial?.hasCaptainVoting ?? majorDefaults.hasCaptainVoting);
+  const [hasDraft, setHasDraft] = useState(initial?.hasDraft ?? majorDefaults.hasDraft);
+  const [maxTeamSize, setMaxTeamSize] = useState(initial?.maxTeamSize ?? majorDefaults.maxTeamSize);
+  const [minTeamSize, setMinTeamSize] = useState(initial?.minTeamSize ?? majorDefaults.minTeamSize);
+  const [starterCount, setStarterCount] = useState(initial?.starterCount ?? majorDefaults.starterCount);
   const [positionsText, setPositionsText] = useState(
-    (initial?.positions ?? CS2_POSITIONS).join(","),
+    (initial?.positions ?? majorDefaults.positions ?? CS2_POSITIONS).join(","),
   );
   const [stagePlan, setStagePlan] = useState<StagePlan>(
-    initial?.stagePlan ?? MAJOR_STAGE_PLAN,
+    initial?.stagePlan ?? majorDefaults.stagePlan,
   );
   const [allowedPlayerTypes, setAllowedPlayerTypes] = useState<PlayerType[]>(
     defaultConfig.allowedPlayerTypes,
@@ -94,7 +96,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [screenshotCount, setScreenshotCount] = useState(defaultConfig.screenshotCount);
   const [maxTotal] = useState(defaultConfig.maxTotal);
   const [mapPoolText, setMapPoolText] = useState(
-    (defaultConfig.mapPool ?? DEFAULT_CS2_MAP_POOL).join(","),
+    defaultConfig.mapPool.join(","),
   );
   const [teamConfig, setTeamConfig] = useState<TeamRegistrationConfig>(defaultTeamConfig);
 
@@ -118,34 +120,41 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
     if (!confirm("应用预设将覆盖当前所有配置，是否继续？")) return;
     if (preset === "major") {
       setKind("Major");
-      handleRegistrationModeChange("team");
-      setMaxTeamSize(9);
-      setMinTeamSize(5);
-      setStarterCount(5);
-      setPositionsText("igl,awper,opener,closer,anchor");
-      setStagePlan(structuredClone(MAJOR_STAGE_PLAN));
-      setAllowedPlayerTypes(["enrolled", "graduated"]);
-      setCurrentMin(NO_RANK);
-      setPeakMin(NO_RANK);
-      setMaxPerPosition(50);
-      setScreenshotCount(1);
-      setMapPoolText([...DEFAULT_CS2_MAP_POOL].join(","));
-      setTeamConfig(MAJOR_TEAM_CONFIG);
+      applyCapabilities(createMajorDefaultCapabilities());
     } else {
       setKind("选秀联赛");
       handleRegistrationModeChange("solo");
       setMaxTeamSize(7);
       setMinTeamSize(7);
       setStarterCount(5);
-      setPositionsText("igl,awper,opener,closer,anchor");
+      setPositionsText(CS2_POSITIONS.join(","));
       setStagePlan(structuredClone(RIVALS_STAGE_PLAN));
       setAllowedPlayerTypes(["enrolled"]);
       setCurrentMin("A");
       setPeakMin("A+");
       setMaxPerPosition(15);
       setScreenshotCount(1);
-      setMapPoolText([...DEFAULT_CS2_MAP_POOL].join(","));
+      setMapPoolText(RIVALS_REGISTRATION_CONFIG.mapPool.join(","));
     }
+  }
+
+  function applyCapabilities(capabilities: ReturnType<typeof createMajorDefaultCapabilities>) {
+    setRegistrationMode(capabilities.registrationMode);
+    setHasCaptainVoting(capabilities.hasCaptainVoting);
+    setHasDraft(capabilities.hasDraft);
+    setMaxTeamSize(capabilities.maxTeamSize);
+    setMinTeamSize(capabilities.minTeamSize);
+    setStarterCount(capabilities.starterCount);
+    setPositionsText(capabilities.positions.join(","));
+    setStagePlan(capabilities.stagePlan);
+    setAllowedPlayerTypes(capabilities.registrationConfig.allowedPlayerTypes);
+    setCurrentMin(capabilities.registrationConfig.rankThreshold.currentMin ?? NO_RANK);
+    setPeakMin(capabilities.registrationConfig.rankThreshold.peakMin ?? NO_RANK);
+    setMaxPerPosition(capabilities.registrationConfig.maxPerPosition);
+    setScreenshotCount(capabilities.registrationConfig.screenshotCount);
+    setMaxTotal(capabilities.registrationConfig.maxTotal);
+    setMapPoolText(capabilities.registrationConfig.mapPool.join(","));
+    setTeamConfig(capabilities.teamRegistrationConfig);
   }
 
   // Auto-set slug from name when slug is empty and in create mode
@@ -200,6 +209,11 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
       teamRegistrationConfig: teamConfig,
     };
   }
+
+  const standardMajorCheck = checkStandardMajorCapabilities(buildPayload() as SeasonCapabilities);
+  const swissFormats = stagePlan.slice(0, 3).map((stage) => stage.matchFormat?.toUpperCase() ?? "未设置");
+  const playoffFormat = stagePlan[3]?.matchFormat?.toUpperCase() ?? "未设置";
+  const finalFormat = stagePlan[3]?.finalFormat?.toUpperCase() ?? playoffFormat;
 
   function handleSubmit() {
     const payload = buildPayload();
@@ -329,6 +343,34 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
               <SelectItem value="__none__">手动配置</SelectItem>
             </SelectContent>
           </Select>
+        </section>
+
+        <section
+          aria-live="polite"
+          className={standardMajorCheck.isStandardMajor
+            ? "rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4 text-sm"
+            : "rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm"}
+        >
+          {standardMajorCheck.isStandardMajor ? (
+            <>
+              <h2 className="font-semibold">标准 Major 摘要</h2>
+              <p className="mt-1 text-[var(--color-fg-mid)]">
+                32 支队伍；队伍整体报名；每队 {minTeamSize}–{maxTeamSize} 人；三阶段瑞士轮；8 队单败淘汰。
+              </p>
+              <p className="mt-1 text-[var(--color-fg-mid)]">
+                当前局制：瑞士轮 {swissFormats.join(" / ")}；淘汰赛 {playoffFormat}，决赛 {finalFormat}。
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="font-semibold">当前配置已偏离标准 Major，将作为自定义赛制运行。</h2>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-[var(--color-fg-mid)]">
+                {standardMajorCheck.failures.slice(0, 4).map((check) => (
+                  <li key={check.key}>{check.reason}</li>
+                ))}
+              </ul>
+            </>
+          )}
         </section>
 
         <section className="space-y-4">

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -94,7 +94,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   const [peakMin, setPeakMin] = useState(defaultConfig.rankThreshold.peakMin ?? NO_RANK);
   const [maxPerPosition, setMaxPerPosition] = useState(defaultConfig.maxPerPosition);
   const [screenshotCount, setScreenshotCount] = useState(defaultConfig.screenshotCount);
-  const [maxTotal] = useState(defaultConfig.maxTotal);
+  const [maxTotal, setMaxTotal] = useState(defaultConfig.maxTotal);
   const [mapPoolText, setMapPoolText] = useState(
     defaultConfig.mapPool.join(","),
   );

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -134,6 +134,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
       setPeakMin("A+");
       setMaxPerPosition(15);
       setScreenshotCount(1);
+      setMaxTotal(RIVALS_REGISTRATION_CONFIG.maxTotal);
       setMapPoolText(RIVALS_REGISTRATION_CONFIG.mapPool.join(","));
     }
   }
@@ -211,6 +212,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
   }
 
   const standardMajorCheck = checkStandardMajorCapabilities(buildPayload() as SeasonCapabilities);
+  const isMajorDisplayContext = kind === "Major";
   const swissFormats = stagePlan.slice(0, 3).map((stage) => stage.matchFormat?.toUpperCase() ?? "未设置");
   const playoffFormat = stagePlan[3]?.matchFormat?.toUpperCase() ?? "未设置";
   const finalFormat = stagePlan[3]?.finalFormat?.toUpperCase() ?? playoffFormat;
@@ -345,7 +347,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
           </Select>
         </section>
 
-        <section
+        {isMajorDisplayContext && <section
           aria-live="polite"
           className={standardMajorCheck.isStandardMajor
             ? "rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4 text-sm"
@@ -371,7 +373,7 @@ export function SeasonForm({ mode, initial }: SeasonFormProps) {
               </ul>
             </>
           )}
-        </section>
+        </section>}
 
         <section className="space-y-4">
           <h2 className="font-semibold">基础信息</h2>

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -333,6 +333,7 @@ export interface StandardMajorRuleCheck {
     | "stage-count"
     | "stage-order"
     | "entry-cohorts"
+    | "stage1-seeds"
     | "stage1"
     | "stage2"
     | "stage3"
@@ -356,6 +357,12 @@ function advancesEight(stage: StageConfig | undefined): boolean {
 function directEntrantCount(stage: StageConfig | undefined, isFirstStage = false): number | undefined {
   if (!stage) return undefined;
   return stage.entrySeeds ?? (isFirstStage ? stage.teamCount : 0);
+}
+
+function hasStandardStageOneSeeds(seeds: readonly number[] | undefined): boolean {
+  return seeds?.length === 16 &&
+    new Set(seeds).size === 16 &&
+    seeds.every((seed) => seed >= 17 && seed <= 32);
 }
 
 /**
@@ -400,6 +407,11 @@ export function checkStandardMajorCapabilities(
         directEntrantCount(stage3) === 8 &&
         directEntrantCount(playoff) === 0,
       reason: "标准 Major 必须按 16 / 8 / 8 三批队伍进入三个瑞士轮阶段，并由阶段三的 8 支晋级队进入淘汰赛。",
+    },
+    {
+      key: "stage1-seeds",
+      passed: hasStandardStageOneSeeds(stage1?.seeds),
+      reason: "阶段一必须完整且唯一地使用 17–32 号种子。",
     },
     {
       key: "stage1",

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -316,6 +316,120 @@ export const CAPABILITY_PRESETS = {
 export const RIVALS_DEFAULT_CAPABILITIES = DRAFT_LEAGUE_PRESET;
 export const MAJOR_DEFAULT_CAPABILITIES = CAPABILITY_PRESETS.major;
 
+/**
+ * 返回一份可安全编辑的 Major 能力配置副本。
+ *
+ * 预设常量是标准规则的唯一来源；表单不能直接持有或修改该常量。
+ */
+export function createMajorDefaultCapabilities(): SeasonCapabilities {
+  return structuredClone(MAJOR_DEFAULT_CAPABILITIES) as SeasonCapabilities;
+}
+
+export interface StandardMajorRuleCheck {
+  key:
+    | "registration-mode"
+    | "captain-voting"
+    | "draft"
+    | "stage-count"
+    | "stage-order"
+    | "entry-cohorts"
+    | "stage1"
+    | "stage2"
+    | "stage3"
+    | "playoff";
+  passed: boolean;
+  reason: string;
+}
+
+export interface StandardMajorCheckResult {
+  isStandardMajor: boolean;
+  checks: StandardMajorRuleCheck[];
+  failures: StandardMajorRuleCheck[];
+}
+
+function advancesEight(stage: StageConfig | undefined): boolean {
+  return stage?.advanceTiers.length === 1 &&
+    stage.advanceTiers[0]?.placement === "*" &&
+    stage.advanceTiers[0]?.count === 8;
+}
+
+function directEntrantCount(stage: StageConfig | undefined, isFirstStage = false): number | undefined {
+  if (!stage) return undefined;
+  return stage.entrySeeds ?? (isFirstStage ? stage.teamCount : 0);
+}
+
+/**
+ * 纯能力配置检查：判断配置是否仍是 RivalHub 当前定义的标准 Major。
+ * 不读取赛事 kind，kind 仅用于展示。
+ */
+export function checkStandardMajorCapabilities(
+  capabilities: SeasonCapabilities,
+): StandardMajorCheckResult {
+  const [stage1, stage2, stage3, playoff] = capabilities.stagePlan;
+  const checks: StandardMajorRuleCheck[] = [
+    {
+      key: "registration-mode",
+      passed: capabilities.registrationMode === "team",
+      reason: "标准 Major 使用队伍整体报名。",
+    },
+    {
+      key: "captain-voting",
+      passed: capabilities.hasCaptainVoting === false,
+      reason: "标准 Major 不启用队长投票。",
+    },
+    {
+      key: "draft",
+      passed: capabilities.hasDraft === false,
+      reason: "标准 Major 不启用蛇形选秀。",
+    },
+    {
+      key: "stage-count",
+      passed: capabilities.stagePlan.length === 4,
+      reason: "标准 Major 必须包含三个瑞士轮阶段和一个淘汰赛阶段。",
+    },
+    {
+      key: "stage-order",
+      passed: capabilities.stagePlan.map(({ type }) => type).join("|") === "swiss|swiss|swiss|single_elim",
+      reason: "标准 Major 的阶段顺序必须为阶段一、阶段二、阶段三瑞士轮，随后是单败淘汰。",
+    },
+    {
+      key: "entry-cohorts",
+      passed:
+        directEntrantCount(stage1, true) === 16 &&
+        directEntrantCount(stage2) === 8 &&
+        directEntrantCount(stage3) === 8 &&
+        directEntrantCount(playoff) === 0,
+      reason: "标准 Major 必须按 16 / 8 / 8 三批队伍进入三个瑞士轮阶段，并由阶段三的 8 支晋级队进入淘汰赛。",
+    },
+    {
+      key: "stage1",
+      passed: stage1?.type === "swiss" && stage1.teamCount === 16 && advancesEight(stage1),
+      reason: "阶段一必须为 16 队瑞士轮，8 队晋级。",
+    },
+    {
+      key: "stage2",
+      passed: stage2?.type === "swiss" && stage2.teamCount === 16 && advancesEight(stage2),
+      reason: "阶段二必须为 16 队瑞士轮，8 队晋级。",
+    },
+    {
+      key: "stage3",
+      passed: stage3?.type === "swiss" && stage3.teamCount === 16 && advancesEight(stage3),
+      reason: "阶段三必须为 16 队瑞士轮，8 队晋级。",
+    },
+    {
+      key: "playoff",
+      passed: playoff?.type === "single_elim" && playoff.teamCount === 8,
+      reason: "淘汰赛必须为 8 队单败淘汰。",
+    },
+  ];
+  const failures = checks.filter((check) => !check.passed);
+  return {
+    isStandardMajor: failures.length === 0,
+    checks,
+    failures,
+  };
+}
+
 // ── 展示标签 ─────────────────────────────────────────────────────────────
 
 export const SEASON_STATUS_LABELS: Record<SeasonStatus, string> = {

--- a/tests/unit/components/admin/SeasonForm.test.tsx
+++ b/tests/unit/components/admin/SeasonForm.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  archiveSeason,
+  createSeason,
+  deleteSeason,
+  forceFinishSeason,
+  publishSeason,
+  revertSeasonToDraft,
+  revertSeasonToRegistration,
+} from "@/actions/seasons";
+import { SeasonForm } from "@/components/admin/SeasonForm";
+import {
+  RIVALS_DEFAULT_CAPABILITIES,
+  createMajorDefaultCapabilities,
+  type SeasonCapabilities,
+} from "@/types/season";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/actions/seasons", () => ({
+  createSeason: vi.fn(),
+  deleteSeason: vi.fn(),
+  publishSeason: vi.fn(),
+  updateSeason: vi.fn(),
+  revertSeasonToDraft: vi.fn(),
+  revertSeasonToRegistration: vi.fn(),
+  forceFinishSeason: vi.fn(),
+  archiveSeason: vi.fn(),
+}));
+
+vi.mock("@/components/ui/select", async () => {
+  const React = await import("react");
+  const SelectContext = React.createContext<((value: string) => void) | undefined>(undefined);
+
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange?: (value: string) => void }) =>
+      React.createElement(SelectContext.Provider, { value: onValueChange }, children),
+    SelectContent: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => {
+      const onValueChange = React.useContext(SelectContext);
+      return React.createElement("button", { type: "button", onClick: () => onValueChange?.(value) }, children);
+    },
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => React.createElement("div", null, children),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => React.createElement("span", null, placeholder),
+  };
+});
+
+const createSeasonMock = vi.mocked(createSeason);
+const archiveSeasonMock = vi.mocked(archiveSeason);
+const deleteSeasonMock = vi.mocked(deleteSeason);
+const forceFinishSeasonMock = vi.mocked(forceFinishSeason);
+const publishSeasonMock = vi.mocked(publishSeason);
+const revertSeasonToDraftMock = vi.mocked(revertSeasonToDraft);
+const revertSeasonToRegistrationMock = vi.mocked(revertSeasonToRegistration);
+
+function createInitial(
+  capabilities: SeasonCapabilities,
+  kind: string,
+  status: "draft" | "registration" | "voting" | "playing" | "finished" = "draft",
+) {
+  return {
+    ...capabilities,
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "测试赛事",
+    slug: "test-season",
+    kind,
+    status,
+    themeColor: "#f97316",
+    startAt: null,
+    registrationDeadline: null,
+    endAt: null,
+  };
+}
+
+describe("SeasonForm presets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("React", React);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    createSeasonMock.mockResolvedValue({
+      success: true,
+      data: { seasonId: "11111111-1111-4111-8111-111111111111", slug: "test-season" },
+    });
+    const successWithSlug = { success: true as const, data: { slug: "test-season" } };
+    archiveSeasonMock.mockResolvedValue(successWithSlug);
+    deleteSeasonMock.mockResolvedValue({ success: true, data: undefined });
+    forceFinishSeasonMock.mockResolvedValue(successWithSlug);
+    publishSeasonMock.mockResolvedValue(successWithSlug);
+    revertSeasonToDraftMock.mockResolvedValue(successWithSlug);
+    revertSeasonToRegistrationMock.mockResolvedValue(successWithSlug);
+  });
+
+  it("does not show Major status in a Rivals display context", () => {
+    render(<SeasonForm mode="create" initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "选秀联赛")} />);
+
+    expect(screen.queryByText(/标准 Major 摘要|当前配置已偏离标准 Major/)).not.toBeInTheDocument();
+  });
+
+  it("resets the registration total after applying Major then Rivals", async () => {
+    const user = userEvent.setup();
+    render(<SeasonForm mode="create" initial={createInitial(createMajorDefaultCapabilities(), "Major")} />);
+
+    await user.click(screen.getByRole("button", { name: "Major 公开赛" }));
+    await user.click(screen.getByRole("button", { name: "Rivals 选秀联赛" }));
+    await user.click(screen.getByRole("button", { name: "创建赛季" }));
+
+    await waitFor(() => {
+      expect(createSeasonMock).toHaveBeenCalledWith(expect.objectContaining({
+        registrationConfig: expect.objectContaining({ maxTotal: 56 }),
+      }));
+    });
+  });
+
+  it("keeps existing season lifecycle controls callable", async () => {
+    const user = userEvent.setup();
+    const capabilities = createMajorDefaultCapabilities();
+    const cases = [
+      { status: "draft" as const, label: "删除赛季", mock: deleteSeasonMock },
+      { status: "registration" as const, label: "撤回至草稿", mock: revertSeasonToDraftMock },
+      { status: "voting" as const, label: "撤回至报名阶段", mock: revertSeasonToRegistrationMock },
+      { status: "playing" as const, label: "手动结束赛季", mock: forceFinishSeasonMock },
+      { status: "finished" as const, label: "归档赛季", mock: archiveSeasonMock },
+    ];
+
+    for (const { status, label, mock } of cases) {
+      const view = render(<SeasonForm mode="edit" initial={createInitial(capabilities, "Major", status)} />);
+      await user.click(screen.getByRole("button", { name: label }));
+      await waitFor(() => expect(mock).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111"));
+      if (status === "draft") {
+        await user.click(screen.getByRole("button", { name: "发布赛季" }));
+        await waitFor(() => expect(publishSeasonMock).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111"));
+      }
+      view.unmount();
+    }
+  });
+});

--- a/tests/unit/components/admin/SeasonForm.test.tsx
+++ b/tests/unit/components/admin/SeasonForm.test.tsx
@@ -5,19 +5,10 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  archiveSeason,
-  createSeason,
-  deleteSeason,
-  forceFinishSeason,
-  publishSeason,
-  revertSeasonToDraft,
-  revertSeasonToRegistration,
-} from "@/actions/seasons";
+import { createSeason } from "@/actions/seasons";
 import { SeasonForm } from "@/components/admin/SeasonForm";
 import {
   RIVALS_DEFAULT_CAPABILITIES,
-  createMajorDefaultCapabilities,
   type SeasonCapabilities,
 } from "@/types/season";
 
@@ -58,12 +49,6 @@ vi.mock("@/components/ui/select", async () => {
 });
 
 const createSeasonMock = vi.mocked(createSeason);
-const archiveSeasonMock = vi.mocked(archiveSeason);
-const deleteSeasonMock = vi.mocked(deleteSeason);
-const forceFinishSeasonMock = vi.mocked(forceFinishSeason);
-const publishSeasonMock = vi.mocked(publishSeason);
-const revertSeasonToDraftMock = vi.mocked(revertSeasonToDraft);
-const revertSeasonToRegistrationMock = vi.mocked(revertSeasonToRegistration);
 
 function createInitial(
   capabilities: SeasonCapabilities,
@@ -93,13 +78,6 @@ describe("SeasonForm presets", () => {
       success: true,
       data: { seasonId: "11111111-1111-4111-8111-111111111111", slug: "test-season" },
     });
-    const successWithSlug = { success: true as const, data: { slug: "test-season" } };
-    archiveSeasonMock.mockResolvedValue(successWithSlug);
-    deleteSeasonMock.mockResolvedValue({ success: true, data: undefined });
-    forceFinishSeasonMock.mockResolvedValue(successWithSlug);
-    publishSeasonMock.mockResolvedValue(successWithSlug);
-    revertSeasonToDraftMock.mockResolvedValue(successWithSlug);
-    revertSeasonToRegistrationMock.mockResolvedValue(successWithSlug);
   });
 
   it("does not show Major status in a Rivals display context", () => {
@@ -110,7 +88,20 @@ describe("SeasonForm presets", () => {
 
   it("resets the registration total after applying Major then Rivals", async () => {
     const user = userEvent.setup();
-    render(<SeasonForm mode="create" initial={createInitial(createMajorDefaultCapabilities(), "Major")} />);
+    render(<SeasonForm mode="create" initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "选秀联赛")} />);
+
+    await user.clear(screen.getByLabelText("位置列表"));
+    await user.type(screen.getByLabelText("位置列表"), "custom");
+    await user.clear(screen.getByLabelText("每队人数上限"));
+    await user.type(screen.getByLabelText("每队人数上限"), "8");
+    await user.clear(screen.getByLabelText("每队人数下限"));
+    await user.type(screen.getByLabelText("每队人数下限"), "4");
+    await user.clear(screen.getByLabelText("每位置上限"));
+    await user.type(screen.getByLabelText("每位置上限"), "3");
+    await user.clear(screen.getByLabelText("截图链接数量"));
+    await user.type(screen.getByLabelText("截图链接数量"), "2");
+    await user.clear(screen.getByLabelText("比赛图池"));
+    await user.type(screen.getByLabelText("比赛图池"), "de_custom");
 
     await user.click(screen.getByRole("button", { name: "Major 公开赛" }));
     await user.click(screen.getByRole("button", { name: "Rivals 选秀联赛" }));
@@ -118,31 +109,14 @@ describe("SeasonForm presets", () => {
 
     await waitFor(() => {
       expect(createSeasonMock).toHaveBeenCalledWith(expect.objectContaining({
-        registrationConfig: expect.objectContaining({ maxTotal: 56 }),
+        registrationConfig: expect.objectContaining({
+          maxPerPosition: 15,
+          maxTotal: 56,
+          mapPool: RIVALS_DEFAULT_CAPABILITIES.registrationConfig.mapPool,
+          screenshotCount: 1,
+        }),
       }));
     });
   });
 
-  it("keeps existing season lifecycle controls callable", async () => {
-    const user = userEvent.setup();
-    const capabilities = createMajorDefaultCapabilities();
-    const cases = [
-      { status: "draft" as const, label: "删除赛季", mock: deleteSeasonMock },
-      { status: "registration" as const, label: "撤回至草稿", mock: revertSeasonToDraftMock },
-      { status: "voting" as const, label: "撤回至报名阶段", mock: revertSeasonToRegistrationMock },
-      { status: "playing" as const, label: "手动结束赛季", mock: forceFinishSeasonMock },
-      { status: "finished" as const, label: "归档赛季", mock: archiveSeasonMock },
-    ];
-
-    for (const { status, label, mock } of cases) {
-      const view = render(<SeasonForm mode="edit" initial={createInitial(capabilities, "Major", status)} />);
-      await user.click(screen.getByRole("button", { name: label }));
-      await waitFor(() => expect(mock).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111"));
-      if (status === "draft") {
-        await user.click(screen.getByRole("button", { name: "发布赛季" }));
-        await waitFor(() => expect(publishSeasonMock).toHaveBeenCalledWith("11111111-1111-4111-8111-111111111111"));
-      }
-      view.unmount();
-    }
-  });
 });

--- a/tests/unit/types/standard-major.test.ts
+++ b/tests/unit/types/standard-major.test.ts
@@ -23,6 +23,9 @@ describe("checkStandardMajorCapabilities()", () => {
     expect(result.isStandardMajor).toBe(true);
     expect(result.failures).toEqual([]);
     expect(result.checks.every((check) => check.passed)).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: "stage1-seeds", passed: true })]),
+    );
   });
 
   it("accepts a deep clone of the standard Major defaults", () => {
@@ -94,6 +97,16 @@ describe("checkStandardMajorCapabilities()", () => {
     capabilities.stagePlan[1].entrySeeds = 7;
 
     expectFailure(capabilities, "entry-cohorts");
+  });
+
+  it("requires Stage 1 to contain exactly the unique 17–32 seed cohort", () => {
+    const wrongCohort = createMajorDefaultCapabilities();
+    wrongCohort.stagePlan[0].seeds = Array.from({ length: 16 }, (_, index) => index + 1);
+    expectFailure(wrongCohort, "stage1-seeds");
+
+    const missingCohort = createMajorDefaultCapabilities();
+    missingCohort.stagePlan[0].seeds = undefined;
+    expectFailure(missingCohort, "stage1-seeds");
   });
 
   it("rejects a changed playoff structure", () => {

--- a/tests/unit/types/standard-major.test.ts
+++ b/tests/unit/types/standard-major.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  RIVALS_DEFAULT_CAPABILITIES,
+  checkStandardMajorCapabilities,
+  createMajorDefaultCapabilities,
+} from "@/types/season";
+
+function expectFailure(
+  capabilities: ReturnType<typeof createMajorDefaultCapabilities>,
+  key: string,
+) {
+  const result = checkStandardMajorCapabilities(capabilities);
+  expect(result.isStandardMajor).toBe(false);
+  expect(result.failures).toEqual(
+    expect.arrayContaining([expect.objectContaining({ key, passed: false })]),
+  );
+}
+
+describe("checkStandardMajorCapabilities()", () => {
+  it("accepts the current standard Major defaults", () => {
+    const result = checkStandardMajorCapabilities(createMajorDefaultCapabilities());
+
+    expect(result.isStandardMajor).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.checks.every((check) => check.passed)).toBe(true);
+  });
+
+  it("accepts a deep clone of the standard Major defaults", () => {
+    const result = checkStandardMajorCapabilities(
+      structuredClone(createMajorDefaultCapabilities()),
+    );
+
+    expect(result.isStandardMajor).toBe(true);
+  });
+
+  it("rejects individual registration", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.registrationMode = "solo";
+
+    expectFailure(capabilities, "registration-mode");
+  });
+
+  it("rejects captain voting or snake draft", () => {
+    const votingEnabled = createMajorDefaultCapabilities();
+    votingEnabled.hasCaptainVoting = true;
+    expectFailure(votingEnabled, "captain-voting");
+
+    const draftEnabled = createMajorDefaultCapabilities();
+    draftEnabled.hasDraft = true;
+    expectFailure(draftEnabled, "draft");
+  });
+
+  it("allows event-specific team roster limits", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.maxTeamSize = 8;
+
+    expect(checkStandardMajorCapabilities(capabilities).isStandardMajor).toBe(true);
+  });
+
+  it("allows event-specific registration limits and map pools", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.registrationConfig.maxTotal = 56;
+    capabilities.registrationConfig.mapPool = ["de_mirage", "de_nuke", "de_inferno"];
+
+    expect(checkStandardMajorCapabilities(capabilities).isStandardMajor).toBe(true);
+  });
+
+  it("rejects reordered stage entry cohorts", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    [capabilities.stagePlan[0], capabilities.stagePlan[1]] = [
+      capabilities.stagePlan[1],
+      capabilities.stagePlan[0],
+    ];
+
+    expectFailure(capabilities, "entry-cohorts");
+  });
+
+  it("rejects a changed stage team count", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.stagePlan[1].teamCount = 24;
+
+    expectFailure(capabilities, "stage2");
+  });
+
+  it("rejects a changed Swiss advancement relationship", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.stagePlan[2].advanceTiers = [{ placement: "*", count: 6 }];
+
+    expectFailure(capabilities, "stage3");
+  });
+
+  it("rejects a changed 16 / 8 / 8 entry cohort", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.stagePlan[1].entrySeeds = 7;
+
+    expectFailure(capabilities, "entry-cohorts");
+  });
+
+  it("rejects a changed playoff structure", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.stagePlan[3].teamCount = 4;
+
+    expectFailure(capabilities, "playoff");
+  });
+
+  it("allows Stage 3 BO3 plus optional playoff variants", () => {
+    const capabilities = createMajorDefaultCapabilities();
+    capabilities.stagePlan[2].matchFormat = "bo3";
+    capabilities.stagePlan[3].hasThirdPlaceMatch = true;
+    capabilities.stagePlan[3].finalFormat = "bo3";
+
+    expect(checkStandardMajorCapabilities(capabilities).isStandardMajor).toBe(true);
+  });
+
+  it("ignores display-only fields outside the capability contract", () => {
+    const capabilities = {
+      ...createMajorDefaultCapabilities(),
+      kind: "任何展示文字",
+      name: "自定义赛事名称",
+    };
+
+    expect(checkStandardMajorCapabilities(capabilities).isStandardMajor).toBe(true);
+  });
+});
+
+describe("createMajorDefaultCapabilities()", () => {
+  it("returns a complete Major replacement without Rivals registration leftovers", () => {
+    const rivals = structuredClone(RIVALS_DEFAULT_CAPABILITIES);
+    const major = createMajorDefaultCapabilities();
+
+    expect(rivals.registrationConfig.maxTotal).toBe(56);
+    expect(major.registrationConfig.maxTotal).toBe(256);
+    expect(major).not.toBe(rivals);
+    expect(checkStandardMajorCapabilities(major).isStandardMajor).toBe(true);
+  });
+
+  it("returns independent editable copies", () => {
+    const first = createMajorDefaultCapabilities();
+    const second = createMajorDefaultCapabilities();
+    first.registrationConfig.maxTotal = 1;
+    first.stagePlan[0].teamCount = 2;
+
+    expect(second.registrationConfig.maxTotal).toBe(256);
+    expect(second.stagePlan[0].teamCount).toBe(16);
+  });
+});


### PR DESCRIPTION
## 修复的产品问题

创建页与“Major 公开赛”预设现在共用 `MAJOR_DEFAULT_CAPABILITIES` 的工厂配置，不再在页面或表单内维护另一套 Major 参数。应用预设会完整重置相关能力和报名配置，避免保留 Rivals 的 `maxTotal` 等值。

本轮审查补充：

- Major 摘要与“偏离标准 Major”提示只在 `kind === "Major"` 的展示语境出现；标准检查函数本身不读取 `kind`。
- 从 Major 再应用 Rivals 预设会恢复 Rivals 默认总报名上限（56）。
- 标准 Major 检查验证 Stage 1 种子必须完整且唯一地为 17–32；由此与 Stage 2 的 9–16 和 Stage 3 的 1–8 直入结构一致。
- 移除了与本 PR 无关、会在 CI 中产生时序不稳定的生命周期操作组合测试；保留的表单测试只覆盖上述 Major/Rivals 预设行为。

## 标准 Major 的判断依据

`checkStandardMajorCapabilities()` 是无副作用的纯函数，返回整体结果、失败项和可读原因。它仅检查结构不变量：

- 队伍整体报名、无队长投票、无蛇形选秀，以及 Major 所需的基础报名/队伍模式；
- 32 队 16 / 8 / 8 批次结构；
- Stage 1 的完整唯一 17–32 号种子；
- 三个 16 队瑞士阶段、每阶段 8 队晋级及阶段关系；
- 最终 8 队单败淘汰。

它不会把 `kind` 当作业务依据，也不会把 Stage 3 全 BO3、季军赛、决赛 BO5、地图池、名单人数或种子产生方式作为硬失败条件。

## 明确未包含

- 数据库结构或迁移；
- 赛前准备状态、种子保存、队伍报名、赛事控制台或自动赛程；
- Major 瑞士轮算法及 `src/lib/major/swiss.ts`；
- 纪律处罚、荣誉系统及无关重构。

Stage 3 全 BO3 与 Swiss 核心硬编码局制的矛盾仍保留给后续独立任务，本 PR 只确保标准检查不会将其判为失败。

## 验证

- `pnpm type-check`
- `pnpm lint`
- `pnpm exec drizzle-kit check`
- `pnpm test:coverage` — 79 个测试文件、623 个测试通过，函数覆盖率 60.52%
- `pnpm build`
- GitHub Actions CI 运行 #31686915978 通过
