### PR TITLE
fix(auth): clarify legacy admin bootstrap entry

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -7,6 +7,7 @@
   "changesets": [
     "calm-pandas-develop",
     "fail-closed-team-registration",
-    "major-rivals-rise"
+    "major-rivals-rise",
+    "quiet-owners-login"
   ]
 }

--- a/.changeset/quiet-owners-login.md
+++ b/.changeset/quiet-owners-login.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+明确 legacy Root 管理员登录入口与标准 owner email bootstrap 的边界。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-rc.1
+
+### Patch Changes
+
+- 明确 legacy Root 管理员登录入口与标准 owner email bootstrap 的边界。
+
 ## 2.0.0-rc.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0-rc.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/app/admin/(auth)/login/page.tsx
+++ b/src/app/admin/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 import { AdminLoginForm } from "@/components/admin/AdminLoginForm";
+import Link from "next/link";
 
 export default function AdminLoginPage() {
   return (
@@ -9,11 +10,11 @@ export default function AdminLoginPage() {
             管理员登录
           </h1>
           <p className="text-sm text-[var(--color-fg-mid)]">
-            首次使用请先运行{" "}
-            <code className="text-xs bg-[var(--color-panel)] px-1 rounded">
-              pnpm seed
-            </code>{" "}
-            创建根管理员
+            标准首个 owner 请通过{" "}
+            <Link href="/login" className="underline hover:text-[var(--color-accent)]">
+              /login
+            </Link>{" "}
+            注册并登录；本页仅保留 legacy Root 兼容/应急入口。
           </p>
         </div>
         <AdminLoginForm />


### PR DESCRIPTION
将 /admin/login 明确为 legacy Root 兼容/应急入口，并引导标准 owner 通过 /login 完成 RIVALHUB_OWNER_EMAIL bootstrap。按 Changesets 进入 2.0.0-rc.1。