### PR TITLE
ci: pin actions to SHAs + explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,20 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: 22
           cache: pnpm
@@ -25,7 +28,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,6 +5,8 @@ on:
     - cron: "*/5 * * * *"  # 每5分钟检查一次（GitHub 对更短间隔会隐性限流）
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         # 不指定 ref，默认 checkout 触发此 workflow 的 tag 所在 commit。
         # 前提：CHANGELOG 更新必须在 `npm version` 之前完成，
         # 这样 tag 指向的 commit 就已包含对应版本的 CHANGELOG 条目。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         # 不指定 ref，默认 checkout 触发此 workflow 的 tag 所在 commit。
         # 前提：CHANGELOG 更新必须在 `npm version` 之前完成，
         # 这样 tag 指向的 commit 就已包含对应版本的 CHANGELOG 条目。


### PR DESCRIPTION
## Why
CI 无显式 permissions；cron 只 curl 外部 API 却继承默认 token 权限；release 的 checkout@v4 未 pin 且 v4 已触发 Node 过旧告警。

## Changes
- ci.yml：补显式 permissions: contents:read；checkout/pnpm/setup-node/cache 全部 pin + 升级 v4→v5/v6
- cron.yml：permissions 收成空 {}（无需仓库内容权限，仅 curl 带 CRON_SECRET 的外部 API）
- release.yml：checkout v4→v5 pin

## Validation
- 无残留 mutable tag
- cron 为 schedule 触发，push 后 GitHub 重新解析 YAML 确认有效
- PR 触发 CI 验证

## Intentionally unchanged
- cron 的 curl 逻辑、secrets 引用、release 权限结构未动