### PR TITLE
ci: upgrade actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -25,7 +25,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         # 不指定 ref，默认 checkout 触发此 workflow 的 tag 所在 commit。
         # 前提：CHANGELOG 更新必须在 `npm version` 之前完成，
         # 这样 tag 指向的 commit 就已包含对应版本的 CHANGELOG 条目。


### PR DESCRIPTION
## Summary
- Upgrade CI actions to Node 24-based releases.
- Upgrade the release workflow checkout action as well.
- Keep the project runtime on Node 22.

## Validation
- `pnpm lint`
- Verified each upgraded action manifest declares a `node24` runtime.
- GitHub Actions CI will validate the workflow end to end.