### PR TITLE
feat(major): persist prestart entrants and tournament seeds

### DIFF
--- a/drizzle/migrations/0003_ordinary_grey_gargoyle.sql
+++ b/drizzle/migrations/0003_ordinary_grey_gargoyle.sql
@@ -1,0 +1,52 @@
+CREATE TYPE "public"."major_prestart_issue_category" AS ENUM('qualification', 'administration');--> statement-breakpoint
+CREATE TABLE "major_prestart_entrants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"team_id" uuid NOT NULL,
+	"roster_confirmed_at" timestamp with time zone,
+	"roster_confirmed_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "major_prestart_entrants_season_team_unique" UNIQUE("season_id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "major_prestart_issues" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"category" "major_prestart_issue_category" NOT NULL,
+	"label" text NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"resolved_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "major_prestart_roster_members" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"entrant_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "major_prestart_roster_members_entrant_user_unique" UNIQUE("entrant_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "major_prestart_states" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"entrants_locked_at" timestamp with time zone,
+	"entrants_locked_by" text,
+	"seed_revision" integer DEFAULT 0 NOT NULL,
+	"confirmed_seed_revision" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "major_prestart_states_season_id_unique" UNIQUE("season_id")
+);
+--> statement-breakpoint
+ALTER TABLE "major_prestart_entrants" ADD CONSTRAINT "major_prestart_entrants_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_prestart_entrants" ADD CONSTRAINT "major_prestart_entrants_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_prestart_issues" ADD CONSTRAINT "major_prestart_issues_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_prestart_roster_members" ADD CONSTRAINT "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk" FOREIGN KEY ("entrant_id") REFERENCES "public"."major_prestart_entrants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_prestart_roster_members" ADD CONSTRAINT "major_prestart_roster_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_prestart_states" ADD CONSTRAINT "major_prestart_states_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "major_prestart_entrants_season_idx" ON "major_prestart_entrants" USING btree ("season_id");--> statement-breakpoint
+CREATE INDEX "major_prestart_issues_season_category_idx" ON "major_prestart_issues" USING btree ("season_id","category");--> statement-breakpoint
+CREATE INDEX "major_prestart_roster_members_entrant_idx" ON "major_prestart_roster_members" USING btree ("entrant_id");

--- a/drizzle/migrations/0004_flowery_legion.sql
+++ b/drizzle/migrations/0004_flowery_legion.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "major_tournament_seeds" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"entrant_id" uuid NOT NULL,
+	"tournament_seed" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "major_tournament_seeds_season_entrant_unique" UNIQUE("season_id","entrant_id"),
+	CONSTRAINT "major_tournament_seeds_season_seed_unique" UNIQUE("season_id","tournament_seed"),
+	CONSTRAINT "major_tournament_seeds_seed_range_check" CHECK ("major_tournament_seeds"."tournament_seed" BETWEEN 1 AND 32)
+);
+--> statement-breakpoint
+ALTER TABLE "major_tournament_seeds" ADD CONSTRAINT "major_tournament_seeds_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_tournament_seeds" ADD CONSTRAINT "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk" FOREIGN KEY ("entrant_id") REFERENCES "public"."major_prestart_entrants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "major_tournament_seeds_season_idx" ON "major_tournament_seeds" USING btree ("season_id");

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,3356 @@
+{
+  "id": "89a6eed7-e135-4e40-a172-c53bf325f35e",
+  "prevId": "8ec4ee3c-8011-417f-bf4a-f963b22bd278",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0004_snapshot.json
+++ b/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,3473 @@
+{
+  "id": "0d356eed-c22b-4cee-a4c1-3aa9b3d0ad05",
+  "prevId": "89a6eed7-e135-4e40-a172-c53bf325f35e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"tournament_seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787645206348,
       "tag": "0002_windy_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787678757036,
+      "tag": "0003_ordinary_grey_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787678757036,
       "tag": "0003_ordinary_grey_gargoyle",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1787679333240,
+      "tag": "0004_flowery_legion",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:team-registration:local": "tsx scripts/db/team-registration-integration.ts",
+    "test:major-prestart:local": "tsx scripts/db/major-prestart-integration.ts",
     "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {

--- a/scripts/db/major-prestart-integration.ts
+++ b/scripts/db/major-prestart-integration.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
+import { createMajorDefaultCapabilities } from "../../src/types/season";
 
 const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
 if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
@@ -32,12 +33,30 @@ async function main(): Promise<void> {
   const userIds = Array.from({ length: 160 }, () => randomUUID());
   const memberIds = Array.from({ length: 160 }, () => randomUUID());
   const entrantId = randomUUID();
+  const capabilities = createMajorDefaultCapabilities();
+  const keepBrowserFixture = process.env.RIVALHUB_LOCAL_KEEP_MAJOR_PRESTART_FIXTURE === "true";
+  const browserSlug = `local-major-prestart-browser-${seasonId}`;
   try {
     await client.query("BEGIN");
     await client.query(
-      `INSERT INTO seasons (id, slug, name, kind, registration_mode, has_captain_voting, has_draft, min_team_size, max_team_size)
-       VALUES ($1, $2, 'Local Major Prestart', 'Major', 'team', false, false, 5, 7)`,
-      [seasonId, `local-major-prestart-${seasonId}`],
+      `INSERT INTO seasons (
+        id, slug, name, kind, registration_mode, has_captain_voting, has_draft,
+        stage_plan, registration_config, team_registration_config, min_team_size, max_team_size, starter_count, positions
+      ) VALUES ($1, $2, 'Local Major Prestart', 'Major', $3, $4, $5, $6::json, $7::json, $8::json, $9, $10, $11, $12::text[])`,
+      [
+        seasonId,
+        keepBrowserFixture ? browserSlug : `local-major-prestart-${seasonId}`,
+        capabilities.registrationMode,
+        capabilities.hasCaptainVoting,
+        capabilities.hasDraft,
+        JSON.stringify(capabilities.stagePlan),
+        JSON.stringify(capabilities.registrationConfig),
+        JSON.stringify(capabilities.teamRegistrationConfig),
+        capabilities.minTeamSize,
+        capabilities.maxTeamSize,
+        capabilities.starterCount,
+        capabilities.positions,
+      ],
     );
     await client.query(
       `INSERT INTO users (id, email) SELECT value::uuid, 'prestart-' || value || '@local.test'
@@ -111,8 +130,59 @@ async function main(): Promise<void> {
       "SELECT count(*) FROM major_prestart_roster_members WHERE entrant_id = $1", [entrantId],
     );
     if (rosterAfterDelete.rows[0]?.count !== "0") throw new Error("最终名单快照没有随正式参赛队级联删除。");
-    await client.query("ROLLBACK");
-    console.log("Major prestart local integration passed: selected entrants, final rosters, issue categories, uniqueness, and cascade boundary.");
+    await client.query(
+      `INSERT INTO major_prestart_entrants (season_id, team_id)
+       SELECT $1, id FROM teams WHERE season_id = $1 ON CONFLICT DO NOTHING`,
+      [seasonId],
+    );
+    const reinserted = await client.query<{ id: string }>(
+      "SELECT id FROM major_prestart_entrants WHERE season_id = $1 AND team_id = $2", [seasonId, teamIds[0]],
+    );
+    const reinsertedEntrantId = reinserted.rows[0]?.id;
+    if (!reinsertedEntrantId) throw new Error("正式参赛队未能重新建立。");
+    await expectPgError(client, () => client.query(
+      "INSERT INTO major_tournament_seeds (season_id, entrant_id, tournament_seed) VALUES ($1, $2, 33)",
+      [seasonId, reinsertedEntrantId],
+    ), "23514");
+    await client.query(
+      `INSERT INTO major_prestart_roster_members (entrant_id, user_id)
+       SELECT e.id, tm.user_id FROM major_prestart_entrants e
+       INNER JOIN team_members tm ON tm.team_id = e.team_id AND tm.season_id = e.season_id
+       WHERE e.season_id = $1 ON CONFLICT DO NOTHING`,
+      [seasonId],
+    );
+    await client.query(
+      `INSERT INTO major_tournament_seeds (season_id, entrant_id, tournament_seed)
+       SELECT $1, id, row_number() OVER (ORDER BY team_id)::int
+       FROM major_prestart_entrants WHERE season_id = $1`,
+      [seasonId],
+    );
+    const seedCount = await client.query<{ count: string }>(
+      "SELECT count(*) FROM major_tournament_seeds WHERE season_id = $1", [seasonId],
+    );
+    if (seedCount.rows[0]?.count !== "32") throw new Error("独立赛事 1–32 种子未完整持久化。");
+    await expectPgError(client, () => client.query(
+      "UPDATE major_tournament_seeds SET tournament_seed = 1 WHERE season_id = $1 AND tournament_seed = 2", [seasonId],
+    ), "23505");
+    await client.query(
+      "UPDATE major_prestart_states SET entrants_locked_at = now(), seed_revision = 1, confirmed_seed_revision = 1 WHERE season_id = $1",
+      [seasonId],
+    );
+    const confirmation = await client.query<{ seed_revision: number; confirmed_seed_revision: number }>(
+      "SELECT seed_revision, confirmed_seed_revision FROM major_prestart_states WHERE season_id = $1", [seasonId],
+    );
+    if (confirmation.rows[0]?.seed_revision !== confirmation.rows[0]?.confirmed_seed_revision) {
+      throw new Error("确认的种子 revision 未持久化。");
+    }
+    if (keepBrowserFixture) {
+      await client.query("UPDATE major_prestart_entrants SET roster_confirmed_at = now() WHERE season_id = $1", [seasonId]);
+      await client.query("UPDATE major_prestart_issues SET resolved_at = now() WHERE season_id = $1", [seasonId]);
+      await client.query("COMMIT");
+      console.log(`Major prestart browser fixture committed: ${browserSlug}`);
+    } else {
+      await client.query("ROLLBACK");
+    }
+    console.log("Major prestart local integration passed: selected entrants, final rosters, issue categories, independent 1–32 seeds, confirmation revision, uniqueness, and cascade boundary.");
   } finally {
     client.release();
     await pool.end();

--- a/scripts/db/major-prestart-integration.ts
+++ b/scripts/db/major-prestart-integration.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+
+const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
+const target = new URL(databaseUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(target.hostname)) {
+  throw new Error("Major 赛前集成测试只允许 Local Supabase loopback 数据库。");
+}
+
+let expectedErrorIndex = 0;
+
+async function expectPgError(client: import("pg").PoolClient, work: () => Promise<unknown>, code: string): Promise<void> {
+  const savepoint = `expected_error_${expectedErrorIndex++}`;
+  await client.query(`SAVEPOINT ${savepoint}`);
+  try {
+    await work();
+  } catch (error) {
+    await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: string }).code === code) return;
+    throw error;
+  }
+  throw new Error(`预期 PostgreSQL 错误 ${code}，但操作成功。`);
+}
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 1 });
+  const client = await pool.connect();
+  const seasonId = randomUUID();
+  const teamIds = Array.from({ length: 32 }, () => randomUUID());
+  const applicationIds = Array.from({ length: 32 }, () => randomUUID());
+  const userIds = Array.from({ length: 160 }, () => randomUUID());
+  const memberIds = Array.from({ length: 160 }, () => randomUUID());
+  const entrantId = randomUUID();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO seasons (id, slug, name, kind, registration_mode, has_captain_voting, has_draft, min_team_size, max_team_size)
+       VALUES ($1, $2, 'Local Major Prestart', 'Major', 'team', false, false, 5, 7)`,
+      [seasonId, `local-major-prestart-${seasonId}`],
+    );
+    await client.query(
+      `INSERT INTO users (id, email) SELECT value::uuid, 'prestart-' || value || '@local.test'
+       FROM unnest($1::text[]) AS value`,
+      [userIds],
+    );
+    for (let index = 0; index < 32; index += 1) {
+      await client.query(
+        `INSERT INTO team_applications (id, season_id, name, captain_user_id, status)
+         VALUES ($1, $2, $3, $4, 'approved')`,
+        [applicationIds[index], seasonId, `Team ${index + 1}`, userIds[index * 5]],
+      );
+      await client.query(
+        `INSERT INTO teams (id, season_id, name, captain_user_id, team_application_id)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [teamIds[index], seasonId, `Team ${index + 1}`, userIds[index * 5], applicationIds[index]],
+      );
+      for (let offset = 0; offset < 5; offset += 1) {
+        const userId = userIds[index * 5 + offset];
+        const memberId = memberIds[index * 5 + offset];
+        await client.query(
+          `INSERT INTO team_application_members (id, application_id, user_id, invited_by_user_id, status, confirmed_at)
+           VALUES ($1, $2, $3, $4, 'confirmed', now())`,
+          [memberId, applicationIds[index], userId, userIds[index * 5]],
+        );
+        await client.query(
+          `INSERT INTO team_members (team_id, season_id, user_id, team_application_member_id)
+           VALUES ($1, $2, $3, $4)`,
+          [teamIds[index], seasonId, userId, memberId],
+        );
+      }
+    }
+    await client.query("INSERT INTO major_prestart_states (season_id) VALUES ($1)", [seasonId]);
+    await client.query(
+      "INSERT INTO major_prestart_entrants (id, season_id, team_id) VALUES ($1, $2, $3)",
+      [entrantId, seasonId, teamIds[0]],
+    );
+    await client.query(
+      "INSERT INTO major_prestart_roster_members (entrant_id, user_id) SELECT $1, unnest($2::uuid[])",
+      [entrantId, userIds.slice(0, 5)],
+    );
+    await expectPgError(client, () => client.query(
+      "INSERT INTO major_prestart_entrants (season_id, team_id) VALUES ($1, $2)", [seasonId, teamIds[0]],
+    ), "23505");
+    await expectPgError(client, () => client.query(
+      "INSERT INTO major_prestart_roster_members (entrant_id, user_id) VALUES ($1, $2)", [entrantId, userIds[0]],
+    ), "23505");
+    const before = await client.query<{ selected: string; total: string }>(`
+      SELECT
+        (SELECT count(*) FROM major_prestart_entrants WHERE season_id = $1) AS selected,
+        (SELECT count(*) FROM teams WHERE season_id = $1) AS total
+    `, [seasonId]);
+    if (before.rows[0]?.selected !== "1" || before.rows[0]?.total !== "32") {
+      throw new Error("正式参赛队集合没有与所有正式 teams 保持分离。");
+    }
+    await client.query(
+      "INSERT INTO major_prestart_issues (season_id, category, label) VALUES ($1, 'qualification', '资格材料复核'), ($1, 'administration', '裁判排班')",
+      [seasonId],
+    );
+    const issues = await client.query<{ qualification: string; administration: string }>(`
+      SELECT
+        count(*) FILTER (WHERE category = 'qualification' AND resolved_at IS NULL) AS qualification,
+        count(*) FILTER (WHERE category = 'administration' AND resolved_at IS NULL) AS administration
+      FROM major_prestart_issues WHERE season_id = $1
+    `, [seasonId]);
+    if (issues.rows[0]?.qualification !== "1" || issues.rows[0]?.administration !== "1") {
+      throw new Error("资格与管理事项未按持久化类别保存。");
+    }
+    await client.query("DELETE FROM major_prestart_entrants WHERE id = $1", [entrantId]);
+    const rosterAfterDelete = await client.query<{ count: string }>(
+      "SELECT count(*) FROM major_prestart_roster_members WHERE entrant_id = $1", [entrantId],
+    );
+    if (rosterAfterDelete.rows[0]?.count !== "0") throw new Error("最终名单快照没有随正式参赛队级联删除。");
+    await client.query("ROLLBACK");
+    console.log("Major prestart local integration passed: selected entrants, final rosters, issue categories, uniqueness, and cascade boundary.");
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -10,6 +10,7 @@ import {
   majorPrestartIssues,
   majorPrestartRosterMembers,
   majorPrestartStates,
+  majorTournamentSeeds,
   seasons,
   teamMembers,
   teams,
@@ -275,4 +276,67 @@ export async function lockMajorPrestartEntrants(input: { seasonId: string }): Pr
     revalidateMajorPrestart(season.slug);
     return ok(undefined);
   } catch (error) { return actionError("lockMajorPrestartEntrants", error); }
+}
+
+export async function saveMajorTournamentSeeds(input: { seasonId: string; teamIds: string[] }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, teamIds: z.array(uuid).length(32) }).safeParse(input);
+  if (!parsed.success) return invalid("赛事种子必须提供恰好 32 支队伍。 ");
+  if (new Set(parsed.data.teamIds).size !== 32) return invalid("赛事种子不能包含重复队伍。 ");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const state = await ensureState(tx, season.id);
+      if (!state.entrantsLockedAt) throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "请先锁定正式参赛队和最终赛事名单。 ");
+      const entrants = await tx.select({ id: majorPrestartEntrants.id, teamId: majorPrestartEntrants.teamId }).from(majorPrestartEntrants)
+        .where(eq(majorPrestartEntrants.seasonId, season.id));
+      const entrantsByTeamId = new Map(entrants.map((entrant) => [entrant.teamId, entrant]));
+      if (entrantsByTeamId.size !== 32 || parsed.data.teamIds.some((teamId) => !entrantsByTeamId.has(teamId))) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "赛事种子必须且只能覆盖已锁定的 32 支正式参赛队。 ");
+      }
+      await tx.delete(majorTournamentSeeds).where(eq(majorTournamentSeeds.seasonId, season.id));
+      await tx.insert(majorTournamentSeeds).values(parsed.data.teamIds.map((teamId, index) => ({
+        seasonId: season.id, entrantId: entrantsByTeamId.get(teamId)!.id, tournamentSeed: index + 1,
+      })));
+      await tx.update(majorPrestartStates).set({
+        seedRevision: state.seedRevision + 1,
+        confirmedSeedRevision: null,
+        updatedAt: new Date(),
+      }).where(eq(majorPrestartStates.id, state.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.save_tournament_seeds", actorId: auditActorId(admin),
+        targetId: state.id, targetType: "major_prestart_state", meta: { seedRevision: state.seedRevision + 1 },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("saveMajorTournamentSeeds", error); }
+}
+
+export async function confirmMajorTournamentSeeds(input: { seasonId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const state = await ensureState(tx, season.id);
+      if (!state.entrantsLockedAt) throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "请先锁定正式参赛队和最终赛事名单。 ");
+      if (state.seedRevision < 1) throw new AppError(ErrorCode.VALIDATION_FAILED, "请先保存赛事 1–32 种子排序。 ");
+      const countResult = await tx.execute<{ seed_count: string; team_count: string }>(sql`
+        SELECT count(*) AS seed_count, count(DISTINCT entrant_id) AS team_count
+        FROM major_tournament_seeds WHERE season_id = ${season.id}
+      `);
+      const counts = countResult.rows[0];
+      if (Number(counts?.seed_count) !== 32 || Number(counts?.team_count) !== 32) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "赛事种子不完整，不能确认。 ");
+      }
+      await tx.update(majorPrestartStates).set({ confirmedSeedRevision: state.seedRevision, updatedAt: new Date() })
+        .where(eq(majorPrestartStates.id, state.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.confirm_tournament_seeds", actorId: auditActorId(admin),
+        targetId: state.id, targetType: "major_prestart_state", meta: { seedRevision: state.seedRevision },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("confirmMajorTournamentSeeds", error); }
 }

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -1,0 +1,278 @@
+"use server";
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db/client";
+import {
+  auditLogs,
+  majorPrestartEntrants,
+  majorPrestartIssues,
+  majorPrestartRosterMembers,
+  majorPrestartStates,
+  seasons,
+  teamMembers,
+  teams,
+} from "@/db/schema";
+import { actionError } from "@/lib/action-utils";
+import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { checkStandardMajorCapabilities, normalizeRegistrationConfig, normalizeStagePlan, normalizeTeamRegistrationConfig } from "@/types/season";
+import { fail, ok, type ActionResult } from "@/types/action";
+
+const uuid = z.string().uuid();
+const issueCategory = z.enum(["qualification", "administration"]);
+const rosterInput = z.object({ seasonId: uuid, entrantId: uuid, userIds: z.array(uuid).min(1).max(16) });
+
+function invalid(message: string): ActionResult<never> {
+  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
+}
+
+function standardMajorOrThrow(season: typeof seasons.$inferSelect): void {
+  const result = checkStandardMajorCapabilities({
+    registrationMode: season.registrationMode,
+    hasCaptainVoting: season.hasCaptainVoting,
+    hasDraft: season.hasDraft,
+    stagePlan: normalizeStagePlan(season.stagePlan),
+    registrationConfig: normalizeRegistrationConfig(season.registrationConfig),
+    teamRegistrationConfig: normalizeTeamRegistrationConfig(season.teamRegistrationConfig),
+    minTeamSize: season.minTeamSize,
+    maxTeamSize: season.maxTeamSize,
+    starterCount: season.starterCount,
+    positions: season.positions,
+  });
+  if (!result.isStandardMajor) {
+    throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "当前赛事不是标准 Major，不能管理赛前事实。");
+  }
+}
+
+async function seasonAndAdminOrThrow(seasonId: string) {
+  const season = await db.query.seasons.findFirst({ where: eq(seasons.id, seasonId) });
+  if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+  standardMajorOrThrow(season);
+  return { season, admin: await requireSeasonAdmin(seasonId) };
+}
+
+async function ensureState(tx: Parameters<Parameters<typeof db.transaction>[0]>[0], seasonId: string) {
+  await tx.insert(majorPrestartStates).values({ seasonId }).onConflictDoNothing();
+  const [state] = await tx.select().from(majorPrestartStates)
+    .where(eq(majorPrestartStates.seasonId, seasonId)).for("update");
+  if (!state) throw new AppError(ErrorCode.INTERNAL_ERROR, "赛前状态初始化失败");
+  return state;
+}
+
+function assertEntrantsMutable(state: { entrantsLockedAt: Date | null }): void {
+  if (state.entrantsLockedAt) {
+    throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "正式参赛队和最终名单已经锁定，不能再修改。");
+  }
+}
+
+function revalidateMajorPrestart(seasonSlug: string): void {
+  revalidatePath(`/admin/${seasonSlug}`);
+}
+
+export async function addMajorPrestartEntrant(input: { seasonId: string; teamId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, teamId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季或队伍标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const state = await ensureState(tx, season.id);
+      assertEntrantsMutable(state);
+      const [team] = await tx.select({ id: teams.id }).from(teams)
+        .where(and(eq(teams.id, parsed.data.teamId), eq(teams.seasonId, season.id)));
+      if (!team) throw new AppError(ErrorCode.NOT_FOUND, "该队伍不属于当前赛事。");
+      const existing = await tx.query.majorPrestartEntrants.findFirst({
+        where: and(eq(majorPrestartEntrants.seasonId, season.id), eq(majorPrestartEntrants.teamId, team.id)),
+      });
+      if (existing) return;
+      const members = await tx.select({ userId: teamMembers.userId }).from(teamMembers)
+        .where(and(eq(teamMembers.teamId, team.id), eq(teamMembers.seasonId, season.id)));
+      if (members.length < season.minTeamSize) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, `正式队伍至少需要 ${season.minTeamSize} 名成员才能进入 Major。`);
+      }
+      const [entrant] = await tx.insert(majorPrestartEntrants).values({ seasonId: season.id, teamId: team.id })
+        .returning({ id: majorPrestartEntrants.id });
+      if (!entrant) throw new AppError(ErrorCode.INTERNAL_ERROR, "正式参赛队创建失败。");
+      await tx.insert(majorPrestartRosterMembers).values(members.map((member) => ({ entrantId: entrant.id, userId: member.userId })));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.add_entrant", actorId: auditActorId(admin),
+        targetId: entrant.id, targetType: "major_prestart_entrant", meta: { teamId: team.id, rosterSize: members.length },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("addMajorPrestartEntrant", error); }
+}
+
+export async function removeMajorPrestartEntrant(input: { seasonId: string; entrantId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, entrantId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季或正式参赛队标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      assertEntrantsMutable(await ensureState(tx, season.id));
+      const [entrant] = await tx.select().from(majorPrestartEntrants)
+        .where(and(eq(majorPrestartEntrants.id, parsed.data.entrantId), eq(majorPrestartEntrants.seasonId, season.id)));
+      if (!entrant) throw new AppError(ErrorCode.NOT_FOUND, "正式参赛队不存在。");
+      await tx.delete(majorPrestartEntrants).where(eq(majorPrestartEntrants.id, entrant.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.remove_entrant", actorId: auditActorId(admin),
+        targetId: entrant.id, targetType: "major_prestart_entrant", meta: { teamId: entrant.teamId },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("removeMajorPrestartEntrant", error); }
+}
+
+export async function saveMajorPrestartRoster(input: z.infer<typeof rosterInput>): Promise<ActionResult<void>> {
+  const parsed = rosterInput.safeParse(input);
+  if (!parsed.success) return invalid("最终名单输入无效。");
+  const userIds = [...new Set(parsed.data.userIds)];
+  if (userIds.length !== parsed.data.userIds.length) return invalid("最终名单中不能重复同一位选手。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    if (userIds.length < season.minTeamSize || userIds.length > season.maxTeamSize) {
+      return invalid(`最终名单必须为 ${season.minTeamSize}-${season.maxTeamSize} 人。`);
+    }
+    await db.transaction(async (tx) => {
+      assertEntrantsMutable(await ensureState(tx, season.id));
+      const [entrant] = await tx.select().from(majorPrestartEntrants)
+        .where(and(eq(majorPrestartEntrants.id, parsed.data.entrantId), eq(majorPrestartEntrants.seasonId, season.id)));
+      if (!entrant) throw new AppError(ErrorCode.NOT_FOUND, "正式参赛队不存在。");
+      const formalMembers = await tx.select({ userId: teamMembers.userId }).from(teamMembers)
+        .where(and(eq(teamMembers.teamId, entrant.teamId), eq(teamMembers.seasonId, season.id), inArray(teamMembers.userId, userIds)));
+      if (formalMembers.length !== userIds.length) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "最终名单只能选择该正式队伍当前的成员。 ");
+      }
+      await tx.delete(majorPrestartRosterMembers).where(eq(majorPrestartRosterMembers.entrantId, entrant.id));
+      await tx.insert(majorPrestartRosterMembers).values(userIds.map((userId) => ({ entrantId: entrant.id, userId })));
+      await tx.update(majorPrestartEntrants).set({ rosterConfirmedAt: null, rosterConfirmedBy: null, updatedAt: new Date() })
+        .where(eq(majorPrestartEntrants.id, entrant.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.save_roster", actorId: auditActorId(admin),
+        targetId: entrant.id, targetType: "major_prestart_entrant", meta: { rosterSize: userIds.length },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("saveMajorPrestartRoster", error); }
+}
+
+export async function confirmMajorPrestartRoster(input: { seasonId: string; entrantId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, entrantId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季或正式参赛队标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      assertEntrantsMutable(await ensureState(tx, season.id));
+      const [entrant] = await tx.select().from(majorPrestartEntrants)
+        .where(and(eq(majorPrestartEntrants.id, parsed.data.entrantId), eq(majorPrestartEntrants.seasonId, season.id)));
+      if (!entrant) throw new AppError(ErrorCode.NOT_FOUND, "正式参赛队不存在。");
+      const roster = await tx.select({ userId: majorPrestartRosterMembers.userId }).from(majorPrestartRosterMembers)
+        .where(eq(majorPrestartRosterMembers.entrantId, entrant.id));
+      if (roster.length < season.minTeamSize || roster.length > season.maxTeamSize) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "最终名单人数不符合赛事规则，不能确认。");
+      }
+      const duplicate = await tx.execute(sql`
+        SELECT r.user_id FROM major_prestart_roster_members r
+        INNER JOIN major_prestart_entrants e ON e.id = r.entrant_id
+        WHERE e.season_id = ${season.id}
+        GROUP BY r.user_id HAVING count(*) > 1 LIMIT 1
+      `);
+      if (duplicate.rows.length > 0) throw new AppError(ErrorCode.VALIDATION_FAILED, "同一选手不能同时出现在多支正式参赛队的最终名单中。");
+      await tx.update(majorPrestartEntrants).set({ rosterConfirmedAt: new Date(), rosterConfirmedBy: auditActorId(admin), updatedAt: new Date() })
+        .where(eq(majorPrestartEntrants.id, entrant.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.confirm_roster", actorId: auditActorId(admin),
+        targetId: entrant.id, targetType: "major_prestart_entrant", meta: { rosterSize: roster.length },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("confirmMajorPrestartRoster", error); }
+}
+
+export async function addMajorPrestartIssue(input: { seasonId: string; category: "qualification" | "administration"; label: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, category: issueCategory, label: z.string().trim().min(1).max(240) }).safeParse(input);
+  if (!parsed.success) return invalid("待处理事项输入无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const state = await ensureState(tx, season.id);
+      assertEntrantsMutable(state);
+      const [issue] = await tx.insert(majorPrestartIssues).values({ ...parsed.data }).returning({ id: majorPrestartIssues.id });
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.add_issue", actorId: auditActorId(admin),
+        targetId: issue?.id, targetType: "major_prestart_issue", meta: { category: parsed.data.category },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("addMajorPrestartIssue", error); }
+}
+
+export async function resolveMajorPrestartIssue(input: { seasonId: string; issueId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid, issueId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季或事项标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const [issue] = await tx.select().from(majorPrestartIssues)
+        .where(and(eq(majorPrestartIssues.id, parsed.data.issueId), eq(majorPrestartIssues.seasonId, season.id)));
+      if (!issue) throw new AppError(ErrorCode.NOT_FOUND, "待处理事项不存在。");
+      await tx.update(majorPrestartIssues).set({ resolvedAt: new Date(), resolvedBy: auditActorId(admin), updatedAt: new Date() })
+        .where(eq(majorPrestartIssues.id, issue.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.resolve_issue", actorId: auditActorId(admin),
+        targetId: issue.id, targetType: "major_prestart_issue", meta: { category: issue.category },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("resolveMajorPrestartIssue", error); }
+}
+
+export async function lockMajorPrestartEntrants(input: { seasonId: string }): Promise<ActionResult<void>> {
+  const parsed = z.object({ seasonId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛季标识无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    await db.transaction(async (tx) => {
+      const state = await ensureState(tx, season.id);
+      if (state.entrantsLockedAt) return;
+      const entrants = await tx.select({ id: majorPrestartEntrants.id, confirmedAt: majorPrestartEntrants.rosterConfirmedAt })
+        .from(majorPrestartEntrants).where(eq(majorPrestartEntrants.seasonId, season.id));
+      if (entrants.length !== 32) throw new AppError(ErrorCode.VALIDATION_FAILED, "锁定前必须恰好选择 32 支正式参赛队。 ");
+      if (entrants.some((entrant) => !entrant.confirmedAt)) throw new AppError(ErrorCode.VALIDATION_FAILED, "所有正式参赛队必须先确认最终赛事名单。 ");
+      const rosterCounts = await tx.execute(sql`
+        SELECT entrant_id, count(*)::int AS count FROM major_prestart_roster_members
+        WHERE entrant_id IN (${sql.join(entrants.map((entrant) => sql`${entrant.id}`), sql`, `)})
+        GROUP BY entrant_id
+      `);
+      if (rosterCounts.rows.length !== entrants.length || rosterCounts.rows.some((row) => Number(row.count) < season.minTeamSize || Number(row.count) > season.maxTeamSize)) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "存在不符合人数规则的最终赛事名单。 ");
+      }
+      const duplicate = await tx.execute(sql`
+        SELECT r.user_id FROM major_prestart_roster_members r
+        INNER JOIN major_prestart_entrants e ON e.id = r.entrant_id
+        WHERE e.season_id = ${season.id}
+        GROUP BY r.user_id HAVING count(*) > 1 LIMIT 1
+      `);
+      if (duplicate.rows.length > 0) throw new AppError(ErrorCode.VALIDATION_FAILED, "最终赛事名单存在重复选手。 ");
+      const unresolved = await tx.query.majorPrestartIssues.findFirst({
+        where: and(eq(majorPrestartIssues.seasonId, season.id), sql`${majorPrestartIssues.resolvedAt} IS NULL`),
+      });
+      if (unresolved) throw new AppError(ErrorCode.VALIDATION_FAILED, "请先处理所有资格和管理事项。 ");
+      await tx.update(majorPrestartStates).set({ entrantsLockedAt: new Date(), entrantsLockedBy: auditActorId(admin), updatedAt: new Date() })
+        .where(eq(majorPrestartStates.id, state.id));
+      await tx.insert(auditLogs).values({
+        seasonId: season.id, action: "major_prestart.lock_entrants", actorId: auditActorId(admin),
+        targetId: state.id, targetType: "major_prestart_state", meta: { entrantCount: entrants.length },
+      });
+    });
+    revalidateMajorPrestart(season.slug);
+    return ok(undefined);
+  } catch (error) { return actionError("lockMajorPrestartEntrants", error); }
+}

--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -1,8 +1,17 @@
 import { notFound } from "next/navigation";
-import { asc, eq, inArray } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { MajorPrestartConsole } from "@/components/admin/MajorPrestartConsole";
 import { db } from "@/db/client";
-import { seasons, teamMembers, teams } from "@/db/schema";
+import {
+  majorPrestartEntrants,
+  majorPrestartIssues,
+  majorPrestartRosterMembers,
+  majorPrestartStates,
+  seasons,
+  teamMembers,
+  teams,
+  users,
+} from "@/db/schema";
 import { evaluateMajorPrestartReadiness } from "@/lib/major/prestart";
 import {
   normalizeRegistrationConfig,
@@ -14,10 +23,6 @@ interface AdminMajorConsolePageProps {
   params: Promise<{ seasonSlug: string }>;
 }
 
-/**
- * 现有 schema 只拥有队伍和正式名单；确认、资格、管理事项和赛事种子尚无
- * 持久化来源。因此明确以 null 交给领域层，避免空数组被误读为“没有问题”。
- */
 export default async function AdminMajorConsolePage({ params }: AdminMajorConsolePageProps) {
   const { seasonSlug } = await params;
   const season = await db.query.seasons.findFirst({
@@ -28,20 +33,46 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
   const seasonTeams = await db.query.teams.findMany({
     where: eq(teams.seasonId, season.id),
     orderBy: [asc(teams.createdAt)],
-    columns: { id: true },
+    columns: { id: true, name: true },
   });
   const teamIds = seasonTeams.map((team) => team.id);
-  const members = teamIds.length === 0
-    ? []
-    : await db
-      .select({ teamId: teamMembers.teamId, playerId: teamMembers.userId })
-      .from(teamMembers)
-      .where(inArray(teamMembers.teamId, teamIds));
-  const playerIdsByTeam = new Map<string, string[]>();
-  for (const member of members) {
-    const playerIds = playerIdsByTeam.get(member.teamId) ?? [];
-    playerIds.push(member.playerId);
-    playerIdsByTeam.set(member.teamId, playerIds);
+  const formalMembers = teamIds.length === 0 ? [] : await db
+    .select({ teamId: teamMembers.teamId, userId: teamMembers.userId, email: users.email })
+    .from(teamMembers)
+    .innerJoin(users, eq(teamMembers.userId, users.id))
+    .where(eq(teamMembers.seasonId, season.id));
+  const candidatesByTeam = new Map<string, Array<{ userId: string; email: string }>>();
+  for (const member of formalMembers) {
+    const candidates = candidatesByTeam.get(member.teamId) ?? [];
+    candidates.push({ userId: member.userId, email: member.email });
+    candidatesByTeam.set(member.teamId, candidates);
+  }
+
+  const [state, entrantRows, rosterRows, issueRows] = await Promise.all([
+    db.query.majorPrestartStates.findFirst({ where: eq(majorPrestartStates.seasonId, season.id) }),
+    db.select({
+      id: majorPrestartEntrants.id,
+      teamId: majorPrestartEntrants.teamId,
+      teamName: teams.name,
+      rosterConfirmedAt: majorPrestartEntrants.rosterConfirmedAt,
+    }).from(majorPrestartEntrants)
+      .innerJoin(teams, eq(majorPrestartEntrants.teamId, teams.id))
+      .where(eq(majorPrestartEntrants.seasonId, season.id))
+      .orderBy(asc(teams.name)),
+    db.select({ entrantId: majorPrestartRosterMembers.entrantId, userId: majorPrestartRosterMembers.userId, email: users.email })
+      .from(majorPrestartRosterMembers)
+      .innerJoin(users, eq(majorPrestartRosterMembers.userId, users.id)),
+    db.select().from(majorPrestartIssues)
+      .where(eq(majorPrestartIssues.seasonId, season.id))
+      .orderBy(asc(majorPrestartIssues.createdAt)),
+  ]);
+  const entrantIds = new Set(entrantRows.map((entrant) => entrant.id));
+  const rosterByEntrant = new Map<string, Array<{ userId: string; email: string }>>();
+  for (const member of rosterRows) {
+    if (!entrantIds.has(member.entrantId)) continue;
+    const roster = rosterByEntrant.get(member.entrantId) ?? [];
+    roster.push({ userId: member.userId, email: member.email });
+    rosterByEntrant.set(member.entrantId, roster);
   }
 
   const readiness = evaluateMajorPrestartReadiness({
@@ -57,16 +88,35 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
       starterCount: season.starterCount,
       positions: season.positions,
     },
-    teams: seasonTeams.map((team) => ({
-      teamId: team.id,
-      playerIds: playerIdsByTeam.get(team.id) ?? [],
+    teams: entrantRows.map((entrant) => ({
+      teamId: entrant.teamId,
+      playerIds: (rosterByEntrant.get(entrant.id) ?? []).map((member) => member.userId),
     })),
-    confirmations: null,
-    qualificationIssues: null,
-    administrativeIssues: null,
+    entrantsLocked: Boolean(state?.entrantsLockedAt),
+    confirmations: entrantRows.map((entrant) => ({ teamId: entrant.teamId, confirmed: Boolean(entrant.rosterConfirmedAt) })),
+    qualificationIssues: issueRows.filter((issue) => issue.category === "qualification").map((issue) => ({ label: issue.label, resolved: Boolean(issue.resolvedAt) })),
+    administrativeIssues: issueRows.filter((issue) => issue.category === "administration").map((issue) => ({ label: issue.label, resolved: Boolean(issue.resolvedAt) })),
     tournamentSeeds: null,
-    reconfirmations: null,
+    seedConfirmation: null,
   });
 
-  return <MajorPrestartConsole seasonName={season.name} readiness={readiness} />;
+  return <MajorPrestartConsole
+    seasonName={season.name}
+    readiness={readiness}
+    management={{
+      seasonId: season.id,
+      entrantsLocked: Boolean(state?.entrantsLockedAt),
+      availableTeams: seasonTeams.filter((team) => !entrantRows.some((entrant) => entrant.teamId === team.id)).map((team) => ({
+        id: team.id,
+        name: team.name,
+        members: candidatesByTeam.get(team.id) ?? [],
+      })),
+      entrants: entrantRows.map((entrant) => ({
+        ...entrant,
+        roster: rosterByEntrant.get(entrant.id) ?? [],
+        candidates: candidatesByTeam.get(entrant.teamId) ?? [],
+      })),
+      issues: issueRows.map((issue) => ({ id: issue.id, category: issue.category, label: issue.label, resolved: Boolean(issue.resolvedAt) })),
+    }}
+  />;
 }

--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -7,12 +7,14 @@ import {
   majorPrestartIssues,
   majorPrestartRosterMembers,
   majorPrestartStates,
+  majorTournamentSeeds,
   seasons,
   teamMembers,
   teams,
   users,
 } from "@/db/schema";
 import { evaluateMajorPrestartReadiness } from "@/lib/major/prestart";
+import { buildMajorOpeningPlan } from "@/lib/major/opening";
 import {
   normalizeRegistrationConfig,
   normalizeStagePlan,
@@ -48,7 +50,7 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     candidatesByTeam.set(member.teamId, candidates);
   }
 
-  const [state, entrantRows, rosterRows, issueRows] = await Promise.all([
+  const [state, entrantRows, rosterRows, issueRows, seedRows] = await Promise.all([
     db.query.majorPrestartStates.findFirst({ where: eq(majorPrestartStates.seasonId, season.id) }),
     db.select({
       id: majorPrestartEntrants.id,
@@ -65,6 +67,11 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     db.select().from(majorPrestartIssues)
       .where(eq(majorPrestartIssues.seasonId, season.id))
       .orderBy(asc(majorPrestartIssues.createdAt)),
+    db.select({ teamId: majorPrestartEntrants.teamId, tournamentSeed: majorTournamentSeeds.tournamentSeed })
+      .from(majorTournamentSeeds)
+      .innerJoin(majorPrestartEntrants, eq(majorTournamentSeeds.entrantId, majorPrestartEntrants.id))
+      .where(eq(majorTournamentSeeds.seasonId, season.id))
+      .orderBy(asc(majorTournamentSeeds.tournamentSeed)),
   ]);
   const entrantIds = new Set(entrantRows.map((entrant) => entrant.id));
   const rosterByEntrant = new Map<string, Array<{ userId: string; email: string }>>();
@@ -96,9 +103,14 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     confirmations: entrantRows.map((entrant) => ({ teamId: entrant.teamId, confirmed: Boolean(entrant.rosterConfirmedAt) })),
     qualificationIssues: issueRows.filter((issue) => issue.category === "qualification").map((issue) => ({ label: issue.label, resolved: Boolean(issue.resolvedAt) })),
     administrativeIssues: issueRows.filter((issue) => issue.category === "administration").map((issue) => ({ label: issue.label, resolved: Boolean(issue.resolvedAt) })),
-    tournamentSeeds: null,
-    seedConfirmation: null,
+    tournamentSeeds: seedRows,
+    seedConfirmation: state ? { seedRevision: state.seedRevision, confirmedSeedRevision: state.confirmedSeedRevision } : null,
   });
+  const stageOneMatchFormat = normalizeStagePlan(season.stagePlan)[0]?.matchFormat;
+  let seedPreview: ReturnType<typeof buildMajorOpeningPlan> | null = null;
+  if (seedRows.length === 32 && (stageOneMatchFormat === "bo1" || stageOneMatchFormat === "bo3")) {
+    try { seedPreview = buildMajorOpeningPlan({ teams: seedRows, stageOneMatchFormat }); } catch { seedPreview = null; }
+  }
 
   return <MajorPrestartConsole
     seasonName={season.name}
@@ -117,6 +129,19 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
         candidates: candidatesByTeam.get(entrant.teamId) ?? [],
       })),
       issues: issueRows.map((issue) => ({ id: issue.id, category: issue.category, label: issue.label, resolved: Boolean(issue.resolvedAt) })),
+    }}
+    seedManagement={{
+      seasonId: season.id,
+      entrantsLocked: Boolean(state?.entrantsLockedAt),
+      entrants: entrantRows.map((entrant) => ({ teamId: entrant.teamId, teamName: entrant.teamName })),
+      seeds: seedRows,
+      seedRevision: state?.seedRevision ?? 0,
+      confirmedSeedRevision: state?.confirmedSeedRevision ?? null,
+      firstRound: seedPreview?.firstRound.pairings.map((pairing) => ({
+        higherSeed: pairing.higherSeed.tournamentSeed,
+        lowerSeed: pairing.lowerSeed.tournamentSeed,
+        format: pairing.format,
+      })) ?? null,
     }}
   />;
 }

--- a/src/components/admin/MajorPrestartConsole.tsx
+++ b/src/components/admin/MajorPrestartConsole.tsx
@@ -1,5 +1,6 @@
 import { Marker, Panel } from "@/components/rivalhub";
 import type { MajorPrestartReadiness } from "@/lib/major/prestart";
+import { MajorPrestartManagement, type MajorPrestartManagementData } from "./MajorPrestartManagement";
 
 const STATE_LABEL = {
   ready: "已就绪",
@@ -16,9 +17,11 @@ const STATE_CLASS = {
 export function MajorPrestartConsole({
   seasonName,
   readiness,
+  management,
 }: {
   seasonName: string;
   readiness: MajorPrestartReadiness;
+  management: MajorPrestartManagementData;
 }) {
   return (
     <div className="space-y-6">
@@ -27,7 +30,7 @@ export function MajorPrestartConsole({
           赛事控制台 · {seasonName}
         </Marker>
         <p className="text-sm text-[var(--color-fg-mid)]">
-          只读赛前检查；本页不启动赛事、不创建对阵，也不修改任何赛事数据。
+          赛前事实与种子独立管理；本页不会启动赛事，也不会创建对阵。
         </p>
       </div>
 
@@ -55,6 +58,8 @@ export function MajorPrestartConsole({
           ))}
         </div>
       </Panel>
+
+      <MajorPrestartManagement data={management} />
 
       <Panel label="阶段一首轮预览">
         {readiness.openingPlan ? (

--- a/src/components/admin/MajorPrestartConsole.tsx
+++ b/src/components/admin/MajorPrestartConsole.tsx
@@ -1,6 +1,7 @@
 import { Marker, Panel } from "@/components/rivalhub";
 import type { MajorPrestartReadiness } from "@/lib/major/prestart";
 import { MajorPrestartManagement, type MajorPrestartManagementData } from "./MajorPrestartManagement";
+import { MajorTournamentSeedsManagement, type MajorTournamentSeedsManagementData } from "./MajorTournamentSeedsManagement";
 
 const STATE_LABEL = {
   ready: "已就绪",
@@ -18,10 +19,12 @@ export function MajorPrestartConsole({
   seasonName,
   readiness,
   management,
+  seedManagement,
 }: {
   seasonName: string;
   readiness: MajorPrestartReadiness;
   management: MajorPrestartManagementData;
+  seedManagement: MajorTournamentSeedsManagementData;
 }) {
   return (
     <div className="space-y-6">
@@ -60,6 +63,7 @@ export function MajorPrestartConsole({
       </Panel>
 
       <MajorPrestartManagement data={management} />
+      <MajorTournamentSeedsManagement data={seedManagement} />
 
       <Panel label="阶段一首轮预览">
         {readiness.openingPlan ? (

--- a/src/components/admin/MajorPrestartManagement.tsx
+++ b/src/components/admin/MajorPrestartManagement.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+  addMajorPrestartEntrant,
+  addMajorPrestartIssue,
+  confirmMajorPrestartRoster,
+  lockMajorPrestartEntrants,
+  removeMajorPrestartEntrant,
+  resolveMajorPrestartIssue,
+  saveMajorPrestartRoster,
+} from "@/actions/major-prestart";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Marker, Panel } from "@/components/rivalhub";
+import type { ActionResult } from "@/types/action";
+
+export interface MajorPrestartManagementData {
+  seasonId: string;
+  entrantsLocked: boolean;
+  availableTeams: Array<{ id: string; name: string; members: Array<{ userId: string; email: string }> }>;
+  entrants: Array<{
+    id: string;
+    teamId: string;
+    teamName: string;
+    rosterConfirmedAt: Date | null;
+    roster: Array<{ userId: string; email: string }>;
+    candidates: Array<{ userId: string; email: string }>;
+  }>;
+  issues: Array<{ id: string; category: "qualification" | "administration"; label: string; resolved: boolean }>;
+}
+
+async function showResult(work: () => Promise<ActionResult<void>>, success: string): Promise<void> {
+  const result = await work();
+  if (!result.success) toast.error(result.error.message);
+  else toast.success(success);
+}
+
+function EntrantRoster({ entrant, seasonId, locked }: {
+  entrant: MajorPrestartManagementData["entrants"][number]; seasonId: string; locked: boolean;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const initial = useMemo(() => entrant.roster.map((member) => member.userId), [entrant.roster]);
+  const [selected, setSelected] = useState(initial);
+  const toggle = (userId: string) => setSelected((current) => current.includes(userId)
+    ? current.filter((id) => id !== userId)
+    : [...current, userId]);
+
+  return (
+    <article className="rounded-md border border-[var(--color-border)] p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-medium text-[var(--color-fg)]">{entrant.teamName}</h3>
+        <span className={`text-xs ${entrant.rosterConfirmedAt ? "text-emerald-700" : "text-amber-800"}`}>
+          {entrant.rosterConfirmedAt ? "名单已确认" : "待确认名单"}
+        </span>
+      </div>
+      <fieldset className="mt-2 grid gap-1 text-sm text-[var(--color-fg-mid)]" disabled={locked || isPending}>
+        <legend className="sr-only">{entrant.teamName} 最终赛事名单</legend>
+        {entrant.candidates.map((candidate) => <label key={candidate.userId} className="flex items-center gap-2">
+          <input type="checkbox" checked={selected.includes(candidate.userId)} onChange={() => toggle(candidate.userId)} />
+          {candidate.email}
+        </label>)}
+      </fieldset>
+      {!locked && <div className="mt-3 flex flex-wrap gap-2">
+        <Button size="sm" variant="outline" disabled={isPending} onClick={() => startTransition(() => void showResult(
+          () => saveMajorPrestartRoster({ seasonId, entrantId: entrant.id, userIds: selected }), "最终名单已保存，需重新确认",
+        ))}>保存最终名单</Button>
+        <Button size="sm" disabled={isPending} onClick={() => startTransition(() => void showResult(
+          () => confirmMajorPrestartRoster({ seasonId, entrantId: entrant.id }), "最终名单已确认",
+        ))}>确认名单</Button>
+      </div>}
+    </article>
+  );
+}
+
+export function MajorPrestartManagement({ data }: { data: MajorPrestartManagementData }) {
+  const [isPending, startTransition] = useTransition();
+  const [teamId, setTeamId] = useState(data.availableTeams[0]?.id ?? "");
+  const [issueLabel, setIssueLabel] = useState("");
+  const [issueCategory, setIssueCategory] = useState<"qualification" | "administration">("qualification");
+  const locked = data.entrantsLocked;
+
+  return <div className="space-y-6">
+    <Panel label="赛前准备生命周期">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div><Marker sub={locked ? "正式参赛队与最终名单已锁定" : "可调整正式参赛队与最终名单"}>
+          {locked ? "已锁定正式参赛队" : "准备正式参赛队"}
+        </Marker><p className="mt-1 text-sm text-[var(--color-fg-mid)]">锁定后，本页不能再修改正式参赛队、最终赛事名单或事项；下一步是独立保存并确认 1–32 种子。</p></div>
+        {!locked && <Button disabled={isPending} onClick={() => startTransition(() => void showResult(
+          () => lockMajorPrestartEntrants({ seasonId: data.seasonId }), "正式参赛队和最终赛事名单已锁定",
+        ))}>锁定正式参赛队</Button>}
+      </div>
+    </Panel>
+
+    <Panel label={`正式参赛队 (${data.entrants.length}/32)`}>
+      {!locked && <div className="mb-4 flex flex-wrap gap-2">
+        <select value={teamId} onChange={(event) => setTeamId(event.target.value)} className="min-w-48 rounded border border-[var(--color-border)] bg-white px-3 py-2 text-sm">
+          <option value="">选择已审核正式队伍</option>
+          {data.availableTeams.map((team) => <option key={team.id} value={team.id}>{team.name}（{team.members.length} 人）</option>)}
+        </select>
+        <Button disabled={isPending || !teamId} onClick={() => startTransition(() => void showResult(
+          () => addMajorPrestartEntrant({ seasonId: data.seasonId, teamId }), "已加入正式参赛队集合",
+        ))}>加入正式参赛队</Button>
+      </div>}
+      {data.entrants.length === 0 ? <p className="text-sm text-[var(--color-fg-mid)]">尚未选择正式参赛队。所有已审核 teams 不会自动成为 Major 参赛队。</p> : <div className="grid gap-3 md:grid-cols-2">
+        {data.entrants.map((entrant) => <div key={entrant.id} className="space-y-2"><EntrantRoster entrant={entrant} seasonId={data.seasonId} locked={locked} />
+          {!locked && <Button size="sm" variant="ghost" disabled={isPending} onClick={() => startTransition(() => void showResult(
+            () => removeMajorPrestartEntrant({ seasonId: data.seasonId, entrantId: entrant.id }), "已移出正式参赛队集合",
+          ))}>移出正式参赛队</Button>}</div>)}
+      </div>}
+    </Panel>
+
+    <Panel label="资格 blocker 与管理事项">
+      {!locked && <form className="mb-4 flex flex-wrap gap-2" onSubmit={(event) => { event.preventDefault(); startTransition(() => void showResult(async () => {
+        const result = await addMajorPrestartIssue({ seasonId: data.seasonId, category: issueCategory, label: issueLabel });
+        if (result.success) setIssueLabel("");
+        return result;
+      }, "赛前事项已记录")); }}>
+        <select value={issueCategory} onChange={(event) => setIssueCategory(event.target.value as typeof issueCategory)} className="rounded border border-[var(--color-border)] bg-white px-3 py-2 text-sm"><option value="qualification">资格事项</option><option value="administration">管理事项</option></select>
+        <Input value={issueLabel} onChange={(event) => setIssueLabel(event.target.value)} placeholder="例如：资格材料复核" className="max-w-sm" />
+        <Button type="submit" disabled={isPending || !issueLabel.trim()}>添加事项</Button>
+      </form>}
+      {data.issues.length === 0 ? <p className="text-sm text-[var(--color-fg-mid)]">尚未记录待处理事项。</p> : <ul className="space-y-2 text-sm">{data.issues.map((issue) => <li key={issue.id} className="flex flex-wrap items-center justify-between gap-2 rounded border border-[var(--color-border)] px-3 py-2"><span>{issue.category === "qualification" ? "资格" : "管理"} · {issue.label} · <span className={issue.resolved ? "text-emerald-700" : "text-amber-800"}>{issue.resolved ? "已处理" : "未处理"}</span></span>{!locked && !issue.resolved && <Button size="sm" variant="outline" disabled={isPending} onClick={() => startTransition(() => void showResult(() => resolveMajorPrestartIssue({ seasonId: data.seasonId, issueId: issue.id }), "事项已标记为已处理"))}>标记已处理</Button>}</li>)}</ul>}
+    </Panel>
+  </div>;
+}

--- a/src/components/admin/MajorTournamentSeedsManagement.tsx
+++ b/src/components/admin/MajorTournamentSeedsManagement.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { confirmMajorTournamentSeeds, saveMajorTournamentSeeds } from "@/actions/major-prestart";
+import { Button } from "@/components/ui/button";
+import { Marker, Panel } from "@/components/rivalhub";
+
+export interface MajorTournamentSeedsManagementData {
+  seasonId: string;
+  entrantsLocked: boolean;
+  entrants: Array<{ teamId: string; teamName: string }>;
+  seeds: Array<{ teamId: string; tournamentSeed: number }>;
+  seedRevision: number;
+  confirmedSeedRevision: number | null;
+  firstRound: Array<{ higherSeed: number; lowerSeed: number; format: "bo1" | "bo3" }> | null;
+}
+
+export function MajorTournamentSeedsManagement({ data }: { data: MajorTournamentSeedsManagementData }) {
+  const [isPending, startTransition] = useTransition();
+  const saved = [...data.seeds].sort((a, b) => a.tournamentSeed - b.tournamentSeed).map((seed) => seed.teamId);
+  const initialOrderKey = (saved.length === 32 ? saved : [...data.entrants]
+    .sort((a, b) => a.teamName.localeCompare(b.teamName))
+    .map((entrant) => entrant.teamId)).join(",");
+  const [order, setOrder] = useState(() => initialOrderKey ? initialOrderKey.split(",") : []);
+  useEffect(() => setOrder(initialOrderKey ? initialOrderKey.split(",") : []), [initialOrderKey]);
+  const teamById = new Map(data.entrants.map((entrant) => [entrant.teamId, entrant]));
+  const confirmed = data.seedRevision > 0 && data.seedRevision === data.confirmedSeedRevision;
+  const move = (index: number, offset: -1 | 1) => setOrder((current) => {
+    const next = index + offset;
+    if (next < 0 || next >= current.length) return current;
+    const copy = [...current];
+    [copy[index], copy[next]] = [copy[next]!, copy[index]!];
+    return copy;
+  });
+
+  return <Panel label="赛事 1–32 种子">
+    {!data.entrantsLocked ? <p className="text-sm text-[var(--color-fg-mid)]">请先锁定正式参赛队和最终赛事名单，种子才能保存。</p> : <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div><Marker sub={confirmed ? "当前排序已确认" : data.seedRevision > 0 ? "排序已变更，需要重新确认" : "尚未保存排序"}>{confirmed ? "种子已确认" : "种子待确认"}</Marker>
+          <p className="mt-1 text-sm text-[var(--color-fg-mid)]">这是独立 tournament seed，不使用蛇形选秀的 <code>teams.draftOrder</code>。保存排序会使此前确认失效。</p></div>
+        <div className="flex gap-2"><Button variant="outline" disabled={isPending || order.length !== 32} onClick={() => startTransition(async () => {
+          const result = await saveMajorTournamentSeeds({ seasonId: data.seasonId, teamIds: order });
+          if (!result.success) toast.error(result.error.message); else toast.success("1–32 种子已保存，需重新确认");
+        })}>保存排序</Button><Button disabled={isPending || confirmed || data.seedRevision < 1} onClick={() => startTransition(async () => {
+          const result = await confirmMajorTournamentSeeds({ seasonId: data.seasonId });
+          if (!result.success) toast.error(result.error.message); else toast.success("赛事种子已确认");
+        })}>确认种子</Button></div>
+      </div>
+
+      <ol className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">{order.map((teamId, index) => <li key={teamId} className="flex items-center gap-2 rounded border border-[var(--color-border)] px-2 py-1.5 text-sm"><span className="w-8 font-mono text-[var(--color-fg-mid)]">#{index + 1}</span><span className="min-w-0 flex-1 truncate">{teamById.get(teamId)?.teamName ?? teamId}</span><div className="flex gap-1"><Button size="sm" variant="ghost" disabled={isPending || index === 0} onClick={() => move(index, -1)}>↑</Button><Button size="sm" variant="ghost" disabled={isPending || index === order.length - 1} onClick={() => move(index, 1)}>↓</Button></div></li>)}</ol>
+
+      {data.seeds.length === 32 ? <div className="grid gap-3 lg:grid-cols-3">
+        <SeedCohort label="Stage 3 · #1–8" seeds={data.seeds.filter((seed) => seed.tournamentSeed <= 8)} teams={teamById} />
+        <SeedCohort label="Stage 2 · #9–16" seeds={data.seeds.filter((seed) => seed.tournamentSeed >= 9 && seed.tournamentSeed <= 16)} teams={teamById} />
+        <SeedCohort label="Stage 1 · #17–32" seeds={data.seeds.filter((seed) => seed.tournamentSeed >= 17)} teams={teamById} />
+      </div> : <p className="text-sm text-[var(--color-fg-mid)]">保存后将按 Stage 3 #1–8、Stage 2 #9–16、Stage 1 #17–32 展示入场批次。</p>}
+
+      <section><h3 className="font-medium text-[var(--color-fg)]">Stage 1 R1 预览</h3>{data.firstRound ? <ol className="mt-2 grid gap-2 text-sm md:grid-cols-2">{data.firstRound.map((pairing) => <li key={`${pairing.higherSeed}-${pairing.lowerSeed}`} className="rounded border border-[var(--color-border)] px-3 py-2">#{pairing.higherSeed} {teamById.get(data.seeds.find((seed) => seed.tournamentSeed === pairing.higherSeed)?.teamId ?? "")?.teamName} vs #{pairing.lowerSeed} {teamById.get(data.seeds.find((seed) => seed.tournamentSeed === pairing.lowerSeed)?.teamId ?? "")?.teamName} · {pairing.format.toUpperCase()}</li>)}</ol> : <p className="mt-1 text-sm text-[var(--color-fg-mid)]">需先保存完整种子才能构造预览。</p>}<p className="mt-2 text-sm text-[var(--color-fg-mid)]">此预览来自 <code>buildMajorOpeningPlan()</code>；尚未创建比赛或对阵记录。</p></section>
+    </div>}
+  </Panel>;
+}
+
+function SeedCohort({ label, seeds, teams }: { label: string; seeds: MajorTournamentSeedsManagementData["seeds"]; teams: Map<string, { teamId: string; teamName: string }> }) {
+  return <section className="rounded border border-[var(--color-border)] p-3"><h3 className="font-medium text-[var(--color-fg)]">{label}</h3><ol className="mt-2 space-y-1 text-sm text-[var(--color-fg-mid)]">{[...seeds].sort((a, b) => a.tournamentSeed - b.tournamentSeed).map((seed) => <li key={seed.teamId}>#{seed.tournamentSeed} {teams.get(seed.teamId)?.teamName}</li>)}</ol></section>;
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -4,6 +4,7 @@ export * from "./registrations";
 export * from "./registration-drafts";
 export * from "./teams";
 export * from "./team-applications";
+export * from "./major-prestart";
 export * from "./votes";
 export * from "./draft";
 export * from "./matches";

--- a/src/db/schema/major-prestart.ts
+++ b/src/db/schema/major-prestart.ts
@@ -1,0 +1,79 @@
+import {
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { seasons } from "./seasons";
+import { teams } from "./teams";
+import { users } from "./users";
+
+export const majorPrestartIssueCategoryEnum = pgEnum("major_prestart_issue_category", [
+  "qualification",
+  "administration",
+]);
+
+/**
+ * Per-season lifecycle facts. The lack of a row means the Major has not yet
+ * entered prestart preparation; actions materialize it before changing facts.
+ */
+export const majorPrestartStates = pgTable("major_prestart_states", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().unique().references(() => seasons.id),
+  entrantsLockedAt: timestamp("entrants_locked_at", { withTimezone: true }),
+  entrantsLockedBy: text("entrants_locked_by"),
+  /** Incremented whenever the saved tournament order changes. */
+  seedRevision: integer("seed_revision").notNull().default(0),
+  /** Equal to seedRevision only after an administrator explicitly reconfirms it. */
+  confirmedSeedRevision: integer("confirmed_seed_revision"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+/** The selected official participant set; it is not inferred from all teams. */
+export const majorPrestartEntrants = pgTable("major_prestart_entrants", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  teamId: uuid("team_id").notNull().references(() => teams.id),
+  rosterConfirmedAt: timestamp("roster_confirmed_at", { withTimezone: true }),
+  rosterConfirmedBy: text("roster_confirmed_by"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  uniqueSeasonTeam: unique("major_prestart_entrants_season_team_unique").on(t.seasonId, t.teamId),
+  seasonIndex: index("major_prestart_entrants_season_idx").on(t.seasonId),
+}));
+
+/** Immutable-after-lock tournament roster snapshot, distinct from match_rosters. */
+export const majorPrestartRosterMembers = pgTable("major_prestart_roster_members", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  entrantId: uuid("entrant_id").notNull().references(() => majorPrestartEntrants.id, { onDelete: "cascade" }),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  uniqueEntrantUser: unique("major_prestart_roster_members_entrant_user_unique").on(t.entrantId, t.userId),
+  entrantIndex: index("major_prestart_roster_members_entrant_idx").on(t.entrantId),
+}));
+
+/** Explicit work items. Empty means none are recorded, never an inferred fact. */
+export const majorPrestartIssues = pgTable("major_prestart_issues", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  category: majorPrestartIssueCategoryEnum("category").notNull(),
+  label: text("label").notNull(),
+  resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+  resolvedBy: text("resolved_by"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  seasonCategoryIndex: index("major_prestart_issues_season_category_idx").on(t.seasonId, t.category),
+}));
+
+export type MajorPrestartState = typeof majorPrestartStates.$inferSelect;
+export type MajorPrestartEntrant = typeof majorPrestartEntrants.$inferSelect;
+export type MajorPrestartRosterMember = typeof majorPrestartRosterMembers.$inferSelect;
+export type MajorPrestartIssue = typeof majorPrestartIssues.$inferSelect;

--- a/src/db/schema/major-prestart.ts
+++ b/src/db/schema/major-prestart.ts
@@ -1,5 +1,6 @@
 import {
   index,
+  check,
   integer,
   pgEnum,
   pgTable,
@@ -8,6 +9,7 @@ import {
   unique,
   uuid,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { seasons } from "./seasons";
 import { teams } from "./teams";
 import { users } from "./users";
@@ -59,6 +61,21 @@ export const majorPrestartRosterMembers = pgTable("major_prestart_roster_members
   entrantIndex: index("major_prestart_roster_members_entrant_idx").on(t.entrantId),
 }));
 
+/** Independent Major 1–32 tournament order. It must never reuse teams.draftOrder. */
+export const majorTournamentSeeds = pgTable("major_tournament_seeds", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  entrantId: uuid("entrant_id").notNull().references(() => majorPrestartEntrants.id),
+  tournamentSeed: integer("tournament_seed").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  uniqueSeasonEntrant: unique("major_tournament_seeds_season_entrant_unique").on(t.seasonId, t.entrantId),
+  uniqueSeasonSeed: unique("major_tournament_seeds_season_seed_unique").on(t.seasonId, t.tournamentSeed),
+  seasonIndex: index("major_tournament_seeds_season_idx").on(t.seasonId),
+  validSeed: check("major_tournament_seeds_seed_range_check", sql`${t.tournamentSeed} BETWEEN 1 AND 32`),
+}));
+
 /** Explicit work items. Empty means none are recorded, never an inferred fact. */
 export const majorPrestartIssues = pgTable("major_prestart_issues", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -76,4 +93,5 @@ export const majorPrestartIssues = pgTable("major_prestart_issues", {
 export type MajorPrestartState = typeof majorPrestartStates.$inferSelect;
 export type MajorPrestartEntrant = typeof majorPrestartEntrants.$inferSelect;
 export type MajorPrestartRosterMember = typeof majorPrestartRosterMembers.$inferSelect;
+export type MajorTournamentSeed = typeof majorTournamentSeeds.$inferSelect;
 export type MajorPrestartIssue = typeof majorPrestartIssues.$inferSelect;

--- a/src/lib/major/prestart.test.ts
+++ b/src/lib/major/prestart.test.ts
@@ -14,11 +14,12 @@ function makeInput(): MajorPrestartReadinessInput {
       teamId,
       playerIds: Array.from({ length: 5 }, (_, playerIndex) => `player-${teamIndex * 5 + playerIndex + 1}`),
     })),
+    entrantsLocked: true,
     confirmations: teamIds.map((teamId) => ({ teamId, confirmed: true })),
     qualificationIssues: [],
     administrativeIssues: [],
     tournamentSeeds: teamIds.map((teamId, index) => ({ teamId, tournamentSeed: index + 1 })),
-    reconfirmations: teamIds.map((teamId) => ({ teamId, confirmed: true })),
+    seedConfirmation: { seedRevision: 1, confirmedSeedRevision: 1 },
   };
 }
 
@@ -44,7 +45,7 @@ describe("evaluateMajorPrestartReadiness", () => {
     input.tournamentSeeds = input.tournamentSeeds!.map((fact, index) => (
       index === 31 ? { ...fact, tournamentSeed: 31 } : fact
     ));
-    input.reconfirmations = input.reconfirmations!.slice(0, 30);
+    input.seedConfirmation = { seedRevision: 2, confirmedSeedRevision: 1 };
 
     expect(() => evaluateMajorPrestartReadiness(input)).not.toThrow();
     const result = evaluateMajorPrestartReadiness(input);
@@ -57,7 +58,7 @@ describe("evaluateMajorPrestartReadiness", () => {
     expect(result.blockers.join("\n")).toContain("资格事项未完成");
     expect(result.blockers.join("\n")).toContain("管理事项未完成");
     expect(result.blockers.join("\n")).toContain("赛事种子 32 尚未分配");
-    expect(result.blockers.join("\n")).toContain("缺少赛前重新确认记录");
+    expect(result.blockers.join("\n")).toContain("赛事种子已变化，必须重新确认");
   });
 
   it("fails closed when schema-less facts are not connected", () => {
@@ -66,14 +67,15 @@ describe("evaluateMajorPrestartReadiness", () => {
     input.qualificationIssues = null;
     input.administrativeIssues = null;
     input.tournamentSeeds = null;
-    input.reconfirmations = null;
+    input.entrantsLocked = null;
+    input.seedConfirmation = null;
 
     const result = evaluateMajorPrestartReadiness(input);
 
     expect(result.canStart).toBe(false);
     expect(result.openingPlan).toBeNull();
     expect(result.checks.filter((check) => check.state === "unavailable").map((check) => check.key)).toEqual([
-      "confirmations", "qualification", "administration", "seeds", "reconfirmations",
+      "entrants-locked", "confirmations", "qualification", "administration", "seeds", "reconfirmations",
     ]);
     expect(result.blockers.every((blocker) => blocker.includes("尚未接入/不可确认") || blocker.includes("开赛计划"))).toBe(true);
   });

--- a/src/lib/major/prestart.ts
+++ b/src/lib/major/prestart.ts
@@ -12,6 +12,7 @@ const MAJOR_TEAM_COUNT = 32;
 export type MajorPrestartCheckKey =
   | "rules"
   | "teams"
+  | "entrants-locked"
   | "rosters"
   | "duplicate-players"
   | "confirmations"
@@ -55,11 +56,12 @@ export interface MajorPrestartTournamentSeedFact {
 export interface MajorPrestartReadinessInput {
   capabilities: SeasonCapabilities;
   teams: readonly MajorPrestartTeamFact[] | null;
+  entrantsLocked: boolean | null;
   confirmations: readonly MajorPrestartTeamConfirmationFact[] | null;
   qualificationIssues: readonly MajorPrestartIssueFact[] | null;
   administrativeIssues: readonly MajorPrestartIssueFact[] | null;
   tournamentSeeds: readonly MajorPrestartTournamentSeedFact[] | null;
-  reconfirmations: readonly MajorPrestartTeamConfirmationFact[] | null;
+  seedConfirmation: { seedRevision: number; confirmedSeedRevision: number | null } | null;
 }
 
 export interface MajorPrestartReadiness {
@@ -193,6 +195,25 @@ function checkIssues(
   return blockers.length === 0 ? ready(key, label) : blocked(key, label, blockers);
 }
 
+function checkEntrantsLocked(entrantsLocked: boolean | null): MajorPrestartCheck {
+  if (entrantsLocked === null) return unavailable("entrants-locked", "正式参赛队锁定");
+  return entrantsLocked
+    ? ready("entrants-locked", "正式参赛队锁定")
+    : blocked("entrants-locked", "正式参赛队锁定", ["请先锁定正式参赛队和最终赛事名单。"]);
+}
+
+function checkSeedConfirmation(
+  fact: MajorPrestartReadinessInput["seedConfirmation"],
+): MajorPrestartCheck {
+  if (fact === null) return unavailable("reconfirmations", "种子重新确认");
+  if (!Number.isInteger(fact.seedRevision) || fact.seedRevision < 1) {
+    return blocked("reconfirmations", "种子重新确认", ["请先保存完整的赛事种子排序。"]);
+  }
+  return fact.confirmedSeedRevision === fact.seedRevision
+    ? ready("reconfirmations", "种子重新确认")
+    : blocked("reconfirmations", "种子重新确认", ["赛事种子已变化，必须重新确认后才能开赛。"]);
+}
+
 function checkSeeds(
   teams: readonly MajorPrestartTeamFact[] | null,
   facts: readonly MajorPrestartTournamentSeedFact[] | null,
@@ -259,6 +280,7 @@ export function evaluateMajorPrestartReadiness(
         ? ready("teams", "32 支参赛队伍")
         : blocked("teams", "32 支参赛队伍", teamBlockers),
   );
+  checks.push(checkEntrantsLocked(input.entrantsLocked));
   checks.push(checkRosters(input.teams, input.capabilities.minTeamSize));
   checks.push(checkDuplicatePlayers(input.teams));
   checks.push(checkTeamConfirmations("confirmations", "参赛确认", input.confirmations, input.teams));
@@ -266,7 +288,7 @@ export function evaluateMajorPrestartReadiness(
   checks.push(checkIssues("administration", "管理事项", input.administrativeIssues));
   const seedResult = checkSeeds(input.teams, input.tournamentSeeds);
   checks.push(seedResult.check);
-  checks.push(checkTeamConfirmations("reconfirmations", "赛前重新确认", input.reconfirmations, input.teams));
+  checks.push(checkSeedConfirmation(input.seedConfirmation));
 
   const blockersBeforePlan = checks.flatMap((check) => check.blockers);
   let openingPlan: MajorOpeningPlan | null = null;

--- a/tests/unit/actions/major-prestart.test.ts
+++ b/tests/unit/actions/major-prestart.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+vi.mock("@/db/client", () => ({ db: {} }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  addMajorPrestartEntrant,
+  addMajorPrestartIssue,
+  confirmMajorPrestartRoster,
+  confirmMajorTournamentSeeds,
+  lockMajorPrestartEntrants,
+  removeMajorPrestartEntrant,
+  resolveMajorPrestartIssue,
+  saveMajorPrestartRoster,
+  saveMajorTournamentSeeds,
+} from "@/actions/major-prestart";
+
+describe("Major prestart actions input boundary", () => {
+  it("fails closed before any database access for malformed entrant and roster input", async () => {
+    await expect(addMajorPrestartEntrant({ seasonId: "bad", teamId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(removeMajorPrestartEntrant({ seasonId: "bad", entrantId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(saveMajorPrestartRoster({ seasonId: "bad", entrantId: "bad", userIds: [] })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(confirmMajorPrestartRoster({ seasonId: "bad", entrantId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+  });
+
+  it("rejects malformed unresolved-work, lock, and independent-seed inputs", async () => {
+    await expect(addMajorPrestartIssue({ seasonId: "bad", category: "qualification", label: "" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(resolveMajorPrestartIssue({ seasonId: "bad", issueId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(lockMajorPrestartEntrants({ seasonId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(saveMajorTournamentSeeds({ seasonId: "bad", teamIds: [] })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+    await expect(confirmMajorTournamentSeeds({ seasonId: "bad" })).resolves.toMatchObject({
+      success: false, error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+  });
+});

--- a/tests/unit/app/admin-major-console-page.test.tsx
+++ b/tests/unit/app/admin-major-console-page.test.tsx
@@ -3,9 +3,11 @@ import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMajorDefaultCapabilities } from "@/types/season";
 
-const { seasonFindFirstMock, teamsFindManyMock } = vi.hoisted(() => ({
+const { seasonFindFirstMock, teamsFindManyMock, stateFindFirstMock, selectMock } = vi.hoisted(() => ({
   seasonFindFirstMock: vi.fn(),
   teamsFindManyMock: vi.fn(),
+  stateFindFirstMock: vi.fn(),
+  selectMock: vi.fn(),
 }));
 
 vi.mock("@/db/client", () => ({
@@ -13,8 +15,9 @@ vi.mock("@/db/client", () => ({
     query: {
       seasons: { findFirst: seasonFindFirstMock },
       teams: { findMany: teamsFindManyMock },
+      majorPrestartStates: { findFirst: stateFindFirstMock },
     },
-    select: vi.fn(),
+    select: selectMock,
   },
 }));
 
@@ -33,9 +36,11 @@ describe("admin Major prestart console page", () => {
       ...capabilities,
     });
     teamsFindManyMock.mockResolvedValue([]);
+    stateFindFirstMock.mockResolvedValue(undefined);
+    selectMock.mockImplementation(() => chain([]));
   });
 
-  it("renders the domain result and keeps unconnected facts explicitly unavailable", async () => {
+  it("reads only persisted prestart facts and leaves seeds explicitly unavailable", async () => {
     const page = await AdminMajorConsolePage({ params: Promise.resolve({ seasonSlug: "major-2027" }) });
     const html = renderToStaticMarkup(page);
 
@@ -43,6 +48,19 @@ describe("admin Major prestart console page", () => {
     expect(html).toContain("准备未完成");
     expect(html).toContain("当前有 0 支队伍，Major 开赛需要恰好 32 支队伍。");
     expect(html).toContain("尚未接入/不可确认");
+    expect(html).toContain("正式参赛队 (0/32)");
+    expect(html).toContain("所有已审核 teams 不会自动成为 Major 参赛队");
     expect(html).toContain("当前不会推导或展示临时对阵");
   });
 });
+
+function chain<T>(value: T) {
+  const result = {
+    from: () => result,
+    innerJoin: () => result,
+    where: () => result,
+    orderBy: () => result,
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) => Promise.resolve(value).then(resolve, reject),
+  };
+  return result;
+}


### PR DESCRIPTION
## Summary

- persist the authoritative Major entrant set, final tournament roster snapshots, qualification/admin blockers, and entrant lock lifecycle
- manage independent 1–32 tournament seeds with save, confirmation, automatic reconfirmation after changes, cohort visibility, and Stage 1 R1 planning preview
- add Drizzle migrations plus Local Supabase integration coverage

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm db:check`
- `pnpm test` (86 files, 680 tests)
- `RIVALHUB_LOCAL_DATABASE_URL=... pnpm test:major-prestart:local`
- Local Supabase active-migration verification and browser walkthrough of save → needs reconfirmation → reconfirm

## Database safety

- Applied and validated locally through active Drizzle migrations only; no `db:push`.
- Applied through the protected Drizzle staging workflow only to `rivalhub-dev` (`cueazphyskstwdhnzsxx`); the script verified five active migrations locally and on staging. Production was not accessed.

## Scope

Draft PR targeting `feat/major-2027-integration`; it intentionally creates no matches or bracket records.