### PR TITLE
feat(major): match fact safety & recovery

### DIFF
--- a/drizzle/migrations/0009_amused_mother_askani.sql
+++ b/drizzle/migrations/0009_amused_mother_askani.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "match_rosters" ALTER COLUMN "submitted_by" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "match_rosters" ADD COLUMN "source" text DEFAULT 'participant' NOT NULL;--> statement-breakpoint
+ALTER TABLE "match_rosters" ADD COLUMN "confirmed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "match_rosters" ADD COLUMN "confirmed_by" text;

--- a/drizzle/migrations/meta/0009_snapshot.json
+++ b/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,4518 @@
+{
+  "id": "f60c7129-5a82-4ad4-89c9-95c41a31758d",
+  "prevId": "3e9aa556-a389-4a07-8091-8e37db884e1d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_url": {
+          "name": "evidence_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "moe_institution_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_active_claims": {
+      "name": "team_application_active_claims",
+      "schema": "",
+      "columns": {
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_active_claims_application_idx": {
+          "name": "team_application_active_claims_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_active_claims_season_id_seasons_id_fk": {
+          "name": "team_application_active_claims_season_id_seasons_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_user_id_users_id_fk": {
+          "name": "team_application_active_claims_user_id_users_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_application_id_team_applications_id_fk": {
+          "name": "team_application_active_claims_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_active_claims_season_user_unique": {
+          "name": "team_application_active_claims_season_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "major_prestart_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "education_verifications",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"tournament_seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_team_id": {
+          "name": "champion_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_team_id_teams_id_fk": {
+          "name": "major_final_results_champion_team_id_teams_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "champion_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_team_id_teams_id_fk": {
+          "name": "major_stage_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_team_unique": {
+          "name": "major_stage_entrants_run_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "team_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1787759760291,
       "tag": "0008_youthful_phalanx",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1787825284855,
+      "tag": "0009_amused_mother_askani",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:major-start:local": "tsx scripts/db/local.ts test-major-start",
     "test:major-swiss:local": "tsx scripts/db/local.ts test-major-start",
     "test:major-roster-safety:local": "tsx scripts/db/local.ts test-major-roster-safety",
+    "test:major-result-recovery:local": "tsx scripts/db/local.ts test-major-result-recovery",
     "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:major-prestart:local": "tsx scripts/db/local.ts test-major-prestart",
     "test:major-start:local": "tsx scripts/db/local.ts test-major-start",
     "test:major-swiss:local": "tsx scripts/db/local.ts test-major-start",
+    "test:major-roster-safety:local": "tsx scripts/db/local.ts test-major-roster-safety",
     "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -46,6 +46,9 @@ try {
     case "test-major-prestart":
       runLocalIntegration("scripts/db/major-prestart-integration.ts");
       break;
+    case "test-major-roster-safety":
+      runLocalIntegration("scripts/db/major-roster-safety-integration.ts");
+      break;
     case "bootstrap":
       startLocalStack();
       migrateLocalDatabase();
@@ -70,7 +73,7 @@ try {
       break;
     default:
       throw new Error(
-        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | bootstrap | reset | stop | studio | dev",
+        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | test-major-roster-safety | bootstrap | reset | stop | studio | dev",
       );
   }
 } catch (error) {

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -49,6 +49,9 @@ try {
     case "test-major-roster-safety":
       runLocalIntegration("scripts/db/major-roster-safety-integration.ts");
       break;
+    case "test-major-result-recovery":
+      runLocalIntegration("scripts/db/major-result-recovery-integration.ts");
+      break;
     case "bootstrap":
       startLocalStack();
       migrateLocalDatabase();
@@ -73,7 +76,7 @@ try {
       break;
     default:
       throw new Error(
-        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | test-major-roster-safety | bootstrap | reset | stop | studio | dev",
+        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | test-major-roster-safety | test-major-result-recovery | bootstrap | reset | stop | studio | dev",
       );
   }
 } catch (error) {

--- a/scripts/db/major-result-recovery-integration.ts
+++ b/scripts/db/major-result-recovery-integration.ts
@@ -1,0 +1,611 @@
+/**
+ * PR G2 — 比分更正与恢复真实 PostgreSQL 集成测试。
+ *
+ * 覆盖场景：
+ *  B. 下游生成前的胜者更正（无需作废任何比赛，修正后 finalize 可重建）
+ *  A. 同胜者比分笔误最小更正（含弃赛形态）
+ *  C. 下游已生成但未开始：plan 展示影响 → 显式确认恢复 → 作废未开始下游
+ *     + 回滚 finalizedRound → 经既有 finalize 确定性重建
+ *  E. 重复更正请求幂等；重复 finalize 幂等
+ *  D. 已开始的下游托管比赛 → fail closed，禁止自动重写
+ *  F. 官方名次存在时禁止胜者更正（赛后裁决边界）
+ *  G. 后续阶段 StageRun 已建立时禁止本阶段胜者更正（stage transition 边界）
+ *
+ * 托管比赛 team_a = 高种子方。fixture 默认高种子获胜；flips 指定场次由低种子爆冷获胜。
+ *
+ * 只允许 loopback Local Supabase。
+ */
+import { randomUUID } from "node:crypto";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool, type PoolClient } from "pg";
+import * as schema from "../../src/db/schema";
+import {
+  applyResultCorrectionInTx,
+  planResultCorrectionInTx,
+} from "../../src/lib/match-corrections/service";
+import { finalizeMajorSwissRoundInTransaction } from "../../src/lib/major/swiss-runtime";
+import { generateNextMajorSwissRound } from "../../src/lib/major/swiss";
+import { AppError, ErrorCode } from "../../src/lib/errors";
+import { createMajorDefaultCapabilities } from "../../src/types/season";
+
+const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
+const target = new URL(databaseUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(target.hostname)) {
+  throw new Error("结果恢复集成测试只允许 Local Supabase loopback 数据库。");
+}
+
+const ACTOR = "local-admin-g2";
+
+function assertCondition(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+async function expectAppError(
+  work: () => Promise<unknown>,
+  code: ErrorCode,
+  messageIncludes?: string,
+  hint?: string,
+): Promise<void> {
+  try {
+    await work();
+  } catch (error) {
+    if (error instanceof AppError && error.code === code) {
+      if (messageIncludes && !error.message.includes(messageIncludes)) {
+        throw new Error(
+          `${hint ?? "操作"}：错误码匹配但文案缺失「${messageIncludes}」，实际「${error.message}」`,
+        );
+      }
+      return;
+    }
+    throw new Error(`${hint ?? "操作"}：预期 AppError(${code})，实际 ${String(error)}`);
+  }
+  throw new Error(`${hint ?? "操作"}：预期失败（${code}），但操作成功。`);
+}
+
+interface RecoveryFixture {
+  seasonId: string;
+  stageKeysWithRuns: { stageKey: string; runId: string }[];
+}
+
+const STAGE_PLAN_KEYS = ["stage1", "stage2", "stage3", "playoff"];
+
+async function prepareFixture(
+  pool: Pool,
+  label: string,
+  extraStageKeys: string[] = [],
+): Promise<RecoveryFixture> {
+  const client = await pool.connect();
+  const seasonId = randomUUID();
+  const capabilities = createMajorDefaultCapabilities();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO seasons (
+        id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft,
+        stage_plan, registration_config, team_registration_config, affiliation_rules, min_team_size, max_team_size, starter_count, positions
+      ) VALUES ($1, $2, 'Local Major Recovery', 'Major', 'playing', $3, $4, $5, $6::json, $7::json, $8::json, $9::json, $10, $11, $12, $13::text[])`,
+      [
+        seasonId,
+        `local-major-recovery-${label}-${seasonId}`,
+        capabilities.registrationMode,
+        capabilities.hasCaptainVoting,
+        capabilities.hasDraft,
+        JSON.stringify(capabilities.stagePlan),
+        JSON.stringify(capabilities.registrationConfig),
+        JSON.stringify(capabilities.teamRegistrationConfig),
+        JSON.stringify(capabilities.affiliationRules),
+        capabilities.minTeamSize,
+        capabilities.maxTeamSize,
+        capabilities.starterCount,
+        capabilities.positions,
+      ],
+    );
+
+    const userIds = Array.from({ length: 16 }, () => randomUUID());
+    for (let i = 0; i < userIds.length; i += 1) {
+      await client.query(`INSERT INTO users (id, email, email_verified_at) VALUES ($1, $2, now())`, [
+        userIds[i], `g2-${i}-${seasonId}@local.test`,
+      ]);
+    }
+    const teamIds: string[] = [];
+    const prestartEntrantIds: string[] = [];
+    for (let i = 0; i < 16; i += 1) {
+      const applicationId = randomUUID();
+      const teamId = randomUUID();
+      const memberId = randomUUID();
+      teamIds.push(teamId);
+      await client.query(
+        `INSERT INTO team_applications (id, season_id, name, captain_user_id, status)
+         VALUES ($1, $2, $3, $4, 'approved')`,
+        [applicationId, seasonId, `Team ${i + 1}`, userIds[i]],
+      );
+      await client.query(
+        `INSERT INTO teams (id, season_id, name, captain_user_id, team_application_id)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [teamId, seasonId, `Team ${i + 1}`, userIds[i], applicationId],
+      );
+      await client.query(
+        `INSERT INTO team_application_members (id, application_id, user_id, invited_by_user_id, status, confirmed_at)
+         VALUES ($1, $2, $3, $4, 'confirmed', now())`,
+        [memberId, applicationId, userIds[i], userIds[i]],
+      );
+      await client.query(
+        `INSERT INTO team_members (team_id, season_id, user_id, team_application_member_id)
+         VALUES ($1, $2, $3, $4)`,
+        [teamId, seasonId, userIds[i], memberId],
+      );
+      const entrant = await client.query<{ id: string }>(
+        `INSERT INTO major_prestart_entrants (season_id, team_id, roster_confirmed_at, roster_confirmed_by)
+         VALUES ($1, $2, now(), 'local-admin') RETURNING id`,
+        [seasonId, teamId],
+      );
+      prestartEntrantIds.push(entrant.rows[0]!.id);
+    }
+
+    await client.query(
+      `INSERT INTO major_prestart_states (season_id, entrants_locked_at, entrants_locked_by, seed_revision, confirmed_seed_revision)
+       VALUES ($1, now(), 'local-admin', 1, 1)`,
+      [seasonId],
+    );
+
+    const stageKeys = ["stage1", ...extraStageKeys];
+    const stageKeysWithRuns: { stageKey: string; runId: string }[] = [];
+    for (const stageKey of stageKeys) {
+      const ruleSnapshot = {
+        version: 2,
+        stage: stageKey === "playoff"
+          ? { key: stageKey, name: stageKey, type: "single_elim", teamCount: 8, matchFormat: "bo3", finalFormat: "bo5" }
+          : { key: stageKey, type: "swiss", teamCount: 16, matchFormat: "bo1" },
+        rosterRules: { minTeamSize: capabilities.minTeamSize, maxTeamSize: capabilities.maxTeamSize, starterCount: capabilities.starterCount },
+        affiliationRules: [],
+        stagePlan: STAGE_PLAN_KEYS.map((key) => ({ key })),
+        tournamentEntrants: [],
+        tournamentSeeds: [],
+        openingPairings: [],
+      };
+      const run = await client.query<{ id: string }>(
+        `INSERT INTO major_stage_runs (season_id, stage_key, rule_snapshot, started_by)
+         VALUES ($1, $2, $3::jsonb, 'local-admin') RETURNING id`,
+        [seasonId, stageKey, JSON.stringify(ruleSnapshot)],
+      );
+      const runId = run.rows[0]!.id;
+      stageKeysWithRuns.push({ stageKey, runId });
+      if (stageKey === "stage1") {
+        for (let i = 0; i < 16; i += 1) {
+          await client.query(
+            `INSERT INTO major_stage_entrants (stage_run_id, entrant_id, team_id, tournament_seed, stage_seed)
+             VALUES ($1, $2, $3, $4, $4)`,
+            [runId, prestartEntrantIds[i], teamIds[i], i + 1],
+          );
+        }
+      }
+    }
+
+    await client.query("COMMIT");
+    return { seasonId, stageKeysWithRuns };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+interface R1Context {
+  matchIdsByIndex: string[];
+}
+
+async function generateAndInsertRound1(pool: Pool, fixture: RecoveryFixture): Promise<R1Context> {
+  const run = fixture.stageKeysWithRuns[0]!;
+  const client = await pool.connect();
+  try {
+    const entrantRows = await client.query<{ team_id: string; stage_seed: number }>(
+      `SELECT team_id, stage_seed FROM major_stage_entrants WHERE stage_run_id = $1 ORDER BY stage_seed`,
+      [run.runId],
+    );
+    const entrants = entrantRows.rows.map((row) => ({
+      teamId: row.team_id,
+      initialStageSeed: row.stage_seed,
+    }));
+    const pairings = generateNextMajorSwissRound({
+      entrants,
+      matches: [],
+      finalizedRound: 0,
+      stageMatchFormat: "bo1",
+    });
+    assertCondition(pairings.length === 8, "engine 必须给出 8 场首轮对阵");
+
+    const ids: string[] = [];
+    for (let index = 0; index < pairings.length; index += 1) {
+      const pairing = pairings[index]!;
+      const inserted = await client.query<{ id: string }>(
+        `INSERT INTO matches (
+           season_id, team_a_id, team_b_id, stage, round, format, status,
+           ownership, major_stage_run_id, managed_key
+         ) VALUES ($1, $2, $3, 'stage1', 1, $4, 'scheduled', 'major_stage', $5, $6)
+         RETURNING id`,
+        [
+          fixture.seasonId, pairing.higherSeedTeamId, pairing.lowerSeedTeamId,
+          pairing.format, run.runId, `r1-${index + 1}`,
+        ],
+      );
+      ids.push(inserted.rows[0]!.id);
+    }
+    return { matchIdsByIndex: ids };
+  } finally {
+    client.release();
+  }
+}
+
+async function finishRound1Matches(
+  pool: Pool,
+  ctx: R1Context,
+  options: { flipMatchIndexes?: number[] } = {},
+): Promise<void> {
+  const flips = new Set(options.flipMatchIndexes ?? []);
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (let index = 0; index < ctx.matchIdsByIndex.length; index += 1) {
+      const matchId = ctx.matchIdsByIndex[index]!;
+      // flipped: 高种子(A) 9 : 低种子(B) 13 —— 爆冷；否则 A 13:4。
+      const [scoreA, scoreB] = flips.has(index) ? [9, 13] : [13, 4];
+      await client.query(
+        `UPDATE matches SET score_a = $2, score_b = $3, status = 'finished', completed_at = now(), updated_at = now()
+         WHERE id = $1`,
+        [matchId, scoreA, scoreB],
+      );
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function countManagedMatches(client: PoolClient, runId: string, round: number): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM matches WHERE major_stage_run_id = $1 AND round = $2 AND ownership = 'major_stage'`,
+    [runId, round],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+async function auditCount(client: PoolClient, action: string, targetId: string): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM audit_logs WHERE action = $1 AND target_id = $2`,
+    [action, targetId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+async function getMatchFact(client: PoolClient, matchId: string): Promise<{ scoreA: number; scoreB: number; isForfeit: boolean }> {
+  const row = await client.query<{ score_a: number; score_b: number; is_forfeit: boolean }>(
+    `SELECT score_a, score_b, is_forfeit FROM matches WHERE id = $1`,
+    [matchId],
+  );
+  return {
+    scoreA: row.rows[0]!.score_a,
+    scoreB: row.rows[0]!.score_b,
+    isForfeit: row.rows[0]!.is_forfeit,
+  };
+}
+
+async function getFinalizedRound(client: PoolClient, runId: string): Promise<number> {
+  const row = await client.query<{ finalized_round: number }>(
+    `SELECT finalized_round FROM major_stage_runs WHERE id = $1`, [runId]);
+  return row.rows[0]!.finalized_round;
+}
+
+async function cleanupFixture(pool: Pool, fixture: RecoveryFixture): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("DELETE FROM audit_logs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_final_results WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM major_stage_entrants e USING major_stage_runs r
+      WHERE e.stage_run_id = r.id AND r.season_id = $1`, [fixture.seasonId]);
+    await client.query("DELETE FROM major_stage_runs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_tournament_seeds WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM major_prestart_roster_members r USING major_prestart_entrants e
+      WHERE r.entrant_id = e.id AND e.season_id = $1`, [fixture.seasonId]);
+    await client.query("DELETE FROM major_prestart_entrants WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_prestart_states WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM team_members WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM team_application_members m USING team_applications a
+      WHERE m.application_id = a.id AND a.season_id = $1`, [fixture.seasonId]);
+    await client.query("DELETE FROM teams WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM team_applications WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM users WHERE email LIKE '%' || $1 || '%'`, [fixture.seasonId]);
+    await client.query("DELETE FROM seasons WHERE id = $1", [fixture.seasonId]);
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 6 });
+  const database = drizzle(pool, { schema });
+  const fixtures: RecoveryFixture[] = [];
+
+  try {
+    // ── B：下游尚未生成的胜者更正 ──────────────────────────────────────
+    {
+      const fixture = await prepareFixture(pool, "before-downstream");
+      fixtures.push(fixture);
+      const run = fixture.stageKeysWithRuns[0]!;
+      const r1 = await generateAndInsertRound1(pool, fixture);
+      // m0 爆冷：低种子 13:9 取胜，随后管理员更正回高种子获胜。
+      await finishRound1Matches(pool, r1, { flipMatchIndexes: [0] });
+
+      const m0 = r1.matchIdsByIndex[0]!;
+      await expectAppError(
+        () => database.transaction((tx) =>
+          applyResultCorrectionInTx(tx, {
+            matchId: m0,
+            proposal: { scoreA: 13, scoreB: 4 },
+            actorId: ACTOR,
+          }),
+        ),
+        ErrorCode.VALIDATION_FAILED,
+        undefined,
+        "B1 缺少恢复确认必须拒绝",
+      );
+
+      const applied = await database.transaction((tx) =>
+        applyResultCorrectionInTx(tx, {
+          matchId: m0,
+          proposal: { scoreA: 13, scoreB: 4 },
+          actorId: ACTOR,
+          confirmRecovery: true,
+        }),
+      );
+      assertCondition(!applied.alreadyApplied && applied.winnerChanged, "B2 应应用胜者变更");
+      assertCondition(applied.invalidatedDownstreamMatches.length === 0, "B2 无下游时不应作废任何比赛");
+
+      const client = await pool.connect();
+      try {
+        const fact = await getMatchFact(client, m0);
+        assertCondition(fact.scoreA === 13 && fact.scoreB === 4, "B2 更正事实必须落库");
+        assertCondition(await auditCount(client, "match.result.corrected", m0) === 1, "B2 更正审计恰好一条");
+
+        // 修正后经既有 finalize 路径重建第 2 轮。
+        const rebuilt = await database.transaction((tx) =>
+          finalizeMajorSwissRoundInTransaction(tx, {
+            seasonId: fixture.seasonId, stageRunId: run.runId, expectedRound: 1, actorId: ACTOR,
+          }),
+        );
+        assertCondition(!rebuilt.alreadyFinalized && rebuilt.createdNextRound === 8, "B3 修正后确认第 1 轮应重建 8 场第 2 轮");
+      } finally {
+        client.release();
+      }
+    }
+
+    // ── A / C / D / E / F / G：主 fixture ───────────────────────────────
+    {
+      const fixture = await prepareFixture(pool, "main-recovery");
+      fixtures.push(fixture);
+      const run = fixture.stageKeysWithRuns[0]!;
+      const r1 = await generateAndInsertRound1(pool, fixture);
+      await finishRound1Matches(pool, r1, { flipMatchIndexes: [0] });
+      await database.transaction((tx) =>
+        finalizeMajorSwissRoundInTransaction(tx, {
+          seasonId: fixture.seasonId, stageRunId: run.runId, expectedRound: 1, actorId: ACTOR,
+        }),
+      );
+
+      const client = await pool.connect();
+
+      // A. 同胜者笔误最小更正。
+      const typoTarget = r1.matchIdsByIndex[1]!;
+      const typoApplied = await database.transaction((tx) =>
+        applyResultCorrectionInTx(tx, {
+          matchId: typoTarget,
+          proposal: { scoreA: 13, scoreB: 9 },
+          actorId: ACTOR,
+        }),
+      );
+      assertCondition(!typoApplied.winnerChanged && !typoApplied.alreadyApplied, "A 同胜者笔误应为普通更正");
+
+      // A2. 弃赛形态同胜者更正。
+      await database.transaction((tx) =>
+        applyResultCorrectionInTx(tx, {
+          matchId: r1.matchIdsByIndex[2]!,
+          proposal: { scoreA: 13, scoreB: 0, isForfeit: true },
+          actorId: ACTOR,
+        }),
+      );
+      {
+        const forfeitFact = await getMatchFact(client, r1.matchIdsByIndex[2]!);
+        assertCondition(forfeitFact.isForfeit, "A2 弃赛标记必须持久化");
+      }
+
+      // C. 计划层展示影响并要求显式确认。
+      const m0 = r1.matchIdsByIndex[0]!;
+      const plan = await database.transaction((tx) =>
+        planResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 } }),
+      );
+      assertCondition(plan.winnerChanges, "C 计划必须识别胜者变更");
+      assertCondition(plan.blockedReasons.length === 0, "C 全部下游未开始时不应有 fail-closed 理由");
+      const plannedInvalidations = plan.impacts.filter((impact) => impact.kind === "downstream_match" && impact.status === "scheduled");
+      assertCondition(plannedInvalidations.length === 8, "C 影响清单必须列出全部 8 场第 2 轮（配对可能涟漪重排）");
+      assertCondition(plan.impacts.some((impact) => impact.kind === "stage_run_rollback"), "C 计划必须包含 finalizedRound 回滚");
+      assertCondition(await auditCount(client, "match.result.corrected", m0) === 0, "C 前置状态：m0 尚无更正审计");
+
+      await expectAppError(
+        () => database.transaction((tx) =>
+          applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR }),
+        ),
+        ErrorCode.VALIDATION_FAILED,
+        "显式确认恢复流程",
+        "C1 未确认恢复必须拒绝",
+      );
+
+      const applied = await database.transaction((tx) =>
+        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR, confirmRecovery: true }),
+      );
+      assertCondition(applied.winnerChanged, "C2 应用必须成功");
+      assertCondition(applied.invalidatedDownstreamMatches.length === 8, "C2 应作废全部 8 场第 2 轮");
+      assertCondition(applied.rolledBackToFinalized === 0, "C2 finalizedRound 应回滚到 0");
+      assertCondition(await auditCount(client, "match.result.corrected", m0) === 1, "C2 更正审计恰好一条");
+      assertCondition(await auditCount(client, "major.stage.finalized_round.revoked", run.runId) === 1, "C2 回滚审计恰好一条");
+      assertCondition(await countManagedMatches(client, run.runId, 2) === 0, "C2 第 2 轮托管比赛应清空");
+      for (const invalidated of applied.invalidatedDownstreamMatches) {
+        assertCondition(await auditCount(client, "match.managed.invalidated", invalidated) === 1, "C2 每场作废必须有独立审计");
+      }
+
+      // E. 重复提交同一更正请求：alreadyApplied 且不新增审计/不再作废。
+      const repeat = await database.transaction((tx) =>
+        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR, confirmRecovery: true }),
+      );
+      assertCondition(repeat.alreadyApplied, "E 重复更正应 alreadyApplied");
+      assertCondition(repeat.invalidatedDownstreamMatches.length === 0, "E 重复更正不得再作废任何比赛");
+      assertCondition(await auditCount(client, "match.result.corrected", m0) === 1, "E 重复更正不得新增审计");
+
+      // C3/F. 经既有 finalize 确定性重建；重复 finalize 幂等。
+      const rebuilt = await database.transaction((tx) =>
+        finalizeMajorSwissRoundInTransaction(tx, {
+          seasonId: fixture.seasonId, stageRunId: run.runId, expectedRound: 1, actorId: ACTOR,
+        }),
+      );
+      assertCondition(!rebuilt.alreadyFinalized && rebuilt.createdNextRound === 8, "C3 重建应重新生成 8 场第 2 轮");
+      const rebuildRepeat = await database.transaction((tx) =>
+        finalizeMajorSwissRoundInTransaction(tx, {
+          seasonId: fixture.seasonId, stageRunId: run.runId, expectedRound: 1, actorId: ACTOR,
+        }),
+      );
+      assertCondition(rebuildRepeat.alreadyFinalized && rebuildRepeat.createdNextRound === 0, "F 重复 finalize 幂等");
+      assertCondition(await countManagedMatches(client, run.runId, 2) === 8, "C3 重建后第 2 轮仍为 8 场");
+
+      // C4. 更正后的胜者（m0 teamA=高种子）必须真实出现在重建后的对阵中。
+      {
+        const m0Teams = await client.query<{ team_a_id: string; team_b_id: string; score_a: number; score_b: number }>(
+          `SELECT team_a_id, team_b_id, score_a, score_b FROM matches WHERE id = $1`, [m0]);
+        const restoredWinner =
+          m0Teams.rows[0]!.score_a > m0Teams.rows[0]!.score_b ? m0Teams.rows[0]!.team_a_id : m0Teams.rows[0]!.team_b_id;
+        const containsNewWinner = await client.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM matches
+           WHERE major_stage_run_id = $1 AND round = 2 AND (team_a_id = $2 OR team_b_id = $2)`,
+          [run.runId, restoredWinner],
+        );
+        assertCondition(Number(containsNewWinner.rows[0]!.count) >= 1, "C4 恢复后的胜者必须出现在重建对阵中");
+      }
+
+      // D. 一场第 2 轮开始后再尝试另一场第 1 轮逆转 → hard block。
+      {
+        const r2Row = await client.query<{ id: string }>(
+          `SELECT id FROM matches WHERE major_stage_run_id = $1 AND round = 2 LIMIT 1`, [run.runId]);
+        await client.query(`UPDATE matches SET status = 'in_progress', updated_at = now() WHERE id = $1`, [r2Row.rows[0]!.id]);
+        const mLast = r1.matchIdsByIndex[r1.matchIdsByIndex.length - 1]!;
+        await expectAppError(
+          () => database.transaction((tx) =>
+            applyResultCorrectionInTx(tx, { matchId: mLast, proposal: { scoreA: 4, scoreB: 13 }, actorId: ACTOR, confirmRecovery: true }),
+          ),
+          ErrorCode.VALIDATION_FAILED,
+          "已经开始或完成",
+          "D 已开始下游必须硬阻断",
+        );
+        const untouched = await getMatchFact(client, mLast);
+        assertCondition(untouched.scoreA === 13 && untouched.scoreB === 4, "D 阻断后原结果不变");
+        assertCondition(await getFinalizedRound(client, run.runId) === 1, "D 阻断后 finalizedRound 不变");
+      }
+
+      // F. 注入官方名次事实 → 任何胜者更正被拒绝。
+      {
+        const finalResultCheck = await client.query<{ id: string }>(
+          `INSERT INTO major_final_results (
+             season_id, playoff_stage_run_id, champion_team_id, placement_groups, status, finalized_by
+           )
+           SELECT $1, $2, (SELECT team_id FROM major_stage_entrants WHERE stage_run_id = $2 ORDER BY stage_seed LIMIT 1), '[]'::jsonb, 'pending_confirmation', 'local-admin'
+           RETURNING id`,
+          [fixture.seasonId, run.runId],
+        );
+        assertCondition(Boolean(finalResultCheck.rows[0]?.id), "F 官方名次夹具注入成功");
+        await expectAppError(
+          () => database.transaction((tx) =>
+            applyResultCorrectionInTx(tx, { matchId: typoTarget, proposal: { scoreA: 4, scoreB: 13 }, actorId: ACTOR, confirmRecovery: true }),
+          ),
+          ErrorCode.VALIDATION_FAILED,
+          "官方名次已经生成",
+          "F 官方名次存在时必须拒绝胜者更正",
+        );
+        await client.query(`DELETE FROM major_final_results WHERE season_id = $1`, [fixture.seasonId]);
+      }
+
+      // G. 后续阶段 StageRun 已建立 → 本阶段胜者更正被拒绝。
+      await client.query(
+        `INSERT INTO major_stage_runs (season_id, stage_key, rule_snapshot, started_by)
+         SELECT r.season_id, 'stage2',
+                jsonb_set(r.rule_snapshot, '{stage}', '{"key":"stage2","type":"swiss","teamCount":16,"matchFormat":"bo1"}'::jsonb),
+                'local-admin'
+         FROM major_stage_runs r WHERE r.id = $1`,
+        [run.runId],
+      );
+      fixtures.at(-1)!.stageKeysWithRuns.push({ stageKey: "stage2", runId: "(via-insert)" });
+
+      client.release();
+
+      // 用独立 fixture 再验证一次完整阻断路径（不依赖主 fixture 内部顺序）。
+      {
+        const staged = await prepareFixture(pool, "post-transition");
+        fixtures.push(staged);
+        const stage1 = staged.stageKeysWithRuns[0]!;
+        const r1Late = await generateAndInsertRound1(pool, staged);
+        await finishRound1Matches(pool, r1Late, { flipMatchIndexes: [0] });
+        await database.transaction((tx) =>
+          finalizeMajorSwissRoundInTransaction(tx, {
+            seasonId: staged.seasonId, stageRunId: stage1.runId, expectedRound: 1, actorId: ACTOR,
+          }),
+        );
+        const separateClient = await pool.connect();
+        try {
+          await separateClient.query(
+            `INSERT INTO major_stage_runs (season_id, stage_key, rule_snapshot, started_by)
+             SELECT r.season_id, 'stage2',
+                    jsonb_set(r.rule_snapshot, '{stage}', '{"key":"stage2","type":"swiss","teamCount":16,"matchFormat":"bo1"}'::jsonb),
+                    'local-admin'
+             FROM major_stage_runs r WHERE r.id = $1`,
+            [stage1.runId],
+          );
+          staged.stageKeysWithRuns.push({ stageKey: "stage2", runId: "(late-marker)" });
+        } finally {
+          separateClient.release();
+        }
+
+        await expectAppError(
+          () => database.transaction((tx) =>
+            applyResultCorrectionInTx(tx, {
+              matchId: r1Late.matchIdsByIndex[0]!,
+              proposal: { scoreA: 13, scoreB: 4 },
+              actorId: ACTOR,
+              confirmRecovery: true,
+            }),
+          ),
+          ErrorCode.VALIDATION_FAILED,
+          "后续阶段",
+          "G 后续阶段存在时必须拒绝胜者更正",
+        );
+      }
+    }
+
+    console.log("G2 result recovery integration suite passed.");
+  } finally {
+    for (const fixture of fixtures.reverse()) {
+      await cleanupFixture(pool, fixture);
+    }
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/db/major-roster-safety-integration.ts
+++ b/scripts/db/major-roster-safety-integration.ts
@@ -1,0 +1,686 @@
+/**
+ * PR G1 — Major 阵容安全真实 PostgreSQL 集成测试。
+ *
+ * 覆盖场景：
+ *  1. 无 roster start → fail（且不产生任何静默补名单）
+ *  2. 4 名首发 → fail
+ *  3. 6 名首发 → fail
+ *  4. 队外选手 / 冻结名单外人 → fail
+ *  5. 重复选择队员 → fail
+ *  6. 合法 5 人但 NJU 首发 <3 → fail
+ *  7. 合法且 NJU 首发 ≥3 → confirm → start 通过
+ *  8. mutable season 规则改变不影响 frozen StageRun 快照
+ *  9. admin 选择默认首发但不确认 → start fail；显式确认 → 通过
+ * 10. repeated submit 幂等/确定性
+ * 11. repeated confirm 幂等且不重复写 audit
+ * 12. 并发 start 只产生一次状态推进、一次 match.start audit，无双 roster
+ *
+ * 只允许 loopback Local Supabase。
+ */
+import { randomUUID } from "node:crypto";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool, type PoolClient } from "pg";
+import * as schema from "../../src/db/schema";
+import { auditLogs } from "../../src/db/schema";
+import {
+  applyMatchStatusTransitionInTx,
+  assertStartingLineupAllowedInTx,
+  confirmMatchRosterInTx,
+  lockMatchInTx,
+  persistMatchRosterInTx,
+  type MatchTransitionOutcome,
+} from "../../src/lib/match-rosters/service";
+import { AppError, ErrorCode } from "../../src/lib/errors";
+import { createMajorDefaultCapabilities } from "../../src/types/season";
+
+const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
+const target = new URL(databaseUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(target.hostname)) {
+  throw new Error("阵容安全集成测试只允许 Local Supabase loopback 数据库。");
+}
+
+const ACTOR = "local-admin-g1";
+
+async function expectAppError(work: () => Promise<unknown>, code: ErrorCode, hint?: string): Promise<AppError> {
+  try {
+    await work();
+  } catch (error) {
+    if (error instanceof AppError && error.code === code) return error;
+    throw new Error(`${hint ?? "操作"}：预期 AppError(${code})，实际 ${String(error)}`);
+  }
+  throw new Error(`${hint ?? "操作"}：预期失败（${code}），但操作成功。`);
+}
+
+function assertCondition(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+async function countAudit(client: PoolClient, matchId: string, action: string): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM audit_logs WHERE target_id = $1 AND target_type = 'match' AND action = $2`,
+    [matchId, action],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+type Database = ReturnType<typeof drizzle<typeof schema>>;
+
+/**
+ * 与 src/actions/matches/roster.ts#submitMatchRoster 的生产事务体一致
+ * （不含 captain session 判定）。
+ */
+async function submitLineupProductionLogic(
+  database: Database,
+  args: {
+    matchId: string;
+    teamId: string;
+    starterIds: string[];
+    substituteIds?: string[];
+    source: "participant" | "admin_select";
+    submittedBy: string | null;
+  },
+): Promise<{ rosterId: string }> {
+  return database.transaction(async (tx) => {
+    const locked = await lockMatchInTx(tx, args.matchId);
+    if (locked.status !== "scheduled") {
+      throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛已开始或取消，不能再调整阵容");
+    }
+    await assertStartingLineupAllowedInTx(tx, {
+      match: locked,
+      teamId: args.teamId,
+      starterIds: args.starterIds,
+      substituteIds: args.substituteIds,
+    });
+    const summary = await persistMatchRosterInTx(tx, {
+      match: locked,
+      teamId: args.teamId,
+      submittedBy: args.submittedBy,
+      source: args.source,
+      starterIds: args.starterIds,
+      substituteIds: args.substituteIds,
+    });
+    await tx.insert(auditLogs).values({
+      seasonId: locked.seasonId,
+      action: "match.roster.submit",
+      actorId: ACTOR,
+      targetId: summary.rosterId,
+      targetType: "match_roster",
+      meta: {
+        matchId: args.matchId,
+        teamId: args.teamId,
+        source: args.source,
+        starterIds: args.starterIds,
+        substituteIds: args.substituteIds ?? [],
+      },
+    });
+    return { rosterId: summary.rosterId };
+  });
+}
+
+async function confirmRosterProductionLogic(database: Database, rosterId: string): Promise<{ alreadyConfirmed: boolean }> {
+  return database.transaction(async (tx) => {
+    const outcome = await confirmMatchRosterInTx(tx, { rosterId, actorId: ACTOR });
+    return { alreadyConfirmed: outcome.alreadyConfirmed };
+  });
+}
+
+// ── Fixture ────────────────────────────────────────────────────────────────
+
+interface RosterSafetyFixture {
+  seasonId: string;
+  runId: string;
+  teamAId: string;
+  teamBId: string;
+  /** Member id lookup by logical position: a0..a5 on team A, b0..b5 on B, plus outsider members aOut/bOut. */
+  memberA: Record<string, string>;
+  memberB: Record<string, string>;
+}
+
+const NJU_CODE = "4132010284";
+const OTHER_CODE = "4111010001";
+
+/** A-team user layout: 0,1,2 NJU enrolled; 3,4 other-graduated; 5 other-enrolled; 6 NJU but excluded from frozen roster. */
+function teamUserLayout(offset: number): { userIdIndex: number; institutionCode: string | null; academicStatus: "enrolled" | "graduated"; frozen: boolean }[] {
+  return [
+    { userIdIndex: offset + 0, institutionCode: NJU_CODE, academicStatus: "enrolled", frozen: true },
+    { userIdIndex: offset + 1, institutionCode: NJU_CODE, academicStatus: "enrolled", frozen: true },
+    { userIdIndex: offset + 2, institutionCode: NJU_CODE, academicStatus: "graduated", frozen: true },
+    { userIdIndex: offset + 3, institutionCode: OTHER_CODE, academicStatus: "graduated", frozen: true },
+    { userIdIndex: offset + 4, institutionCode: OTHER_CODE, academicStatus: "enrolled", frozen: true },
+    { userIdIndex: offset + 5, institutionCode: OTHER_CODE, academicStatus: "enrolled", frozen: true },
+    // Canonical team member who is deliberately absent from the tournament roster.
+    { userIdIndex: offset + 6, institutionCode: NJU_CODE, academicStatus: "enrolled", frozen: false },
+  ];
+}
+
+async function prepareFixture(pool: Pool, label: string): Promise<RosterSafetyFixture> {
+  const client = await pool.connect();
+  const seasonId = randomUUID();
+  const capabilities = createMajorDefaultCapabilities();
+  try {
+    await client.query("BEGIN");
+
+    await client.query(
+      `INSERT INTO seasons (
+        id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft,
+        stage_plan, registration_config, team_registration_config, affiliation_rules, min_team_size, max_team_size, starter_count, positions
+      ) VALUES ($1, $2, 'Local Major Roster Safety', 'Major', 'playing', $3, $4, $5, $6::json, $7::json, $8::json, $9::json, $10, $11, $12, $13::text[])`,
+      [
+        seasonId,
+        `local-major-roster-safety-${label}-${seasonId}`,
+        capabilities.registrationMode,
+        capabilities.hasCaptainVoting,
+        capabilities.hasDraft,
+        JSON.stringify(capabilities.stagePlan),
+        JSON.stringify(capabilities.registrationConfig),
+        JSON.stringify(capabilities.teamRegistrationConfig),
+        JSON.stringify(capabilities.affiliationRules),
+        capabilities.minTeamSize,
+        capabilities.maxTeamSize,
+        capabilities.starterCount,
+        capabilities.positions,
+      ],
+    );
+
+    const allLayouts = [...teamUserLayout(0), ...teamUserLayout(100)];
+    const userIds = allLayouts.map(() => randomUUID());
+    for (let i = 0; i < userIds.length; i += 1) {
+      await client.query(
+        `INSERT INTO users (id, email, email_verified_at) VALUES ($1, $2, now())`,
+        [userIds[i], `g1-${i}-${seasonId}@local.test`],
+      );
+    }
+
+    const applicationIds = [randomUUID(), randomUUID()];
+    const applicationMemberIds: string[][] = [[], []];
+    const teamIds = [randomUUID(), randomUUID()];
+
+    for (const side of [0, 1] as const) {
+      const layouts = teamUserLayout(side === 0 ? 0 : 100);
+      const sideUsers = userIds.filter((_, index) =>
+        index >= (side === 0 ? 0 : 7) && index < (side === 0 ? 7 : 14),
+      );
+      await client.query(
+        `INSERT INTO team_applications (id, season_id, name, captain_user_id, status)
+         VALUES ($1, $2, $3, $4, 'approved')`,
+        [applicationIds[side], seasonId, side === 0 ? "Team Alpha" : "Team Beta", sideUsers[0]],
+      );
+      await client.query(
+        `INSERT INTO teams (id, season_id, name, captain_user_id, team_application_id)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [teamIds[side], seasonId, side === 0 ? "Team Alpha" : "Team Beta", sideUsers[0], applicationIds[side]],
+      );
+      for (let offset = 0; offset < layouts.length; offset += 1) {
+        const memberId = randomUUID();
+        applicationMemberIds[side].push(memberId);
+        await client.query(
+          `INSERT INTO team_application_members (id, application_id, user_id, invited_by_user_id, status, confirmed_at)
+           VALUES ($1, $2, $3, $4, 'confirmed', now())`,
+          [memberId, applicationIds[side], sideUsers[offset], sideUsers[0]],
+        );
+        await client.query(
+          `INSERT INTO team_members (team_id, season_id, user_id, team_application_member_id)
+           VALUES ($1, $2, $3, $4)`,
+          [teamIds[side], seasonId, sideUsers[offset], memberId],
+        );
+      }
+    }
+
+    // Exactly one approved verification per user.
+    for (let i = 0; i < allLayouts.length; i += 1) {
+      const layout = allLayouts[i];
+      if (!layout.institutionCode) continue;
+      await client.query(
+        `INSERT INTO education_verifications (user_id, institution_id, academic_status, evidence_type, status, reviewed_by, reviewed_at)
+         SELECT $1, i.id, $2, 'manual_other', 'approved', 'local-admin', now()
+         FROM institutions i WHERE i.moe_institution_code = $3`,
+        [userIds[i], layout.academicStatus, layout.institutionCode],
+      );
+    }
+
+    await client.query(
+      `INSERT INTO major_prestart_states (season_id, entrants_locked_at, entrants_locked_by, seed_revision, confirmed_seed_revision)
+       VALUES ($1, now(), 'local-admin', 1, 1)`,
+      [seasonId],
+    );
+
+    const entrantRows: string[] = [];
+    for (const side of [0, 1] as const) {
+      const entrant = await client.query<{ id: string }>(
+        `INSERT INTO major_prestart_entrants (season_id, team_id, roster_confirmed_at, roster_confirmed_by)
+         VALUES ($1, $2, now(), 'local-admin') RETURNING id`,
+        [seasonId, teamIds[side]],
+      );
+      const entrantId = entrant.rows[0]!.id;
+      entrantRows.push(entrantId);
+      const sideUsers = userIds.filter((_, index) =>
+        index >= (side === 0 ? 0 : 7) && index < (side === 0 ? 7 : 14),
+      );
+      const layouts = teamUserLayout(side === 0 ? 0 : 100);
+      for (let offset = 0; offset < layouts.length; offset += 1) {
+        if (!layouts[offset].frozen) continue;
+        const verification = await client.query<{ id: string }>(
+          `SELECT v.id FROM education_verifications v
+           INNER JOIN institutions i ON i.id = v.institution_id
+           WHERE v.user_id = $1 AND i.moe_institution_code = $2`,
+          [sideUsers[offset], layouts[offset].institutionCode],
+        );
+        await client.query(
+          `INSERT INTO major_prestart_roster_members (entrant_id, user_id, education_verification_id)
+           VALUES ($1, $2, $3)`,
+          [entrantId, sideUsers[offset], verification.rows[0]!.id],
+        );
+      }
+    }
+
+    // Frozen StageRun carrying the affiliation rules accepted at launch.
+    const ruleSnapshot = {
+      version: 2,
+      stage: { key: "stage1", type: "swiss", teamCount: 16, matchFormat: "bo1" },
+      rosterRules: { minTeamSize: capabilities.minTeamSize, maxTeamSize: capabilities.maxTeamSize, starterCount: capabilities.starterCount },
+      affiliationRules: [
+        {
+          institutionCode: NJU_CODE,
+          eligibleAcademicStatuses: ["enrolled", "graduated"],
+          minRosterMembers: 3,
+          minStartingMembers: 3,
+        },
+      ],
+      tournamentEntrants: [],
+      tournamentSeeds: [],
+    };
+    const runResult = await client.query<{ id: string }>(
+      `INSERT INTO major_stage_runs (season_id, stage_key, rule_snapshot, started_by)
+       VALUES ($1, 'stage1', $2::jsonb, 'local-admin') RETURNING id`,
+      [seasonId, JSON.stringify(ruleSnapshot)],
+    );
+    const runId = runResult.rows[0]!.id;
+
+    await client.query("COMMIT");
+
+    const memberOf = async (userId: string): Promise<string> => {
+      const row = await client.query<{ id: string }>(
+        `SELECT id FROM team_members WHERE season_id = $1 AND user_id = $2`,
+        [seasonId, userId],
+      );
+      return row.rows[0]!.id;
+    };
+
+    const buildMemberMap = async (offset: number): Promise<Record<string, string>> => {
+      const map: Record<string, string> = {};
+      for (let logical = 0; logical <= 6; logical += 1) {
+        map[logical === 6 ? "out" : String(logical)] = await memberOf(userIds[offset + logical]);
+      }
+      return map;
+    };
+
+    const memberA = await buildMemberMap(0);
+    const memberB = await buildMemberMap(7);
+
+    return { seasonId, runId, teamAId: teamIds[0], teamBId: teamIds[1], memberA, memberB };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function createManagedMatch(pool: Pool, fixture: RosterSafetyFixture, managedKey: string): Promise<string> {
+  const client = await pool.connect();
+  try {
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO matches (
+         season_id, team_a_id, team_b_id, stage, round, format, status,
+         ownership, major_stage_run_id, managed_key
+       ) VALUES ($1, $2, $3, 'stage1', 1, 'bo1', 'scheduled', 'major_stage', $4, $5)
+       RETURNING id`,
+      [fixture.seasonId, fixture.teamAId, fixture.teamBId, fixture.runId, managedKey],
+    );
+    return result.rows[0]!.id;
+  } finally {
+    client.release();
+  }
+}
+
+async function cleanupFixture(pool: Pool, fixture: RosterSafetyFixture): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("DELETE FROM audit_logs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM match_roster_players p USING match_rosters r
+      WHERE p.roster_id = r.id AND r.match_id IN (SELECT id FROM matches WHERE season_id = $1)`, [fixture.seasonId]);
+    await client.query(`DELETE FROM match_rosters WHERE match_id IN (SELECT id FROM matches WHERE season_id = $1)`,
+      [fixture.seasonId]);
+    await client.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_stage_runs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM major_prestart_roster_members r USING major_prestart_entrants e
+      WHERE r.entrant_id = e.id AND e.season_id = $1`, [fixture.seasonId]);
+    await client.query("DELETE FROM major_prestart_entrants WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_prestart_states WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM team_members WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM team_application_members m USING team_applications a
+      WHERE m.application_id = a.id AND a.season_id = $1`, [fixture.seasonId]);
+    await client.query("DELETE FROM teams WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM team_applications WHERE season_id = $1", [fixture.seasonId]);
+    await client.query(`DELETE FROM education_verifications WHERE user_id IN (
+      SELECT id FROM users WHERE email LIKE '%' || $1 || '%'
+    )`, [fixture.seasonId]);
+    await client.query("DELETE FROM users WHERE email LIKE '%' || $1 || '%'", [fixture.seasonId]);
+    await client.query("DELETE FROM seasons WHERE id = $1", [fixture.seasonId]);
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function countRosters(client: PoolClient, matchId: string): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM match_rosters WHERE match_id = $1`,
+    [matchId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 6 });
+  const database = drizzle(pool, { schema });
+  let fixture: RosterSafetyFixture | null = null;
+
+  try {
+    fixture = await prepareFixture(pool, "g1");
+    const { seasonId, teamAId, teamBId, memberA, memberB } = fixture;
+
+    const lineupA = {
+      starters: [memberA["0"], memberA["1"], memberA["2"], memberA["3"], memberA["4"]],
+      substitutes: [memberA["5"]],
+    };
+    const lineupB = {
+      starters: [memberB["0"], memberB["1"], memberB["2"], memberB["3"], memberB["4"]],
+      substitutes: [memberB["5"]],
+    };
+    /** Exactly two NJU starters (positions 3–5 are non-NJU roster members). */
+    const twoNjuStartersA = [memberA["0"], memberA["1"], memberA["3"], memberA["4"], memberA["5"]];
+
+    // ── MG：主场景比赛 ────────────────────────────────────────────────
+    const mgMatch = await createManagedMatch(pool, fixture, "r1-mg");
+
+    // S1 无 roster start → fail 且无任何静默补名单。
+    {
+      const client = await pool.connect();
+      try {
+        await expectAppError(
+          () => database.transaction((tx) =>
+            applyMatchStatusTransitionInTx(tx, { matchId: mgMatch, nextStatus: "in_progress", actorId: ACTOR }),
+          ),
+          ErrorCode.VALIDATION_FAILED,
+          "S1 未提交名单时开始比赛",
+        );
+        assertCondition((await countRosters(client, mgMatch)) === 0, "S1 失败后不得产生任何隐式补名单");
+        assertCondition((await countAudit(client, mgMatch, "match.start")) === 0, "S1 不得写入 match.start 审计");
+      } finally {
+        client.release();
+      }
+    }
+
+    // S2/S3/S4/S5/S6/S7 结构与资格校验全部 fail-closed。
+    {
+      await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: lineupA.starters.slice(0, 4), substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S2 4 人首发",
+      );
+      await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: [...lineupA.starters, memberA["out"]!], substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S3 6 人首发",
+      );
+      await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: [lineupA.starters[0]!, lineupA.starters[1]!, lineupA.starters[2]!, lineupA.starters[3]!, randomUUID()],
+          substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S4 非 team_members 选手",
+      );
+      // Canonical team member present but absent from the frozen tournament roster.
+      const outsiderLineup = [...twoNjuStartersA.slice(2), memberA["out"]!, memberA["0"]!, memberA["1"]!];
+      const outsiderFailure = await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: outsiderLineup, substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S5 冻结名单外选手",
+      );
+      assertCondition(outsiderFailure.message.includes("冻结名单"), "S5 需要明确指出冻结名单 blocker");
+      const duplicateFailure = await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: [memberA["0"]!, memberA["0"]!, memberA["1"]!, memberA["2"]!, memberA["3"]!],
+          substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S6 重复选择队员",
+      );
+      assertCondition(duplicateFailure.message.includes("重复选择"), "S6 需要明确指出重复 blocker");
+      const njuShortfall = await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: twoNjuStartersA, substituteIds: [],
+        }),
+        ErrorCode.VALIDATION_FAILED,
+        "S7 NJU 首发不足 3 人",
+      );
+      assertCondition(njuShortfall.message.includes("南京大学"), "S7 需要给出 NJU 归属 shortfall 文案");
+    }
+
+    // S8 admin 选择默认首发但未确认 → start 必须拒绝。
+    const adminSelectARoster = (
+      await submitLineupProductionLogic(database, {
+        matchId: mgMatch, teamId: teamAId, source: "admin_select", submittedBy: null,
+        starterIds: lineupA.starters, substituteIds: lineupA.substitutes,
+      })
+    ).rosterId;
+    const adminSelectBRoster = (
+      await submitLineupProductionLogic(database, {
+        matchId: mgMatch, teamId: teamBId, source: "admin_select", submittedBy: null,
+        starterIds: lineupB.starters, substituteIds: lineupB.substitutes,
+      })
+    ).rosterId;
+    await expectAppError(
+      () => database.transaction((tx) =>
+        applyMatchStatusTransitionInTx(tx, { matchId: mgMatch, nextStatus: "in_progress", actorId: ACTOR }),
+      ),
+      ErrorCode.VALIDATION_FAILED,
+      "S8 默认首发未确认就开赛",
+    );
+
+    // S9 repeated submit 是幂等覆写（同一 roster 行、无重复行）。
+    {
+      const resubmitted = await submitLineupProductionLogic(database, {
+        matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+        starterIds: lineupA.starters, substituteIds: [],
+      });
+      assertCondition(resubmitted.rosterId === adminSelectARoster, "S9 重复提交必须复用同一 roster 行");
+      const client = await pool.connect();
+      try {
+        const players = await client.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM match_roster_players WHERE roster_id = $1`,
+          [resubmitted.rosterId],
+        );
+        assertCondition(Number(players.rows[0]!.count) === 5, "S9 重提交后替补应被替换为空，保留恰好 5 行");
+        const sources = await client.query<{ source: string }>(
+          `SELECT source FROM match_rosters WHERE id = $1`,
+          [resubmitted.rosterId],
+        );
+        assertCondition(sources.rows[0]!.source === "participant", "S9 参赛方重提交必须把 source 改回 participant");
+      } finally {
+        client.release();
+      }
+    }
+
+    // Restore the legal lineups after the overwrite probe, then confirm both sides.
+    await submitLineupProductionLogic(database, {
+      matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+      starterIds: lineupA.starters, substituteIds: lineupA.substitutes,
+    });
+
+    // S10 显式确认 → pass；重复确认幂等且不新增审计。
+    {
+      const first = await confirmRosterProductionLogic(database, adminSelectARoster);
+      assertCondition(!first.alreadyConfirmed, "S10 首次确认应返回 alreadyConfirmed=false");
+      const second = await confirmRosterProductionLogic(database, adminSelectARoster);
+      assertCondition(second.alreadyConfirmed, "S10 重复确认应为幂等 alreadyConfirmed=true");
+      const client = await pool.connect();
+      try {
+        assertCondition((await countAuditById(client, adminSelectARoster)) === 1, "S10 重复确认不得产生第二条 match.roster.confirm 审计");
+      } finally {
+        client.release();
+      }
+      await confirmRosterProductionLogic(database, adminSelectBRoster);
+    }
+
+    // S11 合法且 NJU≥3 → start 成功并持久化 canonical roster fact。
+    {
+      await database.transaction((tx) =>
+        applyMatchStatusTransitionInTx(tx, { matchId: mgMatch, nextStatus: "in_progress", actorId: ACTOR }),
+      );
+      const client = await pool.connect();
+      try {
+        const statusRow = await client.query<{ status: string }>(`SELECT status FROM matches WHERE id = $1`, [mgMatch]);
+        assertCondition(statusRow.rows[0]!.status === "in_progress", "S11 比赛应进入 in_progress");
+        assertCondition((await countAudit(client, mgMatch, "match.start")) === 1, "S11 应恰好一条 match.start 审计");
+        const auditMeta = await client.query<{ meta: { lineups?: unknown[] } }>(
+          `SELECT meta FROM audit_logs WHERE target_id = $1 AND action = 'match.start' LIMIT 1`,
+          [mgMatch],
+        );
+        assertCondition(Array.isArray(auditMeta.rows[0]!.meta?.lineups) && auditMeta.rows[0]!.meta!.lineups!.length === 2,
+          "S11 match.start 审计应包含两队首发摘要");
+        const confirmedRows = await client.query<{ confirmed_by: string | null; confirmed_at: Date | null }>(
+          `SELECT confirmed_by, confirmed_at FROM match_rosters WHERE match_id = $1`,
+          [mgMatch],
+        );
+        assertCondition(confirmedRows.rows.length === 2, "S11 两队各一条 canonical roster fact");
+        for (const row of confirmedRows.rows) {
+          assertCondition(row.confirmed_by === ACTOR && row.confirmed_at !== null, "S11 确认事实必须持久化 confirmed_by/at");
+        }
+      } finally {
+        client.release();
+      }
+      // 开赛后所有阵容修改路径必须关闭。
+      await expectAppError(
+        () => submitLineupProductionLogic(database, {
+          matchId: mgMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: lineupA.starters, substituteIds: lineupA.substitutes,
+        }),
+        ErrorCode.MATCH_INVALID_TRANSITION,
+        "S11 开赛后禁止再改阵容",
+      );
+    }
+
+    // S12 mutable season 规则被清空后，frozen StageRun 规则仍然生效。
+    {
+      const mbMatch = await createManagedMatch(pool, fixture, "r1-mb");
+      const client = await pool.connect();
+      try {
+        // Simulate a legitimate operator mutating the mutable season config.
+        await client.query(
+          `UPDATE seasons SET affiliation_rules = '[]'::json WHERE id = $1`,
+          [seasonId],
+        );
+        // A lineup that only satisfies the mutated season row must still be
+        // rejected against the frozen StageRun snapshot.
+        const failure = await expectAppError(
+          () => submitLineupProductionLogic(database, {
+            matchId: mbMatch, teamId: teamAId, source: "participant", submittedBy: null,
+            starterIds: twoNjuStartersA, substituteIds: [],
+          }),
+          ErrorCode.VALIDATION_FAILED,
+          "S12 mutable 规则清空后冻结规则应继续生效",
+        );
+        assertCondition(failure.message.includes("南京大学"), "S12 必须按冻结快照给出 NJU shortfall 文案");
+      } finally {
+        client.release();
+      }
+    }
+
+    // S13 并发 start：行锁串行化，恰好一个事务成功、一个确定性失败。
+    {
+      const mcMatch = await createManagedMatch(pool, fixture, "r1-mc");
+      const mcRosterA = (
+        await submitLineupProductionLogic(database, {
+          matchId: mcMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: lineupA.starters, substituteIds: lineupA.substitutes,
+        })
+      ).rosterId;
+      const mcRosterB = (
+        await submitLineupProductionLogic(database, {
+          matchId: mcMatch, teamId: teamBId, source: "participant", submittedBy: null,
+          starterIds: lineupB.starters, substituteIds: lineupB.substitutes,
+        })
+      ).rosterId;
+      await database.transaction((tx) =>
+        confirmMatchRosterInTx(tx, { rosterId: mcRosterA, actorId: ACTOR }),
+      );
+      await database.transaction((tx) =>
+        confirmMatchRosterInTx(tx, { rosterId: mcRosterB, actorId: ACTOR }),
+      );
+
+      const results = await Promise.allSettled([
+        database.transaction((tx) =>
+          applyMatchStatusTransitionInTx(tx, { matchId: mcMatch, nextStatus: "in_progress", actorId: `${ACTOR}-a` }),
+        ),
+        database.transaction((tx) =>
+          applyMatchStatusTransitionInTx(tx, { matchId: mcMatch, nextStatus: "in_progress", actorId: `${ACTOR}-b` }),
+        ),
+      ]);
+      const fulfilled = results.filter((r): r is PromiseFulfilledResult<MatchTransitionOutcome> => r.status === "fulfilled");
+      assertCondition(fulfilled.length === 1, "S13 并发 start 必须恰好一个成功");
+      const rejectedReason = results.find((r): r is PromiseRejectedResult => r.status === "rejected")!.reason;
+      assertCondition(
+        rejectedReason instanceof AppError && rejectedReason.code === ErrorCode.MATCH_INVALID_TRANSITION,
+        `S13 失败方必须是确定性的状态机拒绝，实际 ${String(rejectedReason)}`,
+      );
+
+      const client = await pool.connect();
+      try {
+        assertCondition((await countAudit(client, mcMatch, "match.start")) === 1, "S13 只能产生一条 match.start 审计");
+        assertCondition((await countRosters(client, mcMatch)) === 2, "S13 不得产生重复 roster 行");
+        const statusRow = await client.query<{ status: string }>(`SELECT status FROM matches WHERE id = $1`, [mcMatch]);
+        assertCondition(statusRow.rows[0]!.status === "in_progress", "S13 比赛应处于 in_progress");
+      } finally {
+        client.release();
+      }
+    }
+
+    console.log("G1 roster safety integration suite passed.");
+  } finally {
+    if (fixture) await cleanupFixture(pool, fixture);
+    await pool.end();
+  }
+}
+
+async function countAuditById(client: PoolClient, rosterId: string): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM audit_logs WHERE target_id = $1 AND target_type = 'match_roster' AND action = 'match.roster.confirm'`,
+    [rosterId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/actions/matches/corrections.ts
+++ b/src/actions/matches/corrections.ts
@@ -1,0 +1,105 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { ok } from "@/types/action";
+import type { ActionResult } from "@/types/action";
+import { requireSeasonAdmin, auditActorId } from "@/lib/auth/session";
+import { getMatchOrThrow, actionError } from "@/lib/action-utils";
+import { revalidateMatchPaths, revalidateSeasonPaths } from "@/lib/revalidation";
+import {
+  applyResultCorrectionInTx,
+  planResultCorrectionInTx,
+  recordRecoveryAdjudicationInTx,
+} from "@/lib/match-corrections/service";
+
+/**
+ * G2 result-correction workflow: plan → review impact → explicit confirm.
+ * Server Actions stay thin wrappers around the transactional service so the
+ * local PostgreSQL suite exercises the exact production logic.
+ */
+
+export async function planMatchResultCorrection(
+  matchId: string,
+  proposal: { scoreA: number; scoreB: number; isForfeit?: boolean },
+): Promise<ActionResult<unknown>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    await requireSeasonAdmin(match.seasonId);
+    const plan = await db.transaction((tx) =>
+      planResultCorrectionInTx(tx, { matchId, proposal }),
+    );
+    return ok(plan);
+  } catch (e) {
+    return actionError("planMatchResultCorrection", e);
+  }
+}
+
+export async function applyMatchResultCorrection(
+  matchId: string,
+  input: {
+    scoreA: number;
+    scoreB: number;
+    isForfeit?: boolean;
+    /** Must be true when the correction changes the winner. */
+    confirmRecovery?: boolean;
+  },
+): Promise<ActionResult<{
+  alreadyApplied: boolean;
+  winnerChanged: boolean;
+  invalidatedCount: number;
+  rolledBackToFinalized: number | null;
+}>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const admin = await requireSeasonAdmin(match.seasonId);
+
+    const applied = await db.transaction((tx) =>
+      applyResultCorrectionInTx(tx, {
+        matchId,
+        proposal: {
+          scoreA: input.scoreA,
+          scoreB: input.scoreB,
+          isForfeit: input.isForfeit,
+        },
+        actorId: auditActorId(admin),
+        confirmRecovery: input.confirmRecovery === true,
+      }),
+    );
+
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, match.seasonId),
+      columns: { slug: true },
+    });
+    if (season) {
+      revalidateMatchPaths(season.slug, matchId);
+      revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
+    }
+
+    return ok({
+      alreadyApplied: applied.alreadyApplied,
+      winnerChanged: applied.winnerChanged,
+      invalidatedCount: applied.invalidatedDownstreamMatches.length,
+      rolledBackToFinalized: applied.rolledBackToFinalized,
+    });
+  } catch (e) {
+    return actionError("applyMatchResultCorrection", e);
+  }
+}
+
+export async function recordMatchRecoveryAdjudication(
+  matchId: string,
+  note: string,
+): Promise<ActionResult<{ recorded: true }>> {
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const admin = await requireSeasonAdmin(match.seasonId);
+    const result = await db.transaction((tx) =>
+      recordRecoveryAdjudicationInTx(tx, { matchId, actorId: auditActorId(admin), note }),
+    );
+    return ok(result);
+  } catch (e) {
+    return actionError("recordMatchRecoveryAdjudication", e);
+  }
+}

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,5 +1,5 @@
 export { generateSchedule, initializeStage, generatePlayoff, createMatch } from "./schedule";
 export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch, syncBracketMatches } from "./results";
 export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
-export { submitMatchRoster, unlockMatchRoster, getMatchRoster, updateMatchRoster } from "./roster";
+export { submitMatchRoster, unlockMatchRoster, getMatchRoster, adminSelectMatchRoster, confirmMatchRoster } from "./roster";
 export { saveVetoSteps } from "./veto";

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -2,4 +2,5 @@ export { generateSchedule, initializeStage, generatePlayoff, createMatch } from 
 export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch, syncBracketMatches } from "./results";
 export { proposeMatchTime, respondToTimeProposal, forceSetMatchTime, getTimeProposals, runMatchTimeAutoAwardCron } from "./scheduling";
 export { submitMatchRoster, unlockMatchRoster, getMatchRoster, adminSelectMatchRoster, confirmMatchRoster } from "./roster";
+export { planMatchResultCorrection, applyMatchResultCorrection, recordMatchRecoveryAdjudication } from "./corrections";
 export { saveVetoSteps } from "./veto";

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, asc, and, inArray, isNull } from "drizzle-orm";
+import { eq, and, inArray, isNull } from "drizzle-orm";
 import { db } from "@/db/client";
-import { seasons, matches, matchMaps, matchVetoSteps, matchRosters, matchRosterPlayers, teams, teamMembers, auditLogs, matchTimeProposals } from "@/db/schema";
+import { seasons, matches, matchMaps, matchVetoSteps, matchRosters, matchRosterPlayers, teams, auditLogs, matchTimeProposals } from "@/db/schema";
 import { ok } from "@/types/action";
 import type { ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
@@ -15,6 +15,9 @@ import {
 } from "@/lib/match-transitions";
 import { getMaxMaps, getWinThreshold, isMatchStatus } from "@/types/match";
 import { actionError, getSeasonOrThrow, getMatchOrThrow } from "@/lib/action-utils";
+import {
+  applyMatchStatusTransitionInTx,
+} from "@/lib/match-rosters/service";
 import { maybeFinishSeason } from "@/actions/transitions";
 import { revalidateMatchPaths, revalidateSeasonPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
@@ -68,6 +71,9 @@ async function insertResolvedBracketMatches(
 
 /**
  * 将比赛状态推进一步（scheduled→in_progress，scheduled/in_progress→cancelled）。
+ * 开始比赛（in_progress）要求两队均已提交并由管理员确认首发阵容；
+ * 不存在任何隐式补名单路径。核心事务体见
+ * lib/match-rosters/service.ts#applyMatchStatusTransitionInTx。
  */
 export async function updateMatchStatus(
   matchId: string,
@@ -82,55 +88,13 @@ export async function updateMatchStatus(
     assertMatchTransition(match.status, nextStatus);
 
     const seasonForStatus = await getSeasonOrThrow(match.seasonId);
-    await db.transaction(async (tx) => {
-      await tx
-        .update(matches)
-        .set({ status: nextStatus, updatedAt: new Date() })
-        .where(eq(matches.id, matchId));
-
-      // 开赛时自动为两队填充默认名单（若尚未提交）
-      if (nextStatus === "in_progress") {
-        const existingRosters = await tx.query.matchRosters.findMany({
-          where: and(
-            eq(matchRosters.matchId, matchId),
-            inArray(matchRosters.teamId, [match.teamAId, match.teamBId]),
-          ),
-        });
-        const existingTeamIds = new Set(existingRosters.map((r) => r.teamId));
-
-        for (const teamId of [match.teamAId, match.teamBId]) {
-          if (existingTeamIds.has(teamId)) continue;
-          const starterIds = await tx
-            .select({ id: teamMembers.id })
-            .from(teamMembers)
-            .where(eq(teamMembers.teamId, teamId))
-            .orderBy(asc(teamMembers.joinedAt))
-            .limit(5);
-          if (starterIds.length > 0) {
-            const [roster] = await tx
-              .insert(matchRosters)
-              .values({ matchId, teamId, submittedBy: session.userId })
-              .returning({ id: matchRosters.id });
-            await tx.insert(matchRosterPlayers).values(
-              starterIds.map((s) => ({
-                rosterId: roster.id,
-                teamMemberId: s.id,
-                isStarter: true,
-              })),
-            );
-          }
-        }
-      }
-
-      await tx.insert(auditLogs).values({
-        seasonId: match.seasonId,
-        action: "match.status_update",
-        actorId: session.email,
-        targetId: matchId,
-        targetType: "match",
-        meta: { from: match.status, to: nextStatus },
-      });
-    });
+    await db.transaction((tx) =>
+      applyMatchStatusTransitionInTx(tx, {
+        matchId,
+        nextStatus,
+        actorId: auditActorId(session),
+      }),
+    );
 
     revalidateMatchPaths(seasonForStatus.slug, matchId);
 

--- a/src/actions/matches/roster.ts
+++ b/src/actions/matches/roster.ts
@@ -1,35 +1,44 @@
 "use server";
 
-import { eq, and, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matchRosters, matchRosterPlayers, teamMembers, seasons, auditLogs } from "@/db/schema";
+import {
+  auditLogs,
+  matchRosterPlayers,
+  matchRosters,
+  seasons,
+} from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
-import { requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
+import { requireAuth, requireSeasonAdmin, auditActorId } from "@/lib/auth/session";
 import { getMatchOrThrow, actionError } from "@/lib/action-utils";
 import { revalidateMatchPaths } from "@/lib/revalidation";
+import type { Match } from "@/db/schema";
 import {
-  assertAllMembersBelongToTeam,
-  assertRosterSubmissionOpen,
-  validateRosterSelection,
-} from "@/lib/matches/roster-rules";
+  assertStartingLineupAllowedInTx,
+  confirmMatchRosterInTx,
+  lockMatchInTx,
+  persistMatchRosterInTx,
+} from "@/lib/match-rosters/service";
+import { validateRosterSelection } from "@/lib/matches/roster-rules";
 import { getTeamIdForCaptain } from "./_shared";
 
-async function validateTeamMembers(teamId: string, memberIds: string[]): Promise<void> {
-  const rows = await db
-    .select({ id: teamMembers.id })
-    .from(teamMembers)
-    .where(and(eq(teamMembers.teamId, teamId), inArray(teamMembers.id, memberIds)));
-  assertAllMembersBelongToTeam(memberIds, rows.map((row) => row.id));
+function assertLineupShape(starterIds: string[], substituteIds: string[]): void {
+  // Cheap structural check for early UX feedback; eligibility is judged again
+  // against DB facts inside the transaction.
+  validateRosterSelection(starterIds, substituteIds);
+}
+
+async function revalidateAfterRosterChange(match: Pick<Match, "seasonId" | "id">): Promise<void> {
+  const season = await db.query.seasons.findFirst({
+    where: eq(seasons.id, match.seasonId),
+  });
+  if (season) revalidateMatchPaths(season.slug, match.id);
 }
 
 /**
- * 队长提交比赛名单（5 首发 + 0~2 替补）。
- * - 比赛状态需为 scheduled 或 in_progress
- * - 队长身份校验
- * - 队员必须属于本队
- * - 距开赛不足 2 小时锁定
- * - 已 submitted 的名单需管理员 unlock 后才能重新提交
+ * 队长提交本场首发阵容（恰好 5 名首发 + 0~2 替补）。
+ * 仅允许比赛尚未开始（scheduled）时提交；名单通过管理员确认后才能用于开赛。
  */
 export async function submitMatchRoster(
   matchId: string,
@@ -40,8 +49,8 @@ export async function submitMatchRoster(
     const session = await requireAuth();
     const match = await getMatchOrThrow(matchId);
 
-    if (match.status !== "scheduled" && match.status !== "in_progress") {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "比赛状态不允许提交名单");
+    if (match.status !== "scheduled") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "比赛当前状态不允许提交名单");
     }
 
     const teamId = await getTeamIdForCaptain(session.userId, match);
@@ -49,62 +58,152 @@ export async function submitMatchRoster(
       throw new AppError(ErrorCode.FORBIDDEN, "只有队长可以提交名单");
     }
 
-    validateRosterSelection(starterIds, substituteIds);
+    assertLineupShape(starterIds, substituteIds);
 
-    await validateTeamMembers(teamId, [...starterIds, ...substituteIds]);
-    assertRosterSubmissionOpen(match.scheduledAt);
-
+    const actorId = auditActorId(session);
     const rosterId = await db.transaction(async (tx) => {
-      const existing = await tx.query.matchRosters.findFirst({
-        where: and(
-          eq(matchRosters.matchId, matchId),
-          eq(matchRosters.teamId, teamId),
-        ),
-      });
-      let rosterId: string;
-      if (existing) {
-        rosterId = existing.id;
-        await tx
-          .update(matchRosters)
-          .set({ status: "submitted", lockedAt: new Date(), updatedAt: new Date() })
-          .where(eq(matchRosters.id, existing.id));
-        await tx
-          .delete(matchRosterPlayers)
-          .where(eq(matchRosterPlayers.rosterId, existing.id));
-      } else {
-        const [row] = await tx
-          .insert(matchRosters)
-          .values({ matchId, teamId, submittedBy: session.userId })
-          .returning({ id: matchRosters.id });
-        rosterId = row.id;
+      const locked = await lockMatchInTx(tx, matchId);
+      if (locked.status !== "scheduled") {
+        throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛已开始或取消，不能再调整阵容");
       }
+      await assertStartingLineupAllowedInTx(tx, {
+        match: locked,
+        teamId,
+        starterIds,
+        substituteIds,
+      });
+      const summary = await persistMatchRosterInTx(tx, {
+        match: locked,
+        teamId,
+        submittedBy: session.userId,
+        source: "participant",
+        starterIds,
+        substituteIds,
+      });
 
-      const playerRows = [
-        ...starterIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: true })),
-        ...substituteIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: false })),
-      ];
-      await tx.insert(matchRosterPlayers).values(playerRows);
+      await tx.insert(auditLogs).values({
+        seasonId: locked.seasonId,
+        action: "match.roster.submit",
+        actorId,
+        targetId: summary.rosterId,
+        targetType: "match_roster",
+        meta: { matchId, teamId, source: "participant", starterIds, substituteIds },
+      });
 
-      return rosterId;
+      return summary.rosterId;
     });
 
-    await db.insert(auditLogs).values({
-      seasonId: match.seasonId,
-      action: "match.submit_roster",
-      actorId: session.userId,
-      targetId: rosterId,
-      targetType: "match_roster",
-      meta: { matchId, teamId, starters: starterIds.length, substitutes: substituteIds.length },
-    });
-
-    const season = await db.query.seasons.findFirst({
-      where: eq(seasons.id, match.seasonId),
-    });
-    if (season) revalidateMatchPaths(season.slug, matchId);
+    await revalidateAfterRosterChange(match);
 
     return ok({ rosterId });
   } catch (e) {
     return actionError("submitMatchRoster", e);
+  }
+}
+
+/**
+ * 管理员代表队伍选择本场首发（含“使用默认首发”）。
+ * 服务端只接收显式给出的五名选手，绝不隐式推断；仍需另行确认后才能开赛。
+ */
+export async function adminSelectMatchRoster(
+  matchId: string,
+  teamId: string,
+  input: { starterIds: string[]; substituteIds?: string[]; note?: string },
+): Promise<ActionResult<{ rosterId: string }>> {
+  const { starterIds, substituteIds = [], note } = input;
+  try {
+    const match = await getMatchOrThrow(matchId);
+    const admin = await requireSeasonAdmin(match.seasonId);
+    if (match.status !== "scheduled") {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "比赛当前状态不允许选择名单");
+    }
+
+    assertLineupShape(starterIds, substituteIds);
+
+    const actorId = auditActorId(admin);
+    const rosterId = await db.transaction(async (tx) => {
+      const locked = await lockMatchInTx(tx, matchId);
+      if (locked.status !== "scheduled") {
+        throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛已开始或取消，不能再调整阵容");
+      }
+      if (teamId !== locked.teamAId && teamId !== locked.teamBId) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "所选队伍不属于本场比赛");
+      }
+      await assertStartingLineupAllowedInTx(tx, {
+        match: locked,
+        teamId,
+        starterIds,
+        substituteIds,
+      });
+      const summary = await persistMatchRosterInTx(tx, {
+        match: locked,
+        teamId,
+        submittedBy: null,
+        source: "admin_select",
+        starterIds,
+        substituteIds,
+      });
+
+      await tx.insert(auditLogs).values({
+        seasonId: locked.seasonId,
+        action: "match.roster.admin_select",
+        actorId,
+        targetId: summary.rosterId,
+        targetType: "match_roster",
+        meta: {
+          matchId,
+          teamId,
+          source: "admin_select",
+          starterIds,
+          substituteIds,
+          note: note ?? null,
+        },
+      });
+
+      return summary.rosterId;
+    });
+
+    await revalidateAfterRosterChange(match);
+
+    return ok({ rosterId });
+  } catch (e) {
+    return actionError("adminSelectMatchRoster", e);
+  }
+}
+
+/**
+ * 管理员确认一方名单。确认时重新按冻结名单/归属规则完整校验；
+ * 通过后名单成为开赛前提事实，重复确认为幂等。
+ */
+export async function confirmMatchRoster(
+  rosterId: string
+): Promise<ActionResult<{ alreadyConfirmed: boolean; matchId: string; teamId: string }>> {
+  try {
+    const [existing] = await db
+      .select({ matchId: matchRosters.matchId })
+      .from(matchRosters)
+      .where(eq(matchRosters.id, rosterId));
+    if (!existing) {
+      throw new AppError(ErrorCode.NOT_FOUND, ERROR_MESSAGES.NOT_FOUND);
+    }
+    const match = await getMatchOrThrow(existing.matchId);
+    const admin = await requireSeasonAdmin(match.seasonId);
+
+    const outcome = await db.transaction((tx) =>
+      confirmMatchRosterInTx(tx, { rosterId, actorId: auditActorId(admin) }),
+    );
+
+    if (!outcome.alreadyConfirmed) {
+      await revalidateAfterRosterChange({ seasonId: match.seasonId, id: match.id });
+    }
+
+    return ok({
+      alreadyConfirmed: outcome.alreadyConfirmed,
+      matchId: outcome.matchId,
+      teamId: outcome.teamId,
+    });
+  } catch (e) {
+    return actionError("confirmMatchRoster", e);
   }
 }
 
@@ -124,25 +223,29 @@ export async function unlockMatchRoster(
 
     const match = await getMatchOrThrow(roster.matchId);
     const admin = await requireSeasonAdmin(match.seasonId);
+    const actorId = auditActorId(admin);
 
-    await db
-      .update(matchRosters)
-      .set({ status: "unlocked", updatedAt: new Date() })
-      .where(eq(matchRosters.id, rosterId));
+    await db.transaction(async (tx) => {
+      const locked = await lockMatchInTx(tx, roster.matchId);
+      if (locked.status !== "scheduled") {
+        throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛已开始或取消，名单已定格");
+      }
+      await tx
+        .update(matchRosters)
+        .set({ status: "unlocked", confirmedAt: null, confirmedBy: null, updatedAt: new Date() })
+        .where(eq(matchRosters.id, rosterId));
 
-    await db.insert(auditLogs).values({
-      seasonId: match.seasonId,
-      action: "match.unlock_roster",
-      actorId: admin.email,
-      targetId: rosterId,
-      targetType: "match_roster",
-      meta: { matchId: roster.matchId, teamId: roster.teamId },
+      await tx.insert(auditLogs).values({
+        seasonId: locked.seasonId,
+        action: "match.roster.unlock",
+        actorId,
+        targetId: rosterId,
+        targetType: "match_roster",
+        meta: { matchId: roster.matchId, teamId: roster.teamId },
+      });
     });
 
-    const season = await db.query.seasons.findFirst({
-      where: eq(seasons.id, match.seasonId),
-    });
-    if (season) revalidateMatchPaths(season.slug, roster.matchId);
+    await revalidateAfterRosterChange(match);
 
     return ok(undefined);
   } catch (e) {
@@ -153,81 +256,6 @@ export async function unlockMatchRoster(
 /**
  * 查询某场比赛的名单（含首发/替补队员）。
  */
-/**
- * 管理员强制修改比赛名单（覆盖已提交名单）。
- */
-export async function updateMatchRoster(
-  matchId: string,
-  teamId: string,
-  input: { starterIds: string[]; substituteIds?: string[] },
-): Promise<ActionResult<{ rosterId: string }>> {
-  const { starterIds, substituteIds = [] } = input;
-  try {
-    const match = await getMatchOrThrow(matchId);
-    const session = await requireSeasonAdmin(match.seasonId);
-
-    validateRosterSelection(starterIds, substituteIds);
-
-    await validateTeamMembers(teamId, [...starterIds, ...substituteIds]);
-
-    const rosterId = await db.transaction(async (tx) => {
-      const existing = await tx.query.matchRosters.findFirst({
-        where: and(
-          eq(matchRosters.matchId, matchId),
-          eq(matchRosters.teamId, teamId),
-        ),
-      });
-
-      let rosterId: string;
-      if (existing) {
-        rosterId = existing.id;
-        await tx
-          .update(matchRosters)
-          .set({
-            status: "submitted",
-            submittedBy: session.userId,
-            lockedAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .where(eq(matchRosters.id, existing.id));
-        await tx
-          .delete(matchRosterPlayers)
-          .where(eq(matchRosterPlayers.rosterId, existing.id));
-      } else {
-        const [row] = await tx
-          .insert(matchRosters)
-          .values({ matchId, teamId, submittedBy: session.userId })
-          .returning({ id: matchRosters.id });
-        rosterId = row.id;
-      }
-
-      await tx.insert(matchRosterPlayers).values([
-        ...starterIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: true })),
-        ...substituteIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: false })),
-      ]);
-      return rosterId;
-    });
-
-    await db.insert(auditLogs).values({
-      seasonId: match.seasonId,
-      action: "match.admin_update_roster",
-      actorId: session.email,
-      targetId: rosterId,
-      targetType: "match_roster",
-      meta: { matchId, teamId, starters: starterIds.length, substitutes: substituteIds.length },
-    });
-
-    const season = await db.query.seasons.findFirst({
-      where: eq(seasons.id, match.seasonId),
-    });
-    if (season) revalidateMatchPaths(season.slug, matchId);
-
-    return ok({ rosterId });
-  } catch (e) {
-    return actionError("updateMatchRoster", e);
-  }
-}
-
 export async function getMatchRoster(matchId: string, teamId: string) {
   const roster = await db.query.matchRosters.findFirst({
     where: and(

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -310,6 +310,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
         }
       }
       matchMap.set(roster.teamId, {
+        rosterId: roster.id,
         starters,
         substitutes,
         status: roster.status,

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -8,6 +8,7 @@ import { MapByMapInput } from "@/components/matches/MapByMapInput";
 import { ScheduledAtInput } from "@/components/matches/ScheduledAtInput";
 import { VetoInputDialog } from "@/components/matches/VetoInputDialog";
 import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
+import { ResultCorrectionPanel } from "@/components/matches/ResultCorrectionPanel";
 import { StatsOCRPanel } from "@/components/matches/StatsOCRPanel";
 import { ForfeitButton } from "@/components/matches/ForfeitButton";
 import { MapScoreCorrectInput } from "@/components/matches/MapScoreCorrectInput";
@@ -224,6 +225,12 @@ export function AdminMatchRow({
                     currentScoreB={match.scoreB}
                   />
                 )}
+                <ResultCorrectionPanel
+                  matchId={match.id}
+                  teamAName={teamAName}
+                  teamBName={teamBName}
+                  format={match.format}
+                />
                 <CompletedAtInput
                   matchId={match.id}
                   initialValue={toCSTDateTimeInput(match.completedAt)}

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -26,6 +26,7 @@ export interface TeamMemberData {
 }
 
 export interface RosterData {
+  rosterId: string | null;
   starters: string[];
   substitutes: string[];
   status: string | null;

--- a/src/components/matches/AdminRosterDialog.tsx
+++ b/src/components/matches/AdminRosterDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,7 +15,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { getDisplayName } from "@/lib/utils/display-name";
-import { updateMatchRoster } from "@/actions/matches/roster";
+import { adminSelectMatchRoster, confirmMatchRoster } from "@/actions/matches/roster";
 import type { RosterData } from "@/components/matches/AdminMatchRow";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -47,6 +48,12 @@ interface RosterTeamSectionProps {
   existingRoster: RosterData | null;
 }
 
+const STATUS_LABELS: Record<string, string> = {
+  submitted: "已提交，待确认",
+  unlocked: "已解锁，可重新提交",
+  confirmed: "已确认",
+};
+
 // ── RosterTeamSection ───────────────────────────────────────────────────────
 
 function RosterTeamSection({
@@ -56,7 +63,10 @@ function RosterTeamSection({
   members,
   existingRoster,
 }: RosterTeamSectionProps) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  // Two-step explicit flow: first pick, then review the exact five and confirm.
+  const [pendingLineup, setPendingLineup] = useState<{ starterIds: string[]; substituteIds: string[] } | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>(() => {
     if (existingRoster) {
       return [...existingRoster.starters, ...existingRoster.substitutes];
@@ -66,6 +76,8 @@ function RosterTeamSection({
 
   const starterIds = selectedIds.slice(0, 5);
   const substituteIds = selectedIds.slice(5, 7);
+
+  const memberMap = new Map(members.map((m) => [m.id, m]));
 
   function toggleMember(id: string) {
     setSelectedIds((prev) => {
@@ -100,137 +112,194 @@ function RosterTeamSection({
       toast.error("必须选择 5 名首发");
       return;
     }
+    setPendingLineup({ starterIds, substituteIds });
+  }
+
+  function executeSave() {
+    if (!pendingLineup) return;
     startTransition(async () => {
-      const result = await updateMatchRoster(
+      const result = await adminSelectMatchRoster(
         matchId,
         teamId,
-        { starterIds, substituteIds },
+        { starterIds: pendingLineup.starterIds, substituteIds: pendingLineup.substituteIds },
       );
+      setPendingLineup(null);
       if (result.success) {
-        toast.success(`${teamName} 名单已更新`);
+        toast.success(`${teamName} 名单已保存，开赛前需另行确认`);
+        router.refresh();
       } else {
         toast.error(result.error.message);
       }
     });
   }
 
-  const memberMap = new Map(members.map((m) => [m.id, m]));
+  function handleConfirm(rosterId: string) {
+    startTransition(async () => {
+      const result = await confirmMatchRoster(rosterId);
+      if (result.success) {
+        toast.success(result.data.alreadyConfirmed ? `${teamName} 名单此前已确认` : `${teamName} 名单已确认，可以开始比赛`);
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
 
   return (
     <div className="space-y-3">
       <h4 className="font-semibold text-[var(--color-fg)]">{teamName}</h4>
       {existingRoster && (
-        <p className="text-xs text-[var(--color-fg-mid)]">
-          当前名单：{existingRoster.starters.length} 首发
-          {existingRoster.substitutes.length > 0
-            ? ` + ${existingRoster.substitutes.length} 替补`
-            : ""}
-        </p>
-      )}
-
-      {/* Player checkboxes */}
-      <div className="grid grid-cols-2 gap-1.5 max-h-48 overflow-y-auto">
-        {members.map((m) => {
-          const isSelected = selectedIds.includes(m.id);
-          const selectedIndex = selectedIds.indexOf(m.id);
-          const label =
-            isSelected && selectedIndex < 5
-              ? `首发 ${selectedIndex + 1}`
-              : isSelected
-                ? "替补"
-                : null;
-          return (
-            <label
-              key={m.id}
-              className={`flex items-center gap-2 p-1.5 rounded cursor-pointer transition-colors ${
-                isSelected
-                  ? "bg-[var(--color-accent)]/10"
-                  : "hover:bg-[var(--color-panel-low)]"
-              } ${!isSelected && selectedIds.length >= 7 ? "opacity-40 cursor-not-allowed" : ""}`}
-            >
-              <Checkbox
-                checked={isSelected}
-                disabled={!isSelected && selectedIds.length >= 7}
-                onChange={() => toggleMember(m.id)}
-              />
-              <span className="text-sm flex-1 truncate">
-                {getDisplayName(m)}
-              </span>
-              <span className="text-xs text-[var(--color-fg-mid)]">
-                {m.primaryPosition}
-              </span>
-              {label && (
-                <span className="text-xs text-[var(--color-accent)] font-medium ml-1">
-                  {label}
-                </span>
-              )}
-            </label>
-          );
-        })}
-      </div>
-
-      {/* Starter order controls */}
-      {starterIds.length > 0 && (
-        <div className="space-y-1">
-          <Label className="text-xs text-[var(--color-fg-mid)]">
-            首发顺序（点击箭头调整）
-          </Label>
-          <div className="space-y-0.5">
-            {starterIds.map((id, index) => {
-              const member = memberMap.get(id);
-              if (!member) return null;
-              return (
-                <div
-                  key={id}
-                  className="flex items-center gap-2 px-2 py-1 rounded bg-[var(--color-panel-low)]"
-                >
-                  <span className="text-xs text-[var(--color-fg-mid)] w-4 tabular-nums">
-                    {index + 1}
-                  </span>
-                  <span className="text-sm flex-1 truncate">
-                    {getDisplayName(member)}
-                  </span>
-                  <span className="text-xs text-[var(--color-fg-mid)]">
-                    {member.primaryPosition}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => moveStarterUp(index)}
-                    disabled={index === 0}
-                    className="text-xs px-1.5 py-0.5 rounded border border-[var(--color-border)] hover:bg-[var(--color-accent)]/10 disabled:opacity-30 disabled:cursor-not-allowed"
-                    aria-label="上移"
-                  >
-                    ↑
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => moveStarterDown(index)}
-                    disabled={index === starterIds.length - 1}
-                    className="text-xs px-1.5 py-0.5 rounded border border-[var(--color-border)] hover:bg-[var(--color-accent)]/10 disabled:opacity-30 disabled:cursor-not-allowed"
-                    aria-label="下移"
-                  >
-                    ↓
-                  </button>
-                </div>
-              );
-            })}
-          </div>
+        <div className="flex items-center gap-2">
+          <p className="text-xs text-[var(--color-fg-mid)] flex-1">
+            当前名单：{existingRoster.starters.length} 首发
+            {existingRoster.substitutes.length > 0
+              ? ` + ${existingRoster.substitutes.length} 替补`
+              : ""}
+            {existingRoster.status && ` · ${STATUS_LABELS[existingRoster.status] ?? existingRoster.status}`}
+          </p>
+          {existingRoster.rosterId && existingRoster.status !== "confirmed" && (
+            <Button size="sm" variant="secondary" onClick={() => handleConfirm(existingRoster.rosterId!)} disabled={isPending}>
+              确认名单
+            </Button>
+          )}
         </div>
       )}
 
-      {/* Selected count */}
-      <p className="text-xs text-[var(--color-fg-mid)]">
-        已选 {selectedIds.length}/7（首发 {starterIds.length}/5，替补{" "}
-        {substituteIds.length}/2）
-      </p>
+      {/* Explicit review before any admin selection is recorded */}
+      {pendingLineup ? (
+        <div className="space-y-2 rounded-md border border-[var(--color-border)] p-3 bg-[var(--color-panel-low)]">
+          <p className="text-sm font-medium text-[var(--color-fg)]">请核对将保存的首发五人：</p>
+          <ol className="space-y-1">
+            {pendingLineup.starterIds.map((id, index) => (
+              <li key={id} className="text-sm text-[var(--color-fg)]">
+                首发 {index + 1}. {memberMap.get(id) ? getDisplayName(memberMap.get(id)!) : "未知队员"}
+              </li>
+            ))}
+          </ol>
+          {pendingLineup.substituteIds.length > 0 && (
+            <p className="text-xs text-[var(--color-fg-mid)]">
+              替补：{pendingLineup.substituteIds.map((id) => (memberMap.get(id) ? getDisplayName(memberMap.get(id)!) : "")).join("、")}
+            </p>
+          )}
+          <p className="text-xs text-[var(--color-fg-mid)]">
+            保存后仍需点击「确认名单」，否则该场比赛无法开始。
+          </p>
+          <div className="flex gap-2 pt-1">
+            <Button size="sm" onClick={executeSave} disabled={isPending}>
+              {isPending ? "保存中..." : "确认保存"}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setPendingLineup(null)} disabled={isPending}>
+              返回修改
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Player checkboxes */}
+          <div className="grid grid-cols-2 gap-1.5 max-h-48 overflow-y-auto">
+            {members.map((m) => {
+              const isSelected = selectedIds.includes(m.id);
+              const selectedIndex = selectedIds.indexOf(m.id);
+              const label =
+                isSelected && selectedIndex < 5
+                  ? `首发 ${selectedIndex + 1}`
+                  : isSelected
+                    ? "替补"
+                    : null;
+              return (
+                <label
+                  key={m.id}
+                  className={`flex items-center gap-2 p-1.5 rounded cursor-pointer transition-colors ${
+                    isSelected
+                      ? "bg-[var(--color-accent)]/10"
+                      : "hover:bg-[var(--color-panel-low)]"
+                  } ${!isSelected && selectedIds.length >= 7 ? "opacity-40 cursor-not-allowed" : ""}`}
+                >
+                  <Checkbox
+                    checked={isSelected}
+                    disabled={!isSelected && selectedIds.length >= 7}
+                    onChange={() => toggleMember(m.id)}
+                  />
+                  <span className="text-sm flex-1 truncate">
+                    {getDisplayName(m)}
+                  </span>
+                  <span className="text-xs text-[var(--color-fg-mid)]">
+                    {m.primaryPosition}
+                  </span>
+                  {label && (
+                    <span className="text-xs text-[var(--color-accent)] font-medium ml-1">
+                      {label}
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
 
-      <Button
-        size="sm"
-        onClick={handleSave}
-        disabled={isPending || starterIds.length !== 5}
-      >
-        {isPending ? "保存中..." : `保存 ${teamName} 名单`}
-      </Button>
+          {/* Starter order controls */}
+          {starterIds.length > 0 && (
+            <div className="space-y-1">
+              <Label className="text-xs text-[var(--color-fg-mid)]">
+                首发顺序（点击箭头调整）
+              </Label>
+              <div className="space-y-0.5">
+                {starterIds.map((id, index) => {
+                  const member = memberMap.get(id);
+                  if (!member) return null;
+                  return (
+                    <div
+                      key={id}
+                      className="flex items-center gap-2 px-2 py-1 rounded bg-[var(--color-panel-low)]"
+                    >
+                      <span className="text-xs text-[var(--color-fg-mid)] w-4 tabular-nums">
+                        {index + 1}
+                      </span>
+                      <span className="text-sm flex-1 truncate">
+                        {getDisplayName(member)}
+                      </span>
+                      <span className="text-xs text-[var(--color-fg-mid)]">
+                        {member.primaryPosition}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => moveStarterUp(index)}
+                        disabled={index === 0}
+                        className="text-xs px-1.5 py-0.5 rounded border border-[var(--color-border)] hover:bg-[var(--color-accent)]/10 disabled:opacity-30 disabled:cursor-not-allowed"
+                        aria-label="上移"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveStarterDown(index)}
+                        disabled={index === starterIds.length - 1}
+                        className="text-xs px-1.5 py-0.5 rounded border border-[var(--color-border)] hover:bg-[var(--color-accent)]/10 disabled:opacity-30 disabled:cursor-not-allowed"
+                        aria-label="下移"
+                      >
+                        ↓
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Selected count */}
+          <p className="text-xs text-[var(--color-fg-mid)]">
+            已选 {selectedIds.length}/7（首发 {starterIds.length}/5，替补{" "}
+            {substituteIds.length}/2）
+          </p>
+
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={isPending || starterIds.length !== 5}
+          >
+            {isPending ? "处理中..." : `核对并保存 ${teamName} 名单`}
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/matches/AdminRosterDialog.tsx
+++ b/src/components/matches/AdminRosterDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import React, { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";

--- a/src/components/matches/ResultCorrectionPanel.tsx
+++ b/src/components/matches/ResultCorrectionPanel.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import React, { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  applyMatchResultCorrection,
+  planMatchResultCorrection,
+  recordMatchRecoveryAdjudication,
+} from "@/actions/matches/corrections";
+
+interface CorrectionPlan {
+  current: { scoreA: number | null; scoreB: number | null; isForfeit: boolean };
+  proposed: { scoreA: number; scoreB: number; isForfeit: boolean };
+  winnerChanges: boolean;
+  affectsManagedRun: boolean;
+  impacts: {
+    kind: string;
+    matchId?: string;
+    managedKey?: string | null;
+    status: string;
+    description: string;
+  }[];
+  blockedReasons: string[];
+  requiredRecoveryActions: string[];
+}
+
+interface ResultCorrectionPanelProps {
+  matchId: string;
+  teamAName: string;
+  teamBName: string;
+  format: "bo1" | "bo3" | "bo5";
+}
+
+/**
+ * G2 admin recovery UI for finished matches:
+ * propose → review downstream impact / blocked reasons → explicit confirm.
+ */
+export function ResultCorrectionPanel({
+  matchId,
+  teamAName,
+  teamBName,
+  format,
+}: ResultCorrectionPanelProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [scoreA, setScoreA] = useState<string>("");
+  const [scoreB, setScoreB] = useState<string>("");
+  const [isForfeit, setIsForfeit] = useState(false);
+  const [plan, setPlan] = useState<CorrectionPlan | null>(null);
+  const [adjudicationNote, setAdjudicationNote] = useState("");
+
+  function parseScores(): { scoreA: number; scoreB: number } | null {
+    const a = Number(scoreA);
+    const b = Number(scoreB);
+    if (!Number.isInteger(a) || !Number.isInteger(b) || a < 0 || b < 0 || a === b) {
+      toast.error("请输入合法且能分出胜负的整数比分");
+      return null;
+    }
+    return { scoreA: a, scoreB: b };
+  }
+
+  function handlePlan() {
+    const scores = parseScores();
+    if (!scores) return;
+    startTransition(async () => {
+      const result = await planMatchResultCorrection(matchId, {
+        ...scores,
+        isForfeit,
+      });
+      if (result.success) {
+        setPlan(result.data as CorrectionPlan);
+        router.refresh();
+      } else {
+        setPlan(null);
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handleApply(confirmedRecovery: boolean) {
+    const scores = parseScores();
+    if (!scores || !plan) return;
+    startTransition(async () => {
+      const result = await applyMatchResultCorrection(matchId, {
+        ...scores,
+        isForfeit,
+        confirmRecovery: confirmedRecovery,
+      });
+      if (result.success) {
+        toast.success(
+          result.data.alreadyApplied
+            ? "该结果已是目标状态（幂等，无变更）"
+            : result.data.winnerChanged
+              ? `更正已应用；作废 ${result.data.invalidatedCount} 场未开始下游比赛，请按提示重新确认轮次`
+              : "比分已更正",
+        );
+        setPlan(null);
+        setScoreA("");
+        setScoreB("");
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  function handleAdjudicate() {
+    if (!adjudicationNote.trim()) {
+      toast.error("裁决说明不能为空");
+      return;
+    }
+    startTransition(async () => {
+      const result = await recordMatchRecoveryAdjudication(matchId, adjudicationNote);
+      if (result.success) {
+        toast.success("裁决记录已写入审计");
+        setAdjudicationNote("");
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-[var(--color-border)] p-3">
+      <p className="text-sm font-medium text-[var(--color-fg)]">
+        比分更正与恢复 · {teamAName} vs {teamBName}（{format.toUpperCase()}）
+      </p>
+      <p className="text-xs text-[var(--color-fg-mid)]">
+        先计算影响清单并审阅；改变胜者会要求显式确认恢复。已开始/完成的下游比赛不会被自动改写。
+      </p>
+
+      {!plan ? (
+        <>
+          <div className="flex flex-wrap items-end gap-2">
+            <div>
+              <Label className="text-xs">{teamAName}</Label>
+              <Input
+                className="w-20"
+                inputMode="numeric"
+                value={scoreA}
+                onChange={(e) => setScoreA(e.target.value)}
+                placeholder="比分"
+              />
+            </div>
+            <span className="pb-2 text-sm text-[var(--color-fg-mid)]">:</span>
+            <div>
+              <Label className="text-xs">{teamBName}</Label>
+              <Input
+                className="w-20"
+                inputMode="numeric"
+                value={scoreB}
+                onChange={(e) => setScoreB(e.target.value)}
+                placeholder="比分"
+              />
+            </div>
+            <label className="flex items-center gap-1 pb-2 text-xs text-[var(--color-fg-mid)]">
+              <input
+                type="checkbox"
+                checked={isForfeit}
+                onChange={(e) => setIsForfeit(e.target.checked)}
+              />
+              弃赛判负
+            </label>
+            <Button size="sm" variant="outline" onClick={handlePlan} disabled={isPending}>
+              {isPending ? "计算中..." : "计算影响清单"}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <div className="space-y-2 text-xs">
+          <p className="text-[var(--color-fg)]">
+            当前 {plan.current.isForfeit ? `${plan.current.scoreA}:${plan.current.scoreB}（弃赛）` : `${plan.current.scoreA ?? "-"}:${plan.current.scoreB ?? "-"}`}
+            {" → "}
+            提议 {plan.proposed.isForfeit ? `${plan.proposed.scoreA}:${plan.proposed.scoreB}（弃赛）` : `${plan.proposed.scoreA}:${plan.proposed.scoreB}`}
+            {plan.winnerChanges && " · ⚠️ 胜者将变更"}
+          </p>
+          {plan.impacts.length > 0 && (
+            <ul className="list-disc space-y-0.5 pl-4 text-[var(--color-fg-mid)]">
+              {plan.impacts.map((impact) => (
+                <li key={`${impact.kind}-${impact.matchId ?? impact.managedKey ?? impact.description}`}>
+                  [{impact.kind}] {impact.status} — {impact.description}
+                </li>
+              ))}
+            </ul>
+          )}
+          {plan.blockedReasons.length > 0 && (
+            <div className="rounded border border-red-500/40 bg-red-500/10 p-2">
+              <p className="font-medium text-red-500">已拒绝执行（fail closed）：</p>
+              <ul className="list-disc pl-4">
+                {plan.blockedReasons.map((reason) => (
+                  <li key={reason}>{reason}</li>
+                ))}
+              </ul>
+              <p className="mt-1">如确需处理，请通过下方「赛后裁决」流程记录独立事实。</p>
+            </div>
+          )}
+          {plan.requiredRecoveryActions.length > 0 && !plan.blockedReasons.length && (
+            <ul className="list-decimal space-y-0.5 pl-4 text-[var(--color-fg-mid)]">
+              {plan.requiredRecoveryActions.map((action) => (
+                <li key={action}>{action}</li>
+              ))}
+            </ul>
+          )}
+          <div className="flex flex-wrap gap-2 pt-1">
+            {plan.winnerChanges && plan.blockedReasons.length === 0 && (
+              <Button size="sm" onClick={() => handleApply(true)} disabled={isPending}>
+                确认恢复并应用更正
+              </Button>
+            )}
+            {!plan.winnerChanges && plan.blockedReasons.length === 0 && (
+              <Button size="sm" onClick={() => handleApply(false)} disabled={isPending}>
+                应用比分更正
+              </Button>
+            )}
+            <Button size="sm" variant="outline" onClick={() => setPlan(null)} disabled={isPending}>
+              返回修改
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* 赛后裁决入口始终可用：用于 fail-closed 场景的独立事实记录 */}
+      <div className="flex flex-wrap items-center gap-2 border-t border-[var(--color-border)] pt-2">
+        <input
+          className="h-8 flex-1 min-w-48 rounded-md border border-[var(--color-border)] bg-transparent px-2 text-xs"
+          placeholder="赛后裁决说明（用于被拒绝自动重写的场景）"
+          value={adjudicationNote}
+          onChange={(e) => setAdjudicationNote(e.target.value)}
+        />
+        <Button size="sm" variant="ghost" onClick={handleAdjudicate} disabled={isPending}>
+          记录裁决
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/db/schema/match-rosters.ts
+++ b/src/db/schema/match-rosters.ts
@@ -8,9 +8,14 @@ export const matchRosters = pgTable("match_rosters", {
   id: uuid("id").defaultRandom().primaryKey(),
   matchId: uuid("match_id").notNull().references(() => matches.id),
   teamId: uuid("team_id").notNull().references(() => teams.id),
-  submittedBy: uuid("submitted_by").notNull().references(() => users.id),
+  /** The participant who submitted; null when an admin selected the lineup. */
+  submittedBy: uuid("submitted_by").references(() => users.id),
+  /** participant | admin_select — who authored this explicit lineup. */
+  source: text("source").notNull().default("participant"),
   status: text("status").notNull().default("submitted"),
   lockedAt: timestamp("locked_at", { withTimezone: true }).notNull().defaultNow(),
+  confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
+  confirmedBy: text("confirmed_by"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => ({

--- a/src/lib/match-corrections/service.test.ts
+++ b/src/lib/match-corrections/service.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyDownstreamManagedMatches,
+  deriveSwissFinalizedRollback,
+  loadFrozenRunFacts,
+  resolveWinnerTeamId,
+  validateResultCorrectionProposal,
+} from "@/lib/match-corrections/service";
+import { AppError } from "@/lib/errors";
+import type { MajorStageRun } from "@/db/schema";
+
+const TEAM_A = "11111111-1111-1111-1111-111111111111";
+const TEAM_B = "22222222-2222-2222-2222-222222222222";
+
+function baseMatch() {
+  return { teamAId: TEAM_A, teamBId: TEAM_B, format: "bo1" as const, isForfeit: false };
+}
+
+describe("classifyDownstreamManagedMatches", () => {
+  const scheduledRound = (round: number, suffix: string): DownstreamCandidate => ({
+    id: `m-${suffix}`,
+    managedKey: `r${round}-${suffix}`,
+    entryRound: null,
+    round,
+    status: "scheduled",
+  });
+  type DownstreamCandidate = Parameters<typeof classifyDownstreamManagedMatches>[0][number];
+  const started = (row: DownstreamCandidate, status = "in_progress"): DownstreamCandidate => ({
+    ...row,
+    status,
+  });
+
+  it("swiss: classifies every later-round match as invalidatable when unstarted", () => {
+    const impacts = classifyDownstreamManagedMatches(
+      [scheduledRound(1, "same"), scheduledRound(2, "a"), scheduledRound(3, "b")],
+      { id: "m-same", round: 1, entryRound: null },
+      "swiss",
+    );
+    expect(impacts.map((impact) => impact.matchId).sort()).toEqual(["m-a", "m-b"]);
+    expect(impacts.every((impact) => impact.invalidatable)).toBe(true);
+    expect(impacts[0]!.description).toContain("作废并重建");
+  });
+
+  it("swiss: keeps finished/started downstream matches as blocking facts", () => {
+    const impacts = classifyDownstreamManagedMatches(
+      [started(scheduledRound(2, "a")), started(scheduledRound(2, "b"), "finished")],
+      { id: "source", round: 1, entryRound: null },
+      "swiss",
+    );
+    expect(impacts).toHaveLength(2);
+    expect(impacts.every((impact) => !impact.invalidatable)).toBe(true);
+    expect(impacts[0]!.description).toContain("禁止自动改写");
+  });
+
+  it("playoff: orders by elimination step and ignores the bronze match", () => {
+    const qf: DownstreamCandidate = { id: "qf1", managedKey: "qf-1", entryRound: "quarterfinal", round: null, status: "scheduled" };
+    const sf: DownstreamCandidate = { id: "sf1", managedKey: "sf-1", entryRound: "semifinal", round: null, status: "scheduled" };
+    const finalRow: DownstreamCandidate = { id: "f1", managedKey: "f-1", entryRound: "final", round: null, status: "scheduled" };
+    const third: DownstreamCandidate = { id: "t1", managedKey: "t-1", entryRound: "third_place", round: null, status: "scheduled" };
+
+    const fromQf = classifyDownstreamManagedMatches([qf, sf, finalRow, third], { id: "source", round: null, entryRound: "quarterfinal" }, "single_elim");
+    expect(fromQf.map((impact) => impact.matchId).sort()).toEqual(["f1", "sf1"]);
+
+    const fromSf = classifyDownstreamManagedMatches([sf, finalRow], { id: "sf1-source", round: null, entryRound: "semifinal" }, "single_elim");
+    expect(fromSf.map((impact) => impact.matchId)).toEqual(["f1"]);
+
+    const upstreamOnly = classifyDownstreamManagedMatches([qf], { id: "final-source", round: null, entryRound: "final" }, "single_elim");
+    expect(upstreamOnly).toEqual([]);
+  });
+
+  it("never returns the corrected match itself as downstream", () => {
+    const impacts = classifyDownstreamManagedMatches(
+      [{ id: "self", managedKey: "r1-1", entryRound: null, round: 1, status: "scheduled" }],
+      { id: "self", round: 1, entryRound: null },
+      "swiss",
+    );
+    expect(impacts).toHaveLength(0);
+  });
+});
+
+describe("deriveSwissFinalizedRollback", () => {
+  it("rolls back to just before the corrected round", () => {
+    expect(deriveSwissFinalizedRollback(3, 2)).toBe(1);
+    // Correcting an accepted round-1 result must revoke its acceptance too.
+    expect(deriveSwissFinalizedRollback(1, 1)).toBe(0);
+    expect(deriveSwissFinalizedRollback(5, 1)).toBe(0);
+  });
+
+  it("reports no rollback only when nothing beyond the correction was accepted", () => {
+    expect(deriveSwissFinalizedRollback(0, 1)).toBeNull();
+    expect(deriveSwissFinalizedRollback(0, 4)).toBeNull();
+  });
+
+  it("treats unknown rounds conservatively", () => {
+    expect(deriveSwissFinalizedRollback(2, null)).toBe(0);
+  });
+});
+
+describe("validateResultCorrectionProposal", () => {
+  it("accepts a legal BO1 13:x score and resolves the winner", () => {
+    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 13, scoreB: 9 });
+    expect(result.winnerTeamId).toBe(TEAM_A);
+    expect(result.isForfeit).toBe(false);
+  });
+
+  it("resolves a B-side winner", () => {
+    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 4, scoreB: 13 });
+    expect(result.winnerTeamId).toBe(TEAM_B);
+  });
+
+  it("rejects negative and non-integer scores", () => {
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: -1, scoreB: 13 })).toThrow(AppError);
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 12.5, scoreB: 13 })).toThrow(AppError);
+  });
+
+  it("rejects ties", () => {
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 9, scoreB: 9 })).toThrow(/平局/);
+  });
+
+  it("enforces exact series thresholds for non-forfeit corrections", () => {
+    const bo3 = { ...baseMatch(), format: "bo3" as const };
+    // Winner must have exactly maxWins; 3:0 is legal for bo3, 2:1 legal, 13:x not.
+    expect(validateResultCorrectionProposal(bo3, { scoreA: 2, scoreB: 0 }).winnerTeamId).toBe(TEAM_A);
+    expect(() => validateResultCorrectionProposal(bo3, { scoreA: 5, scoreB: 3 })).toThrow(AppError);
+  });
+
+  it("requires the canonical forfeit shape when marked as forfeit", () => {
+    expect(
+      validateResultCorrectionProposal(baseMatch(), { scoreA: 13, scoreB: 0, isForfeit: true }).isForfeit,
+    ).toBe(true);
+    expect(() =>
+      validateResultCorrectionProposal(baseMatch(), { scoreA: 16, scoreB: 3, isForfeit: true }),
+    ).toThrow(/弃赛判负的标准比分为 13:0/);
+    const bo3 = { ...baseMatch(), format: "bo3" as const };
+    expect(() =>
+      validateResultCorrectionProposal(bo3, { scoreA: 1, scoreB: 2, isForfeit: false }),
+    ).not.toThrow();
+    expect(() =>
+      validateResultCorrectionProposal(bo3, { scoreA: 1, scoreB: 2, isForfeit: true }),
+    ).toThrow(/标准比分为 2:0/);
+  });
+
+  it("inherits forfeit semantics from the existing fact when the proposal omits the flag", () => {
+    const forfeited = { ...baseMatch(), isForfeit: true };
+    expect(() => validateResultCorrectionProposal(forfeited, { scoreA: 7, scoreB: 13 })).toThrow(/弃赛判负/);
+  });
+});
+
+describe("resolveWinnerTeamId", () => {
+  it("returns null while scores are missing or tied", () => {
+    expect(resolveWinnerTeamId({ teamAId: TEAM_A, teamBId: TEAM_B, scoreA: null, scoreB: null })).toBeNull();
+    expect(resolveWinnerTeamId({ teamAId: TEAM_A, teamBId: TEAM_B, scoreA: 2, scoreB: 2 })).toBeNull();
+  });
+
+  it("picks the higher-score side", () => {
+    expect(resolveWinnerTeamId({ teamAId: TEAM_A, teamBId: TEAM_B, scoreA: 2, scoreB: 1 })).toBe(TEAM_A);
+    expect(resolveWinnerTeamId({ teamAId: TEAM_A, teamBId: TEAM_B, scoreA: 0, scoreB: 3 })).toBe(TEAM_B);
+  });
+});
+
+describe("loadFrozenRunFacts", () => {
+  function stageRunOf(ruleSnapshot: unknown): Pick<MajorStageRun, "stageKey" | "ruleSnapshot" | "finalizedRound"> {
+    return { stageKey: "stage1", ruleSnapshot: ruleSnapshot as never, finalizedRound: 3 };
+  }
+
+  it("extracts the frozen stage type and ordered stage plan keys", () => {
+    const facts = loadFrozenRunFacts(stageRunOf({
+      version: 2,
+      stage: { key: "stage1", type: "swiss", teamCount: 16, matchFormat: "bo1" },
+      stagePlan: [{ key: "stage1" }, { key: "stage2" }, { key: "playoff" }],
+    }));
+    expect(facts.stageType).toBe("swiss");
+    expect(facts.stagePlanKeys).toEqual(["stage1", "stage2", "playoff"]);
+    expect(facts.finalizedRoundValue).toBe(3);
+  });
+
+  it("accepts single_elim snapshots", () => {
+    const facts = loadFrozenRunFacts({
+      stageKey: "playoff",
+      finalizedRound: 0,
+      ruleSnapshot: {
+        stage: { key: "playoff", type: "single_elim", teamCount: 8 },
+        stagePlan: [{ key: "stage1" }, { key: "playoff" }],
+      },
+    } as never);
+    expect(facts.stageType).toBe("single_elim");
+  });
+
+  it("throws on missing/mismatched/unknown snapshot shapes", () => {
+    expect(() => loadFrozenRunFacts(stageRunOf(null))).toThrow(AppError);
+    expect(() =>
+      loadFrozenRunFacts(stageRunOf({ stage: { key: "other", type: "swiss" }, stagePlan: [] })),
+    ).toThrow(AppError);
+    expect(() =>
+      loadFrozenRunFacts(stageRunOf({ stage: { key: "stage1", type: "round_robin" }, stagePlan: [] })),
+    ).toThrow(AppError);
+  });
+});

--- a/src/lib/match-corrections/service.ts
+++ b/src/lib/match-corrections/service.ts
@@ -1,0 +1,537 @@
+import { and, eq, ne } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import {
+  auditLogs,
+  majorFinalResults,
+  majorStageRuns,
+  matches,
+  type Match,
+} from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { validateSeriesScore } from "@/lib/matches/result-rules";
+
+/**
+ * G2 managed result correction & recovery.
+ *
+ * matches stays the canonical result truth. A correction never silently
+ * rewrites derived facts: the caller plans the correction, sees the downstream
+ * impact, and explicitly confirms recovery. Downstream matches that already
+ * started or finished always fail closed toward adjudication instead of being
+ * rewritten.
+ */
+
+export interface ResultCorrectionProposal {
+  scoreA: number;
+  scoreB: number;
+  /** Marks the corrected fact as a forfeit result (skips normal series shape). */
+  isForfeit?: boolean;
+}
+
+export interface CorrectionPlanImpact {
+  kind: "downstream_match" | "stage_run_rollback";
+  matchId?: string;
+  managedKey?: string | null;
+  entryRound?: string | null;
+  round?: number | null;
+  status: string;
+  description: string;
+}
+
+export interface ResultCorrectionPlan {
+  matchId: string;
+  stageKey: string | null;
+  stageType: "swiss" | "single_elim" | null;
+  current: { scoreA: number | null; scoreB: number | null; isForfeit: boolean };
+  proposed: { scoreA: number; scoreB: number; isForfeit: boolean };
+  currentWinnerTeamId: string | null;
+  proposedWinnerTeamId: string;
+  winnerChanges: boolean;
+  affectsManagedRun: boolean;
+  /** Derived facts that must be invalidated before the correction can rebuild. */
+  impacts: CorrectionPlanImpact[];
+  /** Non-empty means the correction is refused outright (fail closed). */
+  blockedReasons: string[];
+  /** Operator steps still required after applying (e.g. regenerate rounds). */
+  requiredRecoveryActions: string[];
+}
+
+interface FrozenRunFacts {
+  stageKey: string;
+  stageType: "swiss" | "single_elim";
+  stagePlanKeys: string[];
+  finalizedRoundValue: number;
+}
+
+const PLAYOFF_STEPS = ["quarterfinal", "semifinal", "final"] as const;
+
+/** Minimal shape the downstream classifier needs from a managed match row. */
+export interface DownstreamCandidateRow {
+  id: string;
+  managedKey: string | null;
+  entryRound: string | null;
+  round: number | null;
+  status: string;
+}
+
+export interface DownstreamImpactItem {
+  matchId: string;
+  managedKey: string | null;
+  status: string;
+  invalidatable: boolean;
+  description: string;
+}
+
+/**
+ * Pure classifier for within-run downstream facts. Swiss pairings ripple
+ * through whole standings buckets, so EVERY later-round managed match counts —
+ * not only those whose participants happen to change.
+ */
+export function classifyDownstreamManagedMatches(
+  candidates: readonly DownstreamCandidateRow[],
+  sourceMatch: { id: string; round: number | null; entryRound: string | null },
+  stageType: "swiss" | "single_elim",
+): DownstreamImpactItem[] {
+  const isSwiss = stageType === "swiss";
+  const myStepIndex =
+    !isSwiss && sourceMatch.entryRound
+      ? PLAYOFF_STEPS.indexOf(sourceMatch.entryRound as (typeof PLAYOFF_STEPS)[number])
+      : -1;
+
+  const impacts: DownstreamImpactItem[] = [];
+  for (const candidate of candidates) {
+    if (candidate.id === sourceMatch.id) continue;
+    const isDownstream = isSwiss
+      ? candidate.round !== null && sourceMatch.round !== null && candidate.round > sourceMatch.round
+      : candidate.entryRound !== null &&
+        candidate.entryRound !== "third_place" &&
+        myStepIndex >= 0 &&
+        PLAYOFF_STEPS.indexOf(candidate.entryRound as (typeof PLAYOFF_STEPS)[number]) > myStepIndex;
+    if (!isDownstream) continue;
+
+    const invalidatable = candidate.status === "scheduled";
+    impacts.push({
+      matchId: candidate.id,
+      managedKey: candidate.managedKey,
+      status: candidate.status,
+      invalidatable,
+      description: invalidatable
+        ? `${candidate.managedKey ?? candidate.id} 需要在胜者变更后作废并重建（对阵可能随积分重排）。`
+        : `${candidate.managedKey ?? candidate.id} 已经开始或完成（${candidate.status}），禁止自动改写。`,
+    });
+  }
+  return impacts;
+}
+
+/**
+ * The acceptance cursor a swiss correction must roll back to, or null when no
+ * accepted round is affected (nothing was finalized beyond the corrected one).
+ */
+export function deriveSwissFinalizedRollback(
+  runFinalizedRound: number,
+  correctedRound: number | null,
+): number | null {
+  const target = Math.min(runFinalizedRound, Math.max(0, (correctedRound ?? 1) - 1));
+  return target < runFinalizedRound ? target : null;
+}
+
+export function loadFrozenRunFacts(
+  stageRun: Pick<typeof majorStageRuns.$inferSelect, "stageKey" | "ruleSnapshot" | "finalizedRound">,
+): FrozenRunFacts {
+  const snapshot = stageRun.ruleSnapshot as Record<string, unknown> | null;
+  const stage =
+    snapshot && typeof snapshot === "object"
+      ? (snapshot.stage as { key?: unknown; type?: unknown } | undefined)
+      : undefined;
+  if (
+    !snapshot ||
+    typeof snapshot !== "object" ||
+    typeof stage?.key !== "string" ||
+    stage.key !== stageRun.stageKey ||
+    (stage.type !== "swiss" && stage.type !== "single_elim")
+  ) {
+    throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 规则快照缺失或不可识别。");
+  }
+  const rawPlan = Array.isArray(snapshot.stagePlan) ? snapshot.stagePlan : [];
+  const stagePlanKeys = rawPlan
+    .map((entry) => (entry && typeof entry === "object" ? (entry as { key?: unknown }).key : undefined))
+    .filter((key): key is string => typeof key === "string");
+  return {
+    stageKey: stageRun.stageKey,
+    stageType: stage.type,
+    stagePlanKeys,
+    finalizedRoundValue: stageRun.finalizedRound,
+  };
+}
+
+export function resolveWinnerTeamId(match: Pick<Match, "teamAId" | "teamBId" | "scoreA" | "scoreB">): string | null {
+  if (match.scoreA === null || match.scoreB === null || match.scoreA === match.scoreB) return null;
+  return match.scoreA > match.scoreB ? match.teamAId : match.teamBId;
+}
+
+const FORFEIT_WINNER_SCORE: Record<"bo1" | "bo3" | "bo5", number> = {
+  bo1: 13,
+  bo3: 2,
+  bo5: 3,
+};
+
+/**
+ * A corrected fact must either be a normal legal series result or an explicit
+ * forfeit result in the canonical forfeit shape (loser keeps 0).
+ */
+export function validateResultCorrectionProposal(
+  match: Pick<Match, "format" | "isForfeit"> & { teamAId: string; teamBId: string },
+  proposal: ResultCorrectionProposal,
+): { winnerTeamId: string; isForfeit: boolean } {
+  const { scoreA, scoreB } = proposal;
+  if (!Number.isInteger(scoreA) || !Number.isInteger(scoreB) || scoreA < 0 || scoreB < 0) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "比分必须为非负整数。");
+  }
+  if (scoreA === scoreB) {
+    throw new AppError(ErrorCode.MATCH_INVALID_SCORE, "系列赛不能平局，必须分出胜负。");
+  }
+  const isForfeit = proposal.isForfeit ?? match.isForfeit;
+  if (isForfeit) {
+    const expectedWinnerScore = FORFEIT_WINNER_SCORE[match.format];
+    const loserScore = Math.min(scoreA, scoreB);
+    const winnerScore = Math.max(scoreA, scoreB);
+    if (winnerScore !== expectedWinnerScore || loserScore !== 0) {
+      throw new AppError(
+        ErrorCode.MATCH_INVALID_SCORE,
+        `弃赛判负的标准比分为 ${expectedWinnerScore}:0（${match.format.toUpperCase()}）。`,
+      );
+    }
+  } else {
+    try {
+      validateSeriesScore(match.format, scoreA, scoreB);
+    } catch (error) {
+      throw error instanceof AppError
+        ? error
+        : new AppError(ErrorCode.MATCH_INVALID_SCORE, "提议比分不合法。");
+    }
+  }
+  return { winnerTeamId: scoreA > scoreB ? match.teamAId : match.teamBId, isForfeit };
+}
+
+/**
+ * Computes the downstream impact inventory of correcting one finished managed
+ * match. Read-only; call inside the transaction that will later apply so the
+ * plan cannot drift between display and confirmation.
+ */
+export async function planResultCorrectionInTx(
+  tx: TxDb,
+  args: { matchId: string; proposal: ResultCorrectionProposal },
+): Promise<ResultCorrectionPlan> {
+  const [match] = await tx.select().from(matches).where(eq(matches.id, args.matchId)).for("update");
+  if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+  if (match.status !== "finished") {
+    throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "只能修正已结束的比赛结果。");
+  }
+
+  const proposed = validateResultCorrectionProposal(match, args.proposal);
+  const currentWinner = resolveWinnerTeamId(match);
+  const winnerChanges =
+    currentWinner !== null && currentWinner !== proposed.winnerTeamId;
+
+  const plan: ResultCorrectionPlan = {
+    matchId: match.id,
+    stageKey: null,
+    stageType: null,
+    current: {
+      scoreA: match.scoreA,
+      scoreB: match.scoreB,
+      isForfeit: match.isForfeit,
+    },
+    proposed: { scoreA: args.proposal.scoreA, scoreB: args.proposal.scoreB, isForfeit: proposed.isForfeit },
+    currentWinnerTeamId: currentWinner,
+    proposedWinnerTeamId: proposed.winnerTeamId,
+    winnerChanges,
+    affectsManagedRun: false,
+    impacts: [],
+    blockedReasons: [],
+    requiredRecoveryActions: [],
+  };
+
+  if (!winnerChanges) {
+    return plan;
+  }
+
+  if (match.ownership !== "major_stage" || !match.majorStageRunId) {
+    plan.blockedReasons.push(
+      "非托管比赛的胜者更正会与既有赛程矛盾，必须通过赛事事故裁决处理。",
+    );
+    return plan;
+  }
+
+  plan.affectsManagedRun = true;
+  const [run] = await tx.select().from(majorStageRuns).where(eq(majorStageRuns.id, match.majorStageRunId));
+  if (!run) throw new AppError(ErrorCode.INTERNAL_ERROR, "托管比赛缺少对应的 StageRun。");
+  const frozen = loadFrozenRunFacts(run);
+  plan.stageKey = frozen.stageKey;
+  plan.stageType = frozen.stageType;
+
+  // Cross-stage hazard: any later stage materialized for this season means the
+  // current stage's outcome already produced derived truth elsewhere.
+  const allRuns = await tx.select().from(majorStageRuns).where(eq(majorStageRuns.seasonId, match.seasonId));
+  const myIndex = frozen.stagePlanKeys.indexOf(frozen.stageKey);
+  for (const other of allRuns) {
+    if (other.id === run.id) continue;
+    const otherIndex = frozen.stagePlanKeys.indexOf(other.stageKey);
+    if (myIndex >= 0 && otherIndex > myIndex) {
+      plan.blockedReasons.push(
+        `后续阶段 ${other.stageKey} 已基于本阶段结果建立，不能自动重建；需要走赛后裁决。`,
+      );
+    }
+  }
+
+  // Any confirmed official result pins placements/honors: post-event territory.
+  const [finalResult] = await tx
+    .select({ id: majorFinalResults.id })
+    .from(majorFinalResults)
+    .where(eq(majorFinalResults.seasonId, match.seasonId));
+  if (finalResult) {
+    plan.blockedReasons.push("官方名次已经生成，胜者更正被禁止；请使用赛后裁决操作。");
+  }
+
+  // Within-run downstream: later rounds (swiss) or later elimination steps
+  // (playoff). Every downstream managed match must be considered: swiss
+  // pairings ripple through entire standings buckets, so even matches whose
+  // participants did not change may be stale after regeneration.
+  const isSwiss = frozen.stageType === "swiss";
+  const runMatches = await tx.select().from(matches).where(and(eq(matches.majorStageRunId, run.id)));
+  const downstream = classifyDownstreamManagedMatches(
+    runMatches.map((row) => ({
+      id: row.id,
+      managedKey: row.managedKey,
+      entryRound: row.entryRound,
+      round: row.round,
+      status: row.status,
+    })),
+    { id: match.id, round: match.round, entryRound: match.entryRound },
+    frozen.stageType,
+  );
+  let startedDownstream = 0;
+  for (const impact of downstream) {
+    plan.impacts.push({
+      kind: "downstream_match",
+      matchId: impact.matchId,
+      managedKey: impact.managedKey,
+      entryRound: null,
+      round: null,
+      status: impact.status,
+      description: impact.description,
+    });
+    if (!impact.invalidatable) startedDownstream += 1;
+  }
+  if (startedDownstream > 0) {
+    plan.blockedReasons.push(
+      `存在 ${startedDownstream} 场已经开始或完成的下游托管比赛，系统拒绝自动重写；需要走赛后裁决并人工恢复。`,
+    );
+  }
+
+  if (isSwiss) {
+    const targetRollback = deriveSwissFinalizedRollback(run.finalizedRound, match.round);
+    if (targetRollback !== null) {
+      plan.impacts.push({
+        kind: "stage_run_rollback",
+        status: `finalized_round:${run.finalizedRound}`,
+        description: `第 ${targetRollback + 1} 轮及之后的轮次确认将被撤销（finalizedRound ${run.finalizedRound} → ${targetRollback}）。`,
+      });
+      plan.requiredRecoveryActions.push(`从第 ${targetRollback + 1} 轮开始重新逐轮确认（finalize）以重建后续对阵。`);
+    }
+  } else {
+    plan.requiredRecoveryActions.push("重新按顺序确认受影响的淘汰轮次以重建后续对阵。");
+  }
+
+  if (plan.impacts.length > 0) {
+    plan.requiredRecoveryActions.unshift("显式作废列出的未开始下游托管比赛。");
+  }
+
+  return plan;
+}
+
+function assertPlanApplicable(plan: ResultCorrectionPlan): void {
+  if (plan.blockedReasons.length > 0) {
+    throw new AppError(
+      ErrorCode.VALIDATION_FAILED,
+      `该更正触发了 fail-closed 保护：${plan.blockedReasons.join("；")}`,
+    );
+  }
+}
+
+export interface AppliedResultCorrection {
+  alreadyApplied: boolean;
+  winnerChanged: boolean;
+  invalidatedDownstreamMatches: string[];
+  rolledBackToFinalized: number | null;
+}
+
+/**
+ * Applies a planned correction atomically. Winner changes require
+ * `confirmRecovery` and an empty hard-block set; unstarted downstream managed
+ * matches are explicitly invalidated and the StageRun acceptance cursor is
+ * rolled back so the operator can rebuild through the ordinary finalize path.
+ */
+export async function applyResultCorrectionInTx(
+  tx: TxDb,
+  args: {
+    matchId: string;
+    proposal: ResultCorrectionProposal;
+    actorId: string;
+    confirmRecovery?: boolean;
+  },
+): Promise<AppliedResultCorrection> {
+  const plan = await planResultCorrectionInTx(tx, { matchId: args.matchId, proposal: args.proposal });
+
+  if (
+    plan.current.scoreA === plan.proposed.scoreA &&
+    plan.current.scoreB === plan.proposed.scoreB &&
+    plan.current.isForfeit === plan.proposed.isForfeit
+  ) {
+    return {
+      alreadyApplied: true,
+      winnerChanged: false,
+      invalidatedDownstreamMatches: [],
+      rolledBackToFinalized: null,
+    };
+  }
+
+  assertPlanApplicable(plan);
+  if (plan.winnerChanges) {
+    if (!plan.affectsManagedRun) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "非托管比赛不允许通过更正改变胜者。");
+    }
+    if (!args.confirmRecovery) {
+      throw new AppError(
+        ErrorCode.VALIDATION_FAILED,
+        "该更正会改变胜者并影响下游事实：必须先查看影响清单并显式确认恢复流程。",
+      );
+    }
+  }
+
+  const [locked] = await tx.select().from(matches).where(eq(matches.id, args.matchId)).for("update");
+  if (!locked) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+
+  await tx
+    .update(matches)
+    .set({
+      scoreA: plan.proposed.scoreA,
+      scoreB: plan.proposed.scoreB,
+      isForfeit: plan.proposed.isForfeit,
+      updatedAt: new Date(),
+    })
+    .where(eq(matches.id, args.matchId));
+
+  const applied: AppliedResultCorrection = {
+    alreadyApplied: false,
+    winnerChanged: plan.winnerChanges,
+    invalidatedDownstreamMatches: [],
+    rolledBackToFinalized: null,
+  };
+
+  await tx.insert(auditLogs).values({
+    seasonId: locked.seasonId,
+    action: "match.result.corrected",
+    actorId: args.actorId,
+    targetId: locked.id,
+    targetType: "match",
+    meta: {
+      prevScoreA: locked.scoreA,
+      prevScoreB: locked.scoreB,
+      prevIsForfeit: locked.isForfeit,
+      scoreA: plan.proposed.scoreA,
+      scoreB: plan.proposed.scoreB,
+      isForfeit: plan.proposed.isForfeit,
+      winnerChanged: plan.winnerChanges,
+      prevWinnerTeamId: plan.currentWinnerTeamId,
+      nextWinnerTeamId: plan.proposedWinnerTeamId,
+      stageKey: plan.stageKey,
+      stageType: plan.stageType,
+    },
+  });
+
+  if (!plan.winnerChanges) {
+    return applied;
+  }
+
+  // Explicit invalidate phase for unstarted downstream managed matches.
+  const invalidatable = plan.impacts.filter(
+    (impact): impact is CorrectionPlanImpact & { matchId: string } =>
+      impact.kind === "downstream_match" && impact.matchId !== undefined && impact.status === "scheduled",
+  );
+  for (const impact of invalidatable) {
+    const deleted = await tx
+      .delete(matches)
+      .where(and(eq(matches.id, impact.matchId!), eq(matches.status, "scheduled")))
+      .returning({ id: matches.id, managedKey: matches.managedKey });
+    if (deleted.length === 0) continue;
+    applied.invalidatedDownstreamMatches.push(deleted[0]!.id);
+    await tx.insert(auditLogs).values({
+      seasonId: locked.seasonId,
+      action: "match.managed.invalidated",
+      actorId: args.actorId,
+      targetId: deleted[0]!.id,
+      targetType: "match",
+      meta: {
+        reason: "upstream_result_correction",
+        sourceMatchId: locked.id,
+        managedKey: deleted[0]!.managedKey,
+        stageKey: plan.stageKey,
+      },
+    });
+  }
+
+  // Roll back the acceptance cursor so finalize can rebuild deterministically.
+  if (plan.stageType === "swiss" && locked.majorStageRunId) {
+    const target = plan.impacts.find((impact) => impact.kind === "stage_run_rollback");
+    if (target) {
+      const rollbackTo = Math.max(0, (locked.round ?? 1) - 1);
+      await tx
+        .update(majorStageRuns)
+        .set({ finalizedRound: rollbackTo })
+        .where(and(eq(majorStageRuns.id, locked.majorStageRunId), ne(majorStageRuns.finalizedRound, rollbackTo)));
+      applied.rolledBackToFinalized = rollbackTo;
+      await tx.insert(auditLogs).values({
+        seasonId: locked.seasonId,
+        action: "major.stage.finalized_round.revoked",
+        actorId: args.actorId,
+        targetId: locked.majorStageRunId,
+        targetType: "major_stage_run",
+        meta: { stageKey: plan.stageKey, revokedFrom: target.status, rolledBackTo: rollbackTo },
+      });
+    }
+  }
+
+  return applied;
+}
+
+/**
+ * Audits an out-of-band recovery decision for cases the engine refuses to
+ * touch (started downstream facts, later stages, post-event results). This
+ * records the fact that an adjudication happened and who made it — it never
+ * mutates canonical results by itself.
+ */
+export async function recordRecoveryAdjudicationInTx(
+  tx: TxDb,
+  args: { matchId: string; actorId: string; note: string },
+): Promise<{ recorded: true }> {
+  const [locked] = await tx.select().from(matches).where(eq(matches.id, args.matchId)).for("update");
+  if (!locked) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+  if (!args.note.trim()) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "裁决说明不能为空。");
+  }
+  await tx.insert(auditLogs).values({
+    seasonId: locked.seasonId,
+    action: "match.recovery.adjudicated",
+    actorId: args.actorId,
+    targetId: locked.id,
+    targetType: "match",
+    meta: {
+      note: args.note.trim(),
+      stageKey: locked.stage,
+      scoreA: locked.scoreA,
+      scoreB: locked.scoreB,
+      isForfeit: locked.isForfeit,
+    },
+  });
+  return { recorded: true };
+}

--- a/src/lib/match-rosters/lineup.test.ts
+++ b/src/lib/match-rosters/lineup.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateStartingLineup,
+  type LineupMemberFact,
+} from "@/lib/match-rosters/lineup";
+import type { InstitutionAffiliationRule } from "@/types/season";
+
+const NJU_RULE: InstitutionAffiliationRule = {
+  institutionCode: "4132010284",
+  eligibleAcademicStatuses: ["enrolled", "graduated"],
+  minRosterMembers: 3,
+  minStartingMembers: 3,
+};
+
+type Verification = NonNullable<LineupMemberFact["verification"]>;
+type VerificationOverride = Partial<Verification>;
+
+interface FixtureMember {
+  teamMemberId: string;
+  userId: string;
+  verification: Verification | null;
+}
+
+interface World {
+  memberFacts: Map<string, LineupMemberFact>;
+  /** Select teamMemberIds by index in ascending order given. */
+  ids: (...indices: number[]) => string[];
+  allIds: () => string[];
+  rosterUserIds: (...indices: number[]) => Set<string>;
+}
+
+function makeMember(
+  index: number,
+  institutionCode: string | null,
+  overrides?: VerificationOverride,
+): FixtureMember {
+  return {
+    teamMemberId: `member-${index}`,
+    userId: `user-${index}`,
+    verification: institutionCode
+      ? {
+          institutionCode,
+          academicStatus: "enrolled",
+          status: "approved",
+          ...(overrides ?? {}),
+        }
+      : null,
+  };
+}
+
+/** Unaffiliated member without any education link (never on a frozen roster). */
+function plain(index: number): FixtureMember {
+  return makeMember(index, null);
+}
+
+/** Verified NJU-affiliated member. */
+function nju(index: number, overrides?: VerificationOverride): FixtureMember {
+  return makeMember(index, "4132010284", overrides);
+}
+
+/** Verified member of another institution. */
+function otherInstitution(index: number): FixtureMember {
+  return makeMember(index, "4111010001");
+}
+
+function buildWorld(members: readonly FixtureMember[]): World {
+  const memberFacts = new Map<string, LineupMemberFact>();
+  for (const m of members) memberFacts.set(m.teamMemberId, m);
+  return {
+    memberFacts,
+    ids: (...indices: number[]) =>
+      indices.map((i) => `member-${i}`),
+    allIds: () => [...memberFacts.keys()],
+    rosterUserIds: (...indices: number[]) =>
+      new Set(indices.map((i) => `user-${i}`)),
+  };
+}
+
+describe("evaluateStartingLineup — structural rules", () => {
+  it("fails when fewer than 5 starters", () => {
+    const world = buildWorld([plain(1), plain(2), plain(3), plain(4)]);
+    const result = evaluateStartingLineup({
+      starterIds: world.ids(1, 2, 3, 4),
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("必须选择 5 名首发"))).toBe(true);
+  });
+
+  it("fails with 6 starters", () => {
+    const world = buildWorld(Array.from({ length: 6 }, (_, i) => plain(i + 1)));
+    const result = evaluateStartingLineup({
+      starterIds: world.allIds(),
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("必须选择 5 名首发"))).toBe(true);
+  });
+
+  it("fails with more than 2 substitutes", () => {
+    const world = buildWorld(Array.from({ length: 9 }, (_, i) => plain(i + 1)));
+    const result = evaluateStartingLineup({
+      starterIds: world.ids(1, 2, 3, 4, 5),
+      substituteIds: world.ids(6, 7, 8),
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("替补不能超过"))).toBe(true);
+  });
+
+  it("fails on duplicate selection across starters and substitutes", () => {
+    const world = buildWorld([plain(1), plain(2), plain(3), plain(4), plain(5)]);
+    const dupId = world.ids(1)[0]!;
+    const result = evaluateStartingLineup({
+      starterIds: [dupId, ...world.ids(2, 3, 4, 5)],
+      substituteIds: [dupId],
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("重复选择"))).toBe(true);
+  });
+
+  it("fails when a selected player is not a member of the team", () => {
+    const world = buildWorld([plain(1), plain(2), plain(3), plain(4), plain(5)]);
+    const result = evaluateStartingLineup({
+      starterIds: [...world.ids(1, 2, 3, 4), "member-alien"],
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("不属于本队"))).toBe(true);
+  });
+});
+
+describe("evaluateStartingLineup — Major frozen roster & affiliation rules", () => {
+  const rules = [NJU_RULE];
+
+  it("rejects an outsider who is not on the frozen tournament roster", () => {
+    // Members 1–5 are selectable for the canonical team; user-5 is missing from
+    // the frozen tournament roster.
+    const world = buildWorld([
+      nju(1), nju(2), nju(3), otherInstitution(4), otherInstitution(5),
+    ]);
+    const result = evaluateStartingLineup({
+      starterIds: world.ids(1, 2, 3, 4, 5),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("冻结名单"))).toBe(true);
+  });
+
+  it("rejects an outside substitute too", () => {
+    const world = buildWorld([nju(1), nju(2), nju(3), otherInstitution(4), otherInstitution(5), nju(9)]);
+    const result = evaluateStartingLineup({
+      starterIds: world.ids(1, 2, 3, 4, 5),
+      substituteIds: ["member-9"],
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("冻结名单"))).toBe(true);
+  });
+
+  it("enforces at least 3 verified NJU starters from the frozen rule snapshot", () => {
+    const world = buildWorld([
+      nju(1), nju(2), otherInstitution(3), otherInstitution(4), otherInstitution(5),
+    ]);
+    const result = evaluateStartingLineup({
+      starterIds: world.allIds(),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(false);
+    expect(
+      result.blockers.some((b) => b.includes("南京大学成员 2 人") && b.includes("还缺 1 人")),
+    ).toBe(true);
+  });
+
+  it("passes with exactly 3 verified NJU starters; validator reads only the passed rules", () => {
+    // The caller passes rules read from the StageRun snapshot — nothing here can
+    // reach mutable season config, so passing legality depends solely on the
+    // frozen values.
+    const world = buildWorld([
+      nju(1), nju(2), nju(3), otherInstitution(4), otherInstitution(5),
+    ]);
+    const result = evaluateStartingLineup({
+      starterIds: world.allIds(),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.affiliatedStarterCounts.get("4132010284")).toBe(3);
+  });
+
+  it("treats rejected/pending education verifications as lost eligibility", () => {
+    const world = buildWorld([
+      nju(1),
+      nju(2),
+      nju(3),
+      nju(4, { status: "rejected" }),
+      nju(5, { status: "pending" }),
+    ]);
+    const result = evaluateStartingLineup({
+      starterIds: world.allIds(),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("失去本届比赛资格"))).toBe(true);
+    // Later-rejected members no longer count toward the affiliation minimum,
+    // which independently produces its own blocker.
+    expect(
+      result.blockers.some(
+        (b) => b.includes("南京大学成员 3 人") || b.includes("南京大学成员 2 人"),
+      ),
+    ).toBe(false);
+  });
+
+  it("counts graduated NJU members when the frozen rule allows graduated", () => {
+    const world = buildWorld([
+      nju(1),
+      nju(2),
+      nju(3, { academicStatus: "graduated" }),
+      otherInstitution(4),
+      otherInstitution(5),
+    ]);
+    const graduatedRule: InstitutionAffiliationRule = { ...NJU_RULE, minStartingMembers: 2 };
+    const result = evaluateStartingLineup({
+      starterIds: world.allIds(),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5),
+      affiliationRules: [graduatedRule],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.affiliatedStarterCounts.get("4132010284")).toBe(3);
+  });
+
+  it("does not let substitutes satisfy the starter minimum", () => {
+    // Only 2 NJU starters; a 3rd NJU player sits on the bench.
+    const world = buildWorld([
+      nju(1), nju(2), otherInstitution(3), otherInstitution(4), otherInstitution(5), nju(6),
+    ]);
+    const result = evaluateStartingLineup({
+      starterIds: world.ids(1, 2, 3, 4, 5),
+      substituteIds: world.ids(6),
+      memberFacts: world.memberFacts,
+      frozenRosterUserIds: world.rosterUserIds(1, 2, 3, 4, 5, 6),
+      affiliationRules: rules,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.blockers.some((b) => b.includes("还缺 1 人"))).toBe(true);
+  });
+});
+
+describe("evaluateStartingLineup — non-Major matches", () => {
+  it("skips affiliation and frozen-roster checks without rules (manual seasons)", () => {
+    const world = buildWorld([plain(1), plain(2), plain(3), plain(4), plain(5), plain(6)]);
+    const all = world.allIds();
+    const result = evaluateStartingLineup({
+      starterIds: all.slice(0, 5),
+      substituteIds: all.slice(5, 6),
+      memberFacts: world.memberFacts,
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/lib/match-rosters/lineup.ts
+++ b/src/lib/match-rosters/lineup.ts
@@ -1,0 +1,137 @@
+import type { InstitutionAffiliationRule } from "@/types/season";
+
+/**
+ * G1 contract for match starting lineups. A lineup may only ever come from an
+ * explicit submit/confirm flow; nothing in this module infers starters from
+ * team_members ordering or any other implicit fallback.
+ */
+
+export const STARTER_COUNT = 5;
+export const MAX_SUBSTITUTES = 2;
+
+export interface LineupVerificationFact {
+  institutionCode: string | null;
+  academicStatus: "enrolled" | "graduated";
+  status: "pending" | "approved" | "rejected";
+}
+
+/** The membership facts that must be resolved before a lineup can be judged. */
+export interface LineupMemberFact {
+  teamMemberId: string;
+  userId: string;
+  verification: LineupVerificationFact | null;
+}
+
+export interface StartingLineupInput {
+  starterIds: readonly string[];
+  substituteIds?: readonly string[];
+  /** Facts for every team member selectable on this canonical team. */
+  memberFacts: ReadonlyMap<string, LineupMemberFact>;
+  /**
+   * Frozen tournament roster user ids (Major prestart snapshot). When present,
+   * every selected player must appear in it.
+   */
+  frozenRosterUserIds?: ReadonlySet<string>;
+  /**
+   * Affiliation rules frozen in the StageRun ruleSnapshot. When present,
+   * education validity and per-institution starter minimums are enforced.
+   * Never pass rules read from mutable season config here.
+   */
+  affiliationRules?: readonly InstitutionAffiliationRule[];
+}
+
+export interface StartingLineupResult {
+  valid: boolean;
+  blockers: string[];
+  /** Approved, academically-eligible starter count per institution code. */
+  affiliatedStarterCounts: Map<string, number>;
+}
+
+function institutionLabel(code: string): string {
+  return code === "4132010284" ? "南京大学" : code;
+}
+
+function isEligibleForRule(
+  fact: LineupMemberFact,
+  rule: InstitutionAffiliationRule,
+): boolean {
+  return Boolean(
+    fact.verification &&
+      fact.verification.status === "approved" &&
+      fact.verification.institutionCode === rule.institutionCode &&
+      rule.eligibleAcademicStatuses.includes(fact.verification.academicStatus),
+  );
+}
+
+/**
+ * Pure referee for a proposed match lineup. Deterministic, DB-free; both the
+ * confirm flow and the start gate must run it against freshly loaded facts.
+ */
+export function evaluateStartingLineup(input: StartingLineupInput): StartingLineupResult {
+  const { starterIds, substituteIds = [], memberFacts } = input;
+  const blockers: string[] = [];
+  const affiliatedStarterCounts = new Map<string, number>();
+
+  if (starterIds.length !== STARTER_COUNT) {
+    blockers.push(`必须选择 ${STARTER_COUNT} 名首发，当前选择了 ${starterIds.length} 名。`);
+  }
+  if (substituteIds.length > MAX_SUBSTITUTES) {
+    blockers.push(`替补不能超过 ${MAX_SUBSTITUTES} 人，当前选择了 ${substituteIds.length} 名。`);
+  }
+
+  const seen = new Set<string>();
+  let duplicateCount = 0;
+  for (const id of [...starterIds, ...substituteIds]) {
+    if (seen.has(id)) duplicateCount += 1;
+    seen.add(id);
+  }
+  if (duplicateCount > 0) {
+    blockers.push("同一名队员被重复选择，不能提交。");
+  }
+
+  const unknownCount = [...starterIds, ...substituteIds].filter((id) => !memberFacts.has(id)).length;
+  if (unknownCount > 0) {
+    blockers.push(`有 ${unknownCount} 名所选队员不属于本队，不能提交。`);
+  }
+
+  const starterFacts: LineupMemberFact[] = [];
+  const substituteFacts: LineupMemberFact[] = [];
+  for (const id of starterIds) {
+    const fact = memberFacts.get(id);
+    if (fact) starterFacts.push(fact);
+  }
+  for (const id of substituteIds) {
+    const fact = memberFacts.get(id);
+    if (fact) substituteFacts.push(fact);
+  }
+
+  if (input.frozenRosterUserIds) {
+    const outsiders =
+      [...starterFacts, ...substituteFacts].filter(
+        (fact) => !input.frozenRosterUserIds!.has(fact.userId),
+      ).length;
+    if (outsiders > 0) {
+      blockers.push(`有 ${outsiders} 名所选队员不在本届赛事冻结名单内，不能作为本场参赛选手。`);
+    }
+  }
+
+  if (input.affiliationRules) {
+    const rules = input.affiliationRules!;
+    const allSelected = [...starterFacts, ...substituteFacts];
+    if (allSelected.some((fact) => !fact.verification || fact.verification.status !== "approved")) {
+      blockers.push("有队员的教育身份认证已失效或未通过审核，已失去本届比赛资格。");
+    }
+    for (const rule of rules) {
+      const count = starterFacts.filter((fact) => isEligibleForRule(fact, rule)).length;
+      affiliatedStarterCounts.set(rule.institutionCode, count);
+      if (rule.minStartingMembers > 0 && count < rule.minStartingMembers) {
+        const shortfall = rule.minStartingMembers - count;
+        blockers.push(
+          `首发阵容中已认证${institutionLabel(rule.institutionCode)}成员 ${count} 人，至少需要 ${rule.minStartingMembers} 人；还缺 ${shortfall} 人。`,
+        );
+      }
+    }
+  }
+
+  return { valid: blockers.length === 0, blockers, affiliatedStarterCounts };
+}

--- a/src/lib/match-rosters/service.ts
+++ b/src/lib/match-rosters/service.ts
@@ -1,0 +1,426 @@
+import { and, eq } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import {
+  auditLogs,
+  educationVerifications,
+  institutions,
+  majorPrestartEntrants,
+  majorPrestartRosterMembers,
+  majorStageRuns,
+  matchRosterPlayers,
+  matchRosters,
+  matches,
+  teamMembers,
+  teams,
+  type Match,
+} from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { frozenStageRunAffiliationRules } from "@/lib/major/frozen-affiliation-rules";
+import { assertMatchTransition } from "@/lib/match-transitions";
+import type { InstitutionAffiliationRule } from "@/types/season";
+import { evaluateStartingLineup, type LineupMemberFact } from "./lineup";
+
+/**
+ * G1 transactional services behind every explicit lineup action:
+ * participant submit, admin select, confirm, and the start gate.
+ * Server Actions stay thin wrappers (session + revalidate) around these so the
+ * local PostgreSQL integration suite can drive the exact production logic.
+ */
+
+export interface TeamLineupContext {
+  /** Affiliation rules frozen in the StageRun snapshot; empty outside Major. */
+  rules: readonly InstitutionAffiliationRule[];
+  frozenRosterUserIds: ReadonlySet<string> | null;
+  memberFacts: Map<string, LineupMemberFact>;
+}
+
+/** Row-lock the match so status transitions and roster mutations serialize. */
+export async function lockMatchInTx(tx: TxDb, matchId: string): Promise<Match> {
+  const [locked] = await tx
+    .select()
+    .from(matches)
+    .where(eq(matches.id, matchId))
+    .for("update");
+  if (!locked) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+  return locked;
+}
+
+function assertScheduledOrThrow(match: Pick<Match, "status">): void {
+  if (match.status !== "scheduled") {
+    throw new AppError(
+      ErrorCode.MATCH_INVALID_TRANSITION,
+      `比赛当前状态为 ${match.status}，阵容只能在开赛前调整。`,
+    );
+  }
+}
+
+/** Entrant membership resolves the frozen tournament roster per canonical team. */
+async function loadFrozenRosterUserIdsInTx(
+  tx: TxDb,
+  seasonId: string,
+  teamId: string,
+): Promise<{ ids: ReadonlySet<string>; verificationsByUser: Map<string, LineupMemberFact["verification"]> }> {
+  const [entrant] = await tx
+    .select({ id: majorPrestartEntrants.id })
+    .from(majorPrestartEntrants)
+    .where(
+      and(eq(majorPrestartEntrants.seasonId, seasonId), eq(majorPrestartEntrants.teamId, teamId)),
+    );
+  if (!entrant) {
+    throw new AppError(
+      ErrorCode.INTERNAL_ERROR,
+      "参赛队缺少官方 entrant 记录，无法校验本届冻结名单。",
+    );
+  }
+
+  const rows = await tx
+    .select({
+      userId: majorPrestartRosterMembers.userId,
+      status: educationVerifications.status,
+      institutionCode: institutions.moeInstitutionCode,
+      academicStatus: educationVerifications.academicStatus,
+    })
+    .from(majorPrestartRosterMembers)
+    // The authoritative verification adopted by the frozen tournament roster.
+    .innerJoin(
+      educationVerifications,
+      eq(educationVerifications.id, majorPrestartRosterMembers.educationVerificationId),
+    )
+    .innerJoin(institutions, eq(institutions.id, educationVerifications.institutionId))
+    .where(eq(majorPrestartRosterMembers.entrantId, entrant.id));
+
+  const ids = new Set<string>();
+  const verificationsByUser = new Map<string, LineupMemberFact["verification"]>();
+  for (const row of rows) {
+    ids.add(row.userId);
+    if (!verificationsByUser.has(row.userId)) {
+      verificationsByUser.set(row.userId, {
+        institutionCode: row.institutionCode ?? null,
+        academicStatus: row.academicStatus,
+        status: row.status,
+      });
+    }
+  }
+  return { ids, verificationsByUser };
+}
+
+export async function loadTeamLineupContextInTx(
+  tx: TxDb,
+  match: Match,
+  teamId: string,
+): Promise<TeamLineupContext> {
+  const canonicalTeam = await tx
+    .select({ id: teams.id })
+    .from(teams)
+    .where(and(eq(teams.seasonId, match.seasonId), eq(teams.id, teamId)));
+  if (canonicalTeam.length === 0) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "参赛队伍不属于本场比赛的赛季。");
+  }
+
+  let rules: readonly InstitutionAffiliationRule[] = [];
+  let frozenRosterUserIds: ReadonlySet<string> | null = null;
+  let verificationsByUser: Map<string, LineupMemberFact["verification"]> | null = null;
+
+  if (match.ownership === "major_stage") {
+    if (!match.majorStageRunId) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "托管比赛缺少对应的 StageRun。");
+    }
+    const [stageRun] = await tx
+      .select({ ruleSnapshot: majorStageRuns.ruleSnapshot })
+      .from(majorStageRuns)
+      .where(eq(majorStageRuns.id, match.majorStageRunId));
+    if (!stageRun) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "托管比赛缺少对应的 StageRun。");
+    }
+    // Frozen at StageRun creation; never read from mutable season configuration.
+    rules = frozenStageRunAffiliationRules(stageRun.ruleSnapshot);
+    const frozen = await loadFrozenRosterUserIdsInTx(tx, match.seasonId, teamId);
+    frozenRosterUserIds = frozen.ids;
+    verificationsByUser = frozen.verificationsByUser;
+  }
+
+  const memberRows = await tx
+    .select({ id: teamMembers.id, userId: teamMembers.userId })
+    .from(teamMembers)
+    .where(eq(teamMembers.teamId, teamId));
+
+  const memberFacts = new Map<string, LineupMemberFact>();
+  for (const row of memberRows) {
+    memberFacts.set(row.id, {
+      teamMemberId: row.id,
+      userId: row.userId,
+      verification:
+        (rules.length > 0 ? verificationsByUser?.get(row.userId) : null) ?? null,
+    });
+  }
+
+  return { rules, frozenRosterUserIds, memberFacts };
+}
+
+export async function assertStartingLineupAllowedInTx(
+  tx: TxDb,
+  args: {
+    match: Match;
+    teamId: string;
+    starterIds: readonly string[];
+    substituteIds?: readonly string[];
+  },
+): Promise<{ affiliatedStarterCounts: Map<string, number> }> {
+  const context = await loadTeamLineupContextInTx(tx, args.match, args.teamId);
+  const result = evaluateStartingLineup({
+    starterIds: args.starterIds,
+    substituteIds: args.substituteIds,
+    memberFacts: context.memberFacts,
+    frozenRosterUserIds: context.frozenRosterUserIds ?? undefined,
+    affiliationRules: context.rules.length > 0 ? context.rules : undefined,
+  });
+  if (!result.valid) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, result.blockers.join("；"));
+  }
+  return { affiliatedStarterCounts: result.affiliatedStarterCounts };
+}
+
+function loadPersistedPlayers(
+  players: readonly { teamMemberId: string; isStarter: boolean }[],
+): { starterIds: string[]; substituteIds: string[] } {
+  return {
+    starterIds: players.filter((row) => row.isStarter).map((row) => row.teamMemberId),
+    substituteIds: players.filter((row) => !row.isStarter).map((row) => row.teamMemberId),
+  };
+}
+
+export interface PersistedRosterSummary {
+  rosterId: string;
+  matchId: string;
+  teamId: string;
+  starterIds: string[];
+  substituteIds: string[];
+}
+
+/**
+ * Upsert the explicit lineup for (match, team). Callers must have validated the
+ * lineup first; this only records the fact.
+ */
+export async function persistMatchRosterInTx(
+  tx: TxDb,
+  args: {
+    match: Match;
+    teamId: string;
+    submittedBy: string | null;
+    source: "participant" | "admin_select";
+    starterIds: readonly string[];
+    substituteIds?: readonly string[];
+  },
+): Promise<PersistedRosterSummary> {
+  const substituteIds = args.substituteIds ?? [];
+  const now = new Date();
+  const [existing] = await tx
+    .select({ id: matchRosters.id })
+    .from(matchRosters)
+    .where(and(eq(matchRosters.matchId, args.match.id), eq(matchRosters.teamId, args.teamId)));
+
+  let rosterId: string;
+  if (existing) {
+    rosterId = existing.id;
+    await tx
+      .update(matchRosters)
+      .set({
+        status: "submitted",
+        submittedBy: args.submittedBy,
+        source: args.source,
+        lockedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(matchRosters.id, existing.id));
+    await tx.delete(matchRosterPlayers).where(eq(matchRosterPlayers.rosterId, existing.id));
+  } else {
+    const inserted = await tx
+      .insert(matchRosters)
+      .values({
+        matchId: args.match.id,
+        teamId: args.teamId,
+        submittedBy: args.submittedBy,
+        source: args.source,
+        status: "submitted",
+        lockedAt: now,
+      })
+      .returning({ id: matchRosters.id });
+    if (!inserted[0]) throw new AppError(ErrorCode.INTERNAL_ERROR, "写入比赛名单失败。");
+    rosterId = inserted[0].id;
+  }
+
+  await tx.insert(matchRosterPlayers).values([
+    ...args.starterIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: true })),
+    ...substituteIds.map((id) => ({ rosterId, teamMemberId: id, isStarter: false })),
+  ]);
+
+  return {
+    rosterId,
+    matchId: args.match.id,
+    teamId: args.teamId,
+    starterIds: [...args.starterIds],
+    substituteIds: [...substituteIds],
+  };
+}
+
+export interface ConfirmRosterOutcome {
+  rosterId: string;
+  matchId: string;
+  teamId: string;
+  starterIds: string[];
+  alreadyConfirmed: boolean;
+}
+
+export async function confirmMatchRosterInTx(
+  tx: TxDb,
+  args: { rosterId: string; actorId: string },
+): Promise<ConfirmRosterOutcome> {
+  const [roster] = await tx
+    .select()
+    .from(matchRosters)
+    .where(eq(matchRosters.id, args.rosterId))
+    .for("update");
+  if (!roster) throw new AppError(ErrorCode.NOT_FOUND, "名单不存在。");
+
+  const match = await lockMatchInTx(tx, roster.matchId);
+  assertScheduledOrThrow(match);
+
+  const players = await tx
+    .select({ teamMemberId: matchRosterPlayers.teamMemberId, isStarter: matchRosterPlayers.isStarter })
+    .from(matchRosterPlayers)
+    .where(eq(matchRosterPlayers.rosterId, roster.id));
+  if (players.length === 0) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "名单没有任何队员，无法确认。");
+  }
+  const { starterIds, substituteIds } = loadPersistedPlayers(players);
+
+  if (roster.status === "confirmed") {
+    // Idempotent re-confirm: state unchanged, no duplicate audit event.
+    return { rosterId: roster.id, matchId: match.id, teamId: roster.teamId, starterIds, alreadyConfirmed: true };
+  }
+
+  // Re-validate against fresh facts; confirmation is an eligibility decision.
+  await assertStartingLineupAllowedInTx(tx, {
+    match,
+    teamId: roster.teamId,
+    starterIds,
+    substituteIds,
+  });
+
+  const now = new Date();
+  await tx
+    .update(matchRosters)
+    .set({ status: "confirmed", confirmedAt: now, confirmedBy: args.actorId, updatedAt: now })
+    .where(eq(matchRosters.id, roster.id));
+
+  await tx.insert(auditLogs).values({
+    seasonId: match.seasonId,
+    action: "match.roster.confirm",
+    actorId: args.actorId,
+    targetId: roster.id,
+    targetType: "match_roster",
+    meta: { matchId: match.id, teamId: roster.teamId, starterIds, substituteIds },
+  });
+
+  return { rosterId: roster.id, matchId: match.id, teamId: roster.teamId, starterIds, alreadyConfirmed: false };
+}
+
+export interface StartLineupSummary extends PersistedRosterSummary {
+  status: "confirmed";
+}
+
+export interface MatchTransitionOutcome {
+  from: Match["status"];
+  to: "in_progress" | "cancelled";
+  lineups: StartLineupSummary[] | null;
+}
+
+/**
+ * The complete production body of a match status transition, shared by the
+ * Server Action wrapper and the local integration suite:
+ * row-lock → re-checked state machine gate → (start) both-teams-confirmed
+ * lineup gate → status write → audit (match.start / match.status_update).
+ */
+export async function applyMatchStatusTransitionInTx(
+  tx: TxDb,
+  args: { matchId: string; nextStatus: "in_progress" | "cancelled"; actorId: string },
+): Promise<MatchTransitionOutcome> {
+  const locked = await lockMatchInTx(tx, args.matchId);
+  assertMatchTransition(locked.status, args.nextStatus);
+  const lineups =
+    args.nextStatus === "in_progress"
+      ? await assertConfirmedLineupsForStartInTx(tx, locked)
+      : null;
+
+  await tx
+    .update(matches)
+    .set({ status: args.nextStatus, updatedAt: new Date() })
+    .where(eq(matches.id, args.matchId));
+
+  await tx.insert(auditLogs).values({
+    seasonId: locked.seasonId,
+    action: args.nextStatus === "in_progress" ? "match.start" : "match.status_update",
+    actorId: args.actorId,
+    targetId: args.matchId,
+    targetType: "match",
+    meta: {
+      from: locked.status,
+      to: args.nextStatus,
+      ...(lineups
+        ? {
+            lineups: lineups.map((summary) => ({
+              teamId: summary.teamId,
+              rosterId: summary.rosterId,
+              starterIds: summary.starterIds,
+              substituteIds: summary.substituteIds,
+            })),
+          }
+        : {}),
+    },
+  });
+
+  return { from: locked.status, to: args.nextStatus, lineups };
+}
+
+/**
+ * Start gate: both canonical teams must hold an already-confirmed lineup that
+ * still validates against freshly loaded facts. There is no fallback path here
+ * by design — nothing infers starters from team_members ordering.
+ */
+export async function assertConfirmedLineupsForStartInTx(
+  tx: TxDb,
+  match: Match,
+): Promise<StartLineupSummary[]> {
+  const rosters = await tx
+    .select()
+    .from(matchRosters)
+    .where(eq(matchRosters.matchId, match.id));
+  const rosterByTeam = new Map(rosters.map((row) => [row.teamId, row]));
+
+  const summaries: StartLineupSummary[] = [];
+  for (const teamId of [match.teamAId, match.teamBId]) {
+    const roster = rosterByTeam.get(teamId);
+    if (!roster) {
+      throw new AppError(
+        ErrorCode.VALIDATION_FAILED,
+        "该场比赛还有队伍未提交并确认首发阵容，不能开始比赛。",
+      );
+    }
+    if (roster.status !== "confirmed") {
+      throw new AppError(
+        ErrorCode.VALIDATION_FAILED,
+        "存在尚未确认的首发阵容，必须先执行名单确认才能开始比赛。",
+      );
+    }
+
+    const players = await tx
+      .select({ teamMemberId: matchRosterPlayers.teamMemberId, isStarter: matchRosterPlayers.isStarter })
+      .from(matchRosterPlayers)
+      .where(eq(matchRosterPlayers.rosterId, roster.id));
+    const { starterIds, substituteIds } = loadPersistedPlayers(players);
+
+    await assertStartingLineupAllowedInTx(tx, { match, teamId, starterIds, substituteIds });
+    summaries.push({ rosterId: roster.id, matchId: match.id, teamId, starterIds, substituteIds, status: "confirmed" });
+  }
+  return summaries;
+}

--- a/tests/unit/actions/match-lineup-actions.test.ts
+++ b/tests/unit/actions/match-lineup-actions.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+/**
+ * Thin-wrapper contract tests for the G1/G2 lineup & correction actions.
+ * The transactional bodies live in lib/*-service modules (covered by the
+ * real-PostgreSQL local suites); here we pin the wrapper behaviour: actor
+ * resolution, service invocation shape, idempotent results and fail-closed
+ * error mapping.
+ */
+
+const stubs = vi.hoisted(() => {
+  const txStub = {
+    insert: () => ({ values: async () => undefined }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  };
+  return {
+    txStub,
+    lockMatchInTx: vi.fn(),
+    assertStartingLineupAllowedInTx: vi.fn(),
+    persistMatchRosterInTx: vi.fn(),
+    confirmMatchRosterInTx: vi.fn(),
+    planResultCorrectionInTx: vi.fn(),
+    applyResultCorrectionInTx: vi.fn(),
+    recordRecoveryAdjudicationInTx: vi.fn(),
+  };
+});
+
+let rosterRow: unknown = null;
+
+vi.mock("@/db/client", () => ({
+  db: {
+    query: {
+      matchRosters: { findFirst: async () => rosterRow },
+      seasons: { findFirst: async () => ({ slug: "test-season" }) },
+    },
+    select: () => ({
+      from: () => ({
+        where: async () => (rosterRow ? [rosterRow] : []),
+      }),
+    }),
+    transaction: async <T>(body: (tx: unknown) => Promise<T>): Promise<T> =>
+      body(stubs.txStub),
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "user-1", email: "captain@local.test" })),
+  requireSeasonAdmin: vi.fn(async () => ({ userId: "admin-1", email: "admin@local.test" })),
+  auditActorId: vi.fn((session: { email?: string }) => session.email ?? "actor"),
+}));
+
+vi.mock("@/lib/action-utils", () => ({
+  getMatchOrThrow: vi.fn(),
+  actionError: vi.fn(
+    (_scope: string, e: unknown): { success: false; error: { code: string; message: string } } => ({
+      success: false,
+      error: {
+        code:
+          typeof e === "object" && e !== null && "code" in e
+            ? String((e as { code: unknown }).code)
+            : ErrorCode.INTERNAL_ERROR,
+        message: e instanceof Error ? e.message : String(e),
+      },
+    }),
+  ),
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateMatchPaths: vi.fn(),
+  revalidateSeasonPaths: vi.fn(),
+}));
+
+vi.mock("@/actions/matches/_shared", () => ({
+  // The acting user captains team A of the stubbed match.
+  getTeamIdForCaptain: vi.fn(async (_userId: string, match: { teamAId: string; teamBId: string }) =>
+    match.teamAId,
+  ),
+}));
+
+vi.mock("@/lib/match-rosters/service", () => stubs);
+vi.mock("@/lib/match-corrections/service", () => stubs);
+
+import {
+  adminSelectMatchRoster,
+  confirmMatchRoster,
+  submitMatchRoster,
+  unlockMatchRoster,
+} from "@/actions/matches/roster";
+import {
+  applyMatchResultCorrection,
+  planMatchResultCorrection,
+  recordMatchRecoveryAdjudication,
+} from "@/actions/matches/corrections";
+import { AppError } from "@/lib/errors";
+import { getMatchOrThrow } from "@/lib/action-utils";
+
+const mockedGetMatch = vi.mocked(getMatchOrThrow);
+const SCHEDULED_MATCH = {
+  id: "match-1",
+  seasonId: "season-1",
+  status: "scheduled" as const,
+  teamAId: "team-a",
+  teamBId: "team-b",
+};
+
+function fullLockedMatch() {
+  return {
+    id: "match-1",
+    seasonId: "season-1",
+    status: "scheduled" as const,
+    teamAId: "team-a",
+    teamBId: "team-b",
+  };
+}
+
+const serviceMocks = [
+  stubs.lockMatchInTx,
+  stubs.assertStartingLineupAllowedInTx,
+  stubs.persistMatchRosterInTx,
+  stubs.confirmMatchRosterInTx,
+  stubs.planResultCorrectionInTx,
+  stubs.applyResultCorrectionInTx,
+  stubs.recordRecoveryAdjudicationInTx,
+];
+
+beforeEach(() => {
+  for (const mock of serviceMocks) {
+    mock.mockReset();
+  }
+  rosterRow = null;
+});
+
+describe("match lineup actions", () => {
+  it("submits a participant lineup through the transactional service", async () => {
+    mockedGetMatch.mockResolvedValue(SCHEDULED_MATCH as never);
+    stubs.lockMatchInTx.mockResolvedValue(fullLockedMatch());
+    stubs.assertStartingLineupAllowedInTx.mockResolvedValue({ affiliatedStarterCounts: new Map() });
+    stubs.persistMatchRosterInTx.mockResolvedValue({
+      rosterId: "roster-1",
+      matchId: "match-1",
+      teamId: "team-a",
+      starterIds: ["m1"],
+      substituteIds: [],
+    });
+
+    const result = await submitMatchRoster("match-1", { starterIds: ["m1", "m2", "m3", "m4", "m5"] });
+
+    expect(result.success).toBe(true);
+    const [, payload] = stubs.persistMatchRosterInTx.mock.calls[0]!;
+    expect(payload).toMatchObject({ source: "participant", submittedBy: "user-1", teamId: "team-a" });
+  });
+
+  it("maps eligibility failures to failure results without throwing", async () => {
+    mockedGetMatch.mockResolvedValue(SCHEDULED_MATCH as never);
+    stubs.lockMatchInTx.mockResolvedValue(fullLockedMatch());
+    stubs.assertStartingLineupAllowedInTx.mockRejectedValue(
+      new AppError(ErrorCode.VALIDATION_FAILED, "首发不足"),
+    );
+    const result = await submitMatchRoster("match-1", { starterIds: ["m1"] });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
+  });
+
+  it("rejects submissions once the match is not scheduled anymore", async () => {
+    mockedGetMatch.mockResolvedValue({ ...SCHEDULED_MATCH, status: "in_progress" } as never);
+    const result = await submitMatchRoster("match-1", { starterIds: ["m1"] });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
+    expect(stubs.persistMatchRosterInTx).not.toHaveBeenCalled();
+  });
+
+  it("records admin selections explicitly sourced as admin_select", async () => {
+    mockedGetMatch.mockResolvedValue(SCHEDULED_MATCH as never);
+    stubs.lockMatchInTx.mockResolvedValue(fullLockedMatch());
+    stubs.assertStartingLineupAllowedInTx.mockResolvedValue({ affiliatedStarterCounts: new Map() });
+    stubs.persistMatchRosterInTx.mockImplementation(async (_tx, args) => ({
+      rosterId: "roster-2",
+      matchId: args.match.id,
+      teamId: args.teamId,
+      starterIds: [...args.starterIds],
+      substituteIds: [],
+    }));
+
+    const result = await adminSelectMatchRoster("match-1", "team-b", { starterIds: ["b1", "b2", "b3", "b4", "b5"] });
+
+    expect(result.success).toBe(true);
+    const [, payload] = stubs.persistMatchRosterInTx.mock.calls[0]!;
+    expect(payload.source).toBe("admin_select");
+    expect(payload.submittedBy).toBeNull();
+    expect(payload.teamId).toBe("team-b");
+  });
+
+  it("propagates idempotent confirm outcomes untouched", async () => {
+    rosterRow = { matchId: "match-1" };
+    mockedGetMatch.mockResolvedValue({ ...SCHEDULED_MATCH, status: "scheduled" } as never);
+    stubs.confirmMatchRosterInTx.mockResolvedValue({
+      rosterId: "roster-3",
+      matchId: "match-1",
+      teamId: "team-b",
+      starterIds: ["b1", "b2", "b3", "b4", "b5"],
+      alreadyConfirmed: true,
+    });
+
+    const result = await confirmMatchRoster("roster-3");
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.alreadyConfirmed).toBe(true);
+  });
+
+  it("fails closed when unlocking would touch a started match", async () => {
+    rosterRow = { id: "roster-locked", matchId: "match-1", teamId: "team-a", status: "confirmed" };
+    mockedGetMatch.mockResolvedValue(SCHEDULED_MATCH as never);
+    stubs.lockMatchInTx.mockResolvedValue({ ...fullLockedMatch(), status: "in_progress" });
+
+    const result = await unlockMatchRoster("roster-locked");
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe(ErrorCode.MATCH_INVALID_TRANSITION);
+  });
+});
+
+describe("correction workflow actions", () => {
+  const FINISHED_MATCH = { id: "match-1", seasonId: "season-1", status: "finished" as const };
+
+  it("plans corrections read-only and forwards proposals", async () => {
+    mockedGetMatch.mockResolvedValue(FINISHED_MATCH as never);
+    stubs.planResultCorrectionInTx.mockResolvedValue({ winnerChanges: true, impacts: [] });
+
+    const result = await planMatchResultCorrection("match-1", { scoreA: 13, scoreB: 4 });
+
+    expect(result.success).toBe(true);
+    const [txArg, args] = stubs.planResultCorrectionInTx.mock.calls[0]!;
+    expect(txArg).toBe(stubs.txStub);
+    expect(args.proposal).toEqual({ scoreA: 13, scoreB: 4 });
+  });
+
+  it("forwards confirmRecovery as an explicit boolean flag", async () => {
+    mockedGetMatch.mockResolvedValue(FINISHED_MATCH as never);
+    stubs.applyResultCorrectionInTx.mockResolvedValue({
+      alreadyApplied: false,
+      winnerChanged: true,
+      invalidatedDownstreamMatches: ["downstream-1"],
+      rolledBackToFinalized: 0,
+    });
+
+    const result = await applyMatchResultCorrection("match-1", {
+      scoreA: 13,
+      scoreB: 4,
+      confirmRecovery: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(stubs.applyResultCorrectionInTx.mock.calls[0]![1]).toMatchObject({
+      proposal: { scoreA: 13, scoreB: 4 },
+      actorId: "admin@local.test",
+      confirmRecovery: true,
+    });
+    if (result.success) expect(result.data.invalidatedCount).toBe(1);
+  });
+
+  it("records adjudications with the acting administrator", async () => {
+    mockedGetMatch.mockResolvedValue(FINISHED_MATCH as never);
+    stubs.recordRecoveryAdjudicationInTx.mockResolvedValue({ recorded: true });
+
+    const result = await recordMatchRecoveryAdjudication("match-1", "人工恢复说明");
+
+    expect(result.success).toBe(true);
+    expect(stubs.recordRecoveryAdjudicationInTx).toHaveBeenCalledWith(stubs.txStub, {
+      matchId: "match-1",
+      actorId: "admin@local.test",
+      note: "人工恢复说明",
+    });
+  });
+});

--- a/tests/unit/components/matches/AdminRosterDialog.test.tsx
+++ b/tests/unit/components/matches/AdminRosterDialog.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  adminSelectMatchRoster,
+  confirmMatchRoster,
+} from "@/actions/matches/roster";
+import { AdminRosterDialog } from "@/components/matches/AdminRosterDialog";
+import type { RosterData } from "@/components/matches/AdminMatchRow";
+import { ok } from "@/types/action";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/actions/matches/roster", () => ({
+  adminSelectMatchRoster: vi.fn(),
+  confirmMatchRoster: vi.fn(),
+  unlockMatchRoster: vi.fn(),
+  submitMatchRoster: vi.fn(),
+}));
+
+const mockedAdminSelect = vi.mocked(adminSelectMatchRoster);
+const mockedConfirm = vi.mocked(confirmMatchRoster);
+
+function member(id: string) {
+  return { id, steamName: id, displayName: null, perfectName: null, primaryPosition: "rifler" };
+}
+
+const MEMBERS_A = ["a1", "a2", "a3", "a4", "a5", "a6"].map(member);
+const MEMBERS_B = ["b1", "b2", "b3", "b4", "b5", "b6"].map(member);
+
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "管理名单" }));
+}
+
+/** Checks five member checkboxes within one team section. */
+async function pickFiveStarters(user: ReturnType<typeof userEvent.setup>, prefix: string) {
+  const checkboxes = screen.getAllByRole("checkbox");
+  // Checkbox order follows member order per team section; team A first.
+  const scoped = checkboxes.filter((box) => {
+    const label = box.closest("label")?.textContent ?? "";
+    return label.startsWith(prefix);
+  });
+  expect(scoped.length).toBe(6);
+  for (const box of scoped.slice(0, 5)) {
+    await user.click(box);
+  }
+}
+
+beforeEach(() => {
+  mockedAdminSelect.mockReset();
+  mockedConfirm.mockReset();
+});
+
+describe("AdminRosterDialog — explicit two-step lineup selection", () => {
+  it("requires reviewing the exact five starters before recording an admin selection", async () => {
+    const user = userEvent.setup();
+    mockedAdminSelect.mockResolvedValue(ok({ rosterId: "roster-new" }));
+    render(
+      <AdminRosterDialog
+        matchId="match-1"
+        teamAName="Alpha"
+        teamBName="Beta"
+        teamAId="team-a"
+        teamBId="team-b"
+        teamAMembers={MEMBERS_A}
+        teamBMembers={MEMBERS_B}
+        teamARoster={null}
+        teamBRoster={null}
+      />,
+    );
+
+    await openDialog(user);
+    await pickFiveStarters(user, "a");
+
+    await user.click(screen.getAllByRole("button", { name: /核对并保存 Alpha 名单/ })[0]!);
+
+    // Review state lists the exact five players before any action fires.
+    expect(screen.getByText(/请核对将保存的首发五人/)).toBeInTheDocument();
+    expect(screen.getByText(/首发 1\. a1/)).toBeInTheDocument();
+    expect(screen.getByText(/首发 5\. a5/)).toBeInTheDocument();
+    expect(mockedAdminSelect).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "确认保存" }));
+
+    await waitFor(() => expect(mockedAdminSelect).toHaveBeenCalled());
+    const [matchId, teamId, payload] = mockedAdminSelect.mock.calls[0]!;
+    expect(matchId).toBe("match-1");
+    expect(teamId).toBe("team-a");
+    expect(payload!.starterIds).toEqual(["a1", "a2", "a3", "a4", "a5"]);
+    expect(payload!.substituteIds).toEqual([]);
+  });
+
+  it("offers confirmation for saved-but-unconfirmed rosters and stays silent once confirmed", async () => {
+    const user = userEvent.setup();
+    mockedConfirm.mockResolvedValue(
+      ok({ alreadyConfirmed: false, matchId: "match-1", teamId: "team-a" }),
+    );
+    const pending: RosterData = {
+      rosterId: "roster-a",
+      starters: ["a1", "a2", "a3", "a4", "a5"],
+      substitutes: [],
+      status: "submitted",
+    };
+    render(
+      <AdminRosterDialog
+        matchId="match-1"
+        teamAName="Alpha"
+        teamBName="Beta"
+        teamAId="team-a"
+        teamBId="team-b"
+        teamAMembers={MEMBERS_A}
+        teamBMembers={MEMBERS_B}
+        teamARoster={pending}
+        teamBRoster={null}
+      />,
+    );
+
+    await openDialog(user);
+    const confirmButton = screen.getByRole("button", { name: "确认名单" });
+    await user.click(confirmButton);
+
+    await waitFor(() => expect(mockedConfirm).toHaveBeenCalledWith("roster-a"));
+  });
+
+  it("does not offer a confirm button for already-confirmed rosters", async () => {
+    const user = userEvent.setup();
+    const confirmed: RosterData = {
+      rosterId: "roster-b",
+      starters: ["b1", "b2", "b3", "b4", "b5"],
+      substitutes: [],
+      status: "confirmed",
+    };
+    render(
+      <AdminRosterDialog
+        matchId="match-1"
+        teamAName="Alpha"
+        teamBName="Beta"
+        teamAId="team-a"
+        teamBId="team-b"
+        teamAMembers={MEMBERS_A}
+        teamBMembers={MEMBERS_B}
+        teamARoster={null}
+        teamBRoster={confirmed}
+      />,
+    );
+
+    await openDialog(user);
+    expect(mockedConfirm).not.toHaveBeenCalled();
+    // Only team A's section renders an inline confirm control; team B shows 已确认.
+    expect(screen.getByText(/已确认/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "确认名单" })).not.toBeInTheDocument();
+  });
+
+  it("blocks saving until exactly five starters are selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <AdminRosterDialog
+        matchId="match-1"
+        teamAName="Alpha"
+        teamBName="Beta"
+        teamAId="team-a"
+        teamBId="team-b"
+        teamAMembers={MEMBERS_A}
+        teamBMembers={MEMBERS_B}
+        teamARoster={null}
+        teamBRoster={null}
+      />,
+    );
+
+    await openDialog(user);
+    const saveButtons = screen.getAllByRole("button", { name: /核对并保存 .* 名单/ });
+    for (const button of saveButtons) {
+      expect(button).toBeDisabled();
+    }
+    expect(mockedAdminSelect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/matches/ResultCorrectionPanel.test.tsx
+++ b/tests/unit/components/matches/ResultCorrectionPanel.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMatchResultCorrection,
+  planMatchResultCorrection,
+  recordMatchRecoveryAdjudication,
+} from "@/actions/matches/corrections";
+import { ResultCorrectionPanel } from "@/components/matches/ResultCorrectionPanel";
+import { ok } from "@/types/action";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/actions/matches/corrections", () => ({
+  applyMatchResultCorrection: vi.fn(),
+  planMatchResultCorrection: vi.fn(),
+  recordMatchRecoveryAdjudication: vi.fn(),
+}));
+
+const mockedPlan = vi.mocked(planMatchResultCorrection);
+const mockedApply = vi.mocked(applyMatchResultCorrection);
+const mockedAdjudicate = vi.mocked(recordMatchRecoveryAdjudication);
+
+function planFixture(overrides: Partial<{
+  winnerChanges: boolean;
+  blockedReasons: string[];
+  impacts: { kind: string; status: string; description: string; managedKey?: string | null }[];
+  requiredRecoveryActions: string[];
+}> = {}) {
+  return {
+    matchId: "match-1",
+    stageKey: "stage1",
+    stageType: "swiss",
+    current: { scoreA: 9, scoreB: 13, isForfeit: false },
+    proposed: { scoreA: 13, scoreB: 4, isForfeit: false },
+    currentWinnerTeamId: "team-b",
+    proposedWinnerTeamId: "team-a",
+    winnerChanges: true,
+    affectsManagedRun: true,
+    impacts: [],
+    blockedReasons: [],
+    requiredRecoveryActions: [],
+    ...overrides,
+  };
+}
+
+async function fillScores(user: ReturnType<typeof userEvent.setup>) {
+  const inputs = screen.getAllByPlaceholderText("比分");
+  await user.type(inputs[0]!, "13");
+  await user.type(inputs[1]!, "4");
+}
+
+beforeEach(() => {
+  mockedPlan.mockReset();
+  mockedApply.mockReset();
+  mockedAdjudicate.mockReset();
+});
+
+describe("ResultCorrectionPanel", () => {
+  it("plans first and renders the impact inventory before any mutation", async () => {
+    const user = userEvent.setup();
+    mockedPlan.mockResolvedValue(
+      ok(
+        planFixture({
+          impacts: [
+            { kind: "stage_run_rollback", status: "finalized_round:1", description: "finalizedRound 回滚" },
+            { kind: "downstream_match", managedKey: "r2-1", status: "scheduled", description: "r2-1 需要作废" },
+          ],
+          requiredRecoveryActions: ["作废未开始下游托管比赛。"],
+        }),
+      ),
+    );
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+
+    await fillScores(user);
+    await user.click(screen.getByRole("button", { name: "计算影响清单" }));
+
+    await waitFor(() => expect(screen.getByText(/胜者将变更/)).toBeInTheDocument());
+    expect(screen.getByText(/finalizedRound 回滚/)).toBeInTheDocument();
+    expect(screen.getByText(/r2-1 需要作废/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "确认恢复并应用更正" })).toBeInTheDocument();
+    expect(mockedApply).not.toHaveBeenCalled();
+  });
+
+  it("shows fail-closed blocks instead of an apply button when refused", async () => {
+    const user = userEvent.setup();
+    mockedPlan.mockResolvedValue(
+      ok(
+        planFixture({
+          blockedReasons: ["官方名次已经生成，胜者更正被禁止；请使用赛后裁决操作。"],
+        }),
+      ),
+    );
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+
+    await fillScores(user);
+    await user.click(screen.getByRole("button", { name: "计算影响清单" }));
+
+    await waitFor(() => expect(screen.getByText(/官方名次已经生成/)).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /应用比分更正/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /确认恢复/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "记录裁决" })).toBeInTheDocument();
+  });
+
+  it("applies a non-winner correction directly after review without recovery confirmation", async () => {
+    const user = userEvent.setup();
+    mockedPlan.mockResolvedValue(
+      ok(planFixture({ winnerChanges: false })),
+    );
+    mockedApply.mockResolvedValue(
+      ok({ alreadyApplied: false, winnerChanged: false, invalidatedCount: 0, rolledBackToFinalized: null }),
+    );
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+
+    await fillScores(user);
+    await user.click(screen.getByRole("button", { name: "计算影响清单" }));
+    await user.click(await screen.findByRole("button", { name: "应用比分更正" }));
+
+    await waitFor(() => expect(mockedApply).toHaveBeenCalled());
+    expect(mockedApply.mock.calls[0]![0]).toBe("match-1");
+    expect(mockedApply.mock.calls[0]![1]).toMatchObject({ scoreA: 13, scoreB: 4, confirmRecovery: false });
+  });
+
+  it("rejects impossible score input without calling any action", async () => {
+    const user = userEvent.setup();
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+    const inputs = screen.getAllByPlaceholderText("比分");
+    await user.type(inputs[0]!, "5");
+    await user.type(inputs[1]!, "5");
+    await user.click(screen.getByRole("button", { name: "计算影响清单" }));
+    expect(mockedPlan).not.toHaveBeenCalled();
+  });
+
+  it("records adjudications with a non-empty note", async () => {
+    const user = userEvent.setup();
+    mockedAdjudicate.mockResolvedValue(ok({ recorded: true }));
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+    await user.type(
+      screen.getByPlaceholderText(/赛后裁决说明/),
+      "重赛裁决：结果以重赛为准",
+    );
+    await user.click(screen.getByRole("button", { name: "记录裁决" }));
+    await waitFor(() =>
+      expect(mockedAdjudicate).toHaveBeenCalledWith("match-1", "重赛裁决：结果以重赛为准"),
+    );
+  });
+
+  it("refuses adjudication without a note", async () => {
+    const user = userEvent.setup();
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+    await user.click(screen.getByRole("button", { name: "记录裁决" }));
+    expect(mockedAdjudicate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the review form when planning fails closed at the boundary", async () => {
+    const user = userEvent.setup();
+    mockedPlan.mockResolvedValue({
+      success: false as const,
+      error: { code: "VALIDATION_FAILED", message: "只能修正已结束的比赛结果。" },
+    });
+    render(<ResultCorrectionPanel matchId="match-1" teamAName="Alpha" teamBName="Beta" format="bo1" />);
+    await fillScores(user);
+    await user.click(screen.getByRole("button", { name: "计算影响清单" }));
+    await waitFor(() => expect(mockedPlan).toHaveBeenCalled());
+    expect(screen.queryByText(/胜者将变更/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "计算影响清单" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

PR G of the Major main chain — match fact safety & recovery. Two checkpoints, both complete.

### G1 roster safety
- Deleted the silent first-five fallback in `updateMatchStatus`; matches can only start via **submit → confirm → start**
- Pure lineup referee (`lib/match-rosters/lineup.ts`): exactly 5 starters, ≤2 subs, no duplicates, team membership, frozen tournament roster membership, education validity, per-institution starter minimums read from the **StageRun ruleSnapshot** (NJU MOE 4132010284, `minStartingMembers: 3`) — never mutable season config
- Actions: `submitMatchRoster` (scheduled-only), `adminSelectMatchRoster` (explicit ids only; replaces `updateMatchRoster`), new idempotent `confirmMatchRoster`, unlock resets confirmation
- Migration `0009`: match_rosters.source / confirmed_at / confirmed_by; submitted_by nullable for admin selections
- UI: AdminRosterDialog two-step explicit review + confirm button
- Audits: `match.roster.submit` / `match.roster.admin_select` / `match.roster.confirm` / `match.start` / `match.roster.unlock`

### G2 result correction & recovery
- `planResultCorrectionInTx` → review impacts/blocks → `applyResultCorrectionInTx` with explicit `confirmRecovery`
- Winner unchanged: minimal audited correction (incl. canonical forfeit shape)
- Winner change on unstarted downstream: invalidate listed managed matches + revoke `finalizedRound`, rebuild through existing deterministic finalize path (verified against corrected canonical facts)
- Hard blocks (fail closed): started/finished downstream facts, later-stage StageRuns already materialized, official results present → adjudication escape hatch (`match.recovery.adjudicated`, audit-only)
- Repeated corrections/rebuilds are idempotent; every mutation audited
- UI: ResultCorrectionPanel with impact inventory and blocked reasons

## Test evidence (fresh Local Supabase)

- `pnpm test:major-roster-safety:local` — 13 scenarios incl. double-start race ✓
- `pnpm test:major-result-recovery:local` — typo/winner-before/winner-after/hard-block/idempotency/results-block/stage-block ✓
- `test-team-registration` / `test-major-prestart` / `test-major-start` suites ✓
- full vitest 767 passing · coverage thresholds pass · tsc strict · eslint clean · drizzle-kit check (10-migration chain) · production build ✓ · `db:local:reset`+verify (RLS deny-by-default) ✓

Draft → ready after CI green; squash-merge into feat/major-2027-integration.