### PR TITLE
feat(major): transition Swiss stages by StageRun

### DIFF
--- a/scripts/db/major-start-integration.ts
+++ b/scripts/db/major-start-integration.ts
@@ -4,6 +4,7 @@ import { Pool, type PoolClient } from "pg";
 import * as schema from "../../src/db/schema";
 import { startMajorInTransaction } from "../../src/lib/major/start";
 import { finalizeMajorSwissRoundInTransaction } from "../../src/lib/major/swiss-runtime";
+import { transitionMajorSwissStageInTransaction } from "../../src/lib/major/stage-transition";
 import { AppError, ErrorCode } from "../../src/lib/errors";
 import { createMajorDefaultCapabilities } from "../../src/types/season";
 
@@ -180,14 +181,14 @@ async function expectSwissRuntimeFailure(work: () => Promise<unknown>): Promise<
   throw new Error("预期 Swiss 运行时拒绝不完整或非法比赛事实，但操作成功。 ");
 }
 
-async function finishSwissRound(pool: Pool, seasonId: string, round: number): Promise<void> {
+async function finishSwissRound(pool: Pool, stageRunId: string, round: number): Promise<void> {
   const client = await pool.connect();
   try {
     const roundMatches = await client.query<{ id: string; format: "bo1" | "bo3" }>(
       `SELECT id, format FROM matches
-       WHERE season_id = $1 AND ownership = 'major_stage' AND round = $2
+       WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = $2
        ORDER BY managed_key`,
-      [seasonId, round],
+      [stageRunId, round],
     );
     if (roundMatches.rows.length === 0) throw new Error(`第 ${round} 轮没有可完成的托管比赛。`);
     for (let index = 0; index < roundMatches.rows.length; index += 1) {
@@ -209,12 +210,18 @@ async function exerciseSwissRuntime(
   database: ReturnType<typeof drizzle<typeof schema>>,
   pool: Pool,
   fixture: MajorFixture,
-): Promise<void> {
+): Promise<string> {
+  const stageRun = await pool.query<{ id: string }>(
+    "SELECT id FROM major_stage_runs WHERE season_id = $1 AND stage_key = 'stage1'",
+    [fixture.seasonId],
+  );
+  const stageRunId = stageRun.rows[0]?.id;
+  if (!stageRunId) throw new Error("Stage 1 StageRun 不存在。 ");
   await expectSwissRuntimeFailure(() => database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
-    seasonId: fixture.seasonId, expectedRound: 1, actorId: "local-admin",
+    seasonId: fixture.seasonId, stageRunId, expectedRound: 1, actorId: "local-admin",
   })));
 
-  await finishSwissRound(pool, fixture.seasonId, 1);
+  await finishSwissRound(pool, stageRunId, 1);
   const client = await pool.connect();
   let corruptedMatchId: string;
   try {
@@ -229,7 +236,7 @@ async function exerciseSwissRuntime(
     client.release();
   }
   await expectSwissRuntimeFailure(() => database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
-    seasonId: fixture.seasonId, expectedRound: 1, actorId: "local-admin",
+    seasonId: fixture.seasonId, stageRunId, expectedRound: 1, actorId: "local-admin",
   })));
   const restoreClient = await pool.connect();
   try {
@@ -239,17 +246,17 @@ async function exerciseSwissRuntime(
   }
 
   const concurrent = await Promise.all([
-    database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, { seasonId: fixture.seasonId, expectedRound: 1, actorId: "local-admin-a" })),
-    database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, { seasonId: fixture.seasonId, expectedRound: 1, actorId: "local-admin-b" })),
+    database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, { seasonId: fixture.seasonId, stageRunId, expectedRound: 1, actorId: "local-admin-a" })),
+    database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, { seasonId: fixture.seasonId, stageRunId, expectedRound: 1, actorId: "local-admin-b" })),
   ]);
   if (concurrent.filter((result) => !result.alreadyFinalized).length !== 1 || concurrent.some((result) => result.createdNextRound !== 8 && !result.alreadyFinalized)) {
     throw new Error("并发确认没有收敛到一次 R2 托管比赛生成。 ");
   }
 
   for (const round of [2, 3, 4, 5] as const) {
-    await finishSwissRound(pool, fixture.seasonId, round);
+    await finishSwissRound(pool, stageRunId, round);
     const result = await database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
-      seasonId: fixture.seasonId, expectedRound: round, actorId: "local-admin",
+      seasonId: fixture.seasonId, stageRunId, expectedRound: round, actorId: "local-admin",
     }));
     const expectedNextCount = ({ 2: 8, 3: 6, 4: 3, 5: 0 } as const)[round];
     if (result.createdNextRound !== expectedNextCount || result.stageComplete !== (round === 5)) {
@@ -261,21 +268,39 @@ async function exerciseSwissRuntime(
   try {
     const facts = await verifyClient.query<{ finalized_round: number; total_matches: string; r1: string; r2: string; r3: string; r4: string; r5: string; audits: string }>(`
       SELECT
-        (SELECT finalized_round FROM major_stage_runs WHERE season_id = $1) AS finalized_round,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage') AS total_matches,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 1) AS r1,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 2) AS r2,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 3) AS r3,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 4) AS r4,
-        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 5) AS r5,
-        (SELECT count(*) FROM audit_logs WHERE season_id = $1 AND action = 'major.swiss.finalize_round') AS audits
-    `, [fixture.seasonId]);
+        (SELECT finalized_round FROM major_stage_runs WHERE id = $1) AS finalized_round,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage') AS total_matches,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = 1) AS r1,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = 2) AS r2,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = 3) AS r3,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = 4) AS r4,
+        (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage' AND round = 5) AS r5,
+        (SELECT count(*) FROM audit_logs WHERE target_id = $1::text AND action = 'major.swiss.finalize_round') AS audits
+    `, [stageRunId]);
     const fact = facts.rows[0];
     if (!fact || fact.finalized_round !== 5 || fact.total_matches !== "33" || fact.r1 !== "8" || fact.r2 !== "8" || fact.r3 !== "8" || fact.r4 !== "6" || fact.r5 !== "3" || fact.audits !== "5") {
       throw new Error("Swiss 本地流程没有形成完整的 1→5 轮 canonical managed match 与确认审计事实。 ");
     }
   } finally {
     verifyClient.release();
+  }
+  return stageRunId;
+}
+
+async function completeSwissStage(
+  database: ReturnType<typeof drizzle<typeof schema>>,
+  pool: Pool,
+  seasonId: string,
+  stageRunId: string,
+): Promise<void> {
+  for (const round of [1, 2, 3, 4, 5] as const) {
+    await finishSwissRound(pool, stageRunId, round);
+    const result = await database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
+      seasonId, stageRunId, expectedRound: round, actorId: "local-admin",
+    }));
+    if (result.stageRunId !== stageRunId || result.createdNextRound !== ({ 1: 8, 2: 8, 3: 6, 4: 3, 5: 0 } as const)[round]) {
+      throw new Error("后续 Swiss StageRun 没有按其自身身份完整生成托管比赛。 ");
+    }
   }
 }
 
@@ -328,7 +353,39 @@ async function main(): Promise<void> {
       client.release();
     }
 
-    await exerciseSwissRuntime(database, pool, ready);
+    const stage1RunId = await exerciseSwissRuntime(database, pool, ready);
+    const stage2Transitions = await Promise.all([
+      database.transaction((tx) => transitionMajorSwissStageInTransaction(tx, {
+        seasonId: ready.seasonId, sourceStageRunId: stage1RunId, actorId: "local-admin-a",
+      })),
+      database.transaction((tx) => transitionMajorSwissStageInTransaction(tx, {
+        seasonId: ready.seasonId, sourceStageRunId: stage1RunId, actorId: "local-admin-b",
+      })),
+    ]);
+    if (stage2Transitions.filter((result) => result.created).length !== 1 || new Set(stage2Transitions.map((result) => result.stageRunId)).size !== 1 || stage2Transitions.some((result) => result.stageKey !== "stage2" || result.matchCount !== 8)) {
+      throw new Error("并发 Stage 1→Stage 2 切换没有收敛到唯一的 StageRun 和首轮比赛。 ");
+    }
+    const stage2RunId = stage2Transitions[0]!.stageRunId;
+    await completeSwissStage(database, pool, ready.seasonId, stage2RunId);
+    const stage3Transition = await database.transaction((tx) => transitionMajorSwissStageInTransaction(tx, {
+      seasonId: ready.seasonId, sourceStageRunId: stage2RunId, actorId: "local-admin",
+    }));
+    if (!stage3Transition.created || stage3Transition.stageKey !== "stage3" || stage3Transition.matchCount !== 8) {
+      throw new Error("Stage 2→Stage 3 没有创建完整的下一 StageRun。 ");
+    }
+    await completeSwissStage(database, pool, ready.seasonId, stage3Transition.stageRunId);
+    const stageTransitionFacts = await pool.query<{ runs: string; entrants: string; matches: string; complete_runs: string; transitions: string }>(`
+      SELECT
+        (SELECT count(*) FROM major_stage_runs WHERE season_id = $1) AS runs,
+        (SELECT count(*) FROM major_stage_entrants e INNER JOIN major_stage_runs r ON r.id = e.stage_run_id WHERE r.season_id = $1) AS entrants,
+        (SELECT count(*) FROM matches WHERE season_id = $1 AND ownership = 'major_stage') AS matches,
+        (SELECT count(*) FROM major_stage_runs WHERE season_id = $1 AND finalized_round = 5) AS complete_runs,
+        (SELECT count(*) FROM audit_logs WHERE season_id = $1 AND action = 'major.stage.transition') AS transitions
+    `, [ready.seasonId]);
+    const transitionFacts = stageTransitionFacts.rows[0];
+    if (!transitionFacts || transitionFacts.runs !== "3" || transitionFacts.entrants !== "48" || transitionFacts.matches !== "99" || transitionFacts.complete_runs !== "3" || transitionFacts.transitions !== "2") {
+      throw new Error("三阶段连续运行没有形成逐 StageRun 隔离的 canonical entrants、比赛和切换审计事实。 ");
+    }
 
     const rollback = await prepareReadyMajor(pool, "rollback");
     fixtures.push(rollback);
@@ -363,9 +420,9 @@ async function main(): Promise<void> {
       await triggerClient.query("DROP FUNCTION IF EXISTS fail_local_major_start_match()");
       triggerClient.release();
     }
-    console.log("Major local integration passed: start retry, 32-team lock, StageEntrants, managed R1, Swiss R1→R5 runtime, missing/illegal-result rejection, concurrent confirmation, and forced rollback.");
+    console.log("Major local integration passed: start retry, 32-team lock, StageRun-scoped entrants and managed matches, three consecutive Swiss stages, missing/illegal-result rejection, concurrent confirmation and transition, and forced rollback.");
   } finally {
-    await Promise.all(fixtures.map((fixture) => cleanupMajorFixture(pool, fixture)));
+    for (const fixture of fixtures) await cleanupMajorFixture(pool, fixture);
     await pool.end();
   }
 }

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -22,6 +22,7 @@ import { checkStandardMajorCapabilities, normalizeRegistrationConfig, normalizeS
 import { fail, ok, type ActionResult } from "@/types/action";
 import { startMajorInTransaction, type MajorStartResult } from "@/lib/major/start";
 import { finalizeMajorSwissRoundInTransaction, type MajorSwissRoundFinalizationResult } from "@/lib/major/swiss-runtime";
+import { transitionMajorSwissStageInTransaction, type MajorStageTransitionResult } from "@/lib/major/stage-transition";
 import { revalidateSeasonPaths } from "@/lib/revalidation";
 
 const uuid = z.string().uuid();
@@ -362,14 +363,15 @@ export async function startMajor(input: { seasonId: string }): Promise<ActionRes
   } catch (error) { return actionError("startMajor", error); }
 }
 
-/** 明确确认一轮已完成的 Stage 1 Swiss 比赛，并在同一事务中生成下一轮。 */
-export async function finalizeMajorSwissRound(input: { seasonId: string; expectedRound: 1 | 2 | 3 | 4 | 5 }): Promise<ActionResult<MajorSwissRoundFinalizationResult>> {
-  const parsed = z.object({ seasonId: uuid, expectedRound: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)]) }).safeParse(input);
+/** 明确确认指定 StageRun 的一轮 Swiss 比赛，并在同一事务中生成下一轮。 */
+export async function finalizeMajorSwissRound(input: { seasonId: string; stageRunId: string; expectedRound: 1 | 2 | 3 | 4 | 5 }): Promise<ActionResult<MajorSwissRoundFinalizationResult>> {
+  const parsed = z.object({ seasonId: uuid, stageRunId: uuid, expectedRound: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)]) }).safeParse(input);
   if (!parsed.success) return invalid("赛季或待确认轮次无效。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
       seasonId: season.id,
+      stageRunId: parsed.data.stageRunId,
       expectedRound: parsed.data.expectedRound,
       actorId: auditActorId(admin),
     }));
@@ -377,4 +379,20 @@ export async function finalizeMajorSwissRound(input: { seasonId: string; expecte
     revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
     return ok(result);
   } catch (error) { return actionError("finalizeMajorSwissRound", error); }
+}
+
+export async function transitionMajorSwissStage(input: { seasonId: string; sourceStageRunId: string }): Promise<ActionResult<MajorStageTransitionResult>> {
+  const parsed = z.object({ seasonId: uuid, sourceStageRunId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("阶段切换请求无效。 ");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => transitionMajorSwissStageInTransaction(tx, {
+      seasonId: season.id,
+      sourceStageRunId: parsed.data.sourceStageRunId,
+      actorId: auditActorId(admin),
+    }));
+    revalidateMajorPrestart(season.slug);
+    revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
+    return ok(result);
+  } catch (error) { return actionError("transitionMajorSwissStage", error); }
 }

--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -78,7 +78,7 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
       .innerJoin(majorPrestartEntrants, eq(majorTournamentSeeds.entrantId, majorPrestartEntrants.id))
       .where(eq(majorTournamentSeeds.seasonId, season.id))
       .orderBy(asc(majorTournamentSeeds.tournamentSeed)),
-    db.select({ id: majorStageRuns.id, stageKey: majorStageRuns.stageKey, finalizedRound: majorStageRuns.finalizedRound }).from(majorStageRuns)
+    db.select({ id: majorStageRuns.id, stageKey: majorStageRuns.stageKey, finalizedRound: majorStageRuns.finalizedRound, startedAt: majorStageRuns.startedAt }).from(majorStageRuns)
       .where(eq(majorStageRuns.seasonId, season.id)),
     db.select({ stageRunId: matches.majorStageRunId, round: matches.round, status: matches.status })
       .from(matches)
@@ -118,12 +118,15 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     tournamentSeeds: seedRows,
     seedConfirmation: state ? { seedRevision: state.seedRevision, confirmedSeedRevision: state.confirmedSeedRevision } : null,
   });
-  const stageOneMatchFormat = normalizeStagePlan(season.stagePlan)[0]?.matchFormat;
+  const stagePlan = normalizeStagePlan(season.stagePlan);
+  const stageOneMatchFormat = stagePlan[0]?.matchFormat;
   let seedPreview: ReturnType<typeof buildMajorOpeningPlan> | null = null;
   if (seedRows.length === 32 && (stageOneMatchFormat === "bo1" || stageOneMatchFormat === "bo3")) {
     try { seedPreview = buildMajorOpeningPlan({ teams: seedRows, stageOneMatchFormat }); } catch { seedPreview = null; }
   }
-  const stageRun = stageRunRows.length === 1 ? stageRunRows[0] : null;
+  const stageRun = [...stagePlan].reverse()
+    .map((stage) => stageRunRows.find((run) => run.stageKey === stage.key))
+    .find((run) => run !== undefined) ?? null;
   let swissRuntime: import("@/components/admin/MajorSwissRuntimeManagement").MajorSwissRuntimeData | null = null;
   if (stageRun && isMajorSwissFinalizedRound(stageRun.finalizedRound)) {
     const finalizedRound = stageRun.finalizedRound;
@@ -131,12 +134,18 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     const currentMatches = stageMatchRows.filter((match) => match.stageRunId === stageRun.id && match.round === currentRound);
     swissRuntime = {
       seasonId: season.id,
+      stageRunId: stageRun.id,
       stageKey: stageRun.stageKey,
       finalizedRound,
       currentRound,
       currentMatchCount: currentMatches.length,
       completedMatchCount: currentMatches.filter((match) => match.status === "finished").length,
       stageComplete: finalizedRound === 5,
+      nextStageName: finalizedRound === 5
+        ? stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.type === "swiss"
+          ? stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.name ?? null
+          : null
+        : null,
     };
   }
 

--- a/src/components/admin/MajorPrestartConsole.tsx
+++ b/src/components/admin/MajorPrestartConsole.tsx
@@ -39,7 +39,7 @@ export function MajorPrestartConsole({
           赛事控制台 · {seasonName}
         </Marker>
         <p className="text-sm text-[var(--color-fg-mid)]">
-          赛前事实与种子独立管理；只有管理员勾选明确确认后，才会原子启动赛事并创建对阵。
+          赛前事实、StageRun 与托管比赛独立管理；只有管理员勾选明确确认后，才会原子启动或切换阶段。
         </p>
       </div>
 

--- a/src/components/admin/MajorSwissRuntimeManagement.tsx
+++ b/src/components/admin/MajorSwissRuntimeManagement.tsx
@@ -3,18 +3,20 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { finalizeMajorSwissRound } from "@/actions/major-prestart";
+import { finalizeMajorSwissRound, transitionMajorSwissStage } from "@/actions/major-prestart";
 import { Button } from "@/components/ui/button";
 import { Marker, Panel } from "@/components/rivalhub";
 
 export interface MajorSwissRuntimeData {
   seasonId: string;
+  stageRunId: string;
   stageKey: string;
   finalizedRound: 0 | 1 | 2 | 3 | 4 | 5;
   currentRound: 1 | 2 | 3 | 4 | 5;
   currentMatchCount: number;
   completedMatchCount: number;
   stageComplete: boolean;
+  nextStageName: string | null;
 }
 
 export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeData }) {
@@ -26,11 +28,11 @@ export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeD
   return <Panel label="Swiss 逐轮运行">
     <div className="space-y-4">
       <div>
-        <Marker sub={data.stageComplete ? "Stage 1 Swiss 已完成；阶段切换不在本次交付范围内" : `当前第 ${data.currentRound} 轮`}>
-          {data.stageComplete ? "Stage 1 已完成" : `第 ${data.currentRound} 轮待办赛确认`}
+        <Marker sub={data.stageComplete ? data.nextStageName ? "本 StageRun 已完成，等待显式切换下一阶段" : "所有 Swiss 阶段已完成" : `当前第 ${data.currentRound} 轮`}>
+          {data.stageComplete ? `${data.stageKey} 已完成` : `第 ${data.currentRound} 轮待办赛确认`}
         </Marker>
         <p className="mt-1 text-sm text-[var(--color-fg-mid)]">
-          已确认至第 {data.finalizedRound} 轮；本轮 {data.completedMatchCount}/{data.currentMatchCount} 场比赛已完成。确认会在服务器复核正式比分与 Swiss 对阵事实后，原子生成下一轮。
+          已确认至第 {data.finalizedRound} 轮；本轮 {data.completedMatchCount}/{data.currentMatchCount} 场比赛已完成。确认会在服务器复核指定 StageRun 的正式比分与 Swiss 对阵事实后，原子生成下一轮。
         </p>
       </div>
 
@@ -40,7 +42,7 @@ export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeD
           <span>我确认第 {data.currentRound} 轮的所有正式比分已核对无误，并接受其成为后续 Swiss 对阵依据。</span>
         </label>
         <Button disabled={!canFinalize || !confirmed || isPending} onClick={() => startTransition(async () => {
-          const result = await finalizeMajorSwissRound({ seasonId: data.seasonId, expectedRound: data.currentRound });
+          const result = await finalizeMajorSwissRound({ seasonId: data.seasonId, stageRunId: data.stageRunId, expectedRound: data.currentRound });
           if (!result.success) {
             toast.error(result.error.message);
             return;
@@ -48,12 +50,28 @@ export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeD
           toast.success(result.data.alreadyFinalized
             ? `第 ${data.currentRound} 轮已确认，未重复创建比赛`
             : result.data.stageComplete
-              ? "Stage 1 Swiss 已完成；未进行阶段切换"
+              ? `${data.stageKey} Swiss 已完成；请显式确认阶段切换`
               : `第 ${data.currentRound} 轮已确认，已创建 ${result.data.createdNextRound} 场下一轮比赛`);
           setConfirmed(false);
           router.refresh();
         })}>确认本轮并生成下一轮</Button>
         {!canFinalize && <p className="text-xs text-[var(--color-fg-mid)]">必须先完成并录入本轮全部托管比赛的有效正式比分，才能确认。</p>}
+      </>}
+
+      {data.stageComplete && data.nextStageName && <>
+        <label className="flex items-start gap-2 rounded border border-[var(--color-border)] p-3 text-sm text-[var(--color-fg-mid)]">
+          <input type="checkbox" checked={confirmed} disabled={isPending} onChange={(event) => setConfirmed(event.target.checked)} />
+          <span>我确认本 StageRun 的 canonical entrants 与全部已确认比赛事实应成为 {data.nextStageName} 的唯一生成依据。</span>
+        </label>
+        <Button disabled={!confirmed || isPending} onClick={() => startTransition(async () => {
+          const result = await transitionMajorSwissStage({ seasonId: data.seasonId, sourceStageRunId: data.stageRunId });
+          if (!result.success) { toast.error(result.error.message); return; }
+          toast.success(result.data.created
+            ? `已创建 ${result.data.stageKey} StageRun 与 ${result.data.matchCount} 场首轮托管比赛`
+            : `${result.data.stageKey} StageRun 已存在，未重复创建比赛`);
+          setConfirmed(false);
+          router.refresh();
+        })}>确认切换至 {data.nextStageName}</Button>
       </>}
     </div>
   </Panel>;

--- a/src/lib/major/stage-transition.ts
+++ b/src/lib/major/stage-transition.ts
@@ -1,0 +1,227 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import { auditLogs, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { seedMajorLaterStageEntrants } from "@/lib/major/seeding";
+import {
+  generateNextMajorSwissRound,
+  getMajorSwissQualifiers,
+  projectMajorSwissStage,
+  type MajorSwissMatchFact,
+} from "@/lib/major/swiss";
+
+type FrozenStage = {
+  key: string;
+  name: string;
+  type: string;
+  teamCount: number;
+  matchFormat: string;
+  entrySeeds: number | null;
+  advanceTiers: unknown[];
+  finalFormat: string | null;
+  seeds: number[] | null;
+};
+type FrozenSwissStage = FrozenStage & { type: "swiss"; teamCount: 16; matchFormat: "bo1" | "bo3" };
+
+type FrozenTournamentEntrant = { entrantId: string; teamId: string; tournamentSeed: number };
+type FrozenSnapshot = {
+  version: number;
+  stagePlan: FrozenStage[];
+  stage: FrozenSwissStage;
+  tournamentEntrants: FrozenTournamentEntrant[];
+};
+
+export interface MajorStageTransitionResult {
+  sourceStageRunId: string;
+  stageRunId: string;
+  stageKey: string;
+  created: boolean;
+  matchCount: number;
+}
+
+function frozenSnapshot(value: unknown): FrozenSnapshot {
+  if (typeof value !== "object" || value === null) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少规则快照。");
+  }
+  const snapshot = value as Partial<FrozenSnapshot>;
+  if (!Array.isArray(snapshot.stagePlan) || !Array.isArray(snapshot.tournamentEntrants) || !snapshot.stage) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少可审计的赛事阶段或入口快照。");
+  }
+  const validStage = (stage: unknown): stage is FrozenStage => {
+    if (typeof stage !== "object" || stage === null) return false;
+    const candidate = stage as Partial<FrozenSwissStage>;
+    return typeof candidate.key === "string" && typeof candidate.name === "string" &&
+      typeof candidate.type === "string" && Number.isInteger(candidate.teamCount) &&
+      typeof candidate.matchFormat === "string" &&
+      (candidate.entrySeeds === null || typeof candidate.entrySeeds === "number") &&
+      Array.isArray(candidate.advanceTiers) &&
+      (candidate.finalFormat === null || typeof candidate.finalFormat === "string") &&
+      (candidate.seeds === null || (Array.isArray(candidate.seeds) && candidate.seeds.every(Number.isInteger)));
+  };
+  const isSwissStage = (stage: FrozenStage): stage is FrozenSwissStage =>
+    stage.type === "swiss" && stage.teamCount === 16 && (stage.matchFormat === "bo1" || stage.matchFormat === "bo3");
+  if (!validStage(snapshot.stage) || !isSwissStage(snapshot.stage) || !snapshot.stagePlan.every(validStage)) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的 Swiss 规则不可用。");
+  }
+  const entrantIds = new Set<string>();
+  const teamIds = new Set<string>();
+  const tournamentSeeds = new Set<number>();
+  for (const entrant of snapshot.tournamentEntrants) {
+    if (!entrant || typeof entrant.entrantId !== "string" || typeof entrant.teamId !== "string" ||
+      !Number.isInteger(entrant.tournamentSeed) || entrant.tournamentSeed < 1 || entrant.tournamentSeed > 32 ||
+      entrantIds.has(entrant.entrantId) || teamIds.has(entrant.teamId) || tournamentSeeds.has(entrant.tournamentSeed)) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的 32 队入口不可用。");
+    }
+    entrantIds.add(entrant.entrantId);
+    teamIds.add(entrant.teamId);
+    tournamentSeeds.add(entrant.tournamentSeed);
+  }
+  if (entrantIds.size !== 32) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的入口数量不是 32 队。");
+  return snapshot as FrozenSnapshot;
+}
+
+function completedFact(match: typeof matches.$inferSelect): MajorSwissMatchFact {
+  if (match.round === null || match.round < 1 || match.round > 5 || match.status !== "finished" ||
+    match.completedAt === null || match.scoreA === null || match.scoreB === null) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "已确认 StageRun 含未完成或无正式比分的托管比赛。");
+  }
+  try { validateSeriesScore(match.format, match.scoreA, match.scoreB); } catch {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "已确认 StageRun 含非法正式比分。");
+  }
+  return {
+    matchId: match.id,
+    round: match.round as 1 | 2 | 3 | 4 | 5,
+    teamAId: match.teamAId,
+    teamBId: match.teamBId,
+    winnerId: match.scoreA > match.scoreB ? match.teamAId : match.teamBId,
+  };
+}
+
+function directSeedRange(stages: readonly FrozenStage[], targetIndex: number, count: number): readonly [number, number] {
+  const laterDirectCount = stages.slice(targetIndex + 1)
+    .filter((stage) => stage.type === "swiss")
+    .reduce((sum, stage) => sum + (stage.entrySeeds ?? 0), 0);
+  return [laterDirectCount + 1, laterDirectCount + count];
+}
+
+/**
+ * Materialize a later Swiss stage only from frozen StageRun facts. The source
+ * run is the lock and identity boundary; this never asks which StageRun is
+ * "currently" active for a season.
+ */
+export async function transitionMajorSwissStageInTransaction(
+  tx: TxDb,
+  input: { seasonId: string; sourceStageRunId: string; actorId: string },
+): Promise<MajorStageTransitionResult> {
+  const [sourceRun] = await tx.select().from(majorStageRuns)
+    .where(and(eq(majorStageRuns.id, input.sourceStageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
+  if (!sourceRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的源 StageRun 不属于当前赛事。");
+  if (sourceRun.finalizedRound !== 5) {
+    throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有已确认全部五轮的 Swiss StageRun 才能切换阶段。");
+  }
+  const sourceSnapshot = frozenSnapshot(sourceRun.ruleSnapshot);
+  if (sourceSnapshot.stage.key !== sourceRun.stageKey) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "源 StageRun 的阶段快照与记录不一致。");
+  }
+  const sourceIndex = sourceSnapshot.stagePlan.findIndex((stage) => stage.key === sourceRun.stageKey);
+  const nextStage = sourceSnapshot.stagePlan[sourceIndex + 1];
+  if (sourceIndex < 0 || !nextStage || nextStage.type !== "swiss" || nextStage.teamCount !== 16 ||
+    (nextStage.matchFormat !== "bo1" && nextStage.matchFormat !== "bo3")) {
+    throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "当前 Swiss StageRun 后没有可切换的 Swiss 阶段。");
+  }
+  const nextSwissStage = nextStage as FrozenSwissStage;
+
+  const [existingRun] = await tx.select().from(majorStageRuns)
+    .where(and(eq(majorStageRuns.seasonId, input.seasonId), eq(majorStageRuns.stageKey, nextSwissStage.key))).for("update");
+  if (existingRun) {
+    const existingMatches = await tx.select({ id: matches.id }).from(matches)
+      .where(and(eq(matches.majorStageRunId, existingRun.id), eq(matches.ownership, "major_stage"))).for("update");
+    if (existingMatches.length !== 8) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "下一 StageRun 已存在但首轮托管比赛不完整，拒绝静默重建。");
+    }
+    return { sourceStageRunId: sourceRun.id, stageRunId: existingRun.id, stageKey: nextSwissStage.key, created: false, matchCount: 8 };
+  }
+
+  const sourceEntrants = await tx.select({
+    entrantId: majorStageEntrants.entrantId,
+    teamId: majorStageEntrants.teamId,
+    stageSeed: majorStageEntrants.stageSeed,
+  }).from(majorStageEntrants).where(eq(majorStageEntrants.stageRunId, sourceRun.id)).for("update");
+  const sourceMatches = await tx.select().from(matches)
+    .where(and(eq(matches.majorStageRunId, sourceRun.id), eq(matches.ownership, "major_stage"))).for("update");
+  const projection = projectMajorSwissStage({
+    entrants: sourceEntrants.map((entrant) => ({ teamId: entrant.teamId, initialStageSeed: entrant.stageSeed })),
+    matches: sourceMatches.map(completedFact),
+    finalizedRound: 5,
+  });
+  const qualifiers = getMajorSwissQualifiers(projection);
+  if (qualifiers.length !== 8) throw new AppError(ErrorCode.INTERNAL_ERROR, "源 Swiss StageRun 没有形成恰好八支晋级队。");
+
+  const directCount = nextSwissStage.entrySeeds;
+  if (directCount !== 8) {
+    throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "后续 Major Swiss 阶段必须明确配置八支直入队。");
+  }
+  const [fromSeed, toSeed] = directSeedRange(sourceSnapshot.stagePlan, sourceIndex + 1, directCount);
+  const directEntrants = sourceSnapshot.tournamentEntrants
+    .filter((entrant) => entrant.tournamentSeed >= fromSeed && entrant.tournamentSeed <= toSeed)
+    .map((entrant) => ({ teamId: entrant.teamId, tournamentSeed: entrant.tournamentSeed }));
+  const seededEntrants = seedMajorLaterStageEntrants({
+    directEntrants,
+    advancingEntrants: qualifiers.map((qualifier) => ({ teamId: qualifier.teamId, previousStageFinalSeed: qualifier.finalStageSeed })),
+  });
+  const entrantByTeamId = new Map(sourceSnapshot.tournamentEntrants.map((entrant) => [entrant.teamId, entrant]));
+  const firstRound = generateNextMajorSwissRound({ entrants: seededEntrants, matches: [], finalizedRound: 0, stageMatchFormat: nextSwissStage.matchFormat });
+  const now = new Date();
+  const [stageRun] = await tx.insert(majorStageRuns).values({
+    seasonId: input.seasonId,
+    stageKey: nextSwissStage.key,
+    startedAt: now,
+    startedBy: input.actorId,
+    ruleSnapshot: {
+      ...sourceSnapshot,
+      stage: nextSwissStage,
+      openingPairings: firstRound.map((pairing, index) => ({
+        key: `r1-${index + 1}`,
+        teamAId: pairing.higherSeedTeamId,
+        teamBId: pairing.lowerSeedTeamId,
+        format: pairing.format,
+        pairingRule: pairing.pairingRule,
+      })),
+    },
+  }).returning({ id: majorStageRuns.id });
+  if (!stageRun) throw new AppError(ErrorCode.INTERNAL_ERROR, "下一 StageRun 创建失败。");
+  await tx.insert(majorStageEntrants).values(seededEntrants.map((entrant) => {
+    const frozenEntrant = entrantByTeamId.get(entrant.teamId);
+    if (!frozenEntrant) throw new AppError(ErrorCode.INTERNAL_ERROR, "下一 StageRun 的队伍不在冻结的 32 队入口中。");
+    return {
+      stageRunId: stageRun.id,
+      entrantId: frozenEntrant.entrantId,
+      teamId: entrant.teamId,
+      tournamentSeed: frozenEntrant.tournamentSeed,
+      stageSeed: entrant.initialStageSeed,
+    };
+  }));
+  const createdMatches = await tx.insert(matches).values(firstRound.map((pairing, index) => ({
+    seasonId: input.seasonId,
+    teamAId: pairing.higherSeedTeamId,
+    teamBId: pairing.lowerSeedTeamId,
+    stage: nextSwissStage.key,
+    round: 1,
+    format: pairing.format,
+    status: "scheduled" as const,
+    ownership: "major_stage" as const,
+    majorStageRunId: stageRun.id,
+    managedKey: `r1-${index + 1}`,
+  }))).returning({ id: matches.id });
+  if (createdMatches.length !== 8) throw new AppError(ErrorCode.INTERNAL_ERROR, "下一 StageRun 首轮比赛创建数量异常。");
+  await tx.insert(auditLogs).values({
+    seasonId: input.seasonId,
+    action: "major.stage.transition",
+    actorId: input.actorId,
+    targetId: stageRun.id,
+    targetType: "major_stage_run",
+    meta: { sourceStageRunId: sourceRun.id, sourceStageKey: sourceRun.stageKey, stageKey: nextSwissStage.key, directEntrants: directCount, advancingEntrants: qualifiers.length, managedMatches: createdMatches.length },
+  });
+  return { sourceStageRunId: sourceRun.id, stageRunId: stageRun.id, stageKey: nextSwissStage.key, created: true, matchCount: createdMatches.length };
+}

--- a/src/lib/major/start.ts
+++ b/src/lib/major/start.ts
@@ -148,22 +148,41 @@ export async function startMajorInTransaction(
 
   const now = new Date();
   const openingPlan = buildMajorOpeningPlan({ teams: seeds, stageOneMatchFormat: stage.matchFormat });
+  const entrantByTeamId = new Map(entrantRows.map((entrant) => [entrant.teamId, entrant]));
   const ruleSnapshot = {
     version: 1,
+    stagePlan: capabilities.stagePlan.map((configuredStage) => ({
+      key: configuredStage.key,
+      name: configuredStage.name,
+      type: configuredStage.type,
+      teamCount: configuredStage.teamCount,
+      matchFormat: configuredStage.matchFormat,
+      finalFormat: configuredStage.finalFormat ?? null,
+      advanceTiers: configuredStage.advanceTiers.map((tier) => ({ ...tier })),
+      entrySeeds: configuredStage.entrySeeds ?? null,
+      seeds: configuredStage.seeds ? [...configuredStage.seeds] : null,
+    })),
     stage: {
       key: stage.key,
       name: stage.name,
       type: stage.type,
       teamCount: stage.teamCount,
       matchFormat: stage.matchFormat,
+      finalFormat: stage.finalFormat ?? null,
       advanceTiers: stage.advanceTiers,
       entrySeeds: stage.entrySeeds ?? null,
+      seeds: stage.seeds ? [...stage.seeds] : null,
     },
     rosterRules: {
       minTeamSize: season.minTeamSize,
       maxTeamSize: season.maxTeamSize,
       starterCount: season.starterCount,
     },
+    tournamentEntrants: openingPlan.tournamentTeams.map((team) => {
+      const entrant = entrantByTeamId.get(team.teamId);
+      if (!entrant) throw new AppError(ErrorCode.INTERNAL_ERROR, "赛事种子缺少已锁定的正式参赛队。");
+      return { entrantId: entrant.id, teamId: team.teamId, tournamentSeed: team.tournamentSeed };
+    }),
     tournamentSeeds: openingPlan.tournamentTeams.map((team) => ({ ...team })),
     openingPairings: openingPlan.firstRound.pairings.map((pairing) => ({
       key: `r1-${pairing.higherSeed.stageOneSeed}`,
@@ -182,7 +201,6 @@ export async function startMajorInTransaction(
   }).returning({ id: majorStageRuns.id });
   if (!stageRun) throw new AppError(ErrorCode.INTERNAL_ERROR, "Stage 1 运行记录创建失败。");
 
-  const entrantByTeamId = new Map(entrantRows.map((entrant) => [entrant.teamId, entrant]));
   await tx.insert(majorStageEntrants).values(openingPlan.stage1.entrants.map((team) => {
     const entrant = entrantByTeamId.get(team.teamId);
     if (!entrant) throw new AppError(ErrorCode.INTERNAL_ERROR, "Stage 1 入口缺少已锁定的正式参赛队。");

--- a/src/lib/major/swiss-runtime.test.ts
+++ b/src/lib/major/swiss-runtime.test.ts
@@ -16,7 +16,7 @@ describe("finalizeMajorSwissRoundInTransaction", () => {
   it("rejects when the season has no StageRun", async () => {
     const tx = { select: () => lockedSelect([]) } as never;
     await expect(finalizeMajorSwissRoundInTransaction(tx, {
-      seasonId: "season-1", expectedRound: 1, actorId: "admin-1",
+      seasonId: "season-1", stageRunId: "run-1", expectedRound: 1, actorId: "admin-1",
     })).rejects.toMatchObject({ code: ErrorCode.NOT_FOUND });
   });
 
@@ -27,7 +27,7 @@ describe("finalizeMajorSwissRoundInTransaction", () => {
       }]),
     } as never;
     await expect(finalizeMajorSwissRoundInTransaction(tx, {
-      seasonId: "season-1", expectedRound: 1, actorId: "admin-1",
+      seasonId: "season-1", stageRunId: "run-1", expectedRound: 1, actorId: "admin-1",
     })).rejects.toMatchObject({ code: ErrorCode.INTERNAL_ERROR });
   });
 });

--- a/src/lib/major/swiss-runtime.ts
+++ b/src/lib/major/swiss-runtime.ts
@@ -78,11 +78,11 @@ function completedFact(match: typeof matches.$inferSelect): MajorSwissMatchFact 
  */
 export async function finalizeMajorSwissRoundInTransaction(
   tx: TxDb,
-  input: { seasonId: string; expectedRound: MajorSwissRound; actorId: string },
+  input: { seasonId: string; stageRunId: string; expectedRound: MajorSwissRound; actorId: string },
 ): Promise<MajorSwissRoundFinalizationResult> {
   const [stageRun] = await tx.select().from(majorStageRuns)
-    .where(eq(majorStageRuns.seasonId, input.seasonId)).for("update");
-  if (!stageRun) throw new AppError(ErrorCode.NOT_FOUND, "当前赛事尚未创建可运行的 Major Stage。 ");
+    .where(and(eq(majorStageRuns.id, input.stageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
+  if (!stageRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的 Major StageRun 不属于当前赛事。 ");
 
   const stage = frozenSwissStage(stageRun.ruleSnapshot);
   if (stage.key !== stageRun.stageKey) {


### PR DESCRIPTION
## Scope

- Bind Swiss finalization and generated-match identity to an explicit StageRun.
- Persist Stage 1 → Stage 2 → Stage 3 transitions from frozen StageRun entrants and managed match facts.
- Update the Major console and Local Supabase integration rehearsal.

## Verification

- `pnpm type-check`
- `./node_modules/.bin/vitest run src/lib/major/swiss-runtime.test.ts tests/unit/actions/major-prestart.test.ts tests/unit/app/admin-major-console-page.test.tsx`
- `pnpm db:local:migrate`
- `pnpm db:local:verify`
- `pnpm test:major-swiss:local`