### PR TITLE
feat(major): add post-event adjudication and archive

### DIFF
--- a/drizzle/migrations/0011_narrow_the_watchers.sql
+++ b/drizzle/migrations/0011_narrow_the_watchers.sql
@@ -1,0 +1,82 @@
+CREATE TYPE "public"."adjudication_impact" AS ENUM('canonical_matches', 'final_result', 'official_placements', 'honors', 'none');--> statement-breakpoint
+CREATE TYPE "public"."adjudication_kind" AS ENUM('team_sanction', 'result_statement', 'placement_statement', 'honor_directive');--> statement-breakpoint
+CREATE TYPE "public"."adjudication_status" AS ENUM('active', 'revoked');--> statement-breakpoint
+CREATE TYPE "public"."adjudication_target" AS ENUM('season', 'team', 'user', 'match');--> statement-breakpoint
+CREATE TYPE "public"."honor_basis" AS ENUM('final_result', 'manual', 'adjudication');--> statement-breakpoint
+CREATE TYPE "public"."honor_state" AS ENUM('valid', 'revoked', 'vacant', 'not_awarded');--> statement-breakpoint
+CREATE TYPE "public"."honor_type" AS ENUM('champion', 'runner_up', 'placement', 'manual_award');--> statement-breakpoint
+CREATE TABLE "post_event_adjudications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"client_request_id" uuid NOT NULL,
+	"status" "adjudication_status" DEFAULT 'active' NOT NULL,
+	"kind" "adjudication_kind" NOT NULL,
+	"target" "adjudication_target" NOT NULL,
+	"impacts" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"target_team_id" uuid,
+	"target_user_id" uuid,
+	"target_match_id" uuid,
+	"reason" text NOT NULL,
+	"public_explanation" text NOT NULL,
+	"internal_evidence" text,
+	"created_by" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_by" text,
+	"revoked_at" timestamp with time zone,
+	"revocation_reason" text,
+	CONSTRAINT "post_event_adjudications_client_request_id_unique" UNIQUE("client_request_id"),
+	CONSTRAINT "post_event_adjudications_target_check" CHECK (("post_event_adjudications"."target" = 'season' AND "post_event_adjudications"."target_team_id" IS NULL AND "post_event_adjudications"."target_user_id" IS NULL AND "post_event_adjudications"."target_match_id" IS NULL)
+      OR ("post_event_adjudications"."target" = 'team' AND "post_event_adjudications"."target_team_id" IS NOT NULL AND "post_event_adjudications"."target_user_id" IS NULL AND "post_event_adjudications"."target_match_id" IS NULL)
+      OR ("post_event_adjudications"."target" = 'user' AND "post_event_adjudications"."target_team_id" IS NULL AND "post_event_adjudications"."target_user_id" IS NOT NULL AND "post_event_adjudications"."target_match_id" IS NULL)
+      OR ("post_event_adjudications"."target" = 'match' AND "post_event_adjudications"."target_team_id" IS NULL AND "post_event_adjudications"."target_user_id" IS NULL AND "post_event_adjudications"."target_match_id" IS NOT NULL)),
+	CONSTRAINT "post_event_adjudications_revocation_check" CHECK (("post_event_adjudications"."status" = 'revoked') = ("post_event_adjudications"."revoked_at" IS NOT NULL)),
+	CONSTRAINT "post_event_adjudications_impacts_array_check" CHECK (jsonb_typeof("post_event_adjudications"."impacts") = 'array')
+);
+--> statement-breakpoint
+CREATE TABLE "tournament_honors" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"season_id" uuid NOT NULL,
+	"client_request_id" uuid NOT NULL,
+	"honor_key" text NOT NULL,
+	"type" "honor_type" NOT NULL,
+	"label" text NOT NULL,
+	"state" "honor_state" DEFAULT 'valid' NOT NULL,
+	"basis" "honor_basis" NOT NULL,
+	"placement_from" integer,
+	"placement_to" integer,
+	"team_id" uuid,
+	"user_id" uuid,
+	"source_final_result_id" uuid,
+	"adjudication_id" uuid,
+	"awarded_by" text NOT NULL,
+	"awarded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_by" text,
+	"revoked_at" timestamp with time zone,
+	"revocation_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tournament_honors_client_request_id_unique" UNIQUE("client_request_id"),
+	CONSTRAINT "tournament_honors_recipient_check" CHECK (("tournament_honors"."state" IN ('valid', 'revoked') AND (("tournament_honors"."team_id" IS NOT NULL)::int + ("tournament_honors"."user_id" IS NOT NULL)::int) = 1)
+      OR ("tournament_honors"."state" IN ('vacant', 'not_awarded') AND "tournament_honors"."team_id" IS NULL AND "tournament_honors"."user_id" IS NULL)),
+	CONSTRAINT "tournament_honors_placement_check" CHECK (("tournament_honors"."type" = 'placement' AND "tournament_honors"."placement_from" IS NOT NULL AND "tournament_honors"."placement_to" IS NOT NULL AND "tournament_honors"."placement_from" > 0 AND "tournament_honors"."placement_to" >= "tournament_honors"."placement_from")
+      OR ("tournament_honors"."type" <> 'placement' AND "tournament_honors"."placement_from" IS NULL AND "tournament_honors"."placement_to" IS NULL)),
+	CONSTRAINT "tournament_honors_revocation_check" CHECK (("tournament_honors"."state" = 'revoked') = ("tournament_honors"."revoked_at" IS NOT NULL)),
+	CONSTRAINT "tournament_honors_non_blank_key_check" CHECK (length(trim("tournament_honors"."honor_key")) > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "post_event_adjudications" ADD CONSTRAINT "post_event_adjudications_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_event_adjudications" ADD CONSTRAINT "post_event_adjudications_target_team_id_teams_id_fk" FOREIGN KEY ("target_team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_event_adjudications" ADD CONSTRAINT "post_event_adjudications_target_user_id_users_id_fk" FOREIGN KEY ("target_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_event_adjudications" ADD CONSTRAINT "post_event_adjudications_target_match_id_matches_id_fk" FOREIGN KEY ("target_match_id") REFERENCES "public"."matches"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tournament_honors" ADD CONSTRAINT "tournament_honors_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tournament_honors" ADD CONSTRAINT "tournament_honors_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tournament_honors" ADD CONSTRAINT "tournament_honors_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tournament_honors" ADD CONSTRAINT "tournament_honors_source_final_result_id_major_final_results_id_fk" FOREIGN KEY ("source_final_result_id") REFERENCES "public"."major_final_results"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tournament_honors" ADD CONSTRAINT "tournament_honors_adjudication_id_post_event_adjudications_id_fk" FOREIGN KEY ("adjudication_id") REFERENCES "public"."post_event_adjudications"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "post_event_adjudications_season_idx" ON "post_event_adjudications" USING btree ("season_id");--> statement-breakpoint
+CREATE INDEX "tournament_honors_season_idx" ON "tournament_honors" USING btree ("season_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "tournament_honors_one_valid_slot_unique" ON "tournament_honors" USING btree ("season_id","honor_key") WHERE "tournament_honors"."state" = 'valid';
+--> statement-breakpoint
+ALTER TABLE post_event_adjudications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tournament_honors ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON post_event_adjudications, tournament_honors FROM anon, authenticated;

--- a/drizzle/migrations/meta/0011_snapshot.json
+++ b/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,5328 @@
+{
+  "id": "2ce3da14-875e-48ff-9707-1d8c3533cb77",
+  "prevId": "6294bea8-bd2e-4a98-b133-2861cce9ece9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "used_by_usernames": {
+          "name": "used_by_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_case_idempotency": {
+      "name": "disciplinary_case_idempotency",
+      "schema": "",
+      "columns": {
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk": {
+          "name": "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk",
+          "tableFrom": "disciplinary_case_idempotency",
+          "tableTo": "disciplinary_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_cases": {
+      "name": "disciplinary_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_cases_season_subject_idx": {
+          "name": "disciplinary_cases_season_subject_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_cases_status_idx": {
+          "name": "disciplinary_cases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_cases_season_id_seasons_id_fk": {
+          "name": "disciplinary_cases_season_id_seasons_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disciplinary_cases_subject_user_id_users_id_fk": {
+          "name": "disciplinary_cases_subject_user_id_users_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disciplinary_cases_revocation_consistent_check": {
+          "name": "disciplinary_cases_revocation_consistent_check",
+          "value": "(\"disciplinary_cases\".\"status\" = 'revoked') = (\"disciplinary_cases\".\"revoked_at\" IS NOT NULL)"
+        },
+        "disciplinary_cases_window_sane_check": {
+          "name": "disciplinary_cases_window_sane_check",
+          "value": "\"disciplinary_cases\".\"effective_until\" IS NULL OR \"disciplinary_cases\".\"effective_until\" > \"disciplinary_cases\".\"effective_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_team_id_teams_id_fk": {
+          "name": "draft_picks_team_id_teams_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_team_id": {
+          "name": "current_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_team_id_teams_id_fk": {
+          "name": "draft_state_current_team_id_teams_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "current_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_url": {
+          "name": "evidence_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "moe_institution_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "admin_season_id": {
+          "name": "admin_season_id",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "bracket_data": {
+          "name": "bracket_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_member_id": {
+          "name": "team_application_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_registration_id_season_registrations_id_fk": {
+          "name": "team_members_registration_id_season_registrations_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_application_member_id_team_application_members_id_fk": {
+          "name": "team_members_team_application_member_id_team_application_members_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "team_application_members",
+          "columnsFrom": [
+            "team_application_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_season_id_seasons_id_fk": {
+          "name": "team_members_season_id_seasons_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_team_season_fk": {
+          "name": "team_members_team_season_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_members_team_application_member_id_unique": {
+          "name": "team_members_team_application_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_member_id"
+          ]
+        },
+        "team_members_registration_id_unique": {
+          "name": "team_members_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "registration_id"
+          ]
+        },
+        "team_members_season_id_user_id_unique": {
+          "name": "team_members_season_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_registration_id": {
+          "name": "captain_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_application_id": {
+          "name": "team_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_order": {
+          "name": "draft_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_registration_id_season_registrations_id_fk": {
+          "name": "teams_captain_registration_id_season_registrations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "captain_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_application_id_team_applications_id_fk": {
+          "name": "teams_team_application_id_team_applications_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "team_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_team_application_id_unique": {
+          "name": "teams_team_application_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_application_id"
+          ]
+        },
+        "teams_season_id_draft_order_unique": {
+          "name": "teams_season_id_draft_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "draft_order"
+          ]
+        },
+        "teams_id_season_id_unique": {
+          "name": "teams_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_active_claims": {
+      "name": "team_application_active_claims",
+      "schema": "",
+      "columns": {
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_active_claims_application_idx": {
+          "name": "team_application_active_claims_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_active_claims_season_id_seasons_id_fk": {
+          "name": "team_application_active_claims_season_id_seasons_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_user_id_users_id_fk": {
+          "name": "team_application_active_claims_user_id_users_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_active_claims_application_id_team_applications_id_fk": {
+          "name": "team_application_active_claims_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_active_claims",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_active_claims_season_user_unique": {
+          "name": "team_application_active_claims_season_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_application_members": {
+      "name": "team_application_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_application_members_user_status_idx": {
+          "name": "team_application_members_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_application_members_application_id_team_applications_id_fk": {
+          "name": "team_application_members_application_id_team_applications_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "team_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_application_members_user_id_users_id_fk": {
+          "name": "team_application_members_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_application_members_invited_by_user_id_users_id_fk": {
+          "name": "team_application_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_application_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_application_members_application_user_unique": {
+          "name": "team_application_members_application_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_applications": {
+      "name": "team_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_applications_season_status_idx": {
+          "name": "team_applications_season_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_applications_season_id_seasons_id_fk": {
+          "name": "team_applications_season_id_seasons_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_applications_captain_user_id_users_id_fk": {
+          "name": "team_applications_captain_user_id_users_id_fk",
+          "tableFrom": "team_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_entrants": {
+      "name": "major_prestart_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_confirmed_at": {
+          "name": "roster_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_confirmed_by": {
+          "name": "roster_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_entrants_season_idx": {
+          "name": "major_prestart_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_entrants_season_id_seasons_id_fk": {
+          "name": "major_prestart_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_entrants_team_id_teams_id_fk": {
+          "name": "major_prestart_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_prestart_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_entrants_season_team_unique": {
+          "name": "major_prestart_entrants_season_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_roster_members": {
+      "name": "major_prestart_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_roster_members_entrant_idx": {
+          "name": "major_prestart_roster_members_entrant_idx",
+          "columns": [
+            {
+              "expression": "entrant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_prestart_roster_members_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_user_id_users_id_fk": {
+          "name": "major_prestart_roster_members_user_id_users_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_prestart_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "major_prestart_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "major_prestart_roster_members",
+          "tableTo": "education_verifications",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_roster_members_entrant_user_unique": {
+          "name": "major_prestart_roster_members_entrant_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entrant_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_revision": {
+          "name": "seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_seed_revision": {
+          "name": "confirmed_seed_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_tournament_seeds_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"tournament_seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_team_id": {
+          "name": "champion_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_team_id_teams_id_fk": {
+          "name": "major_final_results_champion_team_id_teams_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "champion_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_id": {
+          "name": "entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_seed": {
+          "name": "tournament_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk": {
+          "name": "major_stage_entrants_entrant_id_major_prestart_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_prestart_entrants",
+          "columnsFrom": [
+            "entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_team_id_teams_id_fk": {
+          "name": "major_stage_entrants_team_id_teams_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_team_unique": {
+          "name": "major_stage_entrants_run_team_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "team_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_a_id": {
+          "name": "team_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_b_id": {
+          "name": "team_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_a_id_teams_id_fk": {
+          "name": "matches_team_a_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_team_b_id_teams_id_fk": {
+          "name": "matches_team_b_id_teams_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_teams_different": {
+          "name": "matches_teams_different",
+          "value": "\"matches\".\"team_a_id\" != \"matches\".\"team_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_team_id": {
+          "name": "picked_by_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_team_id_teams_id_fk": {
+          "name": "match_maps_picked_by_team_id_teams_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "picked_by_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_team_id_teams_id_fk": {
+          "name": "swiss_standings_team_id_teams_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_team_id_unique": {
+          "name": "swiss_standings_season_id_stage_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_team_member_id_team_members_id_fk": {
+          "name": "match_roster_players_team_member_id_team_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_team_member_id_unique": {
+          "name": "match_roster_players_roster_id_team_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "team_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_team_id_teams_id_fk": {
+          "name": "match_rosters_team_id_teams_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_team_id_unique": {
+          "name": "match_rosters_match_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_team_id_teams_id_fk": {
+          "name": "match_veto_steps_team_id_teams_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_adjudications": {
+      "name": "post_event_adjudications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "adjudication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "adjudication_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "adjudication_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impacts": {
+          "name": "impacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_team_id": {
+          "name": "target_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_match_id": {
+          "name": "target_match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_event_adjudications_season_idx": {
+          "name": "post_event_adjudications_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_event_adjudications_season_id_seasons_id_fk": {
+          "name": "post_event_adjudications_season_id_seasons_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_team_id_teams_id_fk": {
+          "name": "post_event_adjudications_target_team_id_teams_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "target_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_user_id_users_id_fk": {
+          "name": "post_event_adjudications_target_user_id_users_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_match_id_matches_id_fk": {
+          "name": "post_event_adjudications_target_match_id_matches_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "target_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_event_adjudications_client_request_id_unique": {
+          "name": "post_event_adjudications_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_event_adjudications_target_check": {
+          "name": "post_event_adjudications_target_check",
+          "value": "(\"post_event_adjudications\".\"target\" = 'season' AND \"post_event_adjudications\".\"target_team_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'team' AND \"post_event_adjudications\".\"target_team_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'user' AND \"post_event_adjudications\".\"target_team_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'match' AND \"post_event_adjudications\".\"target_team_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NOT NULL)"
+        },
+        "post_event_adjudications_revocation_check": {
+          "name": "post_event_adjudications_revocation_check",
+          "value": "(\"post_event_adjudications\".\"status\" = 'revoked') = (\"post_event_adjudications\".\"revoked_at\" IS NOT NULL)"
+        },
+        "post_event_adjudications_impacts_array_check": {
+          "name": "post_event_adjudications_impacts_array_check",
+          "value": "jsonb_typeof(\"post_event_adjudications\".\"impacts\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament_honors": {
+      "name": "tournament_honors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "honor_key": {
+          "name": "honor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "honor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "honor_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "basis": {
+          "name": "basis",
+          "type": "honor_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_from": {
+          "name": "placement_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_to": {
+          "name": "placement_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_final_result_id": {
+          "name": "source_final_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjudication_id": {
+          "name": "adjudication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tournament_honors_season_idx": {
+          "name": "tournament_honors_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tournament_honors_one_valid_slot_unique": {
+          "name": "tournament_honors_one_valid_slot_unique",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "honor_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament_honors\".\"state\" = 'valid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_honors_season_id_seasons_id_fk": {
+          "name": "tournament_honors_season_id_seasons_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_team_id_teams_id_fk": {
+          "name": "tournament_honors_team_id_teams_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_user_id_users_id_fk": {
+          "name": "tournament_honors_user_id_users_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_source_final_result_id_major_final_results_id_fk": {
+          "name": "tournament_honors_source_final_result_id_major_final_results_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "major_final_results",
+          "columnsFrom": [
+            "source_final_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_adjudication_id_post_event_adjudications_id_fk": {
+          "name": "tournament_honors_adjudication_id_post_event_adjudications_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "post_event_adjudications",
+          "columnsFrom": [
+            "adjudication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_honors_client_request_id_unique": {
+          "name": "tournament_honors_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_honors_recipient_check": {
+          "name": "tournament_honors_recipient_check",
+          "value": "(\"tournament_honors\".\"state\" IN ('valid', 'revoked') AND ((\"tournament_honors\".\"team_id\" IS NOT NULL)::int + (\"tournament_honors\".\"user_id\" IS NOT NULL)::int) = 1)\n      OR (\"tournament_honors\".\"state\" IN ('vacant', 'not_awarded') AND \"tournament_honors\".\"team_id\" IS NULL AND \"tournament_honors\".\"user_id\" IS NULL)"
+        },
+        "tournament_honors_placement_check": {
+          "name": "tournament_honors_placement_check",
+          "value": "(\"tournament_honors\".\"type\" = 'placement' AND \"tournament_honors\".\"placement_from\" IS NOT NULL AND \"tournament_honors\".\"placement_to\" IS NOT NULL AND \"tournament_honors\".\"placement_from\" > 0 AND \"tournament_honors\".\"placement_to\" >= \"tournament_honors\".\"placement_from\")\n      OR (\"tournament_honors\".\"type\" <> 'placement' AND \"tournament_honors\".\"placement_from\" IS NULL AND \"tournament_honors\".\"placement_to\" IS NULL)"
+        },
+        "tournament_honors_revocation_check": {
+          "name": "tournament_honors_revocation_check",
+          "value": "(\"tournament_honors\".\"state\" = 'revoked') = (\"tournament_honors\".\"revoked_at\" IS NOT NULL)"
+        },
+        "tournament_honors_non_blank_key_check": {
+          "name": "tournament_honors_non_blank_key_check",
+          "value": "length(trim(\"tournament_honors\".\"honor_key\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_role": {
+      "name": "admin_role",
+      "schema": "public",
+      "values": [
+        "super_admin",
+        "admin"
+      ]
+    },
+    "public.sanction_effect": {
+      "name": "sanction_effect",
+      "schema": "public",
+      "values": [
+        "registration_block",
+        "roster_block",
+        "match_participation_block"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_application_member_status": {
+      "name": "team_application_member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed"
+      ]
+    },
+    "public.team_application_status": {
+      "name": "team_application_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "waitlisted",
+        "rejected"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.adjudication_impact": {
+      "name": "adjudication_impact",
+      "schema": "public",
+      "values": [
+        "canonical_matches",
+        "final_result",
+        "official_placements",
+        "honors",
+        "none"
+      ]
+    },
+    "public.adjudication_kind": {
+      "name": "adjudication_kind",
+      "schema": "public",
+      "values": [
+        "team_sanction",
+        "result_statement",
+        "placement_statement",
+        "honor_directive"
+      ]
+    },
+    "public.adjudication_status": {
+      "name": "adjudication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "revoked"
+      ]
+    },
+    "public.adjudication_target": {
+      "name": "adjudication_target",
+      "schema": "public",
+      "values": [
+        "season",
+        "team",
+        "user",
+        "match"
+      ]
+    },
+    "public.honor_basis": {
+      "name": "honor_basis",
+      "schema": "public",
+      "values": [
+        "final_result",
+        "manual",
+        "adjudication"
+      ]
+    },
+    "public.honor_state": {
+      "name": "honor_state",
+      "schema": "public",
+      "values": [
+        "valid",
+        "revoked",
+        "vacant",
+        "not_awarded"
+      ]
+    },
+    "public.honor_type": {
+      "name": "honor_type",
+      "schema": "public",
+      "values": [
+        "champion",
+        "runner_up",
+        "placement",
+        "manual_award"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787829055477,
       "tag": "0010_same_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787844090694,
+      "tag": "0011_narrow_the_watchers",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:major-roster-safety:local": "tsx scripts/db/local.ts test-major-roster-safety",
     "test:major-result-recovery:local": "tsx scripts/db/local.ts test-major-result-recovery",
     "test:discipline:local": "tsx scripts/db/local.ts test-discipline",
+    "test:postevent:local": "tsx scripts/db/local.ts test-postevent",
     "seed": "NODE_OPTIONS='--dns-result-order=ipv4first' tsx --env-file .env.local scripts/seed.ts"
   },
   "dependencies": {

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -55,6 +55,9 @@ try {
     case "test-discipline":
       runLocalIntegration("scripts/db/discipline-integration.ts");
       break;
+    case "test-postevent":
+      runLocalIntegration("scripts/db/postevent-integration.ts");
+      break;
     case "bootstrap":
       startLocalStack();
       migrateLocalDatabase();
@@ -79,7 +82,7 @@ try {
       break;
     default:
       throw new Error(
-        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | test-major-roster-safety | test-major-result-recovery | bootstrap | reset | stop | studio | dev",
+        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-team-registration | test-major-prestart | test-major-roster-safety | test-major-result-recovery | test-discipline | test-postevent | bootstrap | reset | stop | studio | dev",
       );
   }
 } catch (error) {

--- a/scripts/db/postevent-integration.ts
+++ b/scripts/db/postevent-integration.ts
@@ -1,0 +1,264 @@
+/**
+ * PR H2 — 赛后裁决、荣誉、确认与归档的真实 PostgreSQL 集成测试。
+ *
+ * 本套件只使用 loopback Local Supabase，直接驱动生产事务函数：
+ * final confirmation / adjudication / honors / archive guard / audit /
+ * public serializers。它不运行 Golden Major rehearsal。
+ */
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "../../src/db/schema";
+import { issueSanctionInTx } from "../../src/lib/discipline/service";
+import { AppError, ErrorCode } from "../../src/lib/errors";
+import { lockMatchInTx } from "../../src/lib/match-rosters/service";
+import {
+  archiveTournamentInTx,
+  confirmMajorFinalResultInTx,
+  createPostEventAdjudicationInTx,
+  grantTournamentHonorInTx,
+  revokeTournamentHonorInTx,
+  serializePostEventAdjudicationPublic,
+  serializeTournamentHonorPublic,
+} from "../../src/lib/postevent/service";
+
+const databaseUrl = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!databaseUrl) throw new Error("RIVALHUB_LOCAL_DATABASE_URL 未设置。");
+const target = new URL(databaseUrl);
+if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(target.hostname)) {
+  throw new Error("H2 集成测试只允许 Local Supabase loopback 数据库。");
+}
+
+const ACTOR = "local-admin-h2";
+
+function assertCondition(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+async function expectAppError(work: () => Promise<unknown>, code: ErrorCode, message: string): Promise<void> {
+  try {
+    await work();
+  } catch (error) {
+    if (error instanceof AppError && error.code === code) return;
+    throw error;
+  }
+  throw new Error(message);
+}
+
+interface Fixture {
+  seasonId: string;
+  runId: string;
+  resultId: string;
+  matchId: string;
+  championId: string;
+  runnerUpId: string;
+  thirdId: string;
+  userId: string;
+}
+
+async function prepareFixture(pool: Pool): Promise<Fixture> {
+  const seasonId = randomUUID();
+  const runId = randomUUID();
+  const championId = randomUUID();
+  const runnerUpId = randomUUID();
+  const thirdId = randomUUID();
+  const userId = randomUUID();
+  const resultId = randomUUID();
+  const matchId = randomUUID();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO seasons (id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft, stage_plan, registration_config, team_registration_config, affiliation_rules, min_team_size, max_team_size, starter_count, positions)
+       VALUES ($1, $2, 'Local Post-event', 'Major', 'playing', 'team', false, false, '[]'::json, '{}'::json, '{}'::json, '[]'::json, 5, 7, 5, ARRAY['igl','awper','opener','closer','anchor'])`,
+      [seasonId, `local-postevent-${seasonId}`],
+    );
+    await client.query(`INSERT INTO users (id, email, email_verified_at) VALUES ($1, $2, now())`, [userId, `h2-${userId}@local.test`]);
+    for (const [id, name] of [[championId, "Champion Team"], [runnerUpId, "Runner-up Team"], [thirdId, "Third Team"]] as const) {
+      const applicationId = randomUUID();
+      await client.query(`INSERT INTO team_applications (id, season_id, name, captain_user_id, status) VALUES ($1, $2, $3, $4, 'approved')`, [applicationId, seasonId, name, userId]);
+      await client.query(`INSERT INTO teams (id, season_id, name, captain_user_id, team_application_id) VALUES ($1, $2, $3, $4, $5)`, [id, seasonId, name, userId, applicationId]);
+    }
+    await client.query(
+      `INSERT INTO major_stage_runs (id, season_id, stage_key, rule_snapshot, started_by)
+       VALUES ($1, $2, 'playoff', '{}'::jsonb, $3)`,
+      [runId, seasonId, ACTOR],
+    );
+    await client.query(
+      `INSERT INTO matches (id, season_id, team_a_id, team_b_id, stage, entry_round, format, status, score_a, score_b, completed_at, ownership, major_stage_run_id, managed_key)
+       VALUES ($1, $2, $3, $4, 'playoff', 'final', 'bo5', 'finished', 3, 1, now(), 'major_stage', $5, 'final-1')`,
+      [matchId, seasonId, championId, runnerUpId, runId],
+    );
+    await client.query(
+      `INSERT INTO major_final_results (id, season_id, playoff_stage_run_id, champion_team_id, placement_groups, status, finalized_by)
+       VALUES ($1, $2, $3, $4, $5::jsonb, 'pending_confirmation', $6)`,
+      [resultId, seasonId, runId, championId, JSON.stringify([
+        { from: 1, to: 1, teamIds: [championId] },
+        { from: 2, to: 2, teamIds: [runnerUpId] },
+        { from: 3, to: 4, teamIds: [thirdId] },
+      ]), ACTOR],
+    );
+    await client.query("COMMIT");
+    return { seasonId, runId, resultId, matchId, championId, runnerUpId, thirdId, userId };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function cleanup(pool: Pool, fixture: Fixture): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("DELETE FROM audit_logs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM tournament_honors WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM post_event_adjudications WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM disciplinary_cases WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_final_results WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM major_stage_runs WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM teams WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM team_applications WHERE season_id = $1", [fixture.seasonId]);
+    await client.query("DELETE FROM users WHERE id = $1", [fixture.userId]);
+    await client.query("DELETE FROM seasons WHERE id = $1", [fixture.seasonId]);
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function main(): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl, ssl: false, max: 5 });
+  const database = drizzle(pool, { schema });
+  let fixture: Fixture | null = null;
+  try {
+    fixture = await prepareFixture(pool);
+    const f = fixture;
+
+    const rls = await pool.query<{ table_name: string; rls: boolean; anon_can_select: boolean; authenticated_can_select: boolean }>(
+      `SELECT c.relname AS table_name, c.relrowsecurity AS rls,
+              has_table_privilege('anon', c.oid, 'select') AS anon_can_select,
+              has_table_privilege('authenticated', c.oid, 'select') AS authenticated_can_select
+       FROM pg_class c WHERE c.relname IN ('post_event_adjudications', 'tournament_honors') ORDER BY c.relname`,
+    );
+    assertCondition(rls.rows.length === 2 && rls.rows.every((row) => row.rls && !row.anon_can_select && !row.authenticated_can_select), "H2 RLS 必须启用且 anon/authenticated 默认无权读取赛后事实。");
+
+    // 1–2: pending → confirmed; repeated confirmation produces no duplicate audit.
+    const firstConfirmation = await database.transaction((tx) => confirmMajorFinalResultInTx(tx, { seasonId: f.seasonId, actorId: ACTOR }));
+    assertCondition(!firstConfirmation.alreadyConfirmed, "P1 首次最终结果确认必须改变 pending 状态。");
+    const repeatedConfirmation = await database.transaction((tx) => confirmMajorFinalResultInTx(tx, { seasonId: f.seasonId, actorId: ACTOR }));
+    assertCondition(repeatedConfirmation.alreadyConfirmed && repeatedConfirmation.resultId === f.resultId, "P2 重复确认必须幂等返回同一结果。");
+
+    // 3–6: explicit Champion + Runner-up honors; revoke does not promote anyone.
+    const championRequestId = randomUUID();
+    const championHonor = await database.transaction((tx) => grantTournamentHonorInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: championRequestId, type: "champion", label: "Champion", basis: "final_result", teamId: f.championId, actorId: ACTOR,
+    }));
+    const repeatedChampionHonor = await database.transaction((tx) => grantTournamentHonorInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: championRequestId, type: "champion", label: "Champion", basis: "final_result", teamId: f.championId, actorId: ACTOR,
+    }));
+    assertCondition(!repeatedChampionHonor.created && repeatedChampionHonor.honorId === championHonor.honorId, "P3 荣誉授予重试必须命中相同的结构性幂等事实。");
+    const runnerUpHonor = await database.transaction((tx) => grantTournamentHonorInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: randomUUID(), type: "runner_up", label: "Runner-up", basis: "final_result", teamId: f.runnerUpId, actorId: ACTOR,
+    }));
+    const revokeChampion = await database.transaction((tx) => revokeTournamentHonorInTx(tx, { honorId: championHonor.honorId, actorId: ACTOR, reason: "explicit revocation" }));
+    assertCondition(!revokeChampion.alreadyRevoked, "P4 首次冠军撤销必须生效。");
+    const honorState = await pool.query<{ champion: string; runner_up: string }>(
+      `SELECT
+         (SELECT state::text FROM tournament_honors WHERE id = $1) AS champion,
+         (SELECT state::text FROM tournament_honors WHERE id = $2) AS runner_up`,
+      [championHonor.honorId, runnerUpHonor.honorId],
+    );
+    assertCondition(honorState.rows[0]?.champion === "revoked", "P4 冠军荣誉必须保留 revoked provenance。");
+    assertCondition(honorState.rows[0]?.runner_up === "valid", "P5 Runner-up 必须仍为 Runner-up。");
+    const automaticPromotion = await pool.query(`SELECT id FROM tournament_honors WHERE season_id = $1 AND honor_key = 'champion' AND state = 'valid'`, [f.seasonId]);
+    assertCondition(automaticPromotion.rowCount === 0, "P6 不得自动授予新的 Champion。");
+
+    // 7–9: manual award lifecycle also never creates a replacement.
+    const manualHonor = await database.transaction((tx) => grantTournamentHonorInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: randomUUID(), type: "manual_award", label: "Fair Play", honorKey: "fair-play", basis: "manual", teamId: f.thirdId, actorId: ACTOR,
+    }));
+    await database.transaction((tx) => revokeTournamentHonorInTx(tx, { honorId: manualHonor.honorId, actorId: ACTOR, reason: "manual withdrawal" }));
+    const manualState = await pool.query(`SELECT state::text FROM tournament_honors WHERE id = $1`, [manualHonor.honorId]);
+    assertCondition(manualState.rows[0]?.state === "revoked", "P8 手动奖项必须可撤销。");
+    assertCondition((await pool.query(`SELECT id FROM tournament_honors WHERE season_id = $1 AND honor_key = 'manual:fair-play' AND state = 'valid'`, [f.seasonId])).rowCount === 0, "P9 不得自动补发手动奖项。");
+
+    // 10–13: H1 personal case and explicit team adjudication cannot rewrite independent historical facts.
+    const beforeFacts = await pool.query<{ placements: string; honors: string; score_a: number; score_b: number }>(
+      `SELECT (SELECT placement_groups::text FROM major_final_results WHERE id = $1) AS placements,
+              (SELECT json_agg(json_build_object('id', id, 'state', state::text) ORDER BY id)::text FROM tournament_honors WHERE season_id = $2) AS honors,
+              (SELECT score_a FROM matches WHERE id = $3) AS score_a,
+              (SELECT score_b FROM matches WHERE id = $3) AS score_b`,
+      [f.resultId, f.seasonId, f.matchId],
+    );
+    await database.transaction((tx) => issueSanctionInTx(tx, {
+      seasonId: f.seasonId, subjectUserId: f.userId, effects: ["roster_block"], internalEvidence: "private H1 proof", publicExplanation: "personal only", actorId: ACTOR,
+    }));
+    const afterPersonalSanction = await pool.query<{ honors: string }>(
+      `SELECT json_agg(json_build_object('id', id, 'state', state::text) ORDER BY id)::text AS honors FROM tournament_honors WHERE season_id = $1`,
+      [f.seasonId],
+    );
+    assertCondition(beforeFacts.rows[0]?.honors === afterPersonalSanction.rows[0]?.honors, "P11 个人 H1 sanction 不得改写 honors。");
+    const ruling = await database.transaction((tx) => createPostEventAdjudicationInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: randomUUID(), kind: "team_sanction", target: "team", targetTeamId: f.thirdId,
+      impacts: ["honors"], reason: "team ruling", publicExplanation: "public team ruling", internalEvidence: "private ruling proof", actorId: ACTOR,
+    }));
+    const rulingHonor = await database.transaction((tx) => grantTournamentHonorInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: randomUUID(), type: "manual_award", label: "Explicit ruling award", honorKey: "ruling-award", basis: "adjudication", teamId: f.thirdId, adjudicationId: ruling.adjudicationId, actorId: ACTOR,
+    }));
+    const afterFacts = await pool.query<{ placements: string; score_a: number; score_b: number }>(
+      `SELECT (SELECT placement_groups::text FROM major_final_results WHERE id = $1) AS placements,
+              (SELECT score_a FROM matches WHERE id = $2) AS score_a,
+              (SELECT score_b FROM matches WHERE id = $2) AS score_b`,
+      [f.resultId, f.matchId],
+    );
+    assertCondition(beforeFacts.rows[0]?.placements === afterFacts.rows[0]?.placements, "P10/P12 个人处罚与队伍裁决不得改写 placements。");
+    assertCondition(beforeFacts.rows[0]?.score_a === afterFacts.rows[0]?.score_a && beforeFacts.rows[0]?.score_b === afterFacts.rows[0]?.score_b, "P13 赛后事实不得改写 historical matches。");
+    assertCondition(rulingHonor.created, "P12 只有显式关联 honors 的裁决才可创建明确的新荣誉事实。");
+
+    // 19: public serializer is intentionally unable to leak internal evidence.
+    const [rulingRow] = await database.select().from(schema.postEventAdjudications).where(eq(schema.postEventAdjudications.id, ruling.adjudicationId));
+    const [honorRow] = await database.select().from(schema.tournamentHonors).where(eq(schema.tournamentHonors.id, rulingHonor.honorId));
+    assertCondition(!JSON.stringify(serializePostEventAdjudicationPublic(rulingRow!)).includes("private ruling proof"), "P19 裁决公开序列化不得泄露内部证据。");
+    assertCondition(!JSON.stringify(serializeTournamentHonorPublic(honorRow!)).includes("private"), "P19 荣誉公开序列化不得泄露私有字段。");
+
+    // 14–18: archive is idempotent; ordinary match mutation blocks, specialized post-event remains allowed.
+    const firstArchive = await database.transaction((tx) => archiveTournamentInTx(tx, { seasonId: f.seasonId, actorId: ACTOR }));
+    assertCondition(!firstArchive.alreadyArchived, "P14 归档必须成功。");
+    const secondArchive = await database.transaction((tx) => archiveTournamentInTx(tx, { seasonId: f.seasonId, actorId: ACTOR }));
+    assertCondition(secondArchive.alreadyArchived, "P15 重复归档必须幂等。");
+    await expectAppError(
+      () => database.transaction((tx) => lockMatchInTx(tx, f.matchId)),
+      ErrorCode.VALIDATION_FAILED,
+      "P16 归档后普通比赛变更路径必须被 guard 阻断。",
+    );
+    const postArchiveRuling = await database.transaction((tx) => createPostEventAdjudicationInTx(tx, {
+      seasonId: f.seasonId, clientRequestId: randomUUID(), kind: "placement_statement", target: "season", impacts: ["official_placements"], reason: "archived ruling", publicExplanation: "archived public ruling", actorId: ACTOR,
+    }));
+    assertCondition(postArchiveRuling.created, "P17 归档后专用赛后裁决必须允许。");
+    const postArchiveRevoke = await database.transaction((tx) => revokeTournamentHonorInTx(tx, { honorId: rulingHonor.honorId, actorId: ACTOR, reason: "archived revocation" }));
+    assertCondition(!postArchiveRevoke.alreadyRevoked, "P18 归档后专用荣誉撤销必须允许。");
+
+    // 20: each meaningful mutation has an audit entry; idempotent retries do not add duplicate transition audit.
+    const audit = await pool.query<{ action: string; count: string }>(
+      `SELECT action, count(*)::text AS count FROM audit_logs WHERE season_id = $1 GROUP BY action`, [f.seasonId],
+    );
+    const auditCounts = new Map(audit.rows.map((row) => [row.action, Number(row.count)]));
+    for (const action of ["major.result.confirm", "postevent.honor.grant", "postevent.honor.revoke", "sanction.issue", "postevent.adjudication.create", "major.archive"]) {
+      assertCondition((auditCounts.get(action) ?? 0) >= 1, `P20 缺少审计：${action}`);
+    }
+    assertCondition(auditCounts.get("major.result.confirm") === 1, "P20 幂等确认不得重复写审计。");
+    console.log("H2 post-event Local PostgreSQL integration passed (P1–P20).");
+  } finally {
+    if (fixture) await cleanup(pool, fixture);
+    await pool.end();
+  }
+}
+
+void main();

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -60,6 +60,9 @@ function standardMajorOrThrow(season: typeof seasons.$inferSelect): void {
 async function seasonAndAdminOrThrow(seasonId: string) {
   const season = await db.query.seasons.findFirst({ where: eq(seasons.id, seasonId) });
   if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+  if (season.status === "archived") {
+    throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "赛事已归档，普通 Major 运行态变更被拒绝。");
+  }
   standardMajorOrThrow(season);
   return { season, admin: await requireSeasonAdmin(seasonId) };
 }

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -21,6 +21,7 @@ import {
 import { maybeFinishSeason } from "@/actions/transitions";
 import { revalidateMatchPaths, revalidateSeasonPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import {
   computeSeriesScoreAfterMap,
   isValidCS2RoundScore,
@@ -136,6 +137,7 @@ export async function recordMatchResult(
 
     // 事务保护：score 更新 + bracket 推进 + audit 原子化
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx
         .update(matches)
         .set({
@@ -238,6 +240,7 @@ export async function recordMapResult(
     let seriesFinished = false;
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       // 事务内读快照
       const existingMaps = await tx.query.matchMaps.findMany({
         where: eq(matchMaps.matchId, matchId),
@@ -344,6 +347,7 @@ export async function updateMatchScheduledAt(
 
     const seasonForSch = await getSeasonOrThrow(match.seasonId);
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       const now = new Date();
       await tx
         .update(matches)
@@ -411,6 +415,7 @@ export async function updateMatchCompletionDeadline(
 
     const season = await getSeasonOrThrow(match.seasonId);
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx
         .update(matches)
         .set({ completionDeadline, updatedAt: new Date() })
@@ -479,6 +484,7 @@ export async function batchSetCompletionDeadline(input: {
     const matchIds = targetMatches.map((m) => m.id);
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
       await tx
         .update(matches)
         .set({ completionDeadline: input.completionDeadline, updatedAt: new Date() })
@@ -575,6 +581,7 @@ export async function correctMatchScore(
     const prevScoreB = match.scoreB;
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx
         .update(matches)
         .set({ scoreA, scoreB, updatedAt: new Date() })
@@ -615,6 +622,7 @@ export async function deleteMatch(matchId: string): Promise<ActionResult<void>> 
     const season = await getSeasonOrThrow(match.seasonId);
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       // 级联删除相关数据
       await tx.delete(matchVetoSteps).where(eq(matchVetoSteps.matchId, matchId));
       await tx.delete(matchMaps).where(eq(matchMaps.matchId, matchId));
@@ -678,6 +686,7 @@ export async function updateMatchCompletedAt(
     const season = await getSeasonOrThrow(match.seasonId);
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx
         .update(matches)
         .set({ completedAt, updatedAt: new Date() })
@@ -734,6 +743,7 @@ export async function correctMapScore(
     const season = await getSeasonOrThrow(match.seasonId);
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       // 事务内读取所有图，将目标图替换为 proposed score 后按正常语义重算系列赛
       const allMaps = await tx.query.matchMaps.findMany({
         where: eq(matchMaps.matchId, mapRecord.matchId),
@@ -841,6 +851,7 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
     let fixed = 0;
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, seasonId);
       for (const bm of allResolved) {
         const nameA = participantNameById.get(bm.teamAParticipantId);
         const nameB = participantNameById.get(bm.teamBParticipantId);
@@ -912,6 +923,7 @@ export async function forfeitMatch(
     const season = await getSeasonOrThrow(match.seasonId);
 
     await db.transaction(async (tx) => {
+      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx.delete(matchMaps).where(
         and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA))
       );

--- a/src/actions/postevent.ts
+++ b/src/actions/postevent.ts
@@ -1,0 +1,176 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { postEventAdjudications, seasons, tournamentHonors } from "@/db/schema";
+import { actionError } from "@/lib/action-utils";
+import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
+import { AppError, ErrorCode } from "@/lib/errors";
+import {
+  ADJUDICATION_IMPACTS,
+  archiveTournamentInTx,
+  confirmMajorFinalResultInTx,
+  createPostEventAdjudicationInTx,
+  grantTournamentHonorInTx,
+  revokePostEventAdjudicationInTx,
+  revokeTournamentHonorInTx,
+  serializePostEventAdjudicationPublic,
+  serializeTournamentHonorPublic,
+} from "@/lib/postevent/service";
+import { fail, ok, type ActionResult } from "@/types/action";
+
+const uuid = z.string().uuid();
+const clientRequestId = z.string().uuid();
+const impactSchema = z.enum(ADJUDICATION_IMPACTS);
+
+function invalid(message: string): ActionResult<never> {
+  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
+}
+
+async function seasonAndAdminOrThrow(seasonId: string) {
+  const season = await db.query.seasons.findFirst({ where: eq(seasons.id, seasonId), columns: { id: true, slug: true } });
+  if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在。");
+  return { season, admin: await requireSeasonAdmin(seasonId) };
+}
+
+function revalidatePostEvent(slug: string): void {
+  revalidatePath(`/admin/${slug}`);
+  revalidatePath(`/${slug}`);
+  revalidatePath(`/${slug}/matches`);
+  revalidatePath(`/admin/${slug}/matches`);
+}
+
+export async function confirmMajorFinalResult(input: unknown): Promise<ActionResult<{ resultId: string; alreadyConfirmed: boolean }>> {
+  const parsed = z.object({ seasonId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛事结果确认参数无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => confirmMajorFinalResultInTx(tx, { seasonId: season.id, actorId: auditActorId(admin) }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("confirmMajorFinalResult", error); }
+}
+
+const createAdjudicationSchema = z.object({
+  seasonId: uuid,
+  clientRequestId,
+  kind: z.enum(["team_sanction", "result_statement", "placement_statement", "honor_directive"]),
+  target: z.enum(["season", "team", "user", "match"]),
+  targetTeamId: uuid.optional().nullable(),
+  targetUserId: uuid.optional().nullable(),
+  targetMatchId: uuid.optional().nullable(),
+  impacts: z.array(impactSchema).min(1).max(5),
+  reason: z.string().trim().min(1).max(2000),
+  publicExplanation: z.string().trim().min(1).max(2000),
+  internalEvidence: z.string().trim().max(8000).optional().nullable(),
+});
+
+export async function createPostEventAdjudication(input: unknown): Promise<ActionResult<{ adjudicationId: string; created: boolean }>> {
+  const parsed = createAdjudicationSchema.safeParse(input);
+  if (!parsed.success) return invalid("赛后裁决参数无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => createPostEventAdjudicationInTx(tx, {
+      ...parsed.data,
+      seasonId: season.id,
+      actorId: auditActorId(admin),
+    }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("createPostEventAdjudication", error); }
+}
+
+export async function revokePostEventAdjudication(input: unknown): Promise<ActionResult<{ adjudicationId: string; alreadyRevoked: boolean }>> {
+  const parsed = z.object({ adjudicationId: uuid, reason: z.string().trim().min(1).max(2000) }).safeParse(input);
+  if (!parsed.success) return invalid("撤销裁决参数无效。");
+  try {
+    const [adjudication] = await db.select({ seasonId: postEventAdjudications.seasonId }).from(postEventAdjudications)
+      .where(eq(postEventAdjudications.id, parsed.data.adjudicationId));
+    if (!adjudication) throw new AppError(ErrorCode.NOT_FOUND, "赛后裁决不存在。");
+    const { season, admin } = await seasonAndAdminOrThrow(adjudication.seasonId);
+    const result = await db.transaction((tx) => revokePostEventAdjudicationInTx(tx, {
+      adjudicationId: parsed.data.adjudicationId,
+      actorId: auditActorId(admin),
+      reason: parsed.data.reason,
+    }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("revokePostEventAdjudication", error); }
+}
+
+const grantHonorSchema = z.object({
+  seasonId: uuid,
+  clientRequestId,
+  type: z.enum(["champion", "runner_up", "placement", "manual_award"]),
+  label: z.string().trim().min(1).max(160),
+  basis: z.enum(["final_result", "manual", "adjudication"]),
+  teamId: uuid.optional().nullable(),
+  userId: uuid.optional().nullable(),
+  placementFrom: z.number().int().positive().optional(),
+  placementTo: z.number().int().positive().optional(),
+  honorKey: z.string().trim().min(1).max(120).optional(),
+  adjudicationId: uuid.optional().nullable(),
+});
+
+export async function grantTournamentHonor(input: unknown): Promise<ActionResult<{ honorId: string; created: boolean }>> {
+  const parsed = grantHonorSchema.safeParse(input);
+  if (!parsed.success) return invalid("荣誉授予参数无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => grantTournamentHonorInTx(tx, {
+      ...parsed.data,
+      seasonId: season.id,
+      actorId: auditActorId(admin),
+    }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("grantTournamentHonor", error); }
+}
+
+export async function revokeTournamentHonor(input: unknown): Promise<ActionResult<{ honorId: string; alreadyRevoked: boolean }>> {
+  const parsed = z.object({ honorId: uuid, reason: z.string().trim().min(1).max(2000) }).safeParse(input);
+  if (!parsed.success) return invalid("撤销荣誉参数无效。");
+  try {
+    const [honor] = await db.select({ seasonId: tournamentHonors.seasonId }).from(tournamentHonors)
+      .where(eq(tournamentHonors.id, parsed.data.honorId));
+    if (!honor) throw new AppError(ErrorCode.NOT_FOUND, "赛事荣誉不存在。");
+    const { season, admin } = await seasonAndAdminOrThrow(honor.seasonId);
+    const result = await db.transaction((tx) => revokeTournamentHonorInTx(tx, {
+      honorId: parsed.data.honorId,
+      actorId: auditActorId(admin),
+      reason: parsed.data.reason,
+    }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("revokeTournamentHonor", error); }
+}
+
+export async function archiveMajorTournament(input: unknown): Promise<ActionResult<{ archived: boolean; alreadyArchived: boolean }>> {
+  const parsed = z.object({ seasonId: uuid }).safeParse(input);
+  if (!parsed.success) return invalid("赛事归档参数无效。");
+  try {
+    const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
+    const result = await db.transaction((tx) => archiveTournamentInTx(tx, { seasonId: season.id, actorId: auditActorId(admin) }));
+    revalidatePostEvent(season.slug);
+    return ok(result);
+  } catch (error) { return actionError("archiveMajorTournament", error); }
+}
+
+export async function getSeasonPublicPostEventFacts(seasonId: string): Promise<ActionResult<{
+  adjudications: ReturnType<typeof serializePostEventAdjudicationPublic>[];
+  honors: ReturnType<typeof serializeTournamentHonorPublic>[];
+}>> {
+  if (!uuid.safeParse(seasonId).success) return invalid("赛季标识无效。");
+  try {
+    const [adjudications, honors] = await Promise.all([
+      db.select().from(postEventAdjudications).where(eq(postEventAdjudications.seasonId, seasonId)),
+      db.select().from(tournamentHonors).where(eq(tournamentHonors.seasonId, seasonId)),
+    ]);
+    return ok({
+      adjudications: adjudications.map(serializePostEventAdjudicationPublic),
+      honors: honors.map(serializeTournamentHonorPublic),
+    });
+  } catch (error) { return actionError("getSeasonPublicPostEventFacts", error); }
+}

--- a/src/app/admin/[seasonSlug]/page.tsx
+++ b/src/app/admin/[seasonSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { and, asc, eq } from "drizzle-orm";
 import { MajorPrestartConsole } from "@/components/admin/MajorPrestartConsole";
+import { PostEventManagement } from "@/components/admin/PostEventManagement";
 import { db } from "@/db/client";
 import {
   majorPrestartEntrants,
@@ -11,9 +12,11 @@ import {
   majorStageRuns,
   matches,
   majorTournamentSeeds,
+  postEventAdjudications,
   seasons,
   teamMembers,
   teams,
+  tournamentHonors,
   users,
 } from "@/db/schema";
 import { evaluateMajorPrestartReadiness } from "@/lib/major/prestart";
@@ -31,6 +34,16 @@ function isMajorSwissFinalizedRound(value: number): value is 0 | 1 | 2 | 3 | 4 |
 
 interface AdminMajorConsolePageProps {
   params: Promise<{ seasonSlug: string }>;
+}
+
+function placementGroupsForAdmin(value: unknown): Array<{ from: number; to: number; teamIds: string[] }> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((group) => {
+    if (!group || typeof group !== "object") return [];
+    const candidate = group as { from?: unknown; to?: unknown; teamIds?: unknown };
+    if (!Number.isInteger(candidate.from) || !Number.isInteger(candidate.to) || !Array.isArray(candidate.teamIds) || !candidate.teamIds.every((id) => typeof id === "string")) return [];
+    return [{ from: candidate.from as number, to: candidate.to as number, teamIds: candidate.teamIds as string[] }];
+  });
 }
 
 export default async function AdminMajorConsolePage({ params }: AdminMajorConsolePageProps) {
@@ -58,7 +71,7 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     candidatesByTeam.set(member.teamId, candidates);
   }
 
-  const [state, entrantRows, rosterRows, issueRows, seedRows, stageRunRows, stageMatchRows, finalResult] = await Promise.all([
+  const [state, entrantRows, rosterRows, issueRows, seedRows, stageRunRows, stageMatchRows, finalResult, honorRows, adjudicationRows] = await Promise.all([
     db.query.majorPrestartStates.findFirst({ where: eq(majorPrestartStates.seasonId, season.id) }),
     db.select({
       id: majorPrestartEntrants.id,
@@ -87,6 +100,10 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
       .innerJoin(majorStageRuns, eq(matches.majorStageRunId, majorStageRuns.id))
       .where(and(eq(majorStageRuns.seasonId, season.id), eq(matches.ownership, "major_stage"))),
     db.query.majorFinalResults.findFirst({ where: eq(majorFinalResults.seasonId, season.id) }),
+    db.select({ id: tournamentHonors.id, honorKey: tournamentHonors.honorKey, type: tournamentHonors.type, label: tournamentHonors.label, state: tournamentHonors.state, teamId: tournamentHonors.teamId, userId: tournamentHonors.userId, placementFrom: tournamentHonors.placementFrom, placementTo: tournamentHonors.placementTo })
+      .from(tournamentHonors).where(eq(tournamentHonors.seasonId, season.id)).orderBy(asc(tournamentHonors.createdAt)),
+    db.select({ id: postEventAdjudications.id, status: postEventAdjudications.status, kind: postEventAdjudications.kind, target: postEventAdjudications.target, impacts: postEventAdjudications.impacts, targetTeamId: postEventAdjudications.targetTeamId, targetUserId: postEventAdjudications.targetUserId, targetMatchId: postEventAdjudications.targetMatchId, reason: postEventAdjudications.reason, explanation: postEventAdjudications.publicExplanation, createdAt: postEventAdjudications.createdAt })
+      .from(postEventAdjudications).where(eq(postEventAdjudications.seasonId, season.id)).orderBy(asc(postEventAdjudications.createdAt)),
   ]);
   const entrantIds = new Set(entrantRows.map((entrant) => entrant.id));
   const rosterByEntrant = new Map<string, Array<{ userId: string; email: string; educationVerificationId: string | null }>>();
@@ -181,7 +198,8 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     };
   }
 
-  return <MajorPrestartConsole
+  return <div className="space-y-4">
+    <MajorPrestartConsole
     seasonName={season.name}
     readiness={readiness}
     management={{
@@ -215,5 +233,19 @@ export default async function AdminMajorConsolePage({ params }: AdminMajorConsol
     started={stageRunRows.length > 0}
     swissRuntime={swissRuntime}
     playoffRuntime={playoffRuntime}
-  />;
+    />
+    <PostEventManagement data={{
+      seasonId: season.id,
+      seasonStatus: season.status,
+      finalResult: finalResult ? {
+        id: finalResult.id,
+        status: finalResult.status,
+        championTeamId: finalResult.championTeamId,
+        placementGroups: placementGroupsForAdmin(finalResult.placementGroups),
+      } : null,
+      teams: seasonTeams,
+      honors: honorRows,
+      adjudications: adjudicationRows.map((row) => ({ ...row, impacts: row.impacts as string[] })),
+    }} />
+  </div>;
 }

--- a/src/components/admin/PostEventManagement.tsx
+++ b/src/components/admin/PostEventManagement.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  archiveMajorTournament,
+  confirmMajorFinalResult,
+  createPostEventAdjudication,
+  grantTournamentHonor,
+  revokePostEventAdjudication,
+  revokeTournamentHonor,
+} from "@/actions/postevent";
+import { Button } from "@/components/ui/button";
+import { Panel } from "@/components/rivalhub";
+
+type PlacementGroup = { from: number; to: number; teamIds: string[] };
+type Team = { id: string; name: string };
+
+export interface PostEventManagementData {
+  seasonId: string;
+  seasonStatus: string;
+  finalResult: { id: string; status: "pending_confirmation" | "confirmed"; championTeamId: string; placementGroups: PlacementGroup[] } | null;
+  teams: Team[];
+  honors: Array<{ id: string; honorKey: string; type: string; label: string; state: string; teamId: string | null; userId: string | null; placementFrom: number | null; placementTo: number | null }>;
+  adjudications: Array<{ id: string; status: string; kind: string; target: string; impacts: string[]; targetTeamId: string | null; targetUserId: string | null; targetMatchId: string | null; reason: string; explanation: string; createdAt: Date }>;
+}
+
+function requestId(): string {
+  return crypto.randomUUID();
+}
+
+function safeManualKey(value: string): string {
+  const key = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return key || "manual-award";
+}
+
+export function PostEventManagement({ data }: { data: PostEventManagementData }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [confirmed, setConfirmed] = useState(false);
+  const [archiveConfirmed, setArchiveConfirmed] = useState(false);
+  const [manualLabel, setManualLabel] = useState("");
+  const [manualTeamId, setManualTeamId] = useState("");
+  const [placementChoice, setPlacementChoice] = useState("");
+  const [adjudicationTeamId, setAdjudicationTeamId] = useState("");
+  const [reason, setReason] = useState("");
+  const [explanation, setExplanation] = useState("");
+  const [internalEvidence, setInternalEvidence] = useState("");
+  const teamName = useMemo(() => new Map(data.teams.map((team) => [team.id, team.name])), [data.teams]);
+  const runnerUpId = data.finalResult?.placementGroups.find((group) => group.from === 2 && group.to === 2)?.teamIds[0] ?? null;
+  const placementOptions = (data.finalResult?.placementGroups ?? [])
+    .filter((group) => group.from >= 3)
+    .flatMap((group) => group.teamIds.map((teamId) => ({ ...group, teamId, key: `${group.from}:${group.to}:${teamId}` })));
+
+  const run = (work: () => Promise<{ success: boolean; error?: { message: string } }>) => {
+    startTransition(async () => {
+      const result = await work();
+      if (!result.success) { toast.error(result.error?.message ?? "操作失败。"); return; }
+      router.refresh();
+    });
+  };
+
+  const grantResultHonor = (type: "champion" | "runner_up", teamId: string, label: string) => run(async () => {
+    const result = await grantTournamentHonor({
+      seasonId: data.seasonId,
+      clientRequestId: requestId(),
+      type,
+      label,
+      basis: "final_result",
+      teamId,
+    });
+    if (result.success) toast.success(`${label}已作为独立荣誉事实授予。`);
+    return result;
+  });
+
+  return <div className="grid gap-4">
+    <Panel label="最终排名与确认">
+      {!data.finalResult ? <p className="text-sm text-[var(--color-fg-mid)]">尚未形成正式最终结果；无法确认、授予基于结果的荣誉或归档。</p> : <div className="space-y-3 text-sm">
+        <p>当前状态：<strong>{data.finalResult.status === "confirmed" ? "已确认" : "待确认"}</strong>。冠军：{teamName.get(data.finalResult.championTeamId) ?? data.finalResult.championTeamId}。</p>
+        <p className="text-[var(--color-fg-mid)]">名次来源为已持久化的官方 placement groups；确认不会重新计算比赛，也不会修改名次。</p>
+        {data.finalResult.status === "pending_confirmation" && <>
+          <label className="flex items-start gap-2 rounded border border-[var(--color-border)] p-3">
+            <input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} disabled={isPending} />
+            <span>我已核对最终 standings 与 placement groups，并确认将其作为官方赛事结果。</span>
+          </label>
+          <Button disabled={!confirmed || isPending} onClick={() => run(async () => {
+            const result = await confirmMajorFinalResult({ seasonId: data.seasonId });
+            if (result.success) toast.success(result.data.alreadyConfirmed ? "赛事结果已确认。" : "赛事结果已正式确认。");
+            return result;
+          })}>确认最终赛事结果</Button>
+        </>}
+      </div>}
+    </Panel>
+
+    <Panel label="赛事荣誉">
+      <div className="space-y-3 text-sm">
+        <p className="text-[var(--color-fg-mid)]">荣誉独立于比赛与名次。撤销冠军不会自动将 Runner-up 提升为 Champion；任何替补授予都必须由管理员另行明确创建。</p>
+        {data.finalResult?.status === "confirmed" && <div className="flex flex-wrap gap-2">
+          <Button variant="outline" disabled={isPending} onClick={() => grantResultHonor("champion", data.finalResult!.championTeamId, "Champion")}>授予 Champion</Button>
+          {runnerUpId && <Button variant="outline" disabled={isPending} onClick={() => grantResultHonor("runner_up", runnerUpId, "Runner-up")}>授予 Runner-up</Button>}
+        </div>}
+        {data.finalResult?.status === "confirmed" && placementOptions.length > 0 && <div className="grid gap-2 rounded border border-[var(--color-border)] p-3 md:grid-cols-[1fr_auto]">
+          <select className="rounded border bg-transparent px-2 py-1" value={placementChoice} onChange={(event) => setPlacementChoice(event.target.value)}>
+            <option value="">选择官方名次范围与队伍</option>
+            {placementOptions.map((option) => <option key={option.key} value={option.key}>{option.from}–{option.to} · {teamName.get(option.teamId) ?? option.teamId}</option>)}
+          </select>
+          <Button variant="outline" disabled={!placementChoice || isPending} onClick={() => {
+            const selected = placementOptions.find((option) => option.key === placementChoice);
+            if (!selected) return;
+            run(async () => grantTournamentHonor({ seasonId: data.seasonId, clientRequestId: requestId(), type: "placement", label: `Placement ${selected.from}–${selected.to}`, basis: "final_result", teamId: selected.teamId, placementFrom: selected.from, placementTo: selected.to }));
+          }}>授予名次荣誉</Button>
+        </div>}
+        <div className="grid gap-2 rounded border border-[var(--color-border)] p-3 md:grid-cols-[1fr_1fr_auto]">
+          <input className="rounded border bg-transparent px-2 py-1" placeholder="手动奖项名称" value={manualLabel} onChange={(event) => setManualLabel(event.target.value)} />
+          <select className="rounded border bg-transparent px-2 py-1" value={manualTeamId} onChange={(event) => setManualTeamId(event.target.value)}>
+            <option value="">选择获奖队伍</option>{data.teams.map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
+          </select>
+          <Button disabled={!manualLabel.trim() || !manualTeamId || isPending} onClick={() => run(async () => {
+            const result = await grantTournamentHonor({ seasonId: data.seasonId, clientRequestId: requestId(), type: "manual_award", label: manualLabel.trim(), basis: "manual", teamId: manualTeamId, honorKey: safeManualKey(manualLabel) });
+            if (result.success) { toast.success("手动奖项已授予。"); setManualLabel(""); setManualTeamId(""); }
+            return result;
+          })}>授予手动奖项</Button>
+        </div>
+        {data.honors.length === 0 ? <p className="text-[var(--color-fg-mid)]">尚无荣誉事实。</p> : <ul className="space-y-2">{data.honors.map((honor) => <li key={honor.id} className="flex flex-wrap items-center justify-between gap-2 rounded border border-[var(--color-border)] p-3">
+          <span>{honor.label} · {honor.state} · {honor.teamId ? teamName.get(honor.teamId) ?? honor.teamId : honor.userId ?? "未授予"}{honor.placementFrom ? ` · ${honor.placementFrom}–${honor.placementTo}` : ""}</span>
+          {honor.state === "valid" && <Button variant="destructive" size="sm" disabled={isPending} onClick={() => {
+            if (!window.confirm("撤销此荣誉不会自动授予任何其他队伍（包括 Runner-up）。是否继续？")) return;
+            run(async () => revokeTournamentHonor({ honorId: honor.id, reason: "管理员赛后撤销" }));
+          }}>撤销</Button>}
+        </li>)}</ul>}
+      </div>
+    </Panel>
+
+    <Panel label="赛后裁决">
+      <div className="space-y-3 text-sm">
+        <p className="text-[var(--color-fg-mid)]">裁决只记录明确的对象和影响范围；不会隐式修改 historical matches、官方名次或荣誉。</p>
+        <div className="grid gap-2 rounded border border-[var(--color-border)] p-3">
+          <select className="rounded border bg-transparent px-2 py-1" value={adjudicationTeamId} onChange={(event) => setAdjudicationTeamId(event.target.value)}>
+            <option value="">选择被裁决队伍</option>{data.teams.map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
+          </select>
+          <input className="rounded border bg-transparent px-2 py-1" placeholder="裁决依据" value={reason} onChange={(event) => setReason(event.target.value)} />
+          <input className="rounded border bg-transparent px-2 py-1" placeholder="公开说明" value={explanation} onChange={(event) => setExplanation(event.target.value)} />
+          <textarea className="rounded border bg-transparent px-2 py-1" placeholder="内部证据（仅管理端，绝不经公开 serializer）" value={internalEvidence} onChange={(event) => setInternalEvidence(event.target.value)} />
+          <Button disabled={!adjudicationTeamId || !reason.trim() || !explanation.trim() || isPending} onClick={() => run(async () => {
+            const result = await createPostEventAdjudication({ seasonId: data.seasonId, clientRequestId: requestId(), kind: "team_sanction", target: "team", targetTeamId: adjudicationTeamId, impacts: ["none"], reason: reason.trim(), publicExplanation: explanation.trim(), internalEvidence: internalEvidence.trim() || null });
+            if (result.success) { toast.success("赛后裁决已创建；未修改任何比赛、名次或荣誉。"); setReason(""); setExplanation(""); setInternalEvidence(""); }
+            return result;
+          })}>创建队伍裁决</Button>
+        </div>
+        {data.adjudications.length === 0 ? <p className="text-[var(--color-fg-mid)]">尚无赛后裁决。</p> : <ul className="space-y-2">{data.adjudications.map((item) => <li key={item.id} className="flex flex-wrap items-center justify-between gap-2 rounded border border-[var(--color-border)] p-3">
+          <span>{item.kind} · {item.status} · {item.target === "team" ? teamName.get(item.targetTeamId ?? "") ?? item.targetTeamId : item.target} · {item.impacts.join(", ")}<br /><span className="text-[var(--color-fg-mid)]">{item.explanation}</span></span>
+          {item.status === "active" && <Button variant="destructive" size="sm" disabled={isPending} onClick={() => {
+            if (!window.confirm("撤销裁决只改变裁决自身状态，不会回写任何历史比赛、名次或荣誉。是否继续？")) return;
+            run(async () => revokePostEventAdjudication({ adjudicationId: item.id, reason: "管理员赛后撤销" }));
+          }}>撤销</Button>}
+        </li>)}</ul>}
+      </div>
+    </Panel>
+
+    <Panel label="赛事归档">
+      <div className="space-y-3 text-sm">
+        <p>当前 archive 状态：<strong>{data.seasonStatus === "archived" ? "已归档" : "未归档"}</strong>。</p>
+        {data.seasonStatus !== "archived" && <>
+          <p className="text-[var(--color-fg-mid)]">归档后普通赛事运行态变更（名单、开赛/比分、阶段推进、种子与赛事编辑）会在服务端 fail closed。赛后裁决与荣誉撤销仍通过专用 action 允许。</p>
+          <label className="flex items-start gap-2 rounded border border-[var(--color-border)] p-3"><input type="checkbox" checked={archiveConfirmed} onChange={(event) => setArchiveConfirmed(event.target.checked)} disabled={isPending} /><span>我确认将赛事进入只读运行态。</span></label>
+          <Button variant="destructive" disabled={!archiveConfirmed || isPending} onClick={() => run(async () => {
+            const result = await archiveMajorTournament({ seasonId: data.seasonId });
+            if (result.success) toast.success(result.data.alreadyArchived ? "赛事已归档。" : "赛事已归档，普通变更已关闭。");
+            return result;
+          })}>归档赛事</Button>
+        </>}
+      </div>
+    </Panel>
+  </div>;
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -22,3 +22,4 @@ export * from "./match-rosters";
 export * from "./match-veto-steps";
 export * from "./user-sessions";
 export * from "./discipline";
+export * from "./postevent";

--- a/src/db/schema/postevent.ts
+++ b/src/db/schema/postevent.ts
@@ -1,0 +1,137 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { majorFinalResults } from "./major-stage";
+import { matches } from "./matches";
+import { seasons } from "./seasons";
+import { teams } from "./teams";
+import { users } from "./users";
+
+export const adjudicationStatusEnum = pgEnum("adjudication_status", ["active", "revoked"]);
+export const adjudicationKindEnum = pgEnum("adjudication_kind", [
+  "team_sanction",
+  "result_statement",
+  "placement_statement",
+  "honor_directive",
+]);
+export const adjudicationTargetEnum = pgEnum("adjudication_target", ["season", "team", "user", "match"]);
+export const adjudicationImpactEnum = pgEnum("adjudication_impact", [
+  "canonical_matches",
+  "final_result",
+  "official_placements",
+  "honors",
+  "none",
+]);
+
+/**
+ * An explicit post-event ruling. This is a record of the administrator's
+ * decision, not another source of match truth: canonical match corrections
+ * remain exclusively in the G2 correction flow.
+ */
+export const postEventAdjudications = pgTable("post_event_adjudications", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  /** Durable retry key supplied by the caller, never generated server-side. */
+  clientRequestId: uuid("client_request_id").notNull().unique(),
+  status: adjudicationStatusEnum("status").notNull().default("active"),
+  kind: adjudicationKindEnum("kind").notNull(),
+  target: adjudicationTargetEnum("target").notNull(),
+  impacts: jsonb("impacts").$type<AdjudicationImpact[]>().notNull().default(sql`'[]'::jsonb`),
+  targetTeamId: uuid("target_team_id").references(() => teams.id),
+  targetUserId: uuid("target_user_id").references(() => users.id),
+  targetMatchId: uuid("target_match_id").references(() => matches.id),
+  reason: text("reason").notNull(),
+  publicExplanation: text("public_explanation").notNull(),
+  /** Privileged-only evidence. Never include this column in public serializers. */
+  internalEvidence: text("internal_evidence"),
+  createdBy: text("created_by").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  revokedBy: text("revoked_by"),
+  revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  revocationReason: text("revocation_reason"),
+}, (t) => ({
+  seasonIndex: index("post_event_adjudications_season_idx").on(t.seasonId),
+  targetCheck: check(
+    "post_event_adjudications_target_check",
+    sql`(${t.target} = 'season' AND ${t.targetTeamId} IS NULL AND ${t.targetUserId} IS NULL AND ${t.targetMatchId} IS NULL)
+      OR (${t.target} = 'team' AND ${t.targetTeamId} IS NOT NULL AND ${t.targetUserId} IS NULL AND ${t.targetMatchId} IS NULL)
+      OR (${t.target} = 'user' AND ${t.targetTeamId} IS NULL AND ${t.targetUserId} IS NOT NULL AND ${t.targetMatchId} IS NULL)
+      OR (${t.target} = 'match' AND ${t.targetTeamId} IS NULL AND ${t.targetUserId} IS NULL AND ${t.targetMatchId} IS NOT NULL)`,
+  ),
+  revocationCheck: check(
+    "post_event_adjudications_revocation_check",
+    sql`(${t.status} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
+  ),
+  impactsAreArray: check(
+    "post_event_adjudications_impacts_array_check",
+    sql`jsonb_typeof(${t.impacts}) = 'array'`,
+  ),
+}));
+
+export const honorTypeEnum = pgEnum("honor_type", ["champion", "runner_up", "placement", "manual_award"]);
+export const honorStateEnum = pgEnum("honor_state", ["valid", "revoked", "vacant", "not_awarded"]);
+export const honorBasisEnum = pgEnum("honor_basis", ["final_result", "manual", "adjudication"]);
+
+/**
+ * A separately-auditable honor fact. It deliberately never recalculates or
+ * changes matches/final placement. A new recipient must be explicitly
+ * granted as a new row after revocation; no runner-up promotion exists here.
+ */
+export const tournamentHonors = pgTable("tournament_honors", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  seasonId: uuid("season_id").notNull().references(() => seasons.id),
+  clientRequestId: uuid("client_request_id").notNull().unique(),
+  /** Stable slot key: champion, runner_up, placement:3-4:<team>, or manual:<slug>. */
+  honorKey: text("honor_key").notNull(),
+  type: honorTypeEnum("type").notNull(),
+  label: text("label").notNull(),
+  state: honorStateEnum("state").notNull().default("valid"),
+  basis: honorBasisEnum("basis").notNull(),
+  placementFrom: integer("placement_from"),
+  placementTo: integer("placement_to"),
+  teamId: uuid("team_id").references(() => teams.id),
+  userId: uuid("user_id").references(() => users.id),
+  sourceFinalResultId: uuid("source_final_result_id").references(() => majorFinalResults.id),
+  adjudicationId: uuid("adjudication_id").references(() => postEventAdjudications.id),
+  awardedBy: text("awarded_by").notNull(),
+  awardedAt: timestamp("awarded_at", { withTimezone: true }).notNull().defaultNow(),
+  revokedBy: text("revoked_by"),
+  revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  revocationReason: text("revocation_reason"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  seasonIndex: index("tournament_honors_season_idx").on(t.seasonId),
+  onlyOneValidSlot: uniqueIndex("tournament_honors_one_valid_slot_unique")
+    .on(t.seasonId, t.honorKey)
+    .where(sql`${t.state} = 'valid'`),
+  recipientCheck: check(
+    "tournament_honors_recipient_check",
+    sql`(${t.state} IN ('valid', 'revoked') AND ((${t.teamId} IS NOT NULL)::int + (${t.userId} IS NOT NULL)::int) = 1)
+      OR (${t.state} IN ('vacant', 'not_awarded') AND ${t.teamId} IS NULL AND ${t.userId} IS NULL)`,
+  ),
+  placementCheck: check(
+    "tournament_honors_placement_check",
+    sql`(${t.type} = 'placement' AND ${t.placementFrom} IS NOT NULL AND ${t.placementTo} IS NOT NULL AND ${t.placementFrom} > 0 AND ${t.placementTo} >= ${t.placementFrom})
+      OR (${t.type} <> 'placement' AND ${t.placementFrom} IS NULL AND ${t.placementTo} IS NULL)`,
+  ),
+  revocationCheck: check(
+    "tournament_honors_revocation_check",
+    sql`(${t.state} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
+  ),
+  nonBlankKey: check("tournament_honors_non_blank_key_check", sql`length(trim(${t.honorKey})) > 0`),
+}));
+
+export type AdjudicationImpact = "canonical_matches" | "final_result" | "official_placements" | "honors" | "none";
+export type PostEventAdjudication = typeof postEventAdjudications.$inferSelect;
+export type TournamentHonor = typeof tournamentHonors.$inferSelect;

--- a/src/lib/major/playoff-runtime.ts
+++ b/src/lib/major/playoff-runtime.ts
@@ -3,6 +3,7 @@ import type { TxDb } from "@/db/client";
 import { auditLogs, majorFinalResults, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import { buildFinalMajorPlacements } from "@/lib/major/placement";
 import { generateMajorPlayoffQuarterfinals, projectMajorPlayoff, seedMajorPlayoffEntrants, type MajorPlayoffMatchFact, type MajorPlayoffRound } from "@/lib/major/playoff";
 import { getMajorSwissQualifiers, projectMajorSwissStage, type MajorSwissMatchFact } from "@/lib/major/swiss";
@@ -101,6 +102,7 @@ export async function startMajorPlayoffInTransaction(
   tx: TxDb,
   input: { seasonId: string; sourceStageRunId: string; actorId: string },
 ): Promise<MajorPlayoffStartResult> {
+  await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
   const [sourceRun] = await tx.select().from(majorStageRuns)
     .where(and(eq(majorStageRuns.id, input.sourceStageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
   if (!sourceRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的 Stage 3 StageRun 不属于当前赛事。");
@@ -176,6 +178,7 @@ export async function finalizeMajorPlayoffRoundInTransaction(
   tx: TxDb,
   input: { seasonId: string; stageRunId: string; expectedRound: PlayoffStep; actorId: string },
 ): Promise<MajorPlayoffFinalizationResult> {
+  await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
   const [run] = await tx.select().from(majorStageRuns)
     .where(and(eq(majorStageRuns.id, input.stageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
   if (!run) throw new AppError(ErrorCode.NOT_FOUND, "指定的淘汰赛 StageRun 不属于当前赛事。");

--- a/src/lib/major/stage-transition.ts
+++ b/src/lib/major/stage-transition.ts
@@ -3,6 +3,7 @@ import type { TxDb } from "@/db/client";
 import { auditLogs, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import { seedMajorLaterStageEntrants } from "@/lib/major/seeding";
 import {
   generateNextMajorSwissRound,
@@ -114,6 +115,7 @@ export async function transitionMajorSwissStageInTransaction(
   tx: TxDb,
   input: { seasonId: string; sourceStageRunId: string; actorId: string },
 ): Promise<MajorStageTransitionResult> {
+  await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
   const [sourceRun] = await tx.select().from(majorStageRuns)
     .where(and(eq(majorStageRuns.id, input.sourceStageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
   if (!sourceRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的源 StageRun 不属于当前赛事。");

--- a/src/lib/major/start.ts
+++ b/src/lib/major/start.ts
@@ -16,6 +16,7 @@ import { AppError, ErrorCode } from "@/lib/errors";
 import { buildMajorOpeningPlan } from "@/lib/major/opening";
 import { evaluateMajorPrestartReadiness } from "@/lib/major/prestart";
 import { freezeAffiliationRules } from "@/lib/major/frozen-affiliation-rules";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import {
   checkStandardMajorCapabilities,
   normalizeRegistrationConfig,
@@ -57,6 +58,7 @@ export async function startMajorInTransaction(
   tx: TxDb,
   input: { seasonId: string; actorId: string },
 ): Promise<MajorStartResult> {
+  await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
   const [season] = await tx.select().from(seasons)
     .where(eq(seasons.id, input.seasonId)).for("update");
   if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");

--- a/src/lib/major/swiss-runtime.ts
+++ b/src/lib/major/swiss-runtime.ts
@@ -3,6 +3,7 @@ import type { TxDb } from "@/db/client";
 import { auditLogs, majorStageEntrants, majorStageRuns, matches } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import {
   generateNextMajorSwissRound,
   projectMajorSwissStage,
@@ -80,6 +81,7 @@ export async function finalizeMajorSwissRoundInTransaction(
   tx: TxDb,
   input: { seasonId: string; stageRunId: string; expectedRound: MajorSwissRound; actorId: string },
 ): Promise<MajorSwissRoundFinalizationResult> {
+  await assertSeasonAllowsTournamentMutationInTx(tx, input.seasonId);
   const [stageRun] = await tx.select().from(majorStageRuns)
     .where(and(eq(majorStageRuns.id, input.stageRunId), eq(majorStageRuns.seasonId, input.seasonId))).for("update");
   if (!stageRun) throw new AppError(ErrorCode.NOT_FOUND, "指定的 Major StageRun 不属于当前赛事。 ");

--- a/src/lib/match-corrections/service.ts
+++ b/src/lib/match-corrections/service.ts
@@ -9,6 +9,7 @@ import {
 } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { validateSeriesScore } from "@/lib/matches/result-rules";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 
 /**
  * G2 managed result correction & recovery.
@@ -380,6 +381,10 @@ export async function applyResultCorrectionInTx(
     confirmRecovery?: boolean;
   },
 ): Promise<AppliedResultCorrection> {
+  const [source] = await tx.select({ seasonId: matches.seasonId }).from(matches)
+    .where(eq(matches.id, args.matchId)).for("update");
+  if (!source) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+  await assertSeasonAllowsTournamentMutationInTx(tx, source.seasonId);
   const plan = await planResultCorrectionInTx(tx, { matchId: args.matchId, proposal: args.proposal });
 
   if (

--- a/src/lib/match-rosters/service.ts
+++ b/src/lib/match-rosters/service.ts
@@ -18,6 +18,7 @@ import { AppError, ErrorCode } from "@/lib/errors";
 import { frozenStageRunAffiliationRules } from "@/lib/major/frozen-affiliation-rules";
 import { assertMatchTransition } from "@/lib/match-transitions";
 import { loadActiveSanctionsInTx } from "@/lib/discipline/service";
+import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import type { InstitutionAffiliationRule } from "@/types/season";
 import { evaluateStartingLineup, type LineupMemberFact } from "./lineup";
 
@@ -43,6 +44,7 @@ export async function lockMatchInTx(tx: TxDb, matchId: string): Promise<Match> {
     .where(eq(matches.id, matchId))
     .for("update");
   if (!locked) throw new AppError(ErrorCode.NOT_FOUND, "比赛不存在。");
+  await assertSeasonAllowsTournamentMutationInTx(tx, locked.seasonId);
   return locked;
 }
 

--- a/src/lib/postevent/guard.ts
+++ b/src/lib/postevent/guard.ts
@@ -1,0 +1,41 @@
+import { eq } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+/**
+ * Archive guard: once a season/tournament is archived, ordinary mutable
+ * operations fail closed. Explicitly authorized post-event channels
+ * (adjudications, honor lifecycle, sanction governance, audit viewing) live
+ * outside this gate by design.
+ */
+export async function assertSeasonAllowsTournamentMutationInTx(
+  txOrDb: Pick<TxDb, "select">,
+  seasonId: string,
+): Promise<void> {
+  const [row] = await txOrDb
+    .select({ status: seasons.status })
+    .from(seasons)
+    .where(eq(seasons.id, seasonId))
+    .for("update");
+  if (!row) throw new AppError(ErrorCode.NOT_FOUND, "赛季不存在。");
+  if (row.status === "archived") {
+    throw new AppError(
+      ErrorCode.VALIDATION_FAILED,
+      "赛季已归档，普通赛事变更被拒绝；请使用赛后裁决或荣誉专用操作。",
+    );
+  }
+}
+
+export type SeasonArchiveStatus = Awaited<ReturnType<typeof loadSeasonStatusInTx>>;
+
+export async function loadSeasonStatusInTx(
+  txOrDb: Pick<TxDb, "select">,
+  seasonId: string,
+): Promise<string | null> {
+  const [row] = await txOrDb
+    .select({ status: seasons.status })
+    .from(seasons)
+    .where(eq(seasons.id, seasonId));
+  return row?.status ?? null;
+}

--- a/src/lib/postevent/service.ts
+++ b/src/lib/postevent/service.ts
@@ -1,0 +1,397 @@
+import { and, eq } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import {
+  auditLogs,
+  majorFinalResults,
+  matches,
+  postEventAdjudications,
+  seasons,
+  teams,
+  tournamentHonors,
+  type AdjudicationImpact,
+  type PostEventAdjudication,
+  type TournamentHonor,
+} from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+export const ADJUDICATION_IMPACTS = [
+  "canonical_matches",
+  "final_result",
+  "official_placements",
+  "honors",
+  "none",
+] as const satisfies readonly AdjudicationImpact[];
+
+type AdjudicationTarget = "season" | "team" | "user" | "match";
+type AdjudicationKind = "team_sanction" | "result_statement" | "placement_statement" | "honor_directive";
+type HonorType = "champion" | "runner_up" | "placement" | "manual_award";
+type HonorBasis = "final_result" | "manual" | "adjudication";
+
+type PlacementGroup = { from: number; to: number; teamIds: string[] };
+
+function validateImpacts(impacts: readonly AdjudicationImpact[]): AdjudicationImpact[] {
+  const distinct = [...new Set(impacts)];
+  if (distinct.length === 0 || !distinct.every((impact) => ADJUDICATION_IMPACTS.includes(impact))) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "裁决影响范围不合法。");
+  }
+  if (distinct.includes("none") && distinct.length !== 1) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "无实际影响的裁决不能同时声明其他影响范围。");
+  }
+  return distinct;
+}
+
+function parsePlacementGroups(value: unknown): PlacementGroup[] {
+  if (!Array.isArray(value)) throw new AppError(ErrorCode.INTERNAL_ERROR, "官方名次分组格式损坏。");
+  const groups = value.map((group): PlacementGroup => {
+    if (!group || typeof group !== "object") throw new AppError(ErrorCode.INTERNAL_ERROR, "官方名次分组格式损坏。");
+    const candidate = group as Partial<PlacementGroup>;
+    if (!Number.isInteger(candidate.from) || !Number.isInteger(candidate.to) || !Array.isArray(candidate.teamIds) || !candidate.teamIds.every((id) => typeof id === "string")) {
+      throw new AppError(ErrorCode.INTERNAL_ERROR, "官方名次分组格式损坏。");
+    }
+    return { from: candidate.from!, to: candidate.to!, teamIds: candidate.teamIds! };
+  });
+  return groups;
+}
+
+async function lockFinalResultInTx(tx: TxDb, seasonId: string) {
+  const [result] = await tx.select().from(majorFinalResults)
+    .where(eq(majorFinalResults.seasonId, seasonId)).for("update");
+  if (!result) throw new AppError(ErrorCode.NOT_FOUND, "该赛事尚未形成正式最终结果。");
+  return result;
+}
+
+async function assertTeamBelongsToSeasonInTx(tx: TxDb, seasonId: string, teamId: string): Promise<void> {
+  const [team] = await tx.select({ id: teams.id }).from(teams)
+    .where(and(eq(teams.id, teamId), eq(teams.seasonId, seasonId)));
+  if (!team) throw new AppError(ErrorCode.VALIDATION_FAILED, "目标队伍不属于当前赛事。");
+}
+
+async function assertMatchBelongsToSeasonInTx(tx: TxDb, seasonId: string, matchId: string): Promise<void> {
+  const [match] = await tx.select({ id: matches.id }).from(matches)
+    .where(and(eq(matches.id, matchId), eq(matches.seasonId, seasonId)));
+  if (!match) throw new AppError(ErrorCode.VALIDATION_FAILED, "目标比赛不属于当前赛事。");
+}
+
+export async function confirmMajorFinalResultInTx(
+  tx: TxDb,
+  args: { seasonId: string; actorId: string },
+): Promise<{ resultId: string; alreadyConfirmed: boolean }> {
+  const result = await lockFinalResultInTx(tx, args.seasonId);
+  if (result.status === "confirmed") return { resultId: result.id, alreadyConfirmed: true };
+  await tx.update(majorFinalResults).set({
+    status: "confirmed",
+    confirmedAt: new Date(),
+    confirmedBy: args.actorId,
+  }).where(eq(majorFinalResults.id, result.id));
+  await tx.insert(auditLogs).values({
+    seasonId: args.seasonId,
+    action: "major.result.confirm",
+    actorId: args.actorId,
+    targetId: result.id,
+    targetType: "major_final_result",
+    meta: { championTeamId: result.championTeamId, placementGroupCount: parsePlacementGroups(result.placementGroups).length },
+  });
+  return { resultId: result.id, alreadyConfirmed: false };
+}
+
+export async function createPostEventAdjudicationInTx(
+  tx: TxDb,
+  args: {
+    seasonId: string;
+    clientRequestId: string;
+    kind: AdjudicationKind;
+    target: AdjudicationTarget;
+    targetTeamId?: string | null;
+    targetUserId?: string | null;
+    targetMatchId?: string | null;
+    impacts: readonly AdjudicationImpact[];
+    reason: string;
+    publicExplanation: string;
+    internalEvidence?: string | null;
+    actorId: string;
+  },
+): Promise<{ adjudicationId: string; created: boolean }> {
+  const [existing] = await tx.select().from(postEventAdjudications)
+    .where(eq(postEventAdjudications.clientRequestId, args.clientRequestId)).for("update");
+  if (existing) {
+    if (existing.seasonId !== args.seasonId) throw new AppError(ErrorCode.VALIDATION_FAILED, "幂等请求键已属于另一项裁决。");
+    return { adjudicationId: existing.id, created: false };
+  }
+
+  const impacts = validateImpacts(args.impacts);
+  const targetIds = {
+    team: args.targetTeamId ?? null,
+    user: args.targetUserId ?? null,
+    match: args.targetMatchId ?? null,
+  };
+  if ((args.target === "team" && !targetIds.team) || (args.target === "user" && !targetIds.user) || (args.target === "match" && !targetIds.match)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "裁决目标与目标事实不一致。");
+  }
+  if ((args.target === "season" && (targetIds.team || targetIds.user || targetIds.match)) ||
+      (args.target !== "team" && targetIds.team) || (args.target !== "user" && targetIds.user) || (args.target !== "match" && targetIds.match)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "裁决目标必须唯一且明确。");
+  }
+  if (targetIds.team) await assertTeamBelongsToSeasonInTx(tx, args.seasonId, targetIds.team);
+  if (targetIds.match) await assertMatchBelongsToSeasonInTx(tx, args.seasonId, targetIds.match);
+
+  const [created] = await tx.insert(postEventAdjudications).values({
+    seasonId: args.seasonId,
+    clientRequestId: args.clientRequestId,
+    kind: args.kind,
+    target: args.target,
+    impacts,
+    targetTeamId: targetIds.team,
+    targetUserId: targetIds.user,
+    targetMatchId: targetIds.match,
+    reason: args.reason,
+    publicExplanation: args.publicExplanation,
+    internalEvidence: args.internalEvidence ?? null,
+    createdBy: args.actorId,
+  }).onConflictDoNothing().returning({ id: postEventAdjudications.id });
+  if (!created) {
+    const [retry] = await tx.select({ id: postEventAdjudications.id, seasonId: postEventAdjudications.seasonId })
+      .from(postEventAdjudications).where(eq(postEventAdjudications.clientRequestId, args.clientRequestId));
+    if (retry?.seasonId === args.seasonId) return { adjudicationId: retry.id, created: false };
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "赛后裁决幂等键或目标发生冲突。");
+  }
+  await tx.insert(auditLogs).values({
+    seasonId: args.seasonId,
+    action: "postevent.adjudication.create",
+    actorId: args.actorId,
+    targetId: created.id,
+    targetType: "post_event_adjudication",
+    meta: { kind: args.kind, target: args.target, targetTeamId: targetIds.team, targetUserId: targetIds.user, targetMatchId: targetIds.match, impacts },
+  });
+  return { adjudicationId: created.id, created: true };
+}
+
+export async function revokePostEventAdjudicationInTx(
+  tx: TxDb,
+  args: { adjudicationId: string; actorId: string; reason: string },
+): Promise<{ adjudicationId: string; alreadyRevoked: boolean }> {
+  const [adjudication] = await tx.select().from(postEventAdjudications)
+    .where(eq(postEventAdjudications.id, args.adjudicationId)).for("update");
+  if (!adjudication) throw new AppError(ErrorCode.NOT_FOUND, "赛后裁决不存在。");
+  if (adjudication.status === "revoked") return { adjudicationId: adjudication.id, alreadyRevoked: true };
+  await tx.update(postEventAdjudications).set({
+    status: "revoked",
+    revokedAt: new Date(),
+    revokedBy: args.actorId,
+    revocationReason: args.reason,
+  }).where(eq(postEventAdjudications.id, adjudication.id));
+  await tx.insert(auditLogs).values({
+    seasonId: adjudication.seasonId,
+    action: "postevent.adjudication.revoke",
+    actorId: args.actorId,
+    targetId: adjudication.id,
+    targetType: "post_event_adjudication",
+    meta: { reason: args.reason },
+  });
+  return { adjudicationId: adjudication.id, alreadyRevoked: false };
+}
+
+function slotForHonor(args: { type: HonorType; placementFrom?: number; placementTo?: number; teamId?: string | null; honorKey?: string }): string {
+  if (args.type === "champion" || args.type === "runner_up") return args.type;
+  if (args.type === "placement") return `placement:${args.placementFrom}-${args.placementTo}:${args.teamId ?? "unassigned"}`;
+  if (!args.honorKey?.trim()) throw new AppError(ErrorCode.VALIDATION_FAILED, "手动奖项必须提供稳定的奖项键。");
+  return `manual:${args.honorKey.trim()}`;
+}
+
+function assertFinalResultRecipient(
+  result: { championTeamId: string; placementGroups: unknown },
+  args: { type: HonorType; teamId?: string | null; placementFrom?: number; placementTo?: number },
+): void {
+  if (!args.teamId) throw new AppError(ErrorCode.VALIDATION_FAILED, "基于正式结果的荣誉必须授予队伍。");
+  if (args.type === "champion" && args.teamId !== result.championTeamId) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "冠军荣誉只能授予官方结果中的冠军队伍。");
+  }
+  const groups = parsePlacementGroups(result.placementGroups);
+  if (args.type === "runner_up") {
+    const runnerUp = groups.find((group) => group.from === 2 && group.to === 2);
+    if (!runnerUp?.teamIds.includes(args.teamId)) throw new AppError(ErrorCode.VALIDATION_FAILED, "亚军荣誉只能授予官方结果中的亚军队伍。");
+  }
+  if (args.type === "placement") {
+    const group = groups.find((candidate) => candidate.from === args.placementFrom && candidate.to === args.placementTo);
+    if (!group?.teamIds.includes(args.teamId)) throw new AppError(ErrorCode.VALIDATION_FAILED, "名次荣誉必须与官方名次分组完全一致。");
+  }
+}
+
+export async function grantTournamentHonorInTx(
+  tx: TxDb,
+  args: {
+    seasonId: string;
+    clientRequestId: string;
+    type: HonorType;
+    label: string;
+    basis: HonorBasis;
+    teamId?: string | null;
+    userId?: string | null;
+    placementFrom?: number;
+    placementTo?: number;
+    honorKey?: string;
+    adjudicationId?: string | null;
+    actorId: string;
+  },
+): Promise<{ honorId: string; created: boolean }> {
+  const [existing] = await tx.select().from(tournamentHonors)
+    .where(eq(tournamentHonors.clientRequestId, args.clientRequestId)).for("update");
+  if (existing) {
+    if (existing.seasonId !== args.seasonId) throw new AppError(ErrorCode.VALIDATION_FAILED, "幂等请求键已属于另一项荣誉。");
+    return { honorId: existing.id, created: false };
+  }
+  if ((args.teamId ? 1 : 0) + (args.userId ? 1 : 0) !== 1) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "荣誉必须明确授予一支队伍或一名选手。");
+  }
+  if (args.type === "placement" && (!Number.isInteger(args.placementFrom) || !Number.isInteger(args.placementTo) || args.placementFrom! < 1 || args.placementTo! < args.placementFrom!)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "名次范围不合法。");
+  }
+  if (args.type !== "placement" && (args.placementFrom !== undefined || args.placementTo !== undefined)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "只有名次荣誉可以携带名次范围。");
+  }
+  if (args.type === "manual_award" && args.basis === "final_result") {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "手动奖项不能伪装为官方最终结果的自动派生物。");
+  }
+  if (args.type !== "manual_award" && args.basis === "manual") {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "冠军、亚军和名次荣誉必须以官方最终结果或明确赛后裁决为依据。");
+  }
+  if (args.teamId) await assertTeamBelongsToSeasonInTx(tx, args.seasonId, args.teamId);
+
+  const honorKey = slotForHonor(args);
+  const [alreadyValid] = await tx.select({ id: tournamentHonors.id }).from(tournamentHonors)
+    .where(and(eq(tournamentHonors.seasonId, args.seasonId), eq(tournamentHonors.honorKey, honorKey), eq(tournamentHonors.state, "valid")))
+    .for("update");
+  if (alreadyValid) throw new AppError(ErrorCode.VALIDATION_FAILED, "该荣誉席位已有有效授予；请先显式撤销，系统不会自动替换获奖者。");
+
+  let sourceFinalResultId: string | null = null;
+  if (args.basis === "final_result") {
+    const result = await lockFinalResultInTx(tx, args.seasonId);
+    if (result.status !== "confirmed") throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "必须先明确确认最终赛事结果，才能授予基于结果的荣誉。");
+    assertFinalResultRecipient(result, args);
+    sourceFinalResultId = result.id;
+  }
+  if (args.basis === "adjudication") {
+    if (!args.adjudicationId) throw new AppError(ErrorCode.VALIDATION_FAILED, "裁决依据荣誉必须关联有效裁决。");
+    const [adjudication] = await tx.select().from(postEventAdjudications)
+      .where(eq(postEventAdjudications.id, args.adjudicationId)).for("update");
+    if (!adjudication || adjudication.seasonId !== args.seasonId || adjudication.status !== "active" || !(adjudication.impacts as string[]).includes("honors")) {
+      throw new AppError(ErrorCode.VALIDATION_FAILED, "关联裁决不是当前赛事的有效荣誉裁决。");
+    }
+  }
+
+  const [created] = await tx.insert(tournamentHonors).values({
+    seasonId: args.seasonId,
+    clientRequestId: args.clientRequestId,
+    honorKey,
+    type: args.type,
+    label: args.label,
+    state: "valid",
+    basis: args.basis,
+    placementFrom: args.type === "placement" ? args.placementFrom! : null,
+    placementTo: args.type === "placement" ? args.placementTo! : null,
+    teamId: args.teamId ?? null,
+    userId: args.userId ?? null,
+    sourceFinalResultId,
+    adjudicationId: args.adjudicationId ?? null,
+    awardedBy: args.actorId,
+  }).onConflictDoNothing().returning({ id: tournamentHonors.id });
+  if (!created) {
+    const [retry] = await tx.select({ id: tournamentHonors.id, seasonId: tournamentHonors.seasonId })
+      .from(tournamentHonors).where(eq(tournamentHonors.clientRequestId, args.clientRequestId));
+    if (retry?.seasonId === args.seasonId) return { honorId: retry.id, created: false };
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "该荣誉席位已有有效授予；系统不会自动替换获奖者。");
+  }
+  await tx.insert(auditLogs).values({
+    seasonId: args.seasonId,
+    action: "postevent.honor.grant",
+    actorId: args.actorId,
+    targetId: created.id,
+    targetType: "tournament_honor",
+    meta: { honorKey, type: args.type, basis: args.basis, teamId: args.teamId ?? null, userId: args.userId ?? null, placementFrom: args.placementFrom ?? null, placementTo: args.placementTo ?? null, adjudicationId: args.adjudicationId ?? null },
+  });
+  return { honorId: created.id, created: true };
+}
+
+export async function revokeTournamentHonorInTx(
+  tx: TxDb,
+  args: { honorId: string; actorId: string; reason: string },
+): Promise<{ honorId: string; alreadyRevoked: boolean }> {
+  const [honor] = await tx.select().from(tournamentHonors)
+    .where(eq(tournamentHonors.id, args.honorId)).for("update");
+  if (!honor) throw new AppError(ErrorCode.NOT_FOUND, "赛事荣誉不存在。");
+  if (honor.state === "revoked") return { honorId: honor.id, alreadyRevoked: true };
+  if (honor.state !== "valid") throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有有效荣誉可以撤销。");
+  await tx.update(tournamentHonors).set({
+    state: "revoked",
+    revokedAt: new Date(),
+    revokedBy: args.actorId,
+    revocationReason: args.reason,
+    updatedAt: new Date(),
+  }).where(eq(tournamentHonors.id, honor.id));
+  await tx.insert(auditLogs).values({
+    seasonId: honor.seasonId,
+    action: "postevent.honor.revoke",
+    actorId: args.actorId,
+    targetId: honor.id,
+    targetType: "tournament_honor",
+    meta: { honorKey: honor.honorKey, type: honor.type, reason: args.reason, automaticPromotion: false },
+  });
+  return { honorId: honor.id, alreadyRevoked: false };
+}
+
+export async function archiveTournamentInTx(
+  tx: TxDb,
+  args: { seasonId: string; actorId: string },
+): Promise<{ archived: boolean; alreadyArchived: boolean }> {
+  const [season] = await tx.select().from(seasons).where(eq(seasons.id, args.seasonId)).for("update");
+  if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在。");
+  if (season.status === "archived") return { archived: true, alreadyArchived: true };
+  const result = await lockFinalResultInTx(tx, args.seasonId);
+  if (result.status !== "confirmed") throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "必须先明确确认最终赛事结果，才能归档赛事。");
+  await tx.update(seasons).set({ status: "archived", updatedAt: new Date() }).where(eq(seasons.id, season.id));
+  await tx.insert(auditLogs).values({
+    seasonId: season.id,
+    action: "major.archive",
+    actorId: args.actorId,
+    targetId: season.id,
+    targetType: "season",
+    meta: { from: season.status, to: "archived", finalResultId: result.id },
+  });
+  return { archived: true, alreadyArchived: false };
+}
+
+/** Public-safe shapes: private evidence and internal actor provenance are omitted by construction. */
+export function serializePostEventAdjudicationPublic(row: PostEventAdjudication) {
+  return {
+    id: row.id,
+    seasonId: row.seasonId,
+    status: row.status,
+    kind: row.kind,
+    target: row.target,
+    impacts: [...(row.impacts as AdjudicationImpact[])],
+    targetTeamId: row.targetTeamId,
+    targetUserId: row.targetUserId,
+    targetMatchId: row.targetMatchId,
+    reason: row.reason,
+    explanation: row.publicExplanation,
+    createdAt: row.createdAt,
+    revokedAt: row.revokedAt,
+  };
+}
+
+export function serializeTournamentHonorPublic(row: TournamentHonor) {
+  return {
+    id: row.id,
+    seasonId: row.seasonId,
+    honorKey: row.honorKey,
+    type: row.type,
+    label: row.label,
+    state: row.state,
+    basis: row.basis,
+    placementFrom: row.placementFrom,
+    placementTo: row.placementTo,
+    teamId: row.teamId,
+    userId: row.userId,
+    awardedAt: row.awardedAt,
+    revokedAt: row.revokedAt,
+  };
+}

--- a/tests/unit/actions/matches-results.test.ts
+++ b/tests/unit/actions/matches-results.test.ts
@@ -8,6 +8,7 @@ const matchMapsFindFirstMock = vi.hoisted(() => vi.fn());
 const txMatchMapsFindManyMock = vi.hoisted(() => vi.fn());
 const txUpdateMock = vi.hoisted(() => vi.fn());
 const txInsertMock = vi.hoisted(() => vi.fn());
+const txSelectMock = vi.hoisted(() => vi.fn());
 const transactionMock = vi.hoisted(() => vi.fn());
 const requireSeasonAdminMock = vi.hoisted(() => vi.fn());
 const auditActorIdMock = vi.hoisted(() => vi.fn());
@@ -24,6 +25,7 @@ vi.mock("@/db/client", () => {
     },
     update: txUpdateMock,
     insert: txInsertMock,
+    select: txSelectMock,
   };
   return {
     db: {
@@ -89,6 +91,14 @@ function setupAdminSession() {
 }
 
 function setupTxWriteMocks() {
+  txSelectMock.mockImplementation(() => {
+    const result = {
+      from: () => result,
+      where: () => result,
+      for: () => Promise.resolve([{ status: "playing" }]),
+    };
+    return result;
+  });
   txUpdateMock.mockImplementation((table: unknown) => ({
     set: vi.fn((values: unknown) => {
       if (table === matchMaps) matchMapsUpdateSetCalls.push(values);

--- a/tests/unit/app/admin-major-console-page.test.tsx
+++ b/tests/unit/app/admin-major-console-page.test.tsx
@@ -24,6 +24,9 @@ vi.mock("@/db/client", () => ({
 }));
 
 vi.mock("next/navigation", () => ({ notFound: vi.fn() }));
+vi.mock("@/components/admin/PostEventManagement", () => ({
+  PostEventManagement: () => <div data-testid="postevent-management" />,
+}));
 
 import AdminMajorConsolePage from "@/app/admin/[seasonSlug]/page";
 


### PR DESCRIPTION
## Scope

H2 closes the post-event Major lifecycle only: explicit final-result confirmation, auditable post-event adjudications, independently revocable honors, and fail-closed archive behavior.

## Guarantees

- Canonical match facts remain in matches/G2 correction history; adjudications do not rewrite them.
- Champion revocation does not promote Runner-up; any replacement is a new explicit honor fact.
- Archive blocks normal Major/match mutation boundaries while post-event adjudication and honor revocation remain available through dedicated actions.
- Internal adjudication evidence is excluded from public serializers; new tables are RLS-enabled and deny anon/authenticated access by default.

## Verification

- Local Supabase fresh migration/reset/verify; migration chain is 0011 only for H2.
- New Local PostgreSQL P1–P20 post-event suite, including RLS and audit checks.
- Re-ran G1 roster safety, G2 result recovery, H1 discipline, team-registration, Major prestart, and Major lifecycle local suites.
- pnpm test (776), pnpm test:coverage, pnpm type-check, pnpm lint, pnpm build, db:check, and local security advisor.