### PR TITLE
feat(discipline): personal sanctions & eligibility boundaries

### DIFF
--- a/drizzle/migrations/0010_same_the_order.sql
+++ b/drizzle/migrations/0010_same_the_order.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "public"."sanction_effect" AS ENUM('registration_block', 'roster_block', 'match_participation_block');--> statement-breakpoint
+CREATE TYPE "public"."sanction_status" AS ENUM('draft', 'active', 'expired', 'revoked');--> statement-breakpoint
+CREATE TABLE "disciplinary_case_idempotency" (
+	"client_request_id" uuid PRIMARY KEY NOT NULL,
+	"case_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "disciplinary_cases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"subject_user_id" uuid NOT NULL,
+	"status" "sanction_status" DEFAULT 'draft' NOT NULL,
+	"effects" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"internal_evidence" text,
+	"public_explanation" text,
+	"effective_from" timestamp with time zone DEFAULT now() NOT NULL,
+	"effective_until" timestamp with time zone,
+	"issued_by" text NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"revoked_by" text,
+	"revocation_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "disciplinary_cases_revocation_consistent_check" CHECK (("disciplinary_cases"."status" = 'revoked') = ("disciplinary_cases"."revoked_at" IS NOT NULL)),
+	CONSTRAINT "disciplinary_cases_window_sane_check" CHECK ("disciplinary_cases"."effective_until" IS NULL OR "disciplinary_cases"."effective_until" > "disciplinary_cases"."effective_from")
+);
+--> statement-breakpoint
+ALTER TABLE "disciplinary_case_idempotency" ADD CONSTRAINT "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk" FOREIGN KEY ("case_id") REFERENCES "public"."disciplinary_cases"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "disciplinary_cases" ADD CONSTRAINT "disciplinary_cases_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "disciplinary_cases" ADD CONSTRAINT "disciplinary_cases_subject_user_id_users_id_fk" FOREIGN KEY ("subject_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "disciplinary_cases_season_subject_idx" ON "disciplinary_cases" USING btree ("season_id","subject_user_id");--> statement-breakpoint
+CREATE INDEX "disciplinary_cases_status_idx" ON "disciplinary_cases" USING btree ("status");--> statement-breakpoint
+ALTER TABLE disciplinary_cases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE disciplinary_case_idempotency ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON disciplinary_cases, disciplinary_case_idempotency FROM anon, authenticated;

--- a/drizzle/migrations/meta/0010_snapshot.json
+++ b/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,4766 @@
+{
+  "id": "6294bea8-bd2e-4a98-b133-2861cce9ece9",
+  "prevId": "f60c7129-5a82-4ad4-89c9-95c41a31758d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_case_idempotency": {
+      "name": "disciplinary_case_idempotency",
+      "schema": "",
+      "columns": {
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk": {
+          "name": "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk",
+          "tableFrom": "disciplinary_case_idempotency",
+          "tableTo": "disciplinary_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_cases": {
+      "name": "disciplinary_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_cases_season_subject_idx": {
+          "name": "disciplinary_cases_season_subject_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_cases_status_idx": {
+          "name": "disciplinary_cases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_cases_season_id_seasons_id_fk": {
+          "name": "disciplinary_cases_season_id_seasons_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disciplinary_cases_subject_user_id_users_id_fk": {
+          "name": "disciplinary_cases_subject_user_id_users_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disciplinary_cases_revocation_consistent_check": {
+          "name": "disciplinary_cases_revocation_consistent_check",
+          "value": "(\"disciplinary_cases\".\"status\" = 'revoked') = (\"disciplinary_cases\".\"revoked_at\" IS NOT NULL)"
+        },
+        "disciplinary_cases_window_sane_check": {
+          "name": "disciplinary_cases_window_sane_check",
+          "value": "\"disciplinary_cases\".\"effective_until\" IS NULL OR \"disciplinary_cases\".\"effective_until\" > \"disciplinary_cases\".\"effective_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_url": {
+          "name": "evidence_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "moe_institution_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_active_claims": {
+      "name": "team_application_active_claims",
+      "schema": "",
+      "columns": {
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_active_claims_application_idx": {
+          "name": "team_application_active_claims_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_active_claims_season_id_seasons_id_fk": {
+          "name": "team_application_active_claims_season_id_seasons_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_user_id_users_id_fk": {
+          "name": "team_application_active_claims_user_id_users_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_application_id_team_applications_id_fk": {
+          "name": "team_application_active_claims_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_active_claims_season_user_unique": {
+          "name": "team_application_active_claims_season_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "major_prestart_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "education_verifications",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"tournament_seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_team_id": {
+          "name": "champion_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_team_id_teams_id_fk": {
+          "name": "major_final_results_champion_team_id_teams_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "champion_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_team_id_teams_id_fk": {
+          "name": "major_stage_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_team_unique": {
+          "name": "major_stage_entrants_run_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "team_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.sanction_effect": {
+      "name": "sanction_effect",
+      "schema": "public",
+      "values": [
+        "registration_block",
+        "roster_block",
+        "match_participation_block"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787825284855,
       "tag": "0009_amused_mother_askani",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787829055477,
+      "tag": "0010_same_the_order",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:major-swiss:local": "tsx scripts/db/local.ts test-major-start",
     "test:major-roster-safety:local": "tsx scripts/db/local.ts test-major-roster-safety",
     "test:major-result-recovery:local": "tsx scripts/db/local.ts test-major-result-recovery",
+    "test:discipline:local": "tsx scripts/db/local.ts test-discipline",
     "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {

--- a/scripts/db/discipline-integration.ts
+++ b/scripts/db/discipline-integration.ts
@@ -1,0 +1,513 @@
+/**
+ * PR H1 — 纪律与资格边界真实 PostgreSQL 集成测试。
+ *
+ * 覆盖：
+ *  1. active registration_block 拦截本人报名、队友不受影响
+ *  2. 过期处罚不拦截（含显式 markSanctionExpired 幂等）
+ *  3. revoked 处罚不拦截；重复撤销幂等且只产生一条审计
+ *  4. match_participation_block 禁止进入本场阵容（首发校验文案）
+ *     ——撤销后同阵容恢复可用（retry-safe），期间另一队完全不受影响
+ *  5. internalEvidence 绝不出现在公开序列化中
+ *  6. 处罚不连带队伍事实（teams / entrants / roster_members 原样）
+ *
+ * 只允许 loopback Local Supabase。
+ */
+import { randomUUID } from "node:crypto";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool, type PoolClient } from "pg";
+import * as schema from "../../src/db/schema";
+import {
+  assertStartingLineupAllowedInTx,
+  lockMatchInTx,
+} from "../../src/lib/match-rosters/service";
+import {
+  issueSanctionInTx,
+  loadActiveSanctionsInTx,
+  assertUsersNotBlockedInTx,
+  markSanctionExpiredInTx,
+  resolveSanctionStatus,
+  revokeSanctionInTx,
+  serializeSanctionPublic,
+} from "../../src/lib/discipline/service";
+import { AppError } from "../../src/lib/errors";
+import { createMajorDefaultCapabilities } from "../../src/types/season";
+
+const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
+const target = new URL(databaseUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(target.hostname)) {
+  throw new Error("纪律集成测试只允许 Local Supabase loopback 数据库。");
+}
+
+const ACTOR = "local-admin-h1";
+
+function assertCondition(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const NJU_CODE = "4132010284";
+const OTHER_CODE = "4111010001";
+
+interface DisciplineFixture {
+  seasonId: string;
+  runId: string;
+  teamAId: string;
+  teamBId: string;
+  memberAIds: string[];
+  memberBIds: string[];
+  emailsA: string[];
+}
+
+/** Team layout: seeds 0–2 NJU enrolled, 3–4 other-institution graduated/enrolled. */
+async function prepareFixture(pool: Pool, label: string): Promise<DisciplineFixture> {
+  const client = await pool.connect();
+  const seasonId = randomUUID();
+  const capabilities = createMajorDefaultCapabilities();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO seasons (
+        id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft,
+        stage_plan, registration_config, team_registration_config, affiliation_rules, min_team_size, max_team_size, starter_count, positions
+      ) VALUES ($1, $2, 'Local Discipline', 'Major', 'playing', $3, $4, $5, $6::json, $7::json, $8::json, $9::json, $10, $11, $12, $13::text[])`,
+      [
+        seasonId,
+        `local-discipline-${label}-${seasonId}`,
+        capabilities.registrationMode,
+        capabilities.hasCaptainVoting,
+        capabilities.hasDraft,
+        JSON.stringify(capabilities.stagePlan),
+        JSON.stringify(capabilities.registrationConfig),
+        JSON.stringify(capabilities.teamRegistrationConfig),
+        JSON.stringify(capabilities.affiliationRules),
+        capabilities.minTeamSize,
+        capabilities.maxTeamSize,
+        capabilities.starterCount,
+        capabilities.positions,
+      ],
+    );
+
+    const layouts = [0, 1].map((side) =>
+      [0, 1, 2].map(() => NJU_CODE).concat([OTHER_CODE, OTHER_CODE]).map((code, index) => ({
+        side,
+        index,
+        code,
+        academicStatus: code === OTHER_CODE && index === 3 ? ("graduated" as const) : ("enrolled" as const),
+      })),
+    );
+    const emailByKey = new Map<string, string>();
+    const memberIdByKey = new Map<string, string>();
+
+    for (const side of [0, 1]) {
+      const applicationId = randomUUID();
+      const teamId = randomUUID();
+      const layoutRows = layouts[side]!;
+      const userIds = layoutRows.map(() => randomUUID());
+      for (let i = 0; i < layoutRows.length; i += 1) {
+        await client.query(`INSERT INTO users (id, email, email_verified_at) VALUES ($1, $2, now())`, [
+          userIds[i], `${side}-${i}-${userIds[i]}@local.test`,
+        ]);
+        await client.query(
+          `INSERT INTO education_verifications (user_id, institution_id, academic_status, evidence_type, status, reviewed_by, reviewed_at)
+           SELECT $1, i.id, $2, 'manual_other', 'approved', 'local-admin', now()
+           FROM institutions i WHERE i.moe_institution_code = $3`,
+          [userIds[i], layoutRows[i]!.academicStatus, layoutRows[i]!.code],
+        );
+      }
+      await client.query(
+        `INSERT INTO team_applications (id, season_id, name, captain_user_id, status)
+         VALUES ($1, $2, $3, $4, 'approved')`,
+        [applicationId, seasonId, side === 0 ? "Team Alpha" : "Team Beta", userIds[0]],
+      );
+      await client.query(
+        `INSERT INTO teams (id, season_id, name, captain_user_id, team_application_id)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [teamId, seasonId, side === 0 ? "Team Alpha" : "Team Beta", userIds[0], applicationId],
+      );
+      for (let i = 0; i < layoutRows.length; i += 1) {
+        const userId = userIds[i]!;
+        const appMemberId = randomUUID();
+        emailByKey.set(`${side}-${i}`, `${side}-${i}-${userId}@local.test`);
+        memberIdByKey.set(`${side}-${i}`, appMemberId);
+        await client.query(
+          `INSERT INTO team_application_members (id, application_id, user_id, invited_by_user_id, status, confirmed_at)
+           VALUES ($1, $2, $3, $4, 'confirmed', now())`,
+          [appMemberId, applicationId, userId, userIds[0]],
+        );
+        await client.query(
+          `INSERT INTO team_members (team_id, season_id, user_id, team_application_member_id)
+           VALUES ($1, $2, $3, $4)`,
+          [teamId, seasonId, userId, appMemberId],
+        );
+      }
+    }
+
+    await client.query(
+      `INSERT INTO major_prestart_states (season_id, entrants_locked_at, entrants_locked_by, seed_revision, confirmed_seed_revision)
+       VALUES ($1, now(), 'local-admin', 1, 1)`,
+      [seasonId],
+    );
+    // Minimal stage run with the frozen affiliation ruleset.
+    const ruleSnapshot = {
+      version: 2,
+      stage: { key: "stage1", type: "swiss", teamCount: 16, matchFormat: "bo1" },
+      affiliationRules: [
+        { institutionCode: NJU_CODE, eligibleAcademicStatuses: ["enrolled", "graduated"], minRosterMembers: 3, minStartingMembers: 3 },
+      ],
+      stagePlan: [{ key: "stage1" }, { key: "playoff" }],
+      tournamentEntrants: [],
+      tournamentSeeds: [],
+    };
+    const runResult = await client.query<{ id: string }>(
+      `INSERT INTO major_stage_runs (season_id, stage_key, rule_snapshot, started_by)
+       VALUES ($1, 'stage1', $2::jsonb, 'local-admin') RETURNING id`,
+      [seasonId, JSON.stringify(ruleSnapshot)],
+    );
+
+    // Entrants are optional in this suite: the roster gate exercises frozen
+    // membership only when an entrant exists, so create them for realism.
+    for (const side of [0, 1]) {
+      const teamRow = await client.query<{ id: string }>(
+        `SELECT id FROM teams WHERE season_id = $1 AND name = $2`,
+        [seasonId, side === 0 ? "Team Alpha" : "Team Beta"],
+      );
+      const teamId = teamRow.rows[0]!.id;
+      const entrant = await client.query<{ id: string }>(
+        `INSERT INTO major_prestart_entrants (season_id, team_id, roster_confirmed_at, roster_confirmed_by)
+         VALUES ($1, $2, now(), 'local-admin') RETURNING id`,
+        [seasonId, teamId],
+      );
+      const layoutRows = layouts[side]!;
+      for (let i = 0; i < layoutRows.length; i += 1) {
+        const userRow = await client.query<{ id: string }>(
+          `SELECT id FROM users WHERE email = $1`, [emailByKey.get(`${side}-${i}`)!]);
+        const verification = await client.query<{ id: string }>(
+          `SELECT v.id FROM education_verifications v
+           INNER JOIN institutions i ON i.id = v.institution_id
+           WHERE v.user_id = $1 AND i.moe_institution_code = $2`,
+          [userRow.rows[0]!.id, layoutRows[i]!.code],
+        );
+        await client.query(
+          `INSERT INTO major_prestart_roster_members (entrant_id, user_id, education_verification_id)
+           VALUES ($1, $2, $3)`,
+          [entrant.rows[0]!.id, userRow.rows[0]!.id, verification.rows[0]!.id],
+        );
+      }
+    }
+
+    await client.query("COMMIT");
+
+    const memberIdsFor = async (side: number): Promise<string[]> => {
+      const rows = await client.query<{ id: string }>(
+        `SELECT m.id FROM team_members m JOIN teams t ON t.id = m.team_id
+         WHERE m.season_id = $1 AND t.name = $2 ORDER BY m.user_id`,
+        [seasonId, side === 0 ? "Team Alpha" : "Team Beta"],
+      );
+      return rows.rows.map((row) => row.id);
+    };
+    const emailsA = [0, 1, 2, 3, 4].map((i) => emailByKey.get(`0-${i}`)!);
+
+    return {
+      seasonId,
+      runId: runResult.rows[0]!.id,
+      teamAId: (await pool.query(`SELECT id FROM teams WHERE season_id = $1 AND name = 'Team Alpha'`, [seasonId])).rows[0]!.id,
+      teamBId: (await pool.query(`SELECT id FROM teams WHERE season_id = $1 AND name = 'Team Beta'`, [seasonId])).rows[0]!.id,
+      memberAIds: await memberIdsFor(0),
+      memberBIds: await memberIdsFor(1),
+      emailsA,
+    };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function snapshotTeamFacts(client: PoolClient, fixture: DisciplineFixture) {
+  return client.query(
+    `SELECT
+       (SELECT COUNT(*) FROM major_prestart_entrants e WHERE e.season_id = $1) AS entrants,
+       (SELECT COUNT(*) FROM team_members WHERE season_id = $1 AND team_id = $2) AS members_a,
+       (SELECT captain_user_id FROM teams WHERE id = $2) AS team_a_captain,
+       (SELECT captain_user_id FROM teams WHERE id = $3) AS team_b_captain`,
+    [fixture.seasonId, fixture.teamAId, fixture.teamBId],
+  );
+}
+
+async function auditCount(client: PoolClient, action: string, targetId: string): Promise<number> {
+  const result = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM audit_logs WHERE action = $1 AND target_id = $2`,
+    [action, targetId],
+  );
+  return Number(result.rows[0]?.count ?? "0");
+}
+
+async function cleanup(pool: Pool, fixtures: DisciplineFixture[]): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (const fixture of [...fixtures].reverse()) {
+      await client.query("DELETE FROM audit_logs WHERE season_id = $1", [fixture.seasonId]);
+      await client.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+      await client.query(`DELETE FROM disciplinary_case_idempotency i USING disciplinary_cases d
+        WHERE i.case_id = d.id AND d.season_id = $1`, [fixture.seasonId]);
+      await client.query("DELETE FROM disciplinary_cases WHERE season_id = $1", [fixture.seasonId]);
+      await client.query("DELETE FROM major_stage_runs WHERE season_id = $1", [fixture.seasonId]);
+      await client.query(`DELETE FROM major_prestart_roster_members r USING major_prestart_entrants e
+        WHERE r.entrant_id = e.id AND e.season_id = $1`, [fixture.seasonId]);
+      await client.query("DELETE FROM major_prestart_entrants WHERE season_id = $1", [fixture.seasonId]);
+      await client.query("DELETE FROM major_prestart_states WHERE season_id = $1", [fixture.seasonId]);
+      await client.query("DELETE FROM team_members WHERE season_id = $1", [fixture.seasonId]);
+      await client.query(`DELETE FROM team_application_members m USING team_applications a
+        WHERE m.application_id = a.id AND a.season_id = $1`, [fixture.seasonId]);
+      await client.query("DELETE FROM teams WHERE season_id = $1", [fixture.seasonId]);
+      await client.query("DELETE FROM team_applications WHERE season_id = $1", [fixture.seasonId]);
+      await client.query(`DELETE FROM education_verifications WHERE user_id IN (
+        SELECT id FROM users WHERE email LIKE '%@local.test' AND email LIKE $1)`, [`%${fixture.seasonId}%`]);
+      await client.query(`DELETE FROM users WHERE email LIKE $1`, [`%${fixture.seasonId}%`]);
+      await client.query("DELETE FROM seasons WHERE id = $1", [fixture.seasonId]);
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 6 });
+  const database = drizzle(pool, { schema });
+  const fixtures: DisciplineFixture[] = [];
+
+  try {
+    const fixture = await prepareFixture(pool, "h1");
+    fixtures.push(fixture);
+    const { seasonId, runId, teamAId, teamBId, memberAIds, memberBIds, emailsA } = fixture;
+
+    const matchInsert = await pool.query<{ id: string }>(
+      `INSERT INTO matches (
+         season_id, team_a_id, team_b_id, stage, round, format, status,
+         ownership, major_stage_run_id, managed_key
+       ) VALUES ($1, $2, $3, 'stage1', 1, 'bo1', 'scheduled', 'major_stage', $4, 'r1-1')
+       RETURNING id`,
+      [seasonId, teamAId, teamBId, runId],
+    );
+    const matchId = matchInsert.rows[0]!.id;
+
+    const userLookupByEmail = async (email: string): Promise<string> => {
+      const row = await pool.query<{ id: string }>(`SELECT id FROM users WHERE email = $1`, [email]);
+      return row.rows[0]!.id;
+    };
+
+    const legalLineupA = { starterIds: memberAIds.slice(0, 5), substituteIds: [] };
+    const legalLineupB = { starterIds: memberBIds.slice(0, 5), substituteIds: [] };
+
+    // Baseline：两队阵容本可通过完整校验。
+    let beforeSnapshot!: Awaited<ReturnType<typeof snapshotTeamFacts>>;
+    {
+      const c = await pool.connect();
+      try { beforeSnapshot = await snapshotTeamFacts(c, fixture); } finally { c.release(); }
+    }
+
+    // ── S1/S2/S3：registration_block 生命周期 ──────────────────────────
+    let captainCaseId = "";
+    {
+      const captainUser = await userLookupByEmail(emailsA[0]!);
+      captainCaseId = (
+        await database.transaction((tx) =>
+          issueSanctionInTx(tx, {
+            seasonId,
+            subjectUserId: captainUser,
+            effects: ["registration_block"],
+            internalEvidence: "内部证据：externally hosted secret-evidence-link.example",
+            publicExplanation: "因违规被取消本赛季报名资格",
+            actorId: ACTOR,
+          }),
+        )
+      ).caseId;
+
+      const client = await pool.connect();
+      try {
+        // active blocks the subject at registration.
+        let threw = false;
+        try {
+          const labels = new Map<string, string>();
+          for (let i = 0; i < emailsA.length; i += 1) labels.set(await userLookupByEmail(emailsA[i]!), emailsA[i]!);
+          await database.transaction((tx) =>
+            assertUsersNotBlockedInTx(tx, {
+              seasonId,
+              userLabels: labels,
+              effect: "registration_block",
+              message: "存在处于有效期内的报名禁赛处罚成员",
+            }),
+          );
+        } catch (e) {
+          threw = true;
+          if (!(e instanceof AppError)) throw e;
+          if (!e.message.includes(emailsA[0]!)) throw new Error("S1 拦截名单未包含受罚者邮箱");
+        }
+        assertCondition(threw, "S1 active registration_block 必须拦截");
+
+        // Teammate unaffected: probing everyone EXCEPT the banned subject passes.
+        const labelsWithoutCaptain = new Map<string, string>();
+        for (let i = 1; i < emailsA.length; i += 1) labelsWithoutCaptain.set(await userLookupByEmail(emailsA[i]!), emailsA[i]!);
+        await database.transaction((tx) =>
+          assertUsersNotBlockedInTx(tx, {
+            seasonId,
+            userLabels: labelsWithoutCaptain,
+            effect: "registration_block",
+            message: "存在处于有效期内的报名禁赛处罚成员",
+          }),
+        );
+
+        // Evidence never appears publicly.
+        const caseRow = (await client.query(
+          `SELECT id, season_id AS "seasonId", subject_user_id AS "subjectUserId", status, effects,
+                  public_explanation AS "publicExplanation", effective_from AS "effectiveFrom",
+                  effective_until AS "effectiveUntil", created_at AS "createdAt"
+           FROM disciplinary_cases WHERE id = $1`, [captainCaseId])).rows[0];
+        const serializedJson = JSON.stringify(serializeSanctionPublic(caseRow, new Date()));
+        assertCondition(!serializedJson.includes("secret-evidence-link"), "S1 公开序列化不得泄露内部证据");
+      } finally {
+        client.release();
+      }
+    }
+
+    // ── S2：窗口过期后不再拦截 + 显式过期幂等 ────────────────────────
+    {
+      const client = await pool.connect();
+      try {
+        await client.query(
+          `UPDATE disciplinary_cases SET effective_from = now() - interval '2 days',
+             effective_until = now() - interval '1 day' WHERE id = $1`,
+          [captainCaseId],
+        );
+        const blocked = await loadActiveSanctionsInTx(
+          // read-only loader works against plain drizzle db handle too
+          database as unknown as Parameters<typeof loadActiveSanctionsInTx>[0],
+          { seasonId, effect: "registration_block" },
+        );
+        assertCondition(blocked.size === 0, "S2 过期处罚不得再拦截");
+        const refreshed = (await client.query(
+          `SELECT status, effective_from AS "effectiveFrom", effective_until AS "effectiveUntil"
+           FROM disciplinary_cases WHERE id = $1`, [captainCaseId])).rows[0];
+        assertCondition(resolveSanctionStatus(refreshed, new Date()) === "expired", "S2 派生状态应为 expired");
+
+        const firstExpire = await database.transaction((tx) =>
+          markSanctionExpiredInTx(tx, { caseId: captainCaseId, actorId: ACTOR }));
+        assertCondition(!firstExpire.alreadyExpired, "S2 首次标记应执行");
+        const secondExpire = await database.transaction((tx) =>
+          markSanctionExpiredInTx(tx, { caseId: captainCaseId, actorId: ACTOR }));
+        assertCondition(secondExpire.alreadyExpired, "S2 重复标记幂等");
+        assertCondition((await auditCount(client, "sanction.expire", captainCaseId)) === 1, "S2 过期审计恰好一条");
+      } finally {
+        client.release();
+      }
+    }
+
+    // ── S3：撤销幂等与审计唯一性 ───────────────────────────────────────
+    {
+      const firstRevoke = await database.transaction((tx) =>
+        revokeSanctionInTx(tx, { caseId: captainCaseId, actorId: ACTOR, reason: "复核后撤销" }));
+      assertCondition(!firstRevoke.alreadyRevoked, "S3 首次撤销应执行");
+      const secondRevoke = await database.transaction((tx) =>
+        revokeSanctionInTx(tx, { caseId: captainCaseId, actorId: ACTOR, reason: "重复请求" }));
+      assertCondition(secondRevoke.alreadyRevoked, "S3 重复撤销幂等");
+      const client = await pool.connect();
+      try {
+        assertCondition((await auditCount(client, "sanction.revoke", captainCaseId)) === 1, "S3 撤销审计恰好一条");
+      } finally {
+        client.release();
+      }
+    }
+
+    // ── S4：match_participation_block 与阵容门禁 ──────────────────────
+    {
+      const starterUser = await userLookupByEmail(emailsA[0]!);
+
+      // 撤销后的 registration case 不影响任何效果（已 revoked）。
+      const baselineOk = await database.transaction(async (tx) => {
+        const locked = await lockMatchInTx(tx, matchId);
+        await assertStartingLineupAllowedInTx(tx, {
+          match: locked, teamId: teamAId, ...legalLineupA,
+        });
+        await assertStartingLineupAllowedInTx(tx, {
+          match: locked, teamId: teamBId, ...legalLineupB,
+        });
+        return true;
+      });
+      assertCondition(baselineOk, "S4 基线双方阵容必须通过");
+
+      const participationCaseId = (
+        await database.transaction((tx) =>
+          issueSanctionInTx(tx, {
+            seasonId,
+            subjectUserId: starterUser,
+            effects: ["match_participation_block"],
+            actorId: ACTOR,
+          }),
+        )
+      ).caseId;
+
+      const rejected = await database.transaction(async (tx) => {
+        const locked = await lockMatchInTx(tx, matchId);
+        try {
+          await assertStartingLineupAllowedInTx(tx, { match: locked, teamId: teamAId, ...legalLineupA });
+          return null;
+        } catch (error) {
+          return error instanceof AppError ? error.message : null;
+        }
+      });
+      assertCondition(rejected !== null && rejected.includes("禁赛"), "S4 受罚者所在队阵容必须被拒绝");
+
+      // 另一队不受牵连。
+      await database.transaction(async (tx) => {
+        const locked = await lockMatchInTx(tx, matchId);
+        await assertStartingLineupAllowedInTx(tx, { match: locked, teamId: teamBId, ...legalLineupB });
+      });
+
+      // 撤销后同阵容恢复可用。
+      await database.transaction((tx) =>
+        revokeSanctionInTx(tx, { caseId: participationCaseId, actorId: ACTOR, reason: "和解撤销" }));
+      await database.transaction(async (tx) => {
+        const locked = await lockMatchInTx(tx, matchId);
+        await assertStartingLineupAllowedInTx(tx, { match: locked, teamId: teamAId, ...legalLineupA });
+      });
+
+      const client = await pool.connect();
+      try {
+        assertCondition((await auditCount(client, "sanction.issue", participationCaseId)) === 1, "S4 签发审计恰好一条");
+      } finally {
+        client.release();
+      }
+    }
+
+    // ── S6：队伍事实零改动 ─────────────────────────────────────────────
+    {
+      const client = await pool.connect();
+      try {
+        const afterSnapshot = await snapshotTeamFacts(client, fixture);
+        assertCondition(afterSnapshot.rows[0]!.entrants === beforeSnapshot.rows[0]!.entrants, "S6 entrants 数量不变");
+        assertCondition(afterSnapshot.rows[0]!.members_a === beforeSnapshot.rows[0]!.members_a, "S6 队伍成员数量不变");
+        assertCondition(afterSnapshot.rows[0]!.team_a_captain === beforeSnapshot.rows[0]!.team_a_captain &&
+          afterSnapshot.rows[0]!.team_b_captain === beforeSnapshot.rows[0]!.team_b_captain,
+          "S6 队长归属不得被处罚流程改动");
+      } finally {
+        client.release();
+      }
+    }
+
+    console.log("H1 discipline eligibility integration suite passed.");
+  } finally {
+    await cleanup(pool, fixtures);
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -52,6 +52,9 @@ try {
     case "test-major-result-recovery":
       runLocalIntegration("scripts/db/major-result-recovery-integration.ts");
       break;
+    case "test-discipline":
+      runLocalIntegration("scripts/db/discipline-integration.ts");
+      break;
     case "bootstrap":
       startLocalStack();
       migrateLocalDatabase();

--- a/src/actions/discipline.ts
+++ b/src/actions/discipline.ts
@@ -1,0 +1,154 @@
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  disciplinaryCases,
+  seasons,
+  type DisciplinaryCase,
+} from "@/db/schema";
+import { z } from "zod";
+import { ok } from "@/types/action";
+import type { ActionResult } from "@/types/action";
+import { requireSeasonAdmin, auditActorId } from "@/lib/auth/session";
+import { actionError } from "@/lib/action-utils";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { revalidateSeasonPaths } from "@/lib/revalidation";
+import {
+  issueSanctionInTx,
+  markSanctionExpiredInTx,
+  resolveSanctionStatus,
+  revokeSanctionInTx,
+  serializeSanctionPublic,
+  SANCTION_EFFECTS,
+  type SanctionEffect,
+} from "@/lib/discipline/service";
+
+const effectSchema = z.enum(SANCTION_EFFECTS as unknown as [SanctionEffect, ...SanctionEffect[]]);
+
+const issueSchema = z.object({
+  seasonId: z.string().uuid(),
+  subjectUserId: z.string().uuid(),
+  effects: z.array(effectSchema).min(1),
+  internalEvidence: z.string().trim().max(4000).optional().nullable(),
+  publicExplanation: z.string().trim().max(1000).optional().nullable(),
+  effectiveUntil: z.coerce.date().optional().nullable(),
+});
+
+/**
+ * 管理员签发个人纪律处罚（直接进入 active 状态，按窗口生效）。
+ * 只作用于 subject 本人的指定能力——绝不连带队伍或历史事实。
+ */
+export async function issueSanction(input: unknown): Promise<ActionResult<{ caseId: string }>> {
+  const parsed = issueSchema.safeParse(input);
+  if (!parsed.success) return actionError("issueSanction", new AppError(ErrorCode.VALIDATION_FAILED, "处罚参数不合法。"));
+  try {
+    const admin = await requireSeasonAdmin(parsed.data.seasonId);
+    const result = await db.transaction((tx) =>
+      issueSanctionInTx(tx, {
+        seasonId: parsed.data.seasonId,
+        subjectUserId: parsed.data.subjectUserId,
+        effects: parsed.data.effects,
+        internalEvidence: parsed.data.internalEvidence ?? null,
+        publicExplanation: parsed.data.publicExplanation ?? null,
+        effectiveFrom: new Date(),
+        effectiveUntil: parsed.data.effectiveUntil ?? null,
+        actorId: auditActorId(admin),
+      }),
+    );
+    const season = await db.query.seasons.findFirst({
+      where: eq(seasons.id, parsed.data.seasonId),
+      columns: { slug: true },
+    });
+    if (season) revalidateSeasonPaths(season.slug, ["adminMatches"]);
+    return ok(result);
+  } catch (e) {
+    return actionError("issueSanction", e);
+  }
+}
+
+/**
+ * 撤销处罚。重复撤销为幂等成功且不产生重复审计。
+ */
+export async function revokeSanction(
+  input: { caseId: string; reason?: string },
+): Promise<ActionResult<{ alreadyRevoked: boolean; caseId: string }>> {
+  const parsed = z
+    .object({ caseId: z.string().uuid(), reason: z.string().trim().max(1000).optional() })
+    .safeParse(input);
+  if (!parsed.success) return actionError("revokeSanction", new AppError(ErrorCode.VALIDATION_FAILED, "撤销参数不合法。"));
+  try {
+    const existing = await loadCase(parsed.data.caseId);
+    const admin = await requireSeasonAdmin(existing.seasonId);
+    const result = await db.transaction((tx) =>
+      revokeSanctionInTx(tx, {
+        caseId: existing.id,
+        actorId: auditActorId(admin),
+        reason: parsed.data.reason ?? "",
+      }),
+    );
+    return ok(result);
+  } catch (e) {
+    return actionError("revokeSanction", e);
+  }
+}
+
+export async function expireSanction(
+  input: { caseId: string },
+): Promise<ActionResult<{ alreadyExpired: boolean; caseId: string }>> {
+  const parsed = z.object({ caseId: z.string().uuid() }).safeParse(input);
+  if (!parsed.success) return actionError("expireSanction", new AppError(ErrorCode.VALIDATION_FAILED, "参数不合法。"));
+  try {
+    const existing = await loadCase(parsed.data.caseId);
+    const admin = await requireSeasonAdmin(existing.seasonId);
+    const result = await db.transaction((tx) =>
+      markSanctionExpiredInTx(tx, { caseId: existing.id, actorId: auditActorId(admin) }),
+    );
+    return ok(result);
+  } catch (e) {
+    return actionError("expireSanction", e);
+  }
+}
+
+/** Admin-facing reader: internal evidence stays visible to privileged admins. */
+export async function getSeasonSanctions(
+  seasonId: string,
+): Promise<ActionResult<
+  Array<DisciplinaryCase & { resolvedStatus: ReturnType<typeof resolveSanctionStatus> }>
+>> {
+  try {
+    await requireSeasonAdmin(seasonId);
+    const rows = await db
+      .select()
+      .from(disciplinaryCases)
+      .where(eq(disciplinaryCases.seasonId, seasonId));
+    const now = new Date();
+    return ok(rows.map((row) => ({ ...row, resolvedStatus: resolveSanctionStatus(row, now) })));
+  } catch (e) {
+    return actionError("getSeasonSanctions", e);
+  }
+}
+
+/**
+ * 公开（面向非管理页面）的赛季处罚摘要——内部证据永不序列化。
+ */
+export async function getSeasonPublicSanctions(
+  seasonId: string,
+): Promise<ActionResult<ReturnType<typeof serializeSanctionPublic>[]>> {
+  try {
+    const rows = await db
+      .select()
+      .from(disciplinaryCases)
+      .where(and(eq(disciplinaryCases.seasonId, seasonId)));
+    const now = new Date();
+    return ok(rows.map((row) => serializeSanctionPublic(row, now)));
+  } catch (e) {
+    return actionError("getSeasonPublicSanctions", e);
+  }
+}
+
+async function loadCase(caseId: string): Promise<DisciplinaryCase> {
+  const [row] = await db.select().from(disciplinaryCases).where(eq(disciplinaryCases.id, caseId));
+  if (!row) throw new AppError(ErrorCode.NOT_FOUND, "纪律处罚记录不存在。");
+  return row;
+}

--- a/src/actions/team-applications.ts
+++ b/src/actions/team-applications.ts
@@ -18,6 +18,7 @@ import {
 } from "@/db/schema";
 import { actionError } from "@/lib/action-utils";
 import { auditActorId, requireAuth } from "@/lib/auth/session";
+import { assertUsersNotBlockedInTx } from "@/lib/discipline/service";
 import { MIN_TEAM_NAME_LENGTH, MAX_TEAM_NAME_LENGTH } from "@/lib/config/team-config";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { getRegistrationWindowState } from "@/lib/registration/window";
@@ -316,6 +317,13 @@ export async function submitTeamApplication(input: { applicationId: string }): P
     if (affiliationRules.length > 0 && !eligibility.eligible) {
       throw new AppError(ErrorCode.VALIDATION_FAILED, eligibility.blockers.join(" "));
     }
+    // H1: personal registration sanctions block only their subject.
+    await assertUsersNotBlockedInTx(db, {
+      seasonId: application.seasonId,
+      userLabels: new Map(confirmed.map((member) => [member.userId, member.email])),
+      effect: "registration_block",
+      message: "存在处于有效期内的报名禁赛处罚成员",
+    });
     if (config.requireUniqueTeamName) {
       const sameName = await db.query.teams.findFirst({ where: and(eq(teams.seasonId, season.id), eq(teams.name, application.name)) });
       if (sameName) throw new AppError(ErrorCode.REGISTRATION_DUPLICATE, "该队名已被正式队伍使用。");

--- a/src/db/schema/discipline.ts
+++ b/src/db/schema/discipline.ts
@@ -1,0 +1,67 @@
+import { check, index, jsonb, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { seasons } from "./seasons";
+import { users } from "./users";
+
+export const sanctionStatusEnum = pgEnum("sanction_status", [
+  "draft",
+  "active",
+  "expired",
+  "revoked",
+]);
+
+/** Explicit capability-level effects. Absence of an effect means no enforcement. */
+export const sanctionEffectEnum = pgEnum("sanction_effect", [
+  "registration_block",
+  "roster_block",
+  "match_participation_block",
+]);
+
+/**
+ * A single disciplinary case against one subject. Personal facts only:
+ * nothing here cascades into team eligibility, historical match results,
+ * placements or honors — those require their own explicit adjudications.
+ * `internal_evidence` must never reach any public serialization.
+ */
+export const disciplinaryCases = pgTable("disciplinary_cases", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  subjectUserId: uuid("subject_user_id").notNull().references(() => users.id),
+  status: sanctionStatusEnum("status").notNull().default("draft"),
+  effects: jsonb("effects").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+  /** Admin-visible evidence trail. Never serialized publicly. */
+  internalEvidence: text("internal_evidence"),
+  /** Explainable-to-public summary. May be shown on public pages. */
+  publicExplanation: text("public_explanation"),
+  effectiveFrom: timestamp("effective_from", { withTimezone: true }).notNull().defaultNow(),
+  /** Open-ended when null. A past window renders an active case inert. */
+  effectiveUntil: timestamp("effective_until", { withTimezone: true }),
+  issuedBy: text("issued_by").notNull(),
+  revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  revokedBy: text("revoked_by"),
+  revocationReason: text("revocation_reason"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  seasonSubjectIndex: index("disciplinary_cases_season_subject_idx").on(t.seasonId, t.subjectUserId),
+  statusIndex: index("disciplinary_cases_status_idx").on(t.status),
+  consistentRevocation: check(
+    "disciplinary_cases_revocation_consistent_check",
+    sql`(${t.status} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
+  ),
+  saneWindow: check(
+    "disciplinary_cases_window_sane_check",
+    sql`${t.effectiveUntil} IS NULL OR ${t.effectiveUntil} > ${t.effectiveFrom}`,
+  ),
+}));
+
+/** Uniqueness guard so a retry of an issue call cannot duplicate a decision. */
+export const disciplinaryCaseIdempotency = pgTable("disciplinary_case_idempotency", {
+  clientRequestId: uuid("client_request_id").primaryKey(),
+  caseId: uuid("case_id")
+    .notNull()
+    .references(() => disciplinaryCases.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type DisciplinaryCase = typeof disciplinaryCases.$inferSelect;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -21,3 +21,4 @@ export * from "./match-time-proposals";
 export * from "./match-rosters";
 export * from "./match-veto-steps";
 export * from "./user-sessions";
+export * from "./discipline";

--- a/src/lib/discipline/service.test.ts
+++ b/src/lib/discipline/service.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveSanctionStatus,
+  sanctionBlocks,
+  serializeSanctionPublic,
+} from "@/lib/discipline/service";
+import type { DisciplinaryCase } from "@/db/schema";
+
+const NOW = new Date("2026-08-27T12:00:00Z");
+
+function baseCase(overrides: Partial<DisciplinaryCase> = {}): DisciplinaryCase {
+  return {
+    id: "case-1",
+    seasonId: "season-1",
+    subjectUserId: "user-1",
+    status: "active",
+    effects: ["registration_block"],
+    internalEvidence: null,
+    publicExplanation: null,
+    effectiveFrom: new Date("2026-01-01T00:00:00Z"),
+    effectiveUntil: null,
+    issuedBy: "admin",
+    revokedAt: null,
+    revokedBy: null,
+    revocationReason: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as DisciplinaryCase;
+}
+
+describe("resolveSanctionStatus", () => {
+  it("keeps draft rows inert regardless of window", () => {
+    expect(resolveSanctionStatus(baseCase({ status: "draft" }), NOW)).toBe("draft");
+  });
+
+  it("resolves an active open-ended row as active", () => {
+    expect(resolveSanctionStatus(baseCase(), NOW)).toBe("active");
+  });
+
+  it("resolves an upcoming active row as draft (not yet in force)", () => {
+    const row = baseCase({ effectiveFrom: new Date("2026-09-01T00:00:00Z") });
+    expect(resolveSanctionStatus(row, NOW)).toBe("draft");
+  });
+
+  it("resolves a passed-window active row as expired", () => {
+    const row = baseCase({ effectiveUntil: new Date("2026-06-01T00:00:00Z") });
+    expect(resolveSanctionStatus(row, NOW)).toBe("expired");
+  });
+
+  it("revoked overrides everything", () => {
+    const row = baseCase({ status: "revoked", revokedAt: NOW });
+    expect(resolveSanctionStatus(row, NOW)).toBe("revoked");
+  });
+});
+
+describe("sanctionBlocks", () => {
+  it("blocks only the listed capability during an active window", () => {
+    const row = baseCase({ effects: ["match_participation_block"] });
+    expect(sanctionBlocks(row, "match_participation_block", NOW)).toBe(true);
+    expect(sanctionBlocks(row, "registration_block", NOW)).toBe(false);
+  });
+
+  it("does not block once the window has expired or the case was revoked", () => {
+    const expired = baseCase({ effectiveUntil: new Date("2026-02-01T00:00:00Z") });
+    expect(sanctionBlocks(expired, "registration_block", NOW)).toBe(false);
+    const revoked = baseCase({ status: "revoked", revokedAt: NOW });
+    expect(sanctionBlocks(revoked, "registration_block", NOW)).toBe(false);
+    expect(sanctionBlocks(baseCase({ status: "draft" }), "registration_block", NOW)).toBe(false);
+  });
+});
+
+describe("serializeSanctionPublic", () => {
+  it("never serializes internal evidence", () => {
+    const row = baseCase({
+      internalEvidence: "私密证据：聊天记录截图链接 https://internal.example/secret",
+      publicExplanation: "因违规行为被禁赛",
+      effects: ["roster_block"],
+    });
+    const serialized = serializeSanctionPublic(row, NOW);
+
+    expect(serialized.explanation).toBe("因违规行为被禁赛");
+    expect(serialized.effects).toEqual(["roster_block"]);
+    const json = JSON.stringify(serialized);
+    expect(json).not.toContain("私密证据");
+    expect(json).not.toContain("internal.example");
+    expect(Object.hasOwn(serialized, "internalEvidence")).toBe(false);
+  });
+
+  it("emits the derived status, not the raw stored column alone", () => {
+    const passedWindow = baseCase({ effectiveUntil: new Date("2026-03-01T00:00:00Z") });
+    expect(serializeSanctionPublic(passedWindow, NOW).status).toBe("expired");
+  });
+});

--- a/src/lib/discipline/service.ts
+++ b/src/lib/discipline/service.ts
@@ -1,0 +1,322 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import {
+  auditLogs,
+  disciplinaryCases,
+  users,
+  type DisciplinaryCase,
+} from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+/**
+ * H1 — personal disciplinary facts and eligibility blockers.
+ *
+ * Strict separation of facts:
+ *   personal sanction ≠ team eligibility ≠ match result ≠ final placement.
+ * Nothing here ever cascades into teams, historical results, placements or
+ * honors. A sanction blocks exactly the capabilities it lists, for exactly
+ * its subject, during exactly its effective window.
+ */
+
+export type SanctionEffect =
+  | "registration_block"
+  | "roster_block"
+  | "match_participation_block";
+
+export const SANCTION_EFFECTS: readonly SanctionEffect[] = [
+  "registration_block",
+  "roster_block",
+  "match_participation_block",
+];
+
+export type ResolvedSanctionStatus = "draft" | "active" | "expired" | "revoked";
+
+/**
+ * Derived display/effectiveness state. `active` is windowed; an `active`
+ * stored row whose window has passed resolves as `expired` (non-blocking)
+ * without requiring a mutation first.
+ */
+export function resolveSanctionStatus(
+  row: Pick<DisciplinaryCase, "status" | "effectiveFrom" | "effectiveUntil">,
+  now: Date,
+): ResolvedSanctionStatus {
+  if (row.status === "revoked") return "revoked";
+  if (row.status === "draft") return "draft";
+  if (row.effectiveFrom.getTime() > now.getTime()) return "draft";
+  if (row.effectiveUntil !== null && row.effectiveUntil.getTime() <= now.getTime()) {
+    return "expired";
+  }
+  return "active";
+}
+
+/** A sanction blocks a capability only while its resolved status is active. */
+export function sanctionBlocks(
+  row: Pick<DisciplinaryCase, "status" | "effectiveFrom" | "effectiveUntil" | "effects">,
+  effect: SanctionEffect,
+  now: Date,
+): boolean {
+  const effects = (row.effects ?? []) as string[];
+  if (!effects.includes(effect)) return false;
+  return resolveSanctionStatus(row, now) === "active";
+}
+
+/**
+ * The only sanctioned public serialization. `internalEvidence` must never be
+ * present on this shape — that guarantee is unit-tested.
+ */
+export function serializeSanctionPublic(
+  row: Pick<
+    DisciplinaryCase,
+    "id" | "seasonId" | "subjectUserId" | "status" | "effects" | "publicExplanation" | "effectiveFrom" | "effectiveUntil" | "createdAt"
+  >,
+  now: Date,
+): {
+  id: string;
+  seasonId: string;
+  subjectUserId: string;
+  status: ResolvedSanctionStatus;
+  effects: string[];
+  explanation: string | null;
+  effectiveFrom: Date;
+  effectiveUntil: Date | null;
+  issuedAt: Date;
+} {
+  return {
+    id: row.id,
+    seasonId: row.seasonId,
+    subjectUserId: row.subjectUserId,
+    status: resolveSanctionStatus(row, now),
+    effects: [...((row.effects ?? []) as string[])],
+    explanation: row.publicExplanation,
+    effectiveFrom: row.effectiveFrom,
+    effectiveUntil: row.effectiveUntil,
+    issuedAt: row.createdAt,
+  };
+}
+
+function windowPredicate(effect: SanctionEffect, now: Date) {
+  // JSON array containment for the effect list.
+  return sql`${disciplinaryCases.effects} @> ${JSON.stringify([effect])}::jsonb
+    AND ${disciplinaryCases.effectiveFrom} <= ${now.toISOString()}
+    AND (${disciplinaryCases.effectiveUntil} IS NULL OR ${disciplinaryCases.effectiveUntil} >= ${now.toISOString()})`;
+}
+
+/** Read-side loader shared by transactions and direct (read-only) callers. */
+type SanctionQueryable = Pick<TxDb, "select">;
+
+export interface ActiveSanctionSummary {
+  caseId: string;
+  userId: string;
+  effects: string[];
+  until: Date | null;
+}
+
+/** Loads the currently-blocking sanctions for the given subjects (scoped). */
+export async function loadActiveSanctionsInTx(
+  txOrDb: SanctionQueryable,
+  args: {
+    seasonId: string;
+    subjectUserIds?: readonly string[];
+    effect?: SanctionEffect;
+    now?: Date;
+  },
+): Promise<Map<string, ActiveSanctionSummary[]>> {
+  const now = args.now ?? new Date();
+  const conditions = [
+    eq(disciplinaryCases.seasonId, args.seasonId),
+    eq(disciplinaryCases.status, "active"),
+  ];
+  if (args.effect) conditions.push(windowPredicate(args.effect, now));
+  if (args.subjectUserIds && args.subjectUserIds.length > 0) {
+    conditions.push(inArray(disciplinaryCases.subjectUserId, [...args.subjectUserIds]));
+  }
+
+  const rows = await txOrDb
+    .select({
+      id: disciplinaryCases.id,
+      subjectUserId: disciplinaryCases.subjectUserId,
+      effects: disciplinaryCases.effects,
+      effectiveUntil: disciplinaryCases.effectiveUntil,
+    })
+    .from(disciplinaryCases)
+    .where(and(...conditions));
+
+  const byUser = new Map<string, ActiveSanctionSummary[]>();
+  for (const row of rows) {
+    if (args.effect && !(row.effects as string[]).includes(args.effect)) continue;
+    if (
+      row.effectiveUntil !== null &&
+      row.effectiveUntil.getTime() <= now.getTime()
+    ) {
+      // Window already passed: inert even without an explicit expire write.
+      continue;
+    }
+    const list = byUser.get(row.subjectUserId) ?? [];
+    list.push({
+      caseId: row.id,
+      userId: row.subjectUserId,
+      effects: [...(row.effects as string[])],
+      until: row.effectiveUntil,
+    });
+    byUser.set(row.subjectUserId, list);
+  }
+  return byUser;
+}
+
+export async function assertUsersNotBlockedInTx(
+  txOrDb: SanctionQueryable,
+  args: {
+    seasonId: string;
+    userLabels: ReadonlyMap<string, string>;
+    effect: SanctionEffect;
+    message: string;
+  },
+): Promise<void> {
+  const blocked = await loadActiveSanctionsInTx(txOrDb, {
+    seasonId: args.seasonId,
+    subjectUserIds: [...args.userLabels.keys()],
+    effect: args.effect,
+  });
+  if (blocked.size === 0) return;
+
+  const offenders = [...blocked.keys()].map((userId) => {
+    const label = args.userLabels.get(userId) ?? userId;
+    const reasons = blocked.get(userId)!.length;
+    void reasons;
+    return label;
+  });
+  throw new AppError(ErrorCode.VALIDATION_FAILED, `${args.message}：${offenders.join("、")}`);
+}
+
+// ── Sanction state transitions (idempotent, audited) ───────────────────────
+
+async function lockCaseInTx(
+  tx: TxDb,
+  caseId: string,
+): Promise<DisciplinaryCase> {
+  const [locked] = await tx
+    .select()
+    .from(disciplinaryCases)
+    .where(eq(disciplinaryCases.id, caseId))
+    .for("update");
+  if (!locked) throw new AppError(ErrorCode.NOT_FOUND, "纪律处罚记录不存在。");
+  return locked;
+}
+
+export async function issueSanctionInTx(
+  tx: TxDb,
+  args: {
+    seasonId: string;
+    subjectUserId: string;
+    effects: readonly SanctionEffect[];
+    internalEvidence?: string | null;
+    publicExplanation?: string | null;
+    effectiveFrom?: Date;
+    effectiveUntil?: Date | null;
+    actorId: string;
+  },
+): Promise<{ caseId: string }> {
+  const effects = [...new Set(args.effects)];
+  if (effects.length === 0 || !effects.every((effect) => SANCTION_EFFECTS.includes(effect))) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "处罚效果不合法。");
+  }
+  const [subject] = await tx.select({ id: users.id }).from(users).where(eq(users.id, args.subjectUserId));
+  if (!subject) throw new AppError(ErrorCode.NOT_FOUND, "被处罚用户不存在。");
+
+  const effectiveFrom = args.effectiveFrom ?? new Date();
+  if (args.effectiveUntil && args.effectiveUntil.getTime() <= effectiveFrom.getTime()) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "生效窗口结束时间必须晚于开始时间。");
+  }
+
+  const [created] = await tx
+    .insert(disciplinaryCases)
+    .values({
+      seasonId: args.seasonId,
+      subjectUserId: args.subjectUserId,
+      status: "active",
+      effects,
+      internalEvidence: args.internalEvidence ?? null,
+      publicExplanation: args.publicExplanation ?? null,
+      effectiveFrom,
+      effectiveUntil: args.effectiveUntil ?? null,
+      issuedBy: args.actorId,
+    })
+    .returning({ id: disciplinaryCases.id });
+
+  await tx.insert(auditLogs).values({
+    seasonId: args.seasonId,
+    action: "sanction.issue",
+    actorId: args.actorId,
+    targetId: created!.id,
+    targetType: "disciplinary_case",
+    meta: { subjectUserId: args.subjectUserId, effects },
+  });
+  return { caseId: created!.id };
+}
+
+export interface RevokeOutcome {
+  alreadyRevoked: boolean;
+  caseId: string;
+}
+
+export async function revokeSanctionInTx(
+  tx: TxDb,
+  args: { caseId: string; actorId: string; reason: string },
+): Promise<RevokeOutcome> {
+  const locked = await lockCaseInTx(tx, args.caseId);
+  if (locked.revokedAt !== null || locked.status === "revoked") {
+    // Idempotent: repeated revocation requests leave no duplicate audit trail.
+    return { alreadyRevoked: true, caseId: locked.id };
+  }
+
+  await tx
+    .update(disciplinaryCases)
+    .set({
+      status: "revoked",
+      revokedAt: new Date(),
+      revokedBy: args.actorId,
+      revocationReason: args.reason.trim() || null,
+      updatedAt: new Date(),
+    })
+    .where(eq(disciplinaryCases.id, locked.id));
+
+  await tx.insert(auditLogs).values({
+    seasonId: locked.seasonId,
+    action: "sanction.revoke",
+    actorId: args.actorId,
+    targetId: locked.id,
+    targetType: "disciplinary_case",
+    meta: { subjectUserId: locked.subjectUserId, reason: args.reason.trim() || null },
+  });
+  return { alreadyRevoked: false, caseId: locked.id };
+}
+
+export async function markSanctionExpiredInTx(
+  tx: TxDb,
+  args: { caseId: string; actorId: string },
+): Promise<{ alreadyExpired: boolean; caseId: string }> {
+  const locked = await lockCaseInTx(tx, args.caseId);
+  if (locked.status === "expired") return { alreadyExpired: true, caseId: locked.id };
+  if (locked.status !== "active") {
+    throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "只有生效中的处罚可以被标记为过期。");
+  }
+  const resolved = resolveSanctionStatus(locked, new Date());
+  if (resolved !== "expired") {
+    throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "该处罚仍在有效期内，不能标记为过期。");
+  }
+
+  await tx
+    .update(disciplinaryCases)
+    .set({ status: "expired", updatedAt: new Date() })
+    .where(eq(disciplinaryCases.id, locked.id));
+
+  await tx.insert(auditLogs).values({
+    seasonId: locked.seasonId,
+    action: "sanction.expire",
+    actorId: args.actorId,
+    targetId: locked.id,
+    targetType: "disciplinary_case",
+    meta: { subjectUserId: locked.subjectUserId },
+  });
+  return { alreadyExpired: false, caseId: locked.id };
+}

--- a/src/lib/match-rosters/lineup.ts
+++ b/src/lib/match-rosters/lineup.ts
@@ -20,6 +20,8 @@ export interface LineupMemberFact {
   teamMemberId: string;
   userId: string;
   verification: LineupVerificationFact | null;
+  /** Set when an active disciplinary sanction blocks this player's participation. */
+  participationBlocked?: boolean;
 }
 
 export interface StartingLineupInput {
@@ -92,6 +94,12 @@ export function evaluateStartingLineup(input: StartingLineupInput): StartingLine
   const unknownCount = [...starterIds, ...substituteIds].filter((id) => !memberFacts.has(id)).length;
   if (unknownCount > 0) {
     blockers.push(`有 ${unknownCount} 名所选队员不属于本队，不能提交。`);
+  }
+
+  const blockedCount =
+    [...starterIds, ...substituteIds].filter((id) => memberFacts.get(id)?.participationBlocked).length;
+  if (blockedCount > 0) {
+    blockers.push(`有 ${blockedCount} 名队员正在受纪律处罚禁赛期内，不能参加本场比赛。`);
   }
 
   const starterFacts: LineupMemberFact[] = [];

--- a/src/lib/match-rosters/service.ts
+++ b/src/lib/match-rosters/service.ts
@@ -17,6 +17,7 @@ import {
 import { AppError, ErrorCode } from "@/lib/errors";
 import { frozenStageRunAffiliationRules } from "@/lib/major/frozen-affiliation-rules";
 import { assertMatchTransition } from "@/lib/match-transitions";
+import { loadActiveSanctionsInTx } from "@/lib/discipline/service";
 import type { InstitutionAffiliationRule } from "@/types/season";
 import { evaluateStartingLineup, type LineupMemberFact } from "./lineup";
 
@@ -144,6 +145,13 @@ export async function loadTeamLineupContextInTx(
     .from(teamMembers)
     .where(eq(teamMembers.teamId, teamId));
 
+  // H1: active match-participation sanctions apply to every ownership mode.
+  const participationBans = await loadActiveSanctionsInTx(tx, {
+    seasonId: match.seasonId,
+    effect: "match_participation_block",
+    subjectUserIds: memberRows.map((row) => row.userId),
+  });
+
   const memberFacts = new Map<string, LineupMemberFact>();
   for (const row of memberRows) {
     memberFacts.set(row.id, {
@@ -151,6 +159,7 @@ export async function loadTeamLineupContextInTx(
       userId: row.userId,
       verification:
         (rules.length > 0 ? verificationsByUser?.get(row.userId) : null) ?? null,
+      participationBlocked: participationBans.has(row.userId),
     });
   }
 

--- a/tests/unit/actions/team-applications.test.ts
+++ b/tests/unit/actions/team-applications.test.ts
@@ -144,6 +144,15 @@ function mockMembers(rows: unknown[]) {
   });
 }
 
+/** Queued after mockMembers for submit-path tests: no active sanctions. */
+function mockDisciplinaryCases(rows: unknown[] = []) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  });
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
   insertValuesCalls.length = 0;
@@ -237,6 +246,7 @@ describe("team application participant actions", () => {
       { id: MEMBER_ID, userId: CAPTAIN_ID, status: "confirmed", email: "captain@rivalhub.test", emailVerifiedAt: new Date(), verificationId: null, verificationStatus: null, verificationAcademicStatus: null, institutionCode: null, institutionName: null },
       { id: "66666666-6666-6666-6666-666666666666", userId: PLAYER_ID, status: "confirmed", email: "player@rivalhub.test", emailVerifiedAt: new Date(), verificationId: null, verificationStatus: null, verificationAcademicStatus: null, institutionCode: null, institutionName: null },
     ]);
+    mockDisciplinaryCases([]);
     const result = await submitTeamApplication({ applicationId: APPLICATION_ID });
 
     expect(result).toEqual({ success: true, data: undefined });


### PR DESCRIPTION
## Summary

PR H1 — disciplinary facts and eligibility blockers.

Strict fact separation: 个人处罚 ≠ 队伍资格 ≠ 比赛结果 ≠ 最终名次. No auto-cascade anywhere; a team-level consequence requires its own explicit ruling (H2).

- Disciplinary case model: draft/active/expired/revoked + jsonb effect list (`registration_block` / `roster_block` / `match_participation_block`), effective window, `internal_evidence` vs `public_explanation`, full revocation provenance
- Expiry is windowed/derived; explicit idempotent expire/revoke transitions keep the audit trail complete
- Enforcement: registration_block in the application submit path; match_participation_block inside the G1 lineup referee (all ownership modes); roster_block reserved as capability for prestart consoles
- serializer guarantee: internal evidence can never reach public serialization (unit-asserted)
- Migration 0010 with RLS deny-by-default; chain now 11

## Test evidence

- unit: status/effect matrix, window derivation, serializer privacy, wrapper contracts
- real PostgreSQL: `pnpm test:discipline:local` — active blocks subject only, teammate unaffected, expired/revoked non-blocking, lineup gate rejection + retry-safe re-entry after revocation, single-audit idempotent revoke/expire, team-level facts untouched
- gates: fresh local reset (11 migrations), all 6 prior suites green, vitest 776 ✓ coverage thresholds ✓ tsc/lint/build/db:check/diff-check ✓