### PR TITLE
fix: harden auth failure recovery

### DIFF
--- a/.changeset/bright-captains-login.md
+++ b/.changeset/bright-captains-login.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+对齐生产 Supabase 强密码策略，增加注册确认密码，并在注册失败后刷新一次性 Turnstile 校验。

--- a/.changeset/bright-captains-login.md
+++ b/.changeset/bright-captains-login.md
@@ -2,4 +2,4 @@
 "rivalhub": patch
 ---
 
-对齐生产 Supabase 强密码策略，增加注册确认密码，并在注册失败后刷新一次性 Turnstile 校验。
+对齐生产 Supabase 强密码策略，增加注册和重置密码确认，刷新失败的一次性 Turnstile 校验，并避免吞掉密码重置发信错误。

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "rivalhub": "1.30.2"
   },
   "changesets": [
+    "bright-captains-login",
     "calm-pandas-develop",
     "fail-closed-team-registration",
     "major-rivals-rise",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-rc.2
+
+### Patch Changes
+
+- 对齐生产 Supabase 强密码策略，增加注册确认密码，并在注册失败后刷新一次性 Turnstile 校验。
+
 ## 2.0.0-rc.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -9,7 +9,7 @@ import { ok, fail } from "@/types/action";
 import { ErrorCode } from "@/lib/errors";
 import type { ActionResult } from "@/types/action";
 import { actionError } from "@/lib/action-utils";
-import { MIN_PASSWORD_LENGTH } from "@/lib/config/auth-config";
+import { MIN_PASSWORD_LENGTH, isPasswordPolicySatisfied, PASSWORD_POLICY_MESSAGE } from "@/lib/config/auth-config";
 import { normalizeEmail } from "@/lib/utils/email";
 import { bootstrapConfiguredOwnerInTx } from "@/lib/auth/owner-bootstrap";
 import {
@@ -76,6 +76,7 @@ export async function loginWithPassword(
 export async function signUp(
   email: string,
   password: string,
+  confirmPassword: string,
   turnstileToken?: string,
   next?: string,
 ): Promise<ActionResult<{ email: string }>> {
@@ -84,6 +85,12 @@ export async function signUp(
   }
   if (!password || password.length < MIN_PASSWORD_LENGTH) {
     return fail({ code: ErrorCode.VALIDATION_FAILED, message: `密码至少 ${MIN_PASSWORD_LENGTH} 位` });
+  }
+  if (!isPasswordPolicySatisfied(password)) {
+    return fail({ code: ErrorCode.VALIDATION_FAILED, message: PASSWORD_POLICY_MESSAGE });
+  }
+  if (password !== confirmPassword) {
+    return fail({ code: ErrorCode.VALIDATION_FAILED, message: "两次输入的密码不一致" });
   }
   const normalizedEmail = normalizeEmail(email);
 

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -221,14 +221,15 @@ export async function sendPasswordResetEmail(email: string): Promise<ActionResul
   try {
     const supabase = createServiceClient();
     const { error } = await supabase.auth.resetPasswordForEmail(normalizedEmail, {
-      redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/reset-password`,
+      redirectTo: new URL("/reset-password", process.env.NEXT_PUBLIC_APP_URL).toString(),
     });
 
     if (error) {
-      // 不暴露邮箱是否存在（防枚举），统一返回成功提示
+      // 不暴露邮箱是否存在（防枚举），但不能把真实的发信/配置失败伪装成成功。
       if (process.env.NODE_ENV === "development") {
         console.warn("[sendPasswordResetEmail]", error.message);
       }
+      return fail({ code: ErrorCode.INTERNAL_ERROR, message: "重置邮件暂时无法发送，请稍后重试。" });
     }
     return ok(undefined);
   } catch (e) {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
 import { inArray } from "drizzle-orm";
+import { redirect } from "next/navigation";
 import { db } from "@/db/client";
 import { seasons } from "@/db/schema";
 import { checkAdminSession } from "@/lib/auth/session";
 import { Panel, Btn, StatusPill, Marker } from "@/components/rivalhub";
 
 export default async function AdminDashboardPage() {
-  const admin = (await checkAdminSession())!;
+  const admin = await checkAdminSession();
+  if (!admin) redirect("/admin/login");
 
   const allSeasons =
     admin.role === "super_admin"

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -29,6 +29,9 @@ export function ForgotPasswordForm() {
         <p className="text-xs text-[var(--color-fg-mid)]">
           请查看邮箱 {email}，点击邮件中的链接设置新密码。链接 1 小时内有效。
         </p>
+        <p className="mt-2 text-xs text-[var(--color-fg-mid)]">
+          如果几分钟内没有收到，请检查垃圾邮件或稍后重新请求。
+        </p>
       </div>
     );
   }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Field, Btn } from "@/components/rivalhub";
 import { loginWithPassword, resendSignupConfirmation, signUp } from "@/actions/auth";
 import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
+import { isPasswordPolicySatisfied, MIN_PASSWORD_LENGTH, PASSWORD_POLICY_MESSAGE } from "@/lib/config/auth-config";
 
 type Mode = "login" | "register";
 
@@ -17,7 +18,9 @@ function safeRedirect(raw: string | null): string {
 export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [turnstileToken, setTurnstileToken] = useState<string>("");
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
   const [mode, setMode] = useState<Mode>(initialMode);
   const [awaitingEmail, setAwaitingEmail] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -25,12 +28,29 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
     typeof window !== "undefined" ? window.location.search : ""
   ).get("next")));
 
+  const switchMode = (nextMode: Mode) => {
+    setMode(nextMode);
+    setConfirmPassword("");
+    setTurnstileToken("");
+    setTurnstileResetKey((key) => key + 1);
+  };
+
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
+    if (mode === "register") {
+      if (!isPasswordPolicySatisfied(password)) {
+        toast.error(PASSWORD_POLICY_MESSAGE);
+        return;
+      }
+      if (password !== confirmPassword) {
+        toast.error("两次输入的密码不一致");
+        return;
+      }
+    }
     startTransition(async () => {
       const result = mode === "login"
         ? await loginWithPassword(email, password)
-        : await signUp(email, password, turnstileToken, redirectRef.current);
+        : await signUp(email, password, confirmPassword, turnstileToken, redirectRef.current);
       if (result.success) {
         if (mode === "register") {
           setAwaitingEmail(email.trim());
@@ -38,13 +58,17 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
           window.location.href = redirectRef.current;
         }
       } else {
+        if (mode === "register") {
+          setTurnstileToken("");
+          setTurnstileResetKey((key) => key + 1);
+        }
         toast.error(result.error.message);
       }
     });
-  }, [email, password, mode, turnstileToken]);
+  }, [email, password, confirmPassword, mode, turnstileToken]);
 
   if (awaitingEmail) {
-    return <div className="space-y-4"><div className="rounded-sm border border-[var(--color-border)] p-4"><h2 className="font-semibold">验证邮件已发送</h2><p className="mt-2 break-all text-sm text-[var(--color-fg-mid)]">请打开 {awaitingEmail} 中的邮件完成验证。验证前不会登录 RivalHub。</p></div><Btn type="button" full disabled={isPending} onClick={() => startTransition(async () => { const result = await resendSignupConfirmation(awaitingEmail, redirectRef.current); if (result.success) toast.success("验证邮件已重新发送"); else toast.error(result.error.message); })}>重新发送验证邮件</Btn><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setMode("login"); }}>返回登录</button><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setMode("register"); setEmail(""); setPassword(""); }}>修改邮箱或重新注册</button></div>;
+    return <div className="space-y-4"><div className="rounded-sm border border-[var(--color-border)] p-4"><h2 className="font-semibold">验证邮件已发送</h2><p className="mt-2 break-all text-sm text-[var(--color-fg-mid)]">请打开 {awaitingEmail} 中的邮件完成验证。验证前不会登录 RivalHub。</p></div><Btn type="button" full disabled={isPending} onClick={() => startTransition(async () => { const result = await resendSignupConfirmation(awaitingEmail, redirectRef.current); if (result.success) toast.success("验证邮件已重新发送"); else toast.error(result.error.message); })}>重新发送验证邮件</Btn><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setMode("login"); }}>返回登录</button><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setMode("register"); setEmail(""); setPassword(""); setConfirmPassword(""); setTurnstileToken(""); setTurnstileResetKey((key) => key + 1); }}>修改邮箱或重新注册</button></div>;
   }
 
   return (
@@ -52,7 +76,7 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
       <div className="flex rounded-sm bg-[var(--color-panel-low)] p-0.5">
         <button
           type="button"
-          onClick={() => setMode("login")}
+          onClick={() => switchMode("login")}
           className={`flex-1 rounded-sm py-1.5 text-sm font-medium transition-colors ${
             mode === "login"
               ? "bg-[var(--color-panel)] text-[var(--color-fg)] shadow-sm"
@@ -63,7 +87,7 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
         </button>
         <button
           type="button"
-          onClick={() => setMode("register")}
+          onClick={() => switchMode("register")}
           className={`flex-1 rounded-sm py-1.5 text-sm font-medium transition-colors ${
             mode === "register"
               ? "bg-[var(--color-panel)] text-[var(--color-fg)] shadow-sm"
@@ -89,16 +113,35 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
         id="password"
         label="密码"
         type="password"
-        placeholder={mode === "register" ? "至少 6 位" : "输入密码"}
+        placeholder={mode === "register" ? "至少 6 位，含大小写/数字/特殊字符" : "输入密码"}
         value={password}
         onChange={setPassword}
         required
-        minLength={6}
+        minLength={MIN_PASSWORD_LENGTH}
+        autoComplete={mode === "register" ? "new-password" : "current-password"}
       />
+
+      {mode === "register" && (
+        <>
+          <Field
+            id="confirm-password"
+            label="确认密码"
+            type="password"
+            placeholder="再次输入密码"
+            value={confirmPassword}
+            onChange={setConfirmPassword}
+            required
+            minLength={MIN_PASSWORD_LENGTH}
+            autoComplete="new-password"
+          />
+          <p className="text-xs text-[var(--color-fg-mid)]">{PASSWORD_POLICY_MESSAGE}。</p>
+        </>
+      )}
 
       {mode === "register" && (
         <div className="flex justify-center">
           <TurnstileWidget
+            resetSignal={turnstileResetKey}
             onVerify={(token) => setTurnstileToken(token)}
             onError={() => {
               setTurnstileToken("");
@@ -118,7 +161,7 @@ export function LoginForm({ initialMode = "login" }: { initialMode?: Mode }) {
         {mode === "register" ? "已有账号？" : "首次参赛？"}
         <button
           type="button"
-          onClick={() => setMode(mode === "login" ? "register" : "login")}
+          onClick={() => switchMode(mode === "login" ? "register" : "login")}
           className="ml-0.5 underline hover:text-[var(--color-fg)]"
         >
           {mode === "register" ? "切换到登录" : "切换到注册"}

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -5,17 +5,22 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Field, Btn } from "@/components/rivalhub";
 import { createBrowserClient } from "@/lib/auth/supabase";
-import { MIN_PASSWORD_LENGTH } from "@/lib/config/auth-config";
+import { isPasswordPolicySatisfied, MIN_PASSWORD_LENGTH, PASSWORD_POLICY_MESSAGE } from "@/lib/config/auth-config";
 
 export function ResetPasswordForm() {
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      toast.error(`密码至少 ${MIN_PASSWORD_LENGTH} 位`);
+    if (!isPasswordPolicySatisfied(password)) {
+      toast.error(PASSWORD_POLICY_MESSAGE);
+      return;
+    }
+    if (password !== confirmPassword) {
+      toast.error("两次输入的密码不一致");
       return;
     }
     startTransition(async () => {
@@ -32,7 +37,9 @@ export function ResetPasswordForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <Field id="password" label="新密码" type="password" placeholder={`至少 ${MIN_PASSWORD_LENGTH} 位`} value={password} onChange={setPassword} required minLength={MIN_PASSWORD_LENGTH} />
+      <Field id="password" label="新密码" type="password" placeholder={`至少 ${MIN_PASSWORD_LENGTH} 位，含大小写/数字/特殊字符`} value={password} onChange={setPassword} required minLength={MIN_PASSWORD_LENGTH} autoComplete="new-password" />
+      <Field id="confirm-password" label="确认新密码" type="password" placeholder="再次输入密码" value={confirmPassword} onChange={setConfirmPassword} required minLength={MIN_PASSWORD_LENGTH} autoComplete="new-password" />
+      <p className="text-xs text-[var(--color-fg-mid)]">{PASSWORD_POLICY_MESSAGE}。</p>
       <Btn type="submit" full disabled={isPending}>{isPending ? "设置中…" : "设置新密码"}</Btn>
     </form>
   );

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useCallback } from "react";
 interface TurnstileWidgetProps {
   onVerify: (token: string) => void;
   onError?: () => void;
+  resetSignal?: number;
 }
 
 declare global {
@@ -15,6 +16,7 @@ declare global {
         appearance?: "always" | "execute" | "interaction-only";
         callback: (token: string) => void;
         "error-callback"?: () => void;
+        "expired-callback"?: () => void;
       }) => string;
       reset: (id?: string) => void;
     };
@@ -24,7 +26,7 @@ declare global {
 
 const TURNSTILE_SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile";
 
-export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
+export function TurnstileWidget({ onVerify, onError, resetSignal = 0 }: TurnstileWidgetProps) {
   const ref = useRef<HTMLDivElement>(null);
   const widgetId = useRef<string>("");
   const onVerifyRef = useRef(onVerify);
@@ -45,7 +47,14 @@ export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
       appearance: "interaction-only",
       callback: (token: string) => onVerifyRef.current(token),
       "error-callback": () => onErrorRef.current?.(),
+      "expired-callback": () => onVerifyRef.current(""),
     });
+  }, []);
+
+  const resetWidget = useCallback(() => {
+    if (widgetId.current && window.turnstile) {
+      window.turnstile.reset(widgetId.current);
+    }
   }, []);
 
   useEffect(() => {
@@ -73,6 +82,10 @@ export function TurnstileWidget({ onVerify, onError }: TurnstileWidgetProps) {
       window.onLoadTurnstile = originalOnLoad;
     };
   }, [renderWidget]);
+
+  useEffect(() => {
+    if (resetSignal > 0) resetWidget();
+  }, [resetSignal, resetWidget]);
 
   return <div ref={ref} />;
 }

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -1,1 +1,14 @@
 export const MIN_PASSWORD_LENGTH = 6;
+
+export const PASSWORD_POLICY_MESSAGE =
+  `密码至少 ${MIN_PASSWORD_LENGTH} 位，并包含大写字母、小写字母、数字和特殊字符`;
+
+const PASSWORD_SPECIAL_CHARACTERS = "!@#$%^&*()_+-=[]{};':\"|<>?,./`~";
+
+export function isPasswordPolicySatisfied(password: string): boolean {
+  return password.length >= MIN_PASSWORD_LENGTH
+    && /[a-z]/.test(password)
+    && /[A-Z]/.test(password)
+    && /[0-9]/.test(password)
+    && [...password].some((character) => PASSWORD_SPECIAL_CHARACTERS.includes(character));
+}

--- a/tests/unit/actions/auth.test.ts
+++ b/tests/unit/actions/auth.test.ts
@@ -145,7 +145,7 @@ function makeTxInsertChain() {
 }
 
 const SHORT_PASSWORD = "x".repeat(MIN_PASSWORD_LENGTH - 1);
-const VALID_PASSWORD = "x".repeat(MIN_PASSWORD_LENGTH);
+const VALID_PASSWORD = "Aa1!xx";
 const VALID_EMAIL = "test@example.com";
 
 const MOCK_USER_ROW = {
@@ -251,7 +251,7 @@ describe("signUp", () => {
   });
 
   it("空邮箱返回 VALIDATION_FAILED", async () => {
-    const result = await signUp("", VALID_PASSWORD);
+    const result = await signUp("", VALID_PASSWORD, VALID_PASSWORD);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
@@ -259,7 +259,7 @@ describe("signUp", () => {
   });
 
   it("不含 @ 的邮箱返回 VALIDATION_FAILED", async () => {
-    const result = await signUp("notanemail", VALID_PASSWORD);
+    const result = await signUp("notanemail", VALID_PASSWORD, VALID_PASSWORD);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
@@ -267,11 +267,31 @@ describe("signUp", () => {
   });
 
   it(`密码长度不足 ${MIN_PASSWORD_LENGTH} 位返回 VALIDATION_FAILED`, async () => {
-    const result = await signUp(VALID_EMAIL, SHORT_PASSWORD);
+    const result = await signUp(VALID_EMAIL, SHORT_PASSWORD, SHORT_PASSWORD);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
     }
+  });
+
+  it("不满足 Supabase 强密码策略时在验证码前返回明确错误", async () => {
+    const result = await signUp(VALID_EMAIL, "abcdef", "abcdef", "unused-token");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("大写字母、小写字母、数字和特殊字符");
+    }
+    expect(signUpMock).not.toHaveBeenCalled();
+  });
+
+  it("确认密码不一致时在验证码前返回错误", async () => {
+    const result = await signUp(VALID_EMAIL, VALID_PASSWORD, "Aa1!xy", "unused-token");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toBe("两次输入的密码不一致");
+    }
+    expect(signUpMock).not.toHaveBeenCalled();
   });
 
   it("Supabase signUp 失败返回 VALIDATION_FAILED（防枚举，不透传原因）", async () => {
@@ -280,7 +300,7 @@ describe("signUp", () => {
       error: { message: "already registered" },
     });
 
-    const result = await signUp(VALID_EMAIL, VALID_PASSWORD);
+    const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD);
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
@@ -304,7 +324,7 @@ describe("signUp", () => {
 
     try {
       const token = "turnstile-response-token";
-      const result = await signUp(VALID_EMAIL, VALID_PASSWORD, token);
+      const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD, token);
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -357,7 +377,7 @@ describe("signUp", () => {
     makeInsertChain([MOCK_USER_ROW]);
 
     try {
-      const result = await signUp(VALID_EMAIL, VALID_PASSWORD, "valid-token");
+      const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD, "valid-token");
 
       expect(result.success).toBe(true);
       expect(signUpMock).toHaveBeenCalledOnce();
@@ -380,7 +400,7 @@ describe("signUp", () => {
     });
     makeInsertChain([MOCK_USER_ROW]);
 
-    const result = await signUp(VALID_EMAIL, VALID_PASSWORD);
+    const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD);
 
     expect(result.success).toBe(true);
     if (result.success) {

--- a/tests/unit/actions/auth.test.ts
+++ b/tests/unit/actions/auth.test.ts
@@ -9,6 +9,7 @@ const {
   destroyUserSessionMock,
   destroyAdminSessionMock,
   signInWithPasswordMock,
+  resetPasswordForEmailMock,
   signUpMock,
   revalidatePathMock,
   normalizeEmailMock,
@@ -31,6 +32,7 @@ const {
     destroyUserSessionMock: vi.fn(),
     destroyAdminSessionMock: vi.fn(),
     signInWithPasswordMock: vi.fn(),
+    resetPasswordForEmailMock: vi.fn(),
     signUpMock: vi.fn(),
     revalidatePathMock: vi.fn(),
     normalizeEmailMock: vi.fn((email: string) => email),
@@ -56,6 +58,7 @@ vi.mock("@/lib/auth/supabase", () => ({
   createServiceClient: () => ({
     auth: {
       signInWithPassword: signInWithPasswordMock,
+      resetPasswordForEmail: resetPasswordForEmailMock,
       signUp: signUpMock,
     },
   }),
@@ -94,7 +97,7 @@ vi.mock("@/db/client", () => {
   };
 });
 
-import { loginWithPassword, signUp, logoutUser, claimInviteCode } from "@/actions/auth";
+import { loginWithPassword, signUp, sendPasswordResetEmail, logoutUser, claimInviteCode } from "@/actions/auth";
 import { MIN_PASSWORD_LENGTH } from "@/lib/config/auth-config";
 
 // ── helpers ───────────────────────────────────────────────────────────────
@@ -407,6 +410,42 @@ describe("signUp", () => {
       expect(result.data.email).toBe(VALID_EMAIL);
     }
     expect(createUserSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── sendPasswordResetEmail ───────────────────────────────────────────────
+
+describe("sendPasswordResetEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = "https://match.starfie1d.top/";
+    normalizeEmailMock.mockImplementation((e: string) => e.trim().toLowerCase());
+  });
+
+  it("成功请求使用规范化的 reset redirect URL", async () => {
+    resetPasswordForEmailMock.mockResolvedValue({ error: null });
+
+    const result = await sendPasswordResetEmail(" TEST@EXAMPLE.COM ");
+
+    expect(result.success).toBe(true);
+    expect(resetPasswordForEmailMock).toHaveBeenCalledWith("test@example.com", {
+      redirectTo: "https://match.starfie1d.top/reset-password",
+    });
+  });
+
+  it("发信服务失败时返回统一错误而不暴露邮箱是否存在", async () => {
+    resetPasswordForEmailMock.mockResolvedValue({
+      error: { message: "Email address not authorized", status: 400 },
+    });
+
+    const result = await sendPasswordResetEmail("test@example.com");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe(ErrorCode.INTERNAL_ERROR);
+      expect(result.error.message).toBe("重置邮件暂时无法发送，请稍后重试。");
+      expect(result.error.message).not.toContain("authorized");
+    }
   });
 });
 

--- a/tests/unit/app/admin-page.test.tsx
+++ b/tests/unit/app/admin-page.test.tsx
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { checkAdminSessionMock, redirectMock } = vi.hoisted(() => ({
+  checkAdminSessionMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  checkAdminSession: checkAdminSessionMock,
+}));
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+vi.mock("@/db/client", () => ({ db: { select: vi.fn() } }));
+
+import AdminDashboardPage from "@/app/admin/page";
+
+describe("admin dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redirectMock.mockImplementation((path: string) => {
+      throw new Error(`REDIRECT:${path}`);
+    });
+  });
+
+  it("redirects unauthenticated requests without reading admin.role", async () => {
+    checkAdminSessionMock.mockResolvedValue(null);
+
+    await expect(AdminDashboardPage()).rejects.toThrow("REDIRECT:/admin/login");
+    expect(redirectMock).toHaveBeenCalledWith("/admin/login");
+  });
+});

--- a/tests/unit/components/identity-flow.test.tsx
+++ b/tests/unit/components/identity-flow.test.tsx
@@ -22,6 +22,14 @@ describe("identity flow UI", () => {
     expect(screen.getByText(/注册后需要验证邮箱/)).toBeInTheDocument();
   });
 
+  it("shows the production password policy and confirmation field during signup", () => {
+    render(<LoginForm />);
+    fireEvent.click(screen.getByRole("button", { name: "注册" }));
+
+    expect(screen.getByLabelText("确认密码")).toBeInTheDocument();
+    expect(screen.getByText(/至少 6 位，并包含大写字母、小写字母、数字和特殊字符/)).toBeInTheDocument();
+  });
+
   it("shows current email and education verification states without evidence URLs", () => {
     render(<EducationVerificationPanel email="player@example.test" emailVerified={false} hasInstitutionalFastPath={false} verifications={[{ id: "1", institution: "南京大学", code: "4132010284", academicStatus: "enrolled", evidenceType: "chsi_enrollment_report", status: "rejected", reviewNote: "学校不一致", submittedAt: new Date().toISOString() }]} />);
     expect(screen.getByText("邮箱尚未验证")).toBeInTheDocument();

--- a/tests/unit/components/reset-password.test.tsx
+++ b/tests/unit/components/reset-password.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
+
+const { toastErrorMock, updateUserMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  updateUserMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: toastErrorMock, success: vi.fn() } }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/lib/auth/supabase", () => ({
+  createBrowserClient: () => ({ auth: { updateUser: updateUserMock } }),
+}));
+
+describe("ResetPasswordForm", () => {
+  beforeEach(() => {
+    vi.stubGlobal("React", React);
+    vi.clearAllMocks();
+  });
+
+  it("shows the password policy and confirmation field", () => {
+    render(<ResetPasswordForm />);
+
+    expect(screen.getByLabelText("确认新密码")).toBeInTheDocument();
+    expect(screen.getByText(/至少 6 位，并包含大写字母、小写字母、数字和特殊字符/)).toBeInTheDocument();
+  });
+
+  it("rejects a weak replacement password before calling Supabase", () => {
+    render(<ResetPasswordForm />);
+    fireEvent.change(screen.getByLabelText("新密码"), { target: { value: "abcdef" } });
+    fireEvent.change(screen.getByLabelText("确认新密码"), { target: { value: "abcdef" } });
+    fireEvent.click(screen.getByRole("button", { name: "设置新密码" }));
+
+    expect(toastErrorMock).toHaveBeenCalledWith(expect.stringContaining("大写字母、小写字母、数字和特殊字符"));
+    expect(updateUserMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/turnstile-widget.test.tsx
+++ b/tests/unit/components/turnstile-widget.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
+
+describe("TurnstileWidget", () => {
+  beforeEach(() => {
+    vi.stubGlobal("React", React);
+    vi.stubEnv("NEXT_PUBLIC_TURNSTILE_SITE_KEY", "test-site-key");
+  });
+
+  it("resets a consumed token and clears it when the challenge expires", () => {
+    const onVerify = vi.fn();
+    const renderMock = vi.fn().mockReturnValue("widget-1");
+    const resetMock = vi.fn();
+    vi.stubGlobal("turnstile", { render: renderMock, reset: resetMock });
+
+    const { rerender } = render(<TurnstileWidget onVerify={onVerify} resetSignal={0} />);
+    const options = renderMock.mock.calls[0]?.[1] as {
+      "expired-callback": () => void;
+    };
+
+    act(() => options["expired-callback"]());
+    rerender(<TurnstileWidget onVerify={onVerify} resetSignal={1} />);
+
+    expect(onVerify).toHaveBeenCalledWith("");
+    expect(resetMock).toHaveBeenCalledWith("widget-1");
+  });
+});


### PR DESCRIPTION
## Summary\n- show Supabase-compatible password policy and require confirmation on signup\n- reset one-time Turnstile state after expiry or signup failure\n- redirect unauthenticated admin dashboard requests without null access\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm type-check\n- pnpm lint\n- pnpm db:check\n- pnpm test (125 files, 851 tests)\n- pnpm build\n\nThe changeset advances the active RC line to v2.0.0-rc.2.