### PR TITLE
feat(major): build opening plan preview

### DIFF
--- a/src/lib/major/opening.test.ts
+++ b/src/lib/major/opening.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildMajorOpeningPlan } from "./opening";
+import type { MajorTournamentSeededTeam } from "./seeding";
+
+const TOURNAMENT_TEAMS: readonly MajorTournamentSeededTeam[] = Array.from(
+  { length: 32 },
+  (_, index) => ({ teamId: `team-${index + 1}`, tournamentSeed: index + 1 }),
+);
+
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function shuffle<T>(items: readonly T[], rng: () => number): T[] {
+  const result = [...items];
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(rng() * (index + 1));
+    [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+  }
+  return result;
+}
+
+function tournamentSeeds(teams: readonly MajorTournamentSeededTeam[]): number[] {
+  return teams.map((team) => team.tournamentSeed);
+}
+
+describe("buildMajorOpeningPlan", () => {
+  it("builds the standard 32-team entry cohorts and Stage 1 first round", () => {
+    const plan = buildMajorOpeningPlan({ teams: TOURNAMENT_TEAMS, stageOneMatchFormat: "bo1" });
+
+    expect(tournamentSeeds(plan.tournamentTeams)).toEqual(Array.from({ length: 32 }, (_, index) => index + 1));
+    expect(tournamentSeeds(plan.stage3.directEntrants)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(tournamentSeeds(plan.stage2.directEntrants)).toEqual([9, 10, 11, 12, 13, 14, 15, 16]);
+    expect(plan.stage1.entrants.map((entrant) => entrant.tournamentSeed)).toEqual(
+      Array.from({ length: 16 }, (_, index) => index + 17),
+    );
+    expect(plan.stage1.entrants.map((entrant) => entrant.initialStageSeed)).toEqual(
+      Array.from({ length: 16 }, (_, index) => index + 1),
+    );
+    expect(plan.firstRound.pairings).toEqual(
+      Array.from({ length: 8 }, (_, index) => ({
+        round: 1,
+        higherSeed: {
+          teamId: `team-${index + 17}`,
+          tournamentSeed: index + 17,
+          stageOneSeed: index + 1,
+        },
+        lowerSeed: {
+          teamId: `team-${index + 25}`,
+          tournamentSeed: index + 25,
+          stageOneSeed: index + 9,
+        },
+        format: "bo1",
+        pairingRule: "initial",
+      })),
+    );
+  });
+
+  it("is deterministic when the tournament-team input order is shuffled", () => {
+    const baseline = buildMajorOpeningPlan({ teams: TOURNAMENT_TEAMS, stageOneMatchFormat: "bo1" });
+    const shuffled = shuffle(TOURNAMENT_TEAMS, makeRng(73));
+
+    expect(shuffled).not.toEqual(TOURNAMENT_TEAMS);
+    expect(buildMajorOpeningPlan({ teams: shuffled, stageOneMatchFormat: "bo1" })).toEqual(baseline);
+  });
+
+  it("uses the caller-provided BO1 or BO3 format without changing pairings", () => {
+    const bo1 = buildMajorOpeningPlan({ teams: TOURNAMENT_TEAMS, stageOneMatchFormat: "bo1" });
+    const bo3 = buildMajorOpeningPlan({ teams: TOURNAMENT_TEAMS, stageOneMatchFormat: "bo3" });
+    const withoutFormat = (pairing: (typeof bo1.firstRound.pairings)[number]) => ({
+      round: pairing.round,
+      higherSeed: pairing.higherSeed,
+      lowerSeed: pairing.lowerSeed,
+      pairingRule: pairing.pairingRule,
+    });
+
+    expect(bo1.firstRound.pairings.every((pairing) => pairing.format === "bo1")).toBe(true);
+    expect(bo3.firstRound.pairings.every((pairing) => pairing.format === "bo3")).toBe(true);
+    expect(bo3.firstRound.pairings.map(withoutFormat)).toEqual(
+      bo1.firstRound.pairings.map(withoutFormat),
+    );
+  });
+
+  it("rejects malformed complete-Major seed input and unsupported BO5 fail-closed", () => {
+    const withTeam = (index: number, team: MajorTournamentSeededTeam) =>
+      TOURNAMENT_TEAMS.map((current, currentIndex) => (currentIndex === index ? team : current));
+    const build = (teams: readonly MajorTournamentSeededTeam[]) =>
+      () => buildMajorOpeningPlan({ teams, stageOneMatchFormat: "bo1" });
+
+    expect(build(TOURNAMENT_TEAMS.slice(0, 31))).toThrow();
+    expect(build([...TOURNAMENT_TEAMS, { teamId: "team-33", tournamentSeed: 33 }])).toThrow();
+    expect(build(withTeam(31, { teamId: "team-1", tournamentSeed: 32 }))).toThrow();
+    expect(build(withTeam(31, { teamId: "team-32", tournamentSeed: 31 }))).toThrow();
+    expect(build(withTeam(31, { teamId: "team-32", tournamentSeed: 33 }))).toThrow();
+    expect(build(withTeam(0, { teamId: "team-1", tournamentSeed: 0 }))).toThrow();
+    expect(build(withTeam(0, { teamId: "team-1", tournamentSeed: -1 }))).toThrow();
+    expect(build(withTeam(0, { teamId: "team-1", tournamentSeed: 1.5 }))).toThrow();
+    expect(build(withTeam(0, { teamId: "", tournamentSeed: 1 }))).toThrow();
+    expect(() => buildMajorOpeningPlan({ teams: TOURNAMENT_TEAMS, stageOneMatchFormat: "bo5" })).toThrow(
+      "Major Swiss stages do not support bo5 matchFormat",
+    );
+  });
+
+  it("does not mutate the caller-owned array or team objects", () => {
+    const teams = TOURNAMENT_TEAMS.map((team) => ({ ...team }));
+    const snapshot = structuredClone(teams);
+
+    buildMajorOpeningPlan({ teams, stageOneMatchFormat: "bo1" });
+
+    expect(teams).toEqual(snapshot);
+  });
+});

--- a/src/lib/major/opening.ts
+++ b/src/lib/major/opening.ts
@@ -1,0 +1,190 @@
+// RivalHub 2.0 — 标准 32 队 Major 开赛计划（纯领域预览）。
+//
+// 本模块只从管理员已确认的赛事种子构造入场批次与 Stage 1 首轮预览；
+// 不创建比赛、不写数据库、不改变任何赛事状态。
+
+import {
+  seedMajorStageOneEntrants,
+  type MajorTournamentSeededTeam,
+} from "./seeding";
+import {
+  generateNextMajorSwissRound,
+  type MajorSwissEntrant,
+  type MajorSwissMatchFormat,
+  type MajorSwissPairingRule,
+  type MajorSwissStageMatchFormat,
+} from "./swiss";
+
+const MAJOR_TOURNAMENT_TEAM_COUNT = 32;
+const DIRECT_STAGE_THREE_COUNT = 8;
+const DIRECT_STAGE_TWO_COUNT = 8;
+
+export interface MajorOpeningStageOneEntrant extends MajorTournamentSeededTeam {
+  /** Stage 1 内部种子，与赛事级 tournamentSeed 不同。 */
+  initialStageSeed: number;
+}
+
+export interface MajorOpeningFirstRoundTeam {
+  teamId: string;
+  tournamentSeed: number;
+  stageOneSeed: number;
+}
+
+export interface MajorOpeningFirstRoundPairing {
+  round: 1;
+  higherSeed: MajorOpeningFirstRoundTeam;
+  lowerSeed: MajorOpeningFirstRoundTeam;
+  format: MajorSwissMatchFormat;
+  pairingRule: MajorSwissPairingRule;
+}
+
+export interface MajorOpeningPlan {
+  /** 按赛事种子 1..32 升序。 */
+  tournamentTeams: readonly MajorTournamentSeededTeam[];
+  stage1: {
+    /** 按赛事种子与 Stage 1 本阶段种子升序：赛事 #17..#32 / Stage 1 #1..#16。 */
+    entrants: readonly MajorOpeningStageOneEntrant[];
+  };
+  stage2: {
+    /** 按赛事种子升序：赛事 #9..#16。 */
+    directEntrants: readonly MajorTournamentSeededTeam[];
+  };
+  stage3: {
+    /** 按赛事种子升序：赛事 #1..#8。 */
+    directEntrants: readonly MajorTournamentSeededTeam[];
+  };
+  firstRound: {
+    pairings: readonly MajorOpeningFirstRoundPairing[];
+  };
+}
+
+function normalizeTournamentTeams(
+  teams: readonly MajorTournamentSeededTeam[],
+): readonly MajorTournamentSeededTeam[] {
+  if (teams.length !== MAJOR_TOURNAMENT_TEAM_COUNT) {
+    throw new Error(
+      `Major opening requires exactly ${MAJOR_TOURNAMENT_TEAM_COUNT} teams (got ${teams.length})`,
+    );
+  }
+
+  const teamIds = new Set<string>();
+  const tournamentSeeds = new Set<number>();
+  for (const team of teams) {
+    if (typeof team.teamId !== "string" || team.teamId.length === 0) {
+      throw new Error("tournament teamId must be a non-empty string");
+    }
+    if (teamIds.has(team.teamId)) {
+      throw new Error(`duplicate tournament teamId: ${team.teamId}`);
+    }
+    teamIds.add(team.teamId);
+
+    if (
+      !Number.isInteger(team.tournamentSeed) ||
+      team.tournamentSeed < 1 ||
+      team.tournamentSeed > MAJOR_TOURNAMENT_TEAM_COUNT
+    ) {
+      throw new Error(
+        `invalid tournamentSeed ${team.tournamentSeed}: must be an integer in 1..${MAJOR_TOURNAMENT_TEAM_COUNT}`,
+      );
+    }
+    if (tournamentSeeds.has(team.tournamentSeed)) {
+      throw new Error(`duplicate tournamentSeed: ${team.tournamentSeed}`);
+    }
+    tournamentSeeds.add(team.tournamentSeed);
+  }
+
+  for (let seed = 1; seed <= MAJOR_TOURNAMENT_TEAM_COUNT; seed += 1) {
+    if (!tournamentSeeds.has(seed)) {
+      throw new Error(
+        `tournamentSeed set must be exactly 1..${MAJOR_TOURNAMENT_TEAM_COUNT}; missing ${seed}`,
+      );
+    }
+  }
+
+  return [...teams]
+    .map((team) => ({ ...team }))
+    .sort((a, b) => a.tournamentSeed - b.tournamentSeed);
+}
+
+function buildStageOneEntrants(
+  tournamentTeams: readonly MajorTournamentSeededTeam[],
+): readonly MajorOpeningStageOneEntrant[] {
+  const stageOneTournamentTeams = tournamentTeams.slice(
+    DIRECT_STAGE_THREE_COUNT + DIRECT_STAGE_TWO_COUNT,
+  );
+  const stageOneSeeds = seedMajorStageOneEntrants(stageOneTournamentTeams);
+  const tournamentTeamById = new Map(tournamentTeams.map((team) => [team.teamId, team]));
+
+  return stageOneSeeds.map((entrant) => ({
+    ...tournamentTeamById.get(entrant.teamId)!,
+    initialStageSeed: entrant.initialStageSeed,
+  }));
+}
+
+function buildFirstRoundPreview(
+  stageOneEntrants: readonly MajorOpeningStageOneEntrant[],
+  stageOneMatchFormat: MajorSwissStageMatchFormat,
+): readonly MajorOpeningFirstRoundPairing[] {
+  const swissEntrants: readonly MajorSwissEntrant[] = stageOneEntrants.map((entrant) => ({
+    teamId: entrant.teamId,
+    initialStageSeed: entrant.initialStageSeed,
+  }));
+  const entrantById = new Map(stageOneEntrants.map((entrant) => [entrant.teamId, entrant]));
+
+  return generateNextMajorSwissRound({
+    entrants: swissEntrants,
+    matches: [],
+    finalizedRound: 0,
+    stageMatchFormat: stageOneMatchFormat,
+  }).map((pairing) => {
+    const higher = entrantById.get(pairing.higherSeedTeamId)!;
+    const lower = entrantById.get(pairing.lowerSeedTeamId)!;
+    return {
+      // 此调用固定传入 finalizedRound: 0，因此底层生成的只能是 R1。
+      round: 1,
+      higherSeed: {
+        teamId: higher.teamId,
+        tournamentSeed: higher.tournamentSeed,
+        stageOneSeed: higher.initialStageSeed,
+      },
+      lowerSeed: {
+        teamId: lower.teamId,
+        tournamentSeed: lower.tournamentSeed,
+        stageOneSeed: lower.initialStageSeed,
+      },
+      format: pairing.format,
+      pairingRule: pairing.pairingRule,
+    };
+  });
+}
+
+/**
+ * 构造标准 32 队 Major 的开赛预览。
+ *
+ * 输入必须是赛事级种子精确为 1..32 的完整队伍集合；本函数不会修复缺号、
+ * 重号或越界种子。Stage 1 BO5 由底层 Major Swiss 核心明确拒绝。
+ */
+export function buildMajorOpeningPlan(input: {
+  teams: readonly MajorTournamentSeededTeam[];
+  stageOneMatchFormat: MajorSwissStageMatchFormat;
+}): MajorOpeningPlan {
+  const tournamentTeams = normalizeTournamentTeams(input.teams);
+  const stageOneEntrants = buildStageOneEntrants(tournamentTeams);
+
+  return {
+    tournamentTeams,
+    stage1: { entrants: stageOneEntrants },
+    stage2: {
+      directEntrants: tournamentTeams.slice(
+        DIRECT_STAGE_THREE_COUNT,
+        DIRECT_STAGE_THREE_COUNT + DIRECT_STAGE_TWO_COUNT,
+      ),
+    },
+    stage3: {
+      directEntrants: tournamentTeams.slice(0, DIRECT_STAGE_THREE_COUNT),
+    },
+    firstRound: {
+      pairings: buildFirstRoundPreview(stageOneEntrants, input.stageOneMatchFormat),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a pure standard 32-team Major opening-plan builder
- validate an exact tournament seed set of 1..32 before deriving cohorts
- preview Stage 1 R1 through the existing Major seeding and Swiss pairing core

## Validation
- pnpm type-check
- pnpm lint
- pnpm exec drizzle-kit check
- pnpm test:coverage
- pnpm build