### PR TITLE
feat(major): persist playoff results pending confirmation

### DIFF
--- a/drizzle/migrations/0007_bouncy_agent_zero.sql
+++ b/drizzle/migrations/0007_bouncy_agent_zero.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "public"."major_result_status" AS ENUM('pending_confirmation', 'confirmed');--> statement-breakpoint
+CREATE TABLE "major_final_results" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"playoff_stage_run_id" uuid NOT NULL,
+	"champion_team_id" uuid NOT NULL,
+	"placement_groups" jsonb NOT NULL,
+	"status" "major_result_status" DEFAULT 'pending_confirmation' NOT NULL,
+	"finalized_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"finalized_by" text NOT NULL,
+	"confirmed_at" timestamp with time zone,
+	"confirmed_by" text,
+	CONSTRAINT "major_final_results_season_unique" UNIQUE("season_id"),
+	CONSTRAINT "major_final_results_playoff_run_unique" UNIQUE("playoff_stage_run_id")
+);
+--> statement-breakpoint
+ALTER TABLE "major_final_results" ADD CONSTRAINT "major_final_results_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_final_results" ADD CONSTRAINT "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk" FOREIGN KEY ("playoff_stage_run_id") REFERENCES "public"."major_stage_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "major_final_results" ADD CONSTRAINT "major_final_results_champion_team_id_teams_id_fk" FOREIGN KEY ("champion_team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "major_final_results_season_idx" ON "major_final_results" USING btree ("season_id");

--- a/drizzle/migrations/meta/0007_snapshot.json
+++ b/drizzle/migrations/meta/0007_snapshot.json
@@ -1,0 +1,3954 @@
+{
+  "id": "57ff0dce-a855-4443-b220-87933d59a60f",
+  "prevId": "053359f9-f180-440b-b2f5-d3b412097787",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"tournament_seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_team_id": {
+          "name": "champion_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_team_id_teams_id_fk": {
+          "name": "major_final_results_champion_team_id_teams_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "champion_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_team_id_teams_id_fk": {
+          "name": "major_stage_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_team_unique": {
+          "name": "major_stage_entrants_run_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "team_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1787730343261,
       "tag": "0006_aspiring_zarek",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1787756949452,
+      "tag": "0007_bouncy_agent_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/db/major-start-integration.ts
+++ b/scripts/db/major-start-integration.ts
@@ -5,6 +5,7 @@ import * as schema from "../../src/db/schema";
 import { startMajorInTransaction } from "../../src/lib/major/start";
 import { finalizeMajorSwissRoundInTransaction } from "../../src/lib/major/swiss-runtime";
 import { transitionMajorSwissStageInTransaction } from "../../src/lib/major/stage-transition";
+import { finalizeMajorPlayoffRoundInTransaction, startMajorPlayoffInTransaction } from "../../src/lib/major/playoff-runtime";
 import { AppError, ErrorCode } from "../../src/lib/errors";
 import { createMajorDefaultCapabilities } from "../../src/types/season";
 
@@ -127,6 +128,7 @@ async function cleanupMajorFixture(pool: Pool, fixture: MajorFixture): Promise<v
   try {
     await client.query("BEGIN");
     await client.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_final_results WHERE season_id = $1", [fixture.seasonId]);
     await client.query(`DELETE FROM major_stage_entrants e USING major_stage_runs r
       WHERE e.stage_run_id = r.id AND r.season_id = $1`, [fixture.seasonId]);
     await client.query("DELETE FROM major_stage_runs WHERE season_id = $1", [fixture.seasonId]);
@@ -304,6 +306,65 @@ async function completeSwissStage(
   }
 }
 
+async function finishPlayoffRound(pool: Pool, stageRunId: string, round: "quarterfinal" | "semifinal" | "final"): Promise<void> {
+  const client = await pool.connect();
+  try {
+    const result = await client.query<{ id: string; format: "bo3" | "bo5" }>(
+      "SELECT id, format FROM matches WHERE major_stage_run_id = $1 AND entry_round = $2 ORDER BY managed_key",
+      [stageRunId, round],
+    );
+    if (result.rows.length === 0) throw new Error(`${round} 没有可完成的托管淘汰赛比赛。 `);
+    for (const [index, match] of result.rows.entries()) {
+      const winsA = index % 2 === 0;
+      await client.query("UPDATE matches SET score_a = $2, score_b = $3, status = 'finished', completed_at = now(), updated_at = now() WHERE id = $1", [
+        match.id,
+        match.format === "bo5" ? (winsA ? 3 : 2) : (winsA ? 2 : 1),
+        match.format === "bo5" ? (winsA ? 2 : 3) : (winsA ? 1 : 2),
+      ]);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+async function exercisePlayoffRuntime(
+  database: ReturnType<typeof drizzle<typeof schema>>,
+  pool: Pool,
+  seasonId: string,
+  stage3RunId: string,
+): Promise<void> {
+  const starts = await Promise.all([
+    database.transaction((tx) => startMajorPlayoffInTransaction(tx, { seasonId, sourceStageRunId: stage3RunId, actorId: "local-admin-a" })),
+    database.transaction((tx) => startMajorPlayoffInTransaction(tx, { seasonId, sourceStageRunId: stage3RunId, actorId: "local-admin-b" })),
+  ]);
+  if (starts.filter((result) => result.created).length !== 1 || new Set(starts.map((result) => result.stageRunId)).size !== 1 || starts.some((result) => result.matchCount !== 4)) {
+    throw new Error("并发 Stage 3→Playoff 没有收敛到唯一的淘汰赛 StageRun。 ");
+  }
+  const playoffRunId = starts[0]!.stageRunId;
+  for (const round of ["quarterfinal", "semifinal", "final"] as const) {
+    await finishPlayoffRound(pool, playoffRunId, round);
+    const result = await database.transaction((tx) => finalizeMajorPlayoffRoundInTransaction(tx, {
+      seasonId, stageRunId: playoffRunId, expectedRound: round, actorId: "local-admin",
+    }));
+    const expectedNext = ({ quarterfinal: 2, semifinal: 1, final: 0 } as const)[round];
+    if (result.createdNextRound !== expectedNext || result.resultPendingConfirmation !== (round === "final")) {
+      throw new Error(`${round} 没有生成预期的下一轮或待确认赛事结果。 `);
+    }
+  }
+  const facts = await pool.query<{ matches: string; champion: string | null; status: string | null; has_three_four: boolean; groups: string }>(`
+    SELECT
+      (SELECT count(*) FROM matches WHERE major_stage_run_id = $1 AND ownership = 'major_stage') AS matches,
+      (SELECT champion_team_id::text FROM major_final_results WHERE playoff_stage_run_id = $1) AS champion,
+      (SELECT status::text FROM major_final_results WHERE playoff_stage_run_id = $1) AS status,
+      (SELECT EXISTS(SELECT 1 FROM major_final_results, jsonb_to_recordset(placement_groups) AS p("from" integer, "to" integer, "teamIds" jsonb) WHERE playoff_stage_run_id = $1 AND p."from" = 3 AND p."to" = 4)) AS has_three_four,
+      (SELECT jsonb_array_length(placement_groups)::text FROM major_final_results WHERE playoff_stage_run_id = $1) AS groups
+  `, [playoffRunId]);
+  const fact = facts.rows[0];
+  if (!fact || fact.matches !== "7" || !fact.champion || fact.status !== "pending_confirmation" || !fact.has_three_four || fact.groups !== "13") {
+    throw new Error("淘汰赛没有持久化七场比赛、冠军、3–4 名次区间与待确认正式结果。 ");
+  }
+}
+
 async function main(): Promise<void> {
   const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 4 });
   const database = drizzle(pool, { schema });
@@ -386,6 +447,7 @@ async function main(): Promise<void> {
     if (!transitionFacts || transitionFacts.runs !== "3" || transitionFacts.entrants !== "48" || transitionFacts.matches !== "99" || transitionFacts.complete_runs !== "3" || transitionFacts.transitions !== "2") {
       throw new Error("三阶段连续运行没有形成逐 StageRun 隔离的 canonical entrants、比赛和切换审计事实。 ");
     }
+    await exercisePlayoffRuntime(database, pool, ready.seasonId, stage3Transition.stageRunId);
 
     const rollback = await prepareReadyMajor(pool, "rollback");
     fixtures.push(rollback);
@@ -420,7 +482,7 @@ async function main(): Promise<void> {
       await triggerClient.query("DROP FUNCTION IF EXISTS fail_local_major_start_match()");
       triggerClient.release();
     }
-    console.log("Major local integration passed: start retry, 32-team lock, StageRun-scoped entrants and managed matches, three consecutive Swiss stages, missing/illegal-result rejection, concurrent confirmation and transition, and forced rollback.");
+    console.log("Major local integration passed: start retry, 32-team lock, StageRun-scoped entrants and managed matches, three consecutive Swiss stages, persistent playoff through champion, pending final result, missing/illegal-result rejection, concurrent confirmation and transition, and forced rollback.");
   } finally {
     for (const fixture of fixtures) await cleanupMajorFixture(pool, fixture);
     await pool.end();

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -23,6 +23,7 @@ import { fail, ok, type ActionResult } from "@/types/action";
 import { startMajorInTransaction, type MajorStartResult } from "@/lib/major/start";
 import { finalizeMajorSwissRoundInTransaction, type MajorSwissRoundFinalizationResult } from "@/lib/major/swiss-runtime";
 import { transitionMajorSwissStageInTransaction, type MajorStageTransitionResult } from "@/lib/major/stage-transition";
+import { finalizeMajorPlayoffRoundInTransaction, startMajorPlayoffInTransaction, type MajorPlayoffFinalizationResult, type MajorPlayoffStartResult } from "@/lib/major/playoff-runtime";
 import { revalidateSeasonPaths } from "@/lib/revalidation";
 
 const uuid = z.string().uuid();
@@ -395,4 +396,32 @@ export async function transitionMajorSwissStage(input: { seasonId: string; sourc
     revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
     return ok(result);
   } catch (error) { return actionError("transitionMajorSwissStage", error); }
+}
+
+export async function startMajorPlayoff(input: { seasonId: string; sourceStageRunId: string }): Promise<ActionResult<MajorPlayoffStartResult>> {
+  const parsed = z.object({ seasonId: uuid, sourceStageRunId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("淘汰赛启动请求无效。 ");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => startMajorPlayoffInTransaction(tx, {
+      seasonId: season.id, sourceStageRunId: parsed.data.sourceStageRunId, actorId: auditActorId(admin),
+    }));
+    revalidateMajorPrestart(season.slug);
+    revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
+    return ok(result);
+  } catch (error) { return actionError("startMajorPlayoff", error); }
+}
+
+export async function finalizeMajorPlayoffRound(input: { seasonId: string; stageRunId: string; expectedRound: "quarterfinal" | "semifinal" | "final" }): Promise<ActionResult<MajorPlayoffFinalizationResult>> {
+  const parsed = z.object({ seasonId: uuid, stageRunId: uuid, expectedRound: z.enum(["quarterfinal", "semifinal", "final"]) }).safeParse(input);
+  if (!parsed.success) return invalid("淘汰赛确认请求无效。 ");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => finalizeMajorPlayoffRoundInTransaction(tx, {
+      seasonId: season.id, stageRunId: parsed.data.stageRunId, expectedRound: parsed.data.expectedRound, actorId: auditActorId(admin),
+    }));
+    revalidateMajorPrestart(season.slug);
+    revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
+    return ok(result);
+  } catch (error) { return actionError("finalizeMajorPlayoffRound", error); }
 }

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { eq, asc } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, matches, teams } from "@/db/schema";
+import { majorFinalResults, seasons, matches, teams } from "@/db/schema";
 import { serializeBracket } from "@/lib/bracket";
 import { calculateStandings } from "@/lib/standings";
 import { Panel, Marker } from "@/components/rivalhub";
@@ -41,7 +41,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   ]);
   if (!season) notFound();
 
-  const [allTeams, allMatches] = await Promise.all([
+  const [allTeams, allMatches, finalResult] = await Promise.all([
     db.query.teams.findMany({
       where: eq(teams.seasonId, season.id),
       orderBy: [asc(teams.draftOrder)],
@@ -50,6 +50,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
       where: eq(matches.seasonId, season.id),
       orderBy: [asc(matches.createdAt)],
     }),
+    db.query.majorFinalResults.findFirst({ where: eq(majorFinalResults.seasonId, season.id) }),
   ]);
 
   const teamMap = new Map(allTeams.map((team) => [team.id, team.name]));
@@ -115,6 +116,12 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
           <p className="text-sm text-[var(--color-warn)]">
             部分赛程数据与当前阶段配置不一致。
           </p>
+        </Panel>
+      )}
+
+      {finalResult?.status === "pending_confirmation" && (
+        <Panel pad={16} className="border-[rgba(255,196,77,0.3)] bg-[rgba(255,196,77,0.05)]">
+          <p className="text-sm text-[var(--color-warn)]">淘汰赛已结束，冠军和正式名次正在等待赛事方确认；赛事不会静默归档。</p>
         </Panel>
       )}
 

--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -7,6 +7,7 @@ import {
   majorPrestartIssues,
   majorPrestartRosterMembers,
   majorPrestartStates,
+  majorFinalResults,
   majorStageRuns,
   matches,
   majorTournamentSeeds,
@@ -56,7 +57,7 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     candidatesByTeam.set(member.teamId, candidates);
   }
 
-  const [state, entrantRows, rosterRows, issueRows, seedRows, stageRunRows, stageMatchRows] = await Promise.all([
+  const [state, entrantRows, rosterRows, issueRows, seedRows, stageRunRows, stageMatchRows, finalResult] = await Promise.all([
     db.query.majorPrestartStates.findFirst({ where: eq(majorPrestartStates.seasonId, season.id) }),
     db.select({
       id: majorPrestartEntrants.id,
@@ -80,10 +81,11 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
       .orderBy(asc(majorTournamentSeeds.tournamentSeed)),
     db.select({ id: majorStageRuns.id, stageKey: majorStageRuns.stageKey, finalizedRound: majorStageRuns.finalizedRound, startedAt: majorStageRuns.startedAt }).from(majorStageRuns)
       .where(eq(majorStageRuns.seasonId, season.id)),
-    db.select({ stageRunId: matches.majorStageRunId, round: matches.round, status: matches.status })
+    db.select({ stageRunId: matches.majorStageRunId, round: matches.round, entryRound: matches.entryRound, status: matches.status })
       .from(matches)
       .innerJoin(majorStageRuns, eq(matches.majorStageRunId, majorStageRuns.id))
       .where(and(eq(majorStageRuns.seasonId, season.id), eq(matches.ownership, "major_stage"))),
+    db.query.majorFinalResults.findFirst({ where: eq(majorFinalResults.seasonId, season.id) }),
   ]);
   const entrantIds = new Set(entrantRows.map((entrant) => entrant.id));
   const rosterByEntrant = new Map<string, Array<{ userId: string; email: string }>>();
@@ -127,8 +129,10 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
   const stageRun = [...stagePlan].reverse()
     .map((stage) => stageRunRows.find((run) => run.stageKey === stage.key))
     .find((run) => run !== undefined) ?? null;
+  const configuredStage = stageRun ? stagePlan.find((stage) => stage.key === stageRun.stageKey) : null;
   let swissRuntime: import("@/components/admin/MajorSwissRuntimeManagement").MajorSwissRuntimeData | null = null;
-  if (stageRun && isMajorSwissFinalizedRound(stageRun.finalizedRound)) {
+  let playoffRuntime: import("@/components/admin/MajorPlayoffRuntimeManagement").MajorPlayoffRuntimeData | null = null;
+  if (stageRun && configuredStage?.type === "swiss" && isMajorSwissFinalizedRound(stageRun.finalizedRound)) {
     const finalizedRound = stageRun.finalizedRound;
     const currentRound = (finalizedRound === 5 ? 5 : finalizedRound + 1) as 1 | 2 | 3 | 4 | 5;
     const currentMatches = stageMatchRows.filter((match) => match.stageRunId === stageRun.id && match.round === currentRound);
@@ -141,11 +145,36 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
       currentMatchCount: currentMatches.length,
       completedMatchCount: currentMatches.filter((match) => match.status === "finished").length,
       stageComplete: finalizedRound === 5,
-      nextStageName: finalizedRound === 5
+      nextStageName: finalizedRound === 5 ? stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.name ?? null : null,
+      nextStageType: finalizedRound === 5
         ? stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.type === "swiss"
-          ? stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.name ?? null
-          : null
+          ? "swiss"
+          : stagePlan[stagePlan.findIndex((stage) => stage.key === stageRun.stageKey) + 1]?.type === "single_elim"
+            ? "playoff"
+            : null
         : null,
+    };
+  }
+  if (stageRun && configuredStage?.type === "single_elim") {
+    const playoffMatches = stageMatchRows.filter((match) => match.stageRunId === stageRun.id);
+    const inRound = (round: "quarterfinal" | "semifinal" | "final") => playoffMatches.filter((match) => match.entryRound === round);
+    const complete = (round: "quarterfinal" | "semifinal" | "final", count: number) => {
+      const rows = inRound(round);
+      return rows.length === count && rows.every((match) => match.status === "finished");
+    };
+    const currentRound = finalResult?.status === "pending_confirmation"
+      ? null
+      : !complete("quarterfinal", 4) ? "quarterfinal"
+        : !complete("semifinal", 2) ? "semifinal"
+          : "final";
+    const currentMatches = currentRound ? inRound(currentRound) : [];
+    playoffRuntime = {
+      seasonId: season.id,
+      stageRunId: stageRun.id,
+      currentRound,
+      currentMatchCount: currentMatches.length,
+      completedMatchCount: currentMatches.filter((match) => match.status === "finished").length,
+      resultPendingConfirmation: finalResult?.status === "pending_confirmation",
     };
   }
 
@@ -182,5 +211,6 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     }}
     started={stageRunRows.length > 0}
     swissRuntime={swissRuntime}
+    playoffRuntime={playoffRuntime}
   />;
 }

--- a/src/components/admin/MajorPlayoffRuntimeManagement.tsx
+++ b/src/components/admin/MajorPlayoffRuntimeManagement.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { finalizeMajorPlayoffRound } from "@/actions/major-prestart";
+import { Button } from "@/components/ui/button";
+import { Marker, Panel } from "@/components/rivalhub";
+
+export interface MajorPlayoffRuntimeData {
+  seasonId: string;
+  stageRunId: string;
+  currentRound: "quarterfinal" | "semifinal" | "final" | null;
+  currentMatchCount: number;
+  completedMatchCount: number;
+  resultPendingConfirmation: boolean;
+}
+
+const ROUND_LABEL = { quarterfinal: "八强赛", semifinal: "半决赛", final: "总决赛" } as const;
+
+export function MajorPlayoffRuntimeManagement({ data }: { data: MajorPlayoffRuntimeData }) {
+  const router = useRouter();
+  const [confirmed, setConfirmed] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const canFinalize = data.currentRound !== null && data.currentMatchCount > 0 && data.currentMatchCount === data.completedMatchCount;
+
+  return <Panel label="淘汰赛运行">
+    <div className="space-y-4">
+      <Marker sub={data.resultPendingConfirmation ? "冠军与正式名次已生成，等待赛事结果确认" : data.currentRound ? `当前为${ROUND_LABEL[data.currentRound]}` : "托管淘汰赛事实不完整"}>
+        {data.resultPendingConfirmation ? "赛事结果待确认" : data.currentRound ? `${ROUND_LABEL[data.currentRound]} 待确认` : "淘汰赛不可确认"}
+      </Marker>
+      {data.resultPendingConfirmation ? (
+        <p className="text-sm text-[var(--color-fg-mid)]">最后一场比赛已形成冠军和正式名次分组；赛事保持待确认，不会静默归档或伪造季军唯一排名。</p>
+      ) : data.currentRound && <>
+        <p className="text-sm text-[var(--color-fg-mid)]">本轮 {data.completedMatchCount}/{data.currentMatchCount} 场托管比赛已完成。确认会绑定此 StageRun 复核所有比分与上游胜者，再生成下一轮或进入待确认赛事结果。</p>
+        <label className="flex items-start gap-2 rounded border border-[var(--color-border)] p-3 text-sm text-[var(--color-fg-mid)]">
+          <input type="checkbox" checked={confirmed} disabled={!canFinalize || isPending} onChange={(event) => setConfirmed(event.target.checked)} />
+          <span>我确认本轮所有正式比分已核对无误，并接受其成为后续淘汰赛与正式结果的依据。</span>
+        </label>
+        <Button disabled={!canFinalize || !confirmed || isPending} onClick={() => startTransition(async () => {
+          const result = await finalizeMajorPlayoffRound({ seasonId: data.seasonId, stageRunId: data.stageRunId, expectedRound: data.currentRound! });
+          if (!result.success) { toast.error(result.error.message); return; }
+          toast.success(result.data.alreadyFinalized ? `${ROUND_LABEL[data.currentRound!]} 已确认，未重复创建事实` : result.data.resultPendingConfirmation ? "已生成冠军和正式名次，赛事结果待确认" : `已确认${ROUND_LABEL[data.currentRound!]}，生成 ${result.data.createdNextRound} 场下一轮托管比赛`);
+          setConfirmed(false);
+          router.refresh();
+        })}>确认{ROUND_LABEL[data.currentRound]}</Button>
+      </>}
+    </div>
+  </Panel>;
+}

--- a/src/components/admin/MajorPrestartConsole.tsx
+++ b/src/components/admin/MajorPrestartConsole.tsx
@@ -4,6 +4,7 @@ import { MajorPrestartManagement, type MajorPrestartManagementData } from "./Maj
 import { MajorTournamentSeedsManagement, type MajorTournamentSeedsManagementData } from "./MajorTournamentSeedsManagement";
 import { MajorStartManagement } from "./MajorStartManagement";
 import { MajorSwissRuntimeManagement, type MajorSwissRuntimeData } from "./MajorSwissRuntimeManagement";
+import { MajorPlayoffRuntimeManagement, type MajorPlayoffRuntimeData } from "./MajorPlayoffRuntimeManagement";
 
 const STATE_LABEL = {
   ready: "已就绪",
@@ -24,6 +25,7 @@ export function MajorPrestartConsole({
   seedManagement,
   started,
   swissRuntime,
+  playoffRuntime,
 }: {
   seasonName: string;
   readiness: MajorPrestartReadiness;
@@ -31,6 +33,7 @@ export function MajorPrestartConsole({
   seedManagement: MajorTournamentSeedsManagementData;
   started: boolean;
   swissRuntime: MajorSwissRuntimeData | null;
+  playoffRuntime: MajorPlayoffRuntimeData | null;
 }) {
   return (
     <div className="space-y-6">
@@ -72,6 +75,7 @@ export function MajorPrestartConsole({
       <MajorTournamentSeedsManagement data={seedManagement} />
       <MajorStartManagement seasonId={management.seasonId} openingPlan={readiness.openingPlan} started={started} />
       {swissRuntime && <MajorSwissRuntimeManagement data={swissRuntime} />}
+      {playoffRuntime && <MajorPlayoffRuntimeManagement data={playoffRuntime} />}
 
       <Panel label="阶段一首轮预览">
         {readiness.openingPlan ? (

--- a/src/components/admin/MajorSwissRuntimeManagement.tsx
+++ b/src/components/admin/MajorSwissRuntimeManagement.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { finalizeMajorSwissRound, transitionMajorSwissStage } from "@/actions/major-prestart";
+import { finalizeMajorSwissRound, startMajorPlayoff, transitionMajorSwissStage } from "@/actions/major-prestart";
 import { Button } from "@/components/ui/button";
 import { Marker, Panel } from "@/components/rivalhub";
 
@@ -17,6 +17,7 @@ export interface MajorSwissRuntimeData {
   completedMatchCount: number;
   stageComplete: boolean;
   nextStageName: string | null;
+  nextStageType: "swiss" | "playoff" | null;
 }
 
 export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeData }) {
@@ -64,11 +65,13 @@ export function MajorSwissRuntimeManagement({ data }: { data: MajorSwissRuntimeD
           <span>我确认本 StageRun 的 canonical entrants 与全部已确认比赛事实应成为 {data.nextStageName} 的唯一生成依据。</span>
         </label>
         <Button disabled={!confirmed || isPending} onClick={() => startTransition(async () => {
-          const result = await transitionMajorSwissStage({ seasonId: data.seasonId, sourceStageRunId: data.stageRunId });
+          const result = data.nextStageType === "playoff"
+            ? await startMajorPlayoff({ seasonId: data.seasonId, sourceStageRunId: data.stageRunId })
+            : await transitionMajorSwissStage({ seasonId: data.seasonId, sourceStageRunId: data.stageRunId });
           if (!result.success) { toast.error(result.error.message); return; }
           toast.success(result.data.created
-            ? `已创建 ${result.data.stageKey} StageRun 与 ${result.data.matchCount} 场首轮托管比赛`
-            : `${result.data.stageKey} StageRun 已存在，未重复创建比赛`);
+            ? `已创建 ${data.nextStageName} StageRun 与 ${result.data.matchCount} 场首轮托管比赛`
+            : `${data.nextStageName} StageRun 已存在，未重复创建比赛`);
           setConfirmed(false);
           router.refresh();
         })}>确认切换至 {data.nextStageName}</Button>

--- a/src/db/schema/major-stage.ts
+++ b/src/db/schema/major-stage.ts
@@ -1,4 +1,4 @@
-import { check, index, integer, jsonb, pgTable, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import { check, index, integer, jsonb, pgEnum, pgTable, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { majorPrestartEntrants } from "./major-prestart";
 import { seasons } from "./seasons";
@@ -45,5 +45,26 @@ export const majorStageEntrants = pgTable("major_stage_entrants", {
   runIndex: index("major_stage_entrants_run_idx").on(t.stageRunId),
 }));
 
+export const majorResultStatusEnum = pgEnum("major_result_status", ["pending_confirmation", "confirmed"]);
+
+/** Official output is materialized only after the last managed playoff match. */
+export const majorFinalResults = pgTable("major_final_results", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  playoffStageRunId: uuid("playoff_stage_run_id").notNull().references(() => majorStageRuns.id),
+  championTeamId: uuid("champion_team_id").notNull().references(() => teams.id),
+  placementGroups: jsonb("placement_groups").notNull(),
+  status: majorResultStatusEnum("status").notNull().default("pending_confirmation"),
+  finalizedAt: timestamp("finalized_at", { withTimezone: true }).notNull().defaultNow(),
+  finalizedBy: text("finalized_by").notNull(),
+  confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+  confirmedBy: text("confirmed_by"),
+}, (t) => ({
+  uniqueSeason: unique("major_final_results_season_unique").on(t.seasonId),
+  uniquePlayoffRun: unique("major_final_results_playoff_run_unique").on(t.playoffStageRunId),
+  seasonIndex: index("major_final_results_season_idx").on(t.seasonId),
+}));
+
 export type MajorStageRun = typeof majorStageRuns.$inferSelect;
 export type MajorStageEntrant = typeof majorStageEntrants.$inferSelect;
+export type MajorFinalResult = typeof majorFinalResults.$inferSelect;

--- a/src/lib/major/playoff-runtime.ts
+++ b/src/lib/major/playoff-runtime.ts
@@ -1,0 +1,239 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import { auditLogs, majorFinalResults, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { buildFinalMajorPlacements } from "@/lib/major/placement";
+import { generateMajorPlayoffQuarterfinals, projectMajorPlayoff, seedMajorPlayoffEntrants, type MajorPlayoffMatchFact, type MajorPlayoffRound } from "@/lib/major/playoff";
+import { getMajorSwissQualifiers, projectMajorSwissStage, type MajorSwissMatchFact } from "@/lib/major/swiss";
+
+type FrozenStage = { key: string; name: string; type: string; teamCount: number; matchFormat: string; finalFormat: string | null };
+type FrozenTournamentEntrant = { entrantId: string; teamId: string; tournamentSeed: number };
+type FrozenSnapshot = { stagePlan: FrozenStage[]; stage: FrozenStage; tournamentEntrants: FrozenTournamentEntrant[]; hasThirdPlaceMatch?: boolean };
+type PlayoffStep = "quarterfinal" | "semifinal" | "final";
+
+export interface MajorPlayoffStartResult {
+  sourceStageRunId: string;
+  stageRunId: string;
+  created: boolean;
+  matchCount: number;
+}
+
+export interface MajorPlayoffFinalizationResult {
+  stageRunId: string;
+  finalizedRound: PlayoffStep;
+  createdNextRound: number;
+  resultPendingConfirmation: boolean;
+  alreadyFinalized: boolean;
+}
+
+function snapshot(value: unknown): FrozenSnapshot {
+  if (typeof value !== "object" || value === null) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少规则快照。");
+  const parsed = value as Partial<FrozenSnapshot>;
+  if (!Array.isArray(parsed.stagePlan) || !parsed.stage || !Array.isArray(parsed.tournamentEntrants)) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少冻结的赛事阶段或入口。");
+  }
+  const validStage = (stage: unknown): stage is FrozenStage => typeof stage === "object" && stage !== null &&
+    typeof (stage as FrozenStage).key === "string" && typeof (stage as FrozenStage).name === "string" &&
+    typeof (stage as FrozenStage).type === "string" && Number.isInteger((stage as FrozenStage).teamCount) &&
+    typeof (stage as FrozenStage).matchFormat === "string" &&
+    ((stage as FrozenStage).finalFormat === null || typeof (stage as FrozenStage).finalFormat === "string");
+  if (!validStage(parsed.stage) || !parsed.stagePlan.every(validStage)) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的阶段规则不可用。");
+  }
+  const ids = new Set<string>();
+  const teamIds = new Set<string>();
+  const seeds = new Set<number>();
+  for (const entrant of parsed.tournamentEntrants) {
+    if (!entrant || typeof entrant.entrantId !== "string" || typeof entrant.teamId !== "string" || !Number.isInteger(entrant.tournamentSeed) ||
+      entrant.tournamentSeed < 1 || entrant.tournamentSeed > 32 || ids.has(entrant.entrantId) || teamIds.has(entrant.teamId) || seeds.has(entrant.tournamentSeed)) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的赛事入口不可用。");
+    }
+    ids.add(entrant.entrantId); teamIds.add(entrant.teamId); seeds.add(entrant.tournamentSeed);
+  }
+  if (ids.size !== 32) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的入口数量不是 32 队。");
+  return parsed as FrozenSnapshot;
+}
+
+function swissFact(match: typeof matches.$inferSelect): MajorSwissMatchFact {
+  if (match.round === null || match.round < 1 || match.round > 5 || match.status !== "finished" || match.completedAt === null || match.scoreA === null || match.scoreB === null) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "Swiss StageRun 含未完成或无正式比分的托管比赛。");
+  }
+  try { validateSeriesScore(match.format, match.scoreA, match.scoreB); } catch {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "Swiss StageRun 含非法正式比分。");
+  }
+  return { matchId: match.id, round: match.round as 1 | 2 | 3 | 4 | 5, teamAId: match.teamAId, teamBId: match.teamBId, winnerId: match.scoreA > match.scoreB ? match.teamAId : match.teamBId };
+}
+
+function playoffFact(match: typeof matches.$inferSelect): MajorPlayoffMatchFact {
+  if (match.entryRound !== "quarterfinal" && match.entryRound !== "semifinal" && match.entryRound !== "third_place" && match.entryRound !== "final") {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "托管淘汰赛比赛缺少有效轮次身份。");
+  }
+  if (match.status !== "finished" || match.completedAt === null || match.scoreA === null || match.scoreB === null) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "淘汰赛轮次仍有未完成或无正式比分的比赛。");
+  }
+  try { validateSeriesScore(match.format, match.scoreA, match.scoreB); } catch {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "淘汰赛轮次含非法正式比分。");
+  }
+  const slot = Number(match.managedKey?.split("-").at(-1));
+  if (!Number.isInteger(slot) || slot < 1) throw new AppError(ErrorCode.INTERNAL_ERROR, "托管淘汰赛比赛缺少稳定槽位。");
+  return { matchId: match.id, round: match.entryRound as MajorPlayoffRound, slot, teamAId: match.teamAId, teamBId: match.teamBId, winnerId: match.scoreA > match.scoreB ? match.teamAId : match.teamBId };
+}
+
+function samePair(match: typeof matches.$inferSelect, teamAId: string, teamBId: string): boolean {
+  return (match.teamAId === teamAId && match.teamBId === teamBId) || (match.teamAId === teamBId && match.teamBId === teamAId);
+}
+
+function validateStageThree(snapshotValue: FrozenSnapshot, stageRun: typeof majorStageRuns.$inferSelect): FrozenStage {
+  if (snapshotValue.stage.key !== stageRun.stageKey || snapshotValue.stage.type !== "swiss" || stageRun.finalizedRound !== 5) {
+    throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有已确认完成的 Stage 3 Swiss StageRun 可以生成淘汰赛。");
+  }
+  const index = snapshotValue.stagePlan.findIndex((stage) => stage.key === stageRun.stageKey);
+  const playoff = snapshotValue.stagePlan[index + 1];
+  if (!playoff || playoff.type !== "single_elim" || playoff.teamCount !== 8 || playoff.matchFormat !== "bo3" || playoff.finalFormat !== "bo5") {
+    throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "冻结的 Major Stage 3 后未配置可运行的标准淘汰赛。");
+  }
+  return playoff;
+}
+
+/** Creates only the QF facts; later rounds are created after their upstream result is finalized. */
+export async function startMajorPlayoffInTransaction(
+  tx: TxDb,
+  input: { seasonId: string; sourceStageRunId: string; actorId: string },
+): Promise<MajorPlayoffStartResult> {
+  const [sourceRun] = await tx.select().from(majorStageRuns)
+    .where(and(eq(majorStageRuns.id, input.sourceStageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
+  if (!sourceRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的 Stage 3 StageRun 不属于当前赛事。");
+  const sourceSnapshot = snapshot(sourceRun.ruleSnapshot);
+  const playoffStage = validateStageThree(sourceSnapshot, sourceRun);
+  const [existingRun] = await tx.select().from(majorStageRuns)
+    .where(and(eq(majorStageRuns.seasonId, input.seasonId), eq(majorStageRuns.stageKey, playoffStage.key))).for("update");
+  if (existingRun) {
+    const existing = await tx.select({ id: matches.id }).from(matches)
+      .where(and(eq(matches.majorStageRunId, existingRun.id), eq(matches.ownership, "major_stage"), eq(matches.entryRound, "quarterfinal"))).for("update");
+    if (existing.length !== 4) throw new AppError(ErrorCode.INTERNAL_ERROR, "淘汰赛 StageRun 已存在但八强赛不完整，拒绝静默重建。");
+    return { sourceStageRunId: sourceRun.id, stageRunId: existingRun.id, created: false, matchCount: 4 };
+  }
+  const sourceEntrants = await tx.select().from(majorStageEntrants).where(eq(majorStageEntrants.stageRunId, sourceRun.id)).for("update");
+  const sourceMatches = await tx.select().from(matches)
+    .where(and(eq(matches.majorStageRunId, sourceRun.id), eq(matches.ownership, "major_stage"))).for("update");
+  const stageThree = projectMajorSwissStage({
+    entrants: sourceEntrants.map((entrant) => ({ teamId: entrant.teamId, initialStageSeed: entrant.stageSeed })),
+    matches: sourceMatches.map(swissFact), finalizedRound: 5,
+  });
+  const playoffEntrants = seedMajorPlayoffEntrants(getMajorSwissQualifiers(stageThree));
+  const frozenEntrantByTeam = new Map(sourceSnapshot.tournamentEntrants.map((entrant) => [entrant.teamId, entrant]));
+  const [playoffRun] = await tx.insert(majorStageRuns).values({
+    seasonId: input.seasonId, stageKey: playoffStage.key, startedBy: input.actorId,
+    ruleSnapshot: { ...sourceSnapshot, stage: playoffStage, hasThirdPlaceMatch: false },
+  }).returning({ id: majorStageRuns.id });
+  if (!playoffRun) throw new AppError(ErrorCode.INTERNAL_ERROR, "淘汰赛 StageRun 创建失败。");
+  await tx.insert(majorStageEntrants).values(playoffEntrants.map((entrant) => {
+    const frozen = frozenEntrantByTeam.get(entrant.teamId);
+    if (!frozen) throw new AppError(ErrorCode.INTERNAL_ERROR, "淘汰赛入口不属于冻结的 32 队赛事事实。");
+    return { stageRunId: playoffRun.id, entrantId: frozen.entrantId, teamId: entrant.teamId, tournamentSeed: frozen.tournamentSeed, stageSeed: entrant.playoffSeed };
+  }));
+  const quarterfinals = generateMajorPlayoffQuarterfinals(playoffEntrants);
+  const created = await tx.insert(matches).values(quarterfinals.map((pairing) => ({
+    seasonId: input.seasonId, teamAId: pairing.higherSeedTeamId, teamBId: pairing.lowerSeedTeamId,
+    stage: playoffStage.key, round: null, entryRound: "quarterfinal", format: playoffStage.matchFormat as "bo3", status: "scheduled" as const,
+    ownership: "major_stage" as const, majorStageRunId: playoffRun.id, managedKey: `qf-${pairing.slot}`,
+  }))).returning({ id: matches.id });
+  if (created.length !== 4) throw new AppError(ErrorCode.INTERNAL_ERROR, "淘汰赛八强赛创建数量异常。");
+  await tx.insert(auditLogs).values({ seasonId: input.seasonId, action: "major.playoff.start", actorId: input.actorId, targetId: playoffRun.id, targetType: "major_stage_run", meta: { sourceStageRunId: sourceRun.id, stageKey: playoffStage.key, entrants: 8, managedMatches: 4, hasThirdPlaceMatch: false } });
+  return { sourceStageRunId: sourceRun.id, stageRunId: playoffRun.id, created: true, matchCount: created.length };
+}
+
+function expectedMatches(managed: readonly (typeof matches.$inferSelect)[], round: PlayoffStep, expectedCount: number): readonly (typeof matches.$inferSelect)[] {
+  const rows = managed.filter((match) => match.entryRound === round);
+  if (rows.length !== expectedCount) throw new AppError(ErrorCode.VALIDATION_FAILED, `${round} 托管比赛不完整。`);
+  return rows.sort((a, b) => a.managedKey!.localeCompare(b.managedKey!));
+}
+
+async function completeSwissFactsForFinalPlacement(tx: TxDb, seasonId: string, sourceSnapshot: FrozenSnapshot) {
+  const swissKeys = sourceSnapshot.stagePlan.filter((stage) => stage.type === "swiss").map((stage) => stage.key);
+  if (swissKeys.length !== 3) throw new AppError(ErrorCode.INTERNAL_ERROR, "冻结的 Major 规则没有三个 Swiss Stage。 ");
+  const runs = await tx.select().from(majorStageRuns).where(and(eq(majorStageRuns.seasonId, seasonId), inArray(majorStageRuns.stageKey, swissKeys))).orderBy(asc(majorStageRuns.stageKey)).for("update");
+  if (runs.length !== 3 || runs.some((run) => run.finalizedRound !== 5)) throw new AppError(ErrorCode.INTERNAL_ERROR, "最终名次缺少完整的三个 Swiss StageRun。 ");
+  const runByStageKey = new Map(runs.map((run) => [run.stageKey, run]));
+  const runIds = runs.map((run) => run.id);
+  const [entrantRows, matchRows] = await Promise.all([
+    tx.select().from(majorStageEntrants).where(inArray(majorStageEntrants.stageRunId, runIds)).for("update"),
+    tx.select().from(matches).where(and(inArray(matches.majorStageRunId, runIds), eq(matches.ownership, "major_stage"))).for("update"),
+  ]);
+  const factsFor = (key: string) => {
+    const run = runByStageKey.get(key);
+    if (!run) throw new AppError(ErrorCode.INTERNAL_ERROR, "最终名次缺少指定 Swiss StageRun。 ");
+    return {
+      entrants: entrantRows.filter((entrant) => entrant.stageRunId === run.id).map((entrant) => ({ teamId: entrant.teamId, initialStageSeed: entrant.stageSeed })),
+      matches: matchRows.filter((match) => match.majorStageRunId === run.id).map(swissFact),
+    };
+  };
+  return { stage1: factsFor(swissKeys[0]!), stage2: factsFor(swissKeys[1]!), stage3: factsFor(swissKeys[2]!) };
+}
+
+export async function finalizeMajorPlayoffRoundInTransaction(
+  tx: TxDb,
+  input: { seasonId: string; stageRunId: string; expectedRound: PlayoffStep; actorId: string },
+): Promise<MajorPlayoffFinalizationResult> {
+  const [run] = await tx.select().from(majorStageRuns)
+    .where(and(eq(majorStageRuns.id, input.stageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
+  if (!run) throw new AppError(ErrorCode.NOT_FOUND, "指定的淘汰赛 StageRun 不属于当前赛事。");
+  const frozen = snapshot(run.ruleSnapshot);
+  if (frozen.stage.key !== run.stageKey || frozen.stage.type !== "single_elim" || frozen.stage.teamCount !== 8 || frozen.stage.matchFormat !== "bo3" || frozen.stage.finalFormat !== "bo5" || frozen.hasThirdPlaceMatch !== false) {
+    throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "当前 StageRun 不是可运行的无季军赛 Major 淘汰赛。 ");
+  }
+  const entrants = await tx.select().from(majorStageEntrants).where(eq(majorStageEntrants.stageRunId, run.id)).for("update");
+  const managed = await tx.select().from(matches).where(and(eq(matches.majorStageRunId, run.id), eq(matches.ownership, "major_stage"))).for("update");
+  const seeded = seedMajorPlayoffEntrants(entrants.map((entrant) => ({ teamId: entrant.teamId, finalStageSeed: entrant.stageSeed })));
+  const qfs = expectedMatches(managed, "quarterfinal", 4);
+  const expectedQfs = generateMajorPlayoffQuarterfinals(seeded);
+  for (const pairing of expectedQfs) {
+    const match = qfs[pairing.slot - 1];
+    if (!match || !samePair(match, pairing.higherSeedTeamId, pairing.lowerSeedTeamId) || match.managedKey !== `qf-${pairing.slot}` || match.format !== "bo3") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "八强赛托管事实与冻结的淘汰赛种子不一致。 ");
+    }
+  }
+  if (input.expectedRound === "quarterfinal") {
+    const existingSemifinals = managed.filter((match) => match.entryRound === "semifinal");
+    if (existingSemifinals.length > 0) return { stageRunId: run.id, finalizedRound: "quarterfinal", createdNextRound: 0, resultPendingConfirmation: false, alreadyFinalized: true };
+    const qfFacts = qfs.map(playoffFact);
+    const created = await tx.insert(matches).values([
+      { seasonId: input.seasonId, teamAId: qfFacts[0]!.winnerId, teamBId: qfFacts[1]!.winnerId, stage: run.stageKey, entryRound: "semifinal", format: "bo3", status: "scheduled" as const, ownership: "major_stage" as const, majorStageRunId: run.id, managedKey: "sf-1" },
+      { seasonId: input.seasonId, teamAId: qfFacts[2]!.winnerId, teamBId: qfFacts[3]!.winnerId, stage: run.stageKey, entryRound: "semifinal", format: "bo3", status: "scheduled" as const, ownership: "major_stage" as const, majorStageRunId: run.id, managedKey: "sf-2" },
+    ]).returning({ id: matches.id });
+    if (created.length !== 2) throw new AppError(ErrorCode.INTERNAL_ERROR, "半决赛创建数量异常。 ");
+    await tx.insert(auditLogs).values({ seasonId: input.seasonId, action: "major.playoff.finalize_round", actorId: input.actorId, targetId: run.id, targetType: "major_stage_run", meta: { finalizedRound: "quarterfinal", createdNextRound: 2 } });
+    return { stageRunId: run.id, finalizedRound: "quarterfinal", createdNextRound: 2, resultPendingConfirmation: false, alreadyFinalized: false };
+  }
+  const semifinals = expectedMatches(managed, "semifinal", 2);
+  const qfFacts = qfs.map(playoffFact);
+  for (const [index, semifinal] of semifinals.entries()) {
+    if (!samePair(semifinal, qfFacts[index * 2]!.winnerId, qfFacts[index * 2 + 1]!.winnerId) || semifinal.managedKey !== `sf-${index + 1}` || semifinal.format !== "bo3") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "半决赛托管事实与八强赛胜者不一致。 ");
+    }
+  }
+  if (input.expectedRound === "semifinal") {
+    const existingFinal = managed.filter((match) => match.entryRound === "final");
+    if (existingFinal.length > 0) return { stageRunId: run.id, finalizedRound: "semifinal", createdNextRound: 0, resultPendingConfirmation: false, alreadyFinalized: true };
+    const sfFacts = semifinals.map(playoffFact);
+    const [created] = await tx.insert(matches).values({ seasonId: input.seasonId, teamAId: sfFacts[0]!.winnerId, teamBId: sfFacts[1]!.winnerId, stage: run.stageKey, entryRound: "final", format: "bo5", status: "scheduled", ownership: "major_stage", majorStageRunId: run.id, managedKey: "final-1" }).returning({ id: matches.id });
+    if (!created) throw new AppError(ErrorCode.INTERNAL_ERROR, "总决赛创建失败。 ");
+    await tx.insert(auditLogs).values({ seasonId: input.seasonId, action: "major.playoff.finalize_round", actorId: input.actorId, targetId: run.id, targetType: "major_stage_run", meta: { finalizedRound: "semifinal", createdNextRound: 1 } });
+    return { stageRunId: run.id, finalizedRound: "semifinal", createdNextRound: 1, resultPendingConfirmation: false, alreadyFinalized: false };
+  }
+  const existingResult = await tx.select().from(majorFinalResults).where(eq(majorFinalResults.playoffStageRunId, run.id)).for("update");
+  if (existingResult[0]) return { stageRunId: run.id, finalizedRound: "final", createdNextRound: 0, resultPendingConfirmation: true, alreadyFinalized: true };
+  const final = expectedMatches(managed, "final", 1)[0]!;
+  const playoffFacts = [...qfs, ...semifinals, final].map(playoffFact);
+  const playoff = projectMajorPlayoff({ entrants: seeded, matches: playoffFacts, hasThirdPlaceMatch: false });
+  const swiss = await completeSwissFactsForFinalPlacement(tx, input.seasonId, frozen);
+  const placements = buildFinalMajorPlacements({ tournamentTeams: frozen.tournamentEntrants.map(({ teamId, tournamentSeed }) => ({ teamId, tournamentSeed })), ...swiss, playoffMatches: playoffFacts, hasThirdPlaceMatch: false });
+  const [result] = await tx.insert(majorFinalResults).values({ seasonId: input.seasonId, playoffStageRunId: run.id, championTeamId: playoff.championId, placementGroups: placements, status: "pending_confirmation", finalizedBy: input.actorId }).returning({ id: majorFinalResults.id });
+  if (!result) throw new AppError(ErrorCode.INTERNAL_ERROR, "正式最终名次创建失败。 ");
+  await tx.insert(auditLogs).values([
+    { seasonId: input.seasonId, action: "major.playoff.finalize_round", actorId: input.actorId, targetId: run.id, targetType: "major_stage_run", meta: { finalizedRound: "final", createdNextRound: 0 } },
+    { seasonId: input.seasonId, action: "major.result.pending_confirmation", actorId: input.actorId, targetId: result.id, targetType: "major_final_result", meta: { playoffStageRunId: run.id, championTeamId: playoff.championId, placementGroupCount: placements.length, hasThirdPlaceMatch: false } },
+  ]);
+  return { stageRunId: run.id, finalizedRound: "final", createdNextRound: 0, resultPendingConfirmation: true, alreadyFinalized: false };
+}

--- a/src/lib/major/stage-transition.ts
+++ b/src/lib/major/stage-transition.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { TxDb } from "@/db/client";
 import { auditLogs, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";

--- a/tests/unit/app/admin-major-console-page.test.tsx
+++ b/tests/unit/app/admin-major-console-page.test.tsx
@@ -3,10 +3,11 @@ import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMajorDefaultCapabilities } from "@/types/season";
 
-const { seasonFindFirstMock, teamsFindManyMock, stateFindFirstMock, selectMock } = vi.hoisted(() => ({
+const { seasonFindFirstMock, teamsFindManyMock, stateFindFirstMock, finalResultsFindFirstMock, selectMock } = vi.hoisted(() => ({
   seasonFindFirstMock: vi.fn(),
   teamsFindManyMock: vi.fn(),
   stateFindFirstMock: vi.fn(),
+  finalResultsFindFirstMock: vi.fn(),
   selectMock: vi.fn(),
 }));
 
@@ -16,6 +17,7 @@ vi.mock("@/db/client", () => ({
       seasons: { findFirst: seasonFindFirstMock },
       teams: { findMany: teamsFindManyMock },
       majorPrestartStates: { findFirst: stateFindFirstMock },
+      majorFinalResults: { findFirst: finalResultsFindFirstMock },
     },
     select: selectMock,
   },
@@ -37,6 +39,7 @@ describe("admin Major prestart console page", () => {
     });
     teamsFindManyMock.mockResolvedValue([]);
     stateFindFirstMock.mockResolvedValue(undefined);
+    finalResultsFindFirstMock.mockResolvedValue(undefined);
     selectMock.mockImplementation(() => chain([]));
   });
 


### PR DESCRIPTION
## Scope

- Persist the Stage 3 → Playoff StageRun transition and StageRun-owned QF/SF/final matches.
- Materialize the champion and official placement groups after the last match.
- Hold the result at `pending_confirmation`; do not archive the season or fabricate 3rd place without a third-place match.
- Surface the operational state in the console and public schedule.

## Database

- Adds active Drizzle migration `0007_bouncy_agent_zero` for `major_final_results`.
- Applied and verified on Local Supabase, then the only authorized remote staging project `cueazphyskstwdhnzsxx`.

## Verification

- `pnpm db:check`
- `pnpm db:local:migrate`
- `pnpm db:local:verify`
- `pnpm test:major-swiss:local`
- `pnpm db:staging:migrate` / `pnpm db:staging:verify` (8 active migrations)
- `pnpm lint`
- `pnpm type-check`
- `./node_modules/.bin/vitest run` (88 files, 684 tests)
- `pnpm build`