### PR TITLE
feat(major): add prestart readiness console

### DIFF
--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -1,0 +1,72 @@
+import { notFound } from "next/navigation";
+import { asc, eq, inArray } from "drizzle-orm";
+import { MajorPrestartConsole } from "@/components/admin/MajorPrestartConsole";
+import { db } from "@/db/client";
+import { seasons, teamMembers, teams } from "@/db/schema";
+import { evaluateMajorPrestartReadiness } from "@/lib/major/prestart";
+import {
+  normalizeRegistrationConfig,
+  normalizeStagePlan,
+  normalizeTeamRegistrationConfig,
+} from "@/types/season";
+
+interface AdminMajorConsolePageProps {
+  params: Promise<{ seasonSlug: string }>;
+}
+
+/**
+ * 现有 schema 只拥有队伍和正式名单；确认、资格、管理事项和赛事种子尚无
+ * 持久化来源。因此明确以 null 交给领域层，避免空数组被误读为“没有问题”。
+ */
+export default async function AdminMajorConsolePage({ params }: AdminMajorConsolePageProps) {
+  const { seasonSlug } = await params;
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.slug, seasonSlug),
+  });
+  if (!season) notFound();
+
+  const seasonTeams = await db.query.teams.findMany({
+    where: eq(teams.seasonId, season.id),
+    orderBy: [asc(teams.createdAt)],
+    columns: { id: true },
+  });
+  const teamIds = seasonTeams.map((team) => team.id);
+  const members = teamIds.length === 0
+    ? []
+    : await db
+      .select({ teamId: teamMembers.teamId, playerId: teamMembers.userId })
+      .from(teamMembers)
+      .where(inArray(teamMembers.teamId, teamIds));
+  const playerIdsByTeam = new Map<string, string[]>();
+  for (const member of members) {
+    const playerIds = playerIdsByTeam.get(member.teamId) ?? [];
+    playerIds.push(member.playerId);
+    playerIdsByTeam.set(member.teamId, playerIds);
+  }
+
+  const readiness = evaluateMajorPrestartReadiness({
+    capabilities: {
+      registrationMode: season.registrationMode,
+      hasCaptainVoting: season.hasCaptainVoting,
+      hasDraft: season.hasDraft,
+      stagePlan: normalizeStagePlan(season.stagePlan),
+      registrationConfig: normalizeRegistrationConfig(season.registrationConfig),
+      teamRegistrationConfig: normalizeTeamRegistrationConfig(season.teamRegistrationConfig),
+      minTeamSize: season.minTeamSize,
+      maxTeamSize: season.maxTeamSize,
+      starterCount: season.starterCount,
+      positions: season.positions,
+    },
+    teams: seasonTeams.map((team) => ({
+      teamId: team.id,
+      playerIds: playerIdsByTeam.get(team.id) ?? [],
+    })),
+    confirmations: null,
+    qualificationIssues: null,
+    administrativeIssues: null,
+    tournamentSeeds: null,
+    reconfirmations: null,
+  });
+
+  return <MajorPrestartConsole seasonName={season.name} readiness={readiness} />;
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -17,9 +17,9 @@ export default async function AdminLayout({ children }: { children: ReactNode })
   const session = await checkAdminSession();
   if (!session) redirect("/admin/login");
   return (
-    <div className="grid min-h-screen" style={{ gridTemplateColumns: "200px 1fr" }}>
+    <div className="grid min-h-screen grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)]">
       <AdminSidebar email={session.email} />
-      <main>{children}</main>
+      <main className="min-w-0">{children}</main>
     </div>
   );
 }

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -29,16 +29,14 @@ export function AdminSidebar({ email }: { email: string }) {
 
   return (
     <div
-      className="flex flex-col h-full"
+      className="flex items-center border-b border-[var(--color-border)] md:h-full md:flex-col md:items-stretch md:border-b-0 md:border-r"
       style={{
         background: "var(--color-panel-low)",
-        borderRight: "1px solid var(--color-border)",
-        padding: "20px 0",
       }}
     >
       {/* header */}
       <div
-        className="px-5 pb-4 font-bold uppercase"
+        className="shrink-0 px-4 py-3 font-bold uppercase md:px-5 md:pb-4 md:pt-5"
         style={{
           fontFamily: "var(--font-mono)",
           fontSize: 10,
@@ -50,7 +48,7 @@ export function AdminSidebar({ email }: { email: string }) {
       </div>
 
       {/* nav */}
-      <nav className="flex-1">
+      <nav className="flex min-w-0 flex-1 overflow-x-auto md:block">
         {NAV_ITEMS.map((item) => {
           const active = item.href === "/admin"
             ? pathname === "/admin"
@@ -59,9 +57,8 @@ export function AdminSidebar({ email }: { email: string }) {
             <Link
               key={item.href}
               href={item.href}
-              className="block"
+              className="inline-flex shrink-0 items-center px-3 py-3 md:block md:px-5 md:py-2.5"
               style={{
-                padding: "10px 20px",
                 background: active ? "var(--color-panel)" : "transparent",
                 borderLeft: `2px solid ${active ? "var(--color-accent)" : "transparent"}`,
                 color: active ? "var(--color-fg)" : "var(--color-fg-mid)",
@@ -78,11 +75,11 @@ export function AdminSidebar({ email }: { email: string }) {
 
       {/* footer */}
       <div
-        className="px-5 pt-4 mt-auto"
+        className="ml-auto shrink-0 px-4 md:mt-auto md:px-5 md:pt-4"
         style={{ borderTop: "1px solid var(--color-border)" }}
       >
         <div
-          className="truncate mb-2"
+          className="mb-2 hidden truncate md:block"
           style={{
             fontFamily: "var(--font-mono)",
             fontSize: 10,

--- a/src/components/admin/MajorPrestartConsole.tsx
+++ b/src/components/admin/MajorPrestartConsole.tsx
@@ -1,0 +1,76 @@
+import { Marker, Panel } from "@/components/rivalhub";
+import type { MajorPrestartReadiness } from "@/lib/major/prestart";
+
+const STATE_LABEL = {
+  ready: "已就绪",
+  blocked: "需处理",
+  unavailable: "尚未接入/不可确认",
+} as const;
+
+const STATE_CLASS = {
+  ready: "text-emerald-700 border-emerald-300 bg-emerald-50",
+  blocked: "text-amber-800 border-amber-300 bg-amber-50",
+  unavailable: "text-slate-700 border-slate-300 bg-slate-50",
+} as const;
+
+export function MajorPrestartConsole({
+  seasonName,
+  readiness,
+}: {
+  seasonName: string;
+  readiness: MajorPrestartReadiness;
+}) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Marker sub={readiness.canStart ? "可进入开赛流程" : "准备未完成"}>
+          赛事控制台 · {seasonName}
+        </Marker>
+        <p className="text-sm text-[var(--color-fg-mid)]">
+          只读赛前检查；本页不启动赛事、不创建对阵，也不修改任何赛事数据。
+        </p>
+      </div>
+
+      <Panel label="赛前检查">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {readiness.checks.map((check) => (
+            <section
+              key={check.key}
+              className="rounded-md border border-[var(--color-border)] p-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h2 className="font-medium text-[var(--color-fg)]">{check.label}</h2>
+                <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${STATE_CLASS[check.state]}`}>
+                  {STATE_LABEL[check.state]}
+                </span>
+              </div>
+              {check.blockers.length > 0 ? (
+                <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[var(--color-fg-mid)]">
+                  {check.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-[var(--color-fg-mid)]">已满足该项开赛条件。</p>
+              )}
+            </section>
+          ))}
+        </div>
+      </Panel>
+
+      <Panel label="阶段一首轮预览">
+        {readiness.openingPlan ? (
+          <ol className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            {readiness.openingPlan.firstRound.pairings.map((pairing) => (
+              <li key={`${pairing.higherSeed.teamId}-${pairing.lowerSeed.teamId}`} className="rounded border border-[var(--color-border)] px-3 py-2">
+                #{pairing.higherSeed.tournamentSeed} vs #{pairing.lowerSeed.tournamentSeed} · {pairing.format.toUpperCase()}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="text-sm text-[var(--color-fg-mid)]">
+            开赛计划会在所有赛前条件通过后由领域结果提供；当前不会推导或展示临时对阵。
+          </p>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/src/components/admin/SeasonSubNav.tsx
+++ b/src/components/admin/SeasonSubNav.tsx
@@ -19,6 +19,7 @@ export function SeasonSubNav({
   const pathname = usePathname();
 
   const tabs: { label: string; href: string }[] = [
+    { label: "赛事控制台", href: `/admin/${seasonSlug}` },
     { label: "报名审核", href: `/admin/${seasonSlug}/registrations` },
     ...(hasCaptainVoting ? [{ label: "队长确认", href: `/admin/${seasonSlug}/captains` }] : []),
     ...(hasDraft ? [{ label: "选秀控制", href: `/admin/${seasonSlug}/draft` }] : []),

--- a/src/lib/major/prestart.test.ts
+++ b/src/lib/major/prestart.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createMajorDefaultCapabilities } from "@/types/season";
+import {
+  evaluateMajorPrestartReadiness,
+  type MajorPrestartReadinessInput,
+} from "./prestart";
+
+const teamIds = Array.from({ length: 32 }, (_, index) => `team-${index + 1}`);
+
+function makeInput(): MajorPrestartReadinessInput {
+  return {
+    capabilities: createMajorDefaultCapabilities(),
+    teams: teamIds.map((teamId, teamIndex) => ({
+      teamId,
+      playerIds: Array.from({ length: 5 }, (_, playerIndex) => `player-${teamIndex * 5 + playerIndex + 1}`),
+    })),
+    confirmations: teamIds.map((teamId) => ({ teamId, confirmed: true })),
+    qualificationIssues: [],
+    administrativeIssues: [],
+    tournamentSeeds: teamIds.map((teamId, index) => ({ teamId, tournamentSeed: index + 1 })),
+    reconfirmations: teamIds.map((teamId) => ({ teamId, confirmed: true })),
+  };
+}
+
+describe("evaluateMajorPrestartReadiness", () => {
+  it("returns a startable domain result and opening plan for complete factual input", () => {
+    const result = evaluateMajorPrestartReadiness(makeInput());
+
+    expect(result.canStart).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.openingPlan?.firstRound.pairings).toHaveLength(8);
+    expect(result.checks.every((check) => check.state === "ready")).toBe(true);
+  });
+
+  it("returns Chinese blockers instead of throwing for ordinary incomplete conditions", () => {
+    const input = makeInput();
+    input.capabilities.hasDraft = true;
+    input.teams = input.teams!.slice(0, 31).map((team, index) => (
+      index === 0 ? { ...team, playerIds: [team.playerIds[0]!, team.playerIds[1]!, "player-6"] } : team
+    ));
+    input.confirmations = input.confirmations!.map((fact, index) => ({ ...fact, confirmed: index !== 0 }));
+    input.qualificationIssues = [{ label: "资格材料复核", resolved: false }];
+    input.administrativeIssues = [{ label: "裁判排班", resolved: false }];
+    input.tournamentSeeds = input.tournamentSeeds!.map((fact, index) => (
+      index === 31 ? { ...fact, tournamentSeed: 31 } : fact
+    ));
+    input.reconfirmations = input.reconfirmations!.slice(0, 30);
+
+    expect(() => evaluateMajorPrestartReadiness(input)).not.toThrow();
+    const result = evaluateMajorPrestartReadiness(input);
+    expect(result.canStart).toBe(false);
+    expect(result.openingPlan).toBeNull();
+    expect(result.blockers.join("\n")).toContain("Major 开赛需要恰好 32 支队伍");
+    expect(result.blockers.join("\n")).toContain("名单不足 5 人");
+    expect(result.checks.find((check) => check.key === "duplicate-players")?.state).toBe("blocked");
+    expect(result.blockers.join("\n")).toContain("尚未参赛确认");
+    expect(result.blockers.join("\n")).toContain("资格事项未完成");
+    expect(result.blockers.join("\n")).toContain("管理事项未完成");
+    expect(result.blockers.join("\n")).toContain("赛事种子 32 尚未分配");
+    expect(result.blockers.join("\n")).toContain("缺少赛前重新确认记录");
+  });
+
+  it("fails closed when schema-less facts are not connected", () => {
+    const input = makeInput();
+    input.confirmations = null;
+    input.qualificationIssues = null;
+    input.administrativeIssues = null;
+    input.tournamentSeeds = null;
+    input.reconfirmations = null;
+
+    const result = evaluateMajorPrestartReadiness(input);
+
+    expect(result.canStart).toBe(false);
+    expect(result.openingPlan).toBeNull();
+    expect(result.checks.filter((check) => check.state === "unavailable").map((check) => check.key)).toEqual([
+      "confirmations", "qualification", "administration", "seeds", "reconfirmations",
+    ]);
+    expect(result.blockers.every((blocker) => blocker.includes("尚未接入/不可确认") || blocker.includes("开赛计划"))).toBe(true);
+  });
+});

--- a/src/lib/major/prestart.ts
+++ b/src/lib/major/prestart.ts
@@ -1,0 +1,299 @@
+import {
+  checkStandardMajorCapabilities,
+  type SeasonCapabilities,
+} from "@/types/season";
+import {
+  buildMajorOpeningPlan,
+  type MajorOpeningPlan,
+} from "./opening";
+
+const MAJOR_TEAM_COUNT = 32;
+
+export type MajorPrestartCheckKey =
+  | "rules"
+  | "teams"
+  | "rosters"
+  | "duplicate-players"
+  | "confirmations"
+  | "qualification"
+  | "administration"
+  | "seeds"
+  | "reconfirmations"
+  | "opening-plan";
+
+export type MajorPrestartCheckState = "ready" | "blocked" | "unavailable";
+
+export interface MajorPrestartCheck {
+  key: MajorPrestartCheckKey;
+  label: string;
+  state: MajorPrestartCheckState;
+  blockers: readonly string[];
+}
+
+/** 已持久化的队伍和名单事实。playerId 必须是赛季内稳定的人员标识。 */
+export interface MajorPrestartTeamFact {
+  teamId: string;
+  playerIds: readonly string[];
+}
+
+export interface MajorPrestartTeamConfirmationFact {
+  teamId: string;
+  confirmed: boolean;
+}
+
+/** 资格或管理事项由拥有它的上游流程提供；未接入时传 null，而不是空数组。 */
+export interface MajorPrestartIssueFact {
+  label: string;
+  resolved: boolean;
+}
+
+export interface MajorPrestartTournamentSeedFact {
+  teamId: string;
+  tournamentSeed: number;
+}
+
+export interface MajorPrestartReadinessInput {
+  capabilities: SeasonCapabilities;
+  teams: readonly MajorPrestartTeamFact[] | null;
+  confirmations: readonly MajorPrestartTeamConfirmationFact[] | null;
+  qualificationIssues: readonly MajorPrestartIssueFact[] | null;
+  administrativeIssues: readonly MajorPrestartIssueFact[] | null;
+  tournamentSeeds: readonly MajorPrestartTournamentSeedFact[] | null;
+  reconfirmations: readonly MajorPrestartTeamConfirmationFact[] | null;
+}
+
+export interface MajorPrestartReadiness {
+  /** 唯一可供界面消费的开赛结论；界面不得自行重新计算。 */
+  canStart: boolean;
+  checks: readonly MajorPrestartCheck[];
+  blockers: readonly string[];
+  /** 仅当所有开赛前条件满足时构造；否则为 null。 */
+  openingPlan: MajorOpeningPlan | null;
+}
+
+function ready(key: MajorPrestartCheckKey, label: string): MajorPrestartCheck {
+  return { key, label, state: "ready", blockers: [] };
+}
+
+function blocked(
+  key: MajorPrestartCheckKey,
+  label: string,
+  blockers: readonly string[],
+): MajorPrestartCheck {
+  return { key, label, state: "blocked", blockers };
+}
+
+function unavailable(key: MajorPrestartCheckKey, label: string): MajorPrestartCheck {
+  return {
+    key,
+    label,
+    state: "unavailable",
+    blockers: [`${label}尚未接入/不可确认。`],
+  };
+}
+
+function invalidTeamIds(teams: readonly MajorPrestartTeamFact[]): string[] {
+  const ids = new Set<string>();
+  const blockers: string[] = [];
+  for (const team of teams) {
+    const teamId = team.teamId.trim();
+    if (!teamId) {
+      blockers.push("存在缺少队伍标识的报名队伍。");
+    } else if (ids.has(teamId)) {
+      blockers.push(`队伍 ${teamId} 重复出现。`);
+    } else {
+      ids.add(teamId);
+    }
+  }
+  return blockers;
+}
+
+function checkRosters(
+  teams: readonly MajorPrestartTeamFact[] | null,
+  minTeamSize: number,
+): MajorPrestartCheck {
+  if (teams === null) return unavailable("rosters", "队伍名单");
+
+  const blockers = teams.flatMap((team) => {
+    if (team.playerIds.length < minTeamSize) {
+      return [`队伍 ${team.teamId || "（未命名）"} 名单不足 ${minTeamSize} 人。`];
+    }
+    return [];
+  });
+  return blockers.length === 0
+    ? ready("rosters", "队伍名单")
+    : blocked("rosters", "队伍名单", blockers);
+}
+
+function checkDuplicatePlayers(teams: readonly MajorPrestartTeamFact[] | null): MajorPrestartCheck {
+  if (teams === null) return unavailable("duplicate-players", "重复 player 检查");
+
+  const playerTeams = new Map<string, string[]>();
+  const blockers: string[] = [];
+  for (const team of teams) {
+    for (const rawPlayerId of team.playerIds) {
+      const playerId = rawPlayerId.trim();
+      if (!playerId) {
+        blockers.push(`队伍 ${team.teamId || "（未命名）"} 存在缺少 player 标识的成员。`);
+        continue;
+      }
+      const memberships = playerTeams.get(playerId) ?? [];
+      memberships.push(team.teamId || "（未命名）");
+      playerTeams.set(playerId, memberships);
+    }
+  }
+
+  for (const [playerId, teamIds] of playerTeams) {
+    if (teamIds.length > 1) {
+      blockers.push(`player ${playerId} 同时出现在 ${teamIds.join("、")} 的名单中。`);
+    }
+  }
+  return blockers.length === 0
+    ? ready("duplicate-players", "重复 player 检查")
+    : blocked("duplicate-players", "重复 player 检查", blockers);
+}
+
+function checkTeamConfirmations(
+  key: "confirmations" | "reconfirmations",
+  label: string,
+  facts: readonly MajorPrestartTeamConfirmationFact[] | null,
+  teams: readonly MajorPrestartTeamFact[] | null,
+): MajorPrestartCheck {
+  if (facts === null) return unavailable(key, label);
+  if (teams === null) return unavailable(key, label);
+
+  const teamIds = new Set(teams.map((team) => team.teamId));
+  const seen = new Set<string>();
+  const blockers: string[] = [];
+  for (const fact of facts) {
+    if (!teamIds.has(fact.teamId)) {
+      blockers.push(`${label}包含不在本届赛事内的队伍 ${fact.teamId}。`);
+    }
+    if (seen.has(fact.teamId)) {
+      blockers.push(`队伍 ${fact.teamId} 存在重复的${label}记录。`);
+    }
+    seen.add(fact.teamId);
+    if (!fact.confirmed) blockers.push(`队伍 ${fact.teamId} 尚未${label}。`);
+  }
+  for (const teamId of teamIds) {
+    if (!seen.has(teamId)) blockers.push(`队伍 ${teamId} 缺少${label}记录。`);
+  }
+  return blockers.length === 0 ? ready(key, label) : blocked(key, label, blockers);
+}
+
+function checkIssues(
+  key: "qualification" | "administration",
+  label: string,
+  facts: readonly MajorPrestartIssueFact[] | null,
+): MajorPrestartCheck {
+  if (facts === null) return unavailable(key, label);
+  const blockers = facts
+    .filter((fact) => !fact.resolved)
+    .map((fact) => `${label}未完成：${fact.label || "未命名事项"}。`);
+  return blockers.length === 0 ? ready(key, label) : blocked(key, label, blockers);
+}
+
+function checkSeeds(
+  teams: readonly MajorPrestartTeamFact[] | null,
+  facts: readonly MajorPrestartTournamentSeedFact[] | null,
+): { check: MajorPrestartCheck; seeds: readonly MajorPrestartTournamentSeedFact[] | null } {
+  if (facts === null || teams === null) {
+    return { check: unavailable("seeds", "赛事 1–32 种子"), seeds: null };
+  }
+
+  const teamIds = new Set(teams.map((team) => team.teamId));
+  const seenTeams = new Set<string>();
+  const seenSeeds = new Set<number>();
+  const blockers: string[] = [];
+  for (const fact of facts) {
+    if (!teamIds.has(fact.teamId)) blockers.push(`种子 ${fact.tournamentSeed} 指向不存在的队伍 ${fact.teamId}。`);
+    if (seenTeams.has(fact.teamId)) blockers.push(`队伍 ${fact.teamId} 被分配了重复种子。`);
+    seenTeams.add(fact.teamId);
+    if (!Number.isInteger(fact.tournamentSeed) || fact.tournamentSeed < 1 || fact.tournamentSeed > MAJOR_TEAM_COUNT) {
+      blockers.push(`队伍 ${fact.teamId} 的种子必须是 1–32 的整数。`);
+    } else if (seenSeeds.has(fact.tournamentSeed)) {
+      blockers.push(`赛事种子 ${fact.tournamentSeed} 重复。`);
+    }
+    seenSeeds.add(fact.tournamentSeed);
+  }
+  for (let seed = 1; seed <= MAJOR_TEAM_COUNT; seed += 1) {
+    if (!seenSeeds.has(seed)) blockers.push(`赛事种子 ${seed} 尚未分配。`);
+  }
+  for (const teamId of teamIds) {
+    if (!seenTeams.has(teamId)) blockers.push(`队伍 ${teamId} 尚未分配赛事种子。`);
+  }
+  return {
+    check: blockers.length === 0 ? ready("seeds", "赛事 1–32 种子") : blocked("seeds", "赛事 1–32 种子", blockers),
+    seeds: blockers.length === 0 ? facts : null,
+  };
+}
+
+/**
+ * 评估标准 32 队 Major 的赛前就绪状态。
+ *
+ * 这是纯领域函数：它不读写数据库、不改变赛季状态，也不创建比赛。未接入
+ * 的持久化事实必须以 null 表示；函数将其保留为不可确认状态而不是当作无问题。
+ */
+export function evaluateMajorPrestartReadiness(
+  input: MajorPrestartReadinessInput,
+): MajorPrestartReadiness {
+  const rules = checkStandardMajorCapabilities(input.capabilities);
+  const checks: MajorPrestartCheck[] = [
+    rules.isStandardMajor
+      ? ready("rules", "标准 Major 规则")
+      : blocked("rules", "标准 Major 规则", rules.failures.map((failure) => failure.reason)),
+  ];
+
+  const teamBlockers = input.teams === null
+    ? null
+    : [
+        ...invalidTeamIds(input.teams),
+        ...(input.teams.length === MAJOR_TEAM_COUNT
+          ? []
+          : [`当前有 ${input.teams.length} 支队伍，Major 开赛需要恰好 32 支队伍。`]),
+      ];
+  checks.push(
+    teamBlockers === null
+      ? unavailable("teams", "32 支参赛队伍")
+      : teamBlockers.length === 0
+        ? ready("teams", "32 支参赛队伍")
+        : blocked("teams", "32 支参赛队伍", teamBlockers),
+  );
+  checks.push(checkRosters(input.teams, input.capabilities.minTeamSize));
+  checks.push(checkDuplicatePlayers(input.teams));
+  checks.push(checkTeamConfirmations("confirmations", "参赛确认", input.confirmations, input.teams));
+  checks.push(checkIssues("qualification", "资格事项", input.qualificationIssues));
+  checks.push(checkIssues("administration", "管理事项", input.administrativeIssues));
+  const seedResult = checkSeeds(input.teams, input.tournamentSeeds);
+  checks.push(seedResult.check);
+  checks.push(checkTeamConfirmations("reconfirmations", "赛前重新确认", input.reconfirmations, input.teams));
+
+  const blockersBeforePlan = checks.flatMap((check) => check.blockers);
+  let openingPlan: MajorOpeningPlan | null = null;
+  if (blockersBeforePlan.length > 0 || seedResult.seeds === null) {
+    checks.push(blocked("opening-plan", "开赛计划", ["开赛计划依赖所有赛前检查通过。"]));
+  } else {
+    try {
+      const stageOneMatchFormat = input.capabilities.stagePlan[0]?.matchFormat;
+      if (stageOneMatchFormat !== "bo1" && stageOneMatchFormat !== "bo3") {
+        checks.push(blocked("opening-plan", "开赛计划", ["阶段一比赛赛制必须是 BO1 或 BO3。"]));
+      } else {
+        openingPlan = buildMajorOpeningPlan({
+          teams: seedResult.seeds,
+          stageOneMatchFormat,
+        });
+        checks.push(ready("opening-plan", "开赛计划"));
+      }
+    } catch {
+      checks.push(blocked("opening-plan", "开赛计划", ["开赛计划无法构造，请核对赛事种子和阶段规则。"]));
+    }
+  }
+
+  const blockers = checks.flatMap((check) => check.blockers);
+  return {
+    canStart: blockers.length === 0,
+    checks,
+    blockers,
+    openingPlan,
+  };
+}

--- a/tests/unit/app/admin-major-console-page.test.tsx
+++ b/tests/unit/app/admin-major-console-page.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMajorDefaultCapabilities } from "@/types/season";
+
+const { seasonFindFirstMock, teamsFindManyMock } = vi.hoisted(() => ({
+  seasonFindFirstMock: vi.fn(),
+  teamsFindManyMock: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    query: {
+      seasons: { findFirst: seasonFindFirstMock },
+      teams: { findMany: teamsFindManyMock },
+    },
+    select: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({ notFound: vi.fn() }));
+
+import AdminMajorConsolePage from "@/app/admin/[seasonSlug]/page";
+
+describe("admin Major prestart console page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("React", React);
+    const capabilities = createMajorDefaultCapabilities();
+    seasonFindFirstMock.mockResolvedValue({
+      id: "season-1",
+      name: "RivalHub Major 2027",
+      ...capabilities,
+    });
+    teamsFindManyMock.mockResolvedValue([]);
+  });
+
+  it("renders the domain result and keeps unconnected facts explicitly unavailable", async () => {
+    const page = await AdminMajorConsolePage({ params: Promise.resolve({ seasonSlug: "major-2027" }) });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("赛事控制台 · RivalHub Major 2027");
+    expect(html).toContain("准备未完成");
+    expect(html).toContain("当前有 0 支队伍，Major 开赛需要恰好 32 支队伍。");
+    expect(html).toContain("尚未接入/不可确认");
+    expect(html).toContain("当前不会推导或展示临时对阵");
+  });
+});


### PR DESCRIPTION
## Summary

- add a pure `evaluateMajorPrestartReadiness()` domain gate for standard rules, 32 teams, rosters, duplicate players, confirmations, qualification/admin facts, 1–32 seeds, reconfirmations, and the opening-plan preview
- add the read-only `/admin/[seasonSlug]` tournament console and admin navigation; absent persistent facts are explicitly shown as `尚未接入/不可确认`
- make the admin shell responsive so the console is usable at a 393px viewport

## Validation

- `pnpm type-check`
- `pnpm lint`
- `pnpm test` — 82 files, 656 tests
- Local Supabase active migration / fixture / Auth / Storage / Data API verification on the guarded dependency branch
- authenticated browser check at desktop and 393px viewport; no horizontal overflow

## Scope

Pure domain and read-only UI only. No schema change, migration, seed, remote staging write, or production operation.