### PR TITLE
ci: add Dependabot config (github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# GitHub Actions supply-chain hygiene: keep third-party action SHA pins current.
+# Dependabot updates the 40-char SHA refs; keep the version comment in sync.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Why
Dependabot alerts 已启用；version updates 只开 github-actions，让 SHA pin 保持更新。

## Changes
- .github/dependabot.yml：github-actions ecosystem，weekly 检查

## Validation
- PR CI 等待绿

## Intentionally unchanged
- npm/Python 依赖未开 version updates（避免 PR 洪水）；security updates 走 automated-security-fixes 已开