### PR TITLE
fix: harden 2.0 release invariants

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ RivalHub 以最高已完成的验证层级描述能力证据：
 | Rivals · Spring | 生产实战验证 | 2026 NJU Rivals 完成个人报名、审核、队长投票、选秀、循环赛、双败淘汰、比赛管理、时间协商、BP/赛果、MVP、OCR 统计与赛季结束 |
 | Major · Autumn | 自动化生命周期验证 | unit/integration、Local Supabase 和 browser fixture 覆盖队伍报名、资格、prestart、三段 Swiss、Playoffs、roster、recovery、discipline 与 post-event |
 
-**Major 正式上线门槛：**在独立 staging DB 完成一次完整运营生命周期并完成清理验证。
+**2.0 RC 正式验证策略：**自动化与 Local Supabase 集成验证完成后，进行 RC production smoke；随后以真实报名逐步验证运营流程。完整 32 队 staging lifecycle 仍可作为专项演练，但不再是稳定 RC 的强制 gate。
 
 ## Repository checks
 
@@ -56,14 +56,14 @@ Local Supabase integration
         ↓
 Playwright browser E2E
         ↓
-staging full-lifecycle acceptance
+RC production smoke
         ↓
-production smoke / real-world operation
+real registrations progressive validation
 ```
 
-每一层回答不同问题：Vitest 验证 pure rules 与 action boundary；Local Supabase 验证真实 Postgres/Auth/Storage 合作；Playwright 验证浏览器任务；staging 验证独立环境中的完整运营；production 只承载真实赛事所需 smoke 与实战事实。
+每一层回答不同问题：Vitest 验证 pure rules 与 action boundary；Local Supabase 验证真实 Postgres/Auth/Storage 合作；Playwright 验证浏览器任务；RC production 只承载最小 smoke，后续真实报名以渐进方式验证运营事实。完整 staging lifecycle 可补充验证，但不替代这些分层证据。
 
-## 2.0 staging lifecycle gate
+## 完整 staging lifecycle（专项演练，非稳定 RC 强制 gate）
 
 正式上线前，在独立 staging DB 完成一次完整 lifecycle：
 
@@ -77,7 +77,7 @@ production smoke / real-world operation
 → post-event → archive
 ```
 
-完整 destructive lifecycle 只在独立 staging DB 执行，结束后 reset staging DB。production 仅进行真实赛事所需 smoke，不承担模拟清理工作。
+完整 destructive lifecycle 只在独立 staging DB 执行，结束后 reset staging DB。它用于专项运营演练；2.0 RC 的稳定 gate 是 automated/local integration → RC production smoke → real registrations progressive validation。production 仅进行真实赛事所需 smoke，不承担模拟清理工作。
 
 本轮覆盖 canonical Rivals/Major template、custom definition fail-closed publish gate、平台赛季目录身份与冻结引用、qualification 单一 owner、empty-draft 删除/撤回 guard 与队长交接事务语义；完整 32 队 staging lifecycle acceptance 仍按上线门槛单独执行。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,7 +79,7 @@ real registrations progressive validation
 
 完整 destructive lifecycle 只在独立 staging DB 执行，结束后 reset staging DB。它用于专项运营演练；2.0 RC 的稳定 gate 是 automated/local integration → RC production smoke → real registrations progressive validation。production 仅进行真实赛事所需 smoke，不承担模拟清理工作。
 
-本轮覆盖 canonical Rivals/Major template、custom definition fail-closed publish gate、平台赛季目录身份与冻结引用、qualification 单一 owner、empty-draft 删除/撤回 guard 与队长交接事务语义；完整 32 队 staging lifecycle acceptance 仍按上线门槛单独执行。
+本轮覆盖 canonical Rivals/Major template、custom definition fail-closed publish gate、平台赛季目录身份与冻结引用、qualification 单一 owner、empty-draft 删除/撤回 guard 与队长交接事务语义；完整 staging lifecycle 仅作为专项演练，不构成 RC 上线门槛。
 
 ## Change-level validation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,7 +65,7 @@ real registrations progressive validation
 
 ## 完整 staging lifecycle（专项演练，非稳定 RC 强制 gate）
 
-正式上线前，在独立 staging DB 完成一次完整 lifecycle：
+如需进行完整 staging lifecycle，可在独立 staging DB 按以下流程专项演练：
 
 ```text
 管理员创建 Major → 发布 → 用户注册 → 邮箱确认 → participant profile

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:major-swiss:local": "pnpm run test:major-lifecycle:local",
     "test:major-roster-safety:local": "tsx scripts/db/local.ts test-major-roster-safety",
     "test:major-result-recovery:local": "tsx scripts/db/local.ts test-major-result-recovery",
+    "test:invite-concurrency:local": "tsx scripts/db/local.ts test-invite-concurrency",
     "test:discipline:local": "tsx scripts/db/local.ts test-discipline",
     "test:postevent:local": "tsx scripts/db/local.ts test-postevent",
     "test:season-governance:local": "tsx scripts/db/local.ts test-season-governance",

--- a/scripts/db/invite-concurrency-integration.ts
+++ b/scripts/db/invite-concurrency-integration.ts
@@ -1,0 +1,44 @@
+/** Local PostgreSQL canary for claimInviteCode's invite-row serialization. */
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+
+const url = process.env.RIVALHUB_LOCAL_DATABASE_URL;
+if (!url || !["localhost", "127.0.0.1", "::1", "[::1]"].includes(new URL(url).hostname)) {
+  throw new Error("邀请码并发测试只允许 Local Supabase loopback 数据库。");
+}
+
+async function main() {
+  const pool = new Pool({ connectionString: url, ssl: false, max: 4 });
+  const seasonId = randomUUID(); const inviteId = randomUUID(); const users = [randomUUID(), randomUUID()];
+  try {
+    await pool.query(`INSERT INTO seasons (id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft, stage_plan, registration_config, team_registration_config, affiliation_rules, min_team_size, max_team_size, starter_count, positions)
+      VALUES ($1, $2, 'Invite concurrency', 'Rivals', 'draft', 'solo', false, false, '[]', '{}', '{}', '[]', 5, 9, 5, ARRAY['any'])`, [seasonId, `local-invite-${seasonId}`]);
+    for (const [index, userId] of users.entries()) await pool.query(`INSERT INTO users (id, email, role) VALUES ($1, $2, 'user')`, [userId, `invite-${index}-${seasonId}@local.test`]);
+    await pool.query(`INSERT INTO admin_invites (id, code, created_by, role, season_id, max_uses, used_count, is_active) VALUES ($1, $2, 'local', 'admin', $3, 1, 0, true)`, [inviteId, `LOCAL-${inviteId}`, seasonId]);
+
+    const claim = async (userId: string) => {
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        const invite = await client.query(`SELECT * FROM admin_invites WHERE id = $1 FOR UPDATE`, [inviteId]);
+        const user = await client.query(`SELECT role FROM users WHERE id = $1 FOR UPDATE`, [userId]);
+        const row = invite.rows[0];
+        if (!row || !user.rows[0] || !row.is_active || row.used_count >= row.max_uses) { await client.query("ROLLBACK"); return false; }
+        await client.query(`UPDATE users SET role = (CASE WHEN $2 = 'super_admin' THEN 'super_admin' ELSE 'season_admin' END)::user_role, admin_season_id = array_append(admin_season_id, $3::uuid) WHERE id = $1`, [userId, user.rows[0].role, seasonId]);
+        await client.query(`UPDATE admin_invites SET used_count = used_count + 1, is_active = false WHERE id = $1`, [inviteId]);
+        await client.query("COMMIT"); return true;
+      } catch (error) { await client.query("ROLLBACK"); throw error; } finally { client.release(); }
+    };
+    const results = await Promise.all(users.map(claim));
+    const [{ used_count }] = (await pool.query<{ used_count: number }>(`SELECT used_count FROM admin_invites WHERE id = $1`, [inviteId])).rows;
+    const [{ count }] = (await pool.query<{ count: string }>(`SELECT count(*)::text AS count FROM users WHERE id = ANY($1::uuid[]) AND role = 'season_admin'`, [users])).rows;
+    if (results.filter(Boolean).length !== 1 || used_count !== 1 || Number(count) !== 1) throw new Error("maxUses=1 并发 claim 未收敛为一次成功、一次提权与 usedCount=1。");
+    console.log("Invite concurrency local integration passed.");
+  } finally {
+    await pool.query(`DELETE FROM admin_invites WHERE id = $1`, [inviteId]);
+    await pool.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [users]);
+    await pool.query(`DELETE FROM seasons WHERE id = $1`, [seasonId]);
+    await pool.end();
+  }
+}
+void main();

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -64,6 +64,9 @@ try {
     case "test-major-result-recovery":
       runLocalIntegration("scripts/db/major-result-recovery-integration.ts");
       break;
+    case "test-invite-concurrency":
+      runLocalIntegration("scripts/db/invite-concurrency-integration.ts");
+      break;
     case "test-discipline":
       runLocalIntegration("scripts/db/discipline-integration.ts");
       break;
@@ -97,7 +100,7 @@ try {
       break;
     default:
       throw new Error(
-        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-major-golden | test-major-browser | cleanup-major-browser | test-team-registration | test-major-profile | test-major-prestart | test-major-roster-safety | test-major-result-recovery | test-discipline | test-postevent | test-season-governance | bootstrap | reset | stop | studio | dev",
+        "未知命令。可用命令：start | status | migrate | seed | verify | verify-migrations | test-major-start | test-major-golden | test-major-browser | cleanup-major-browser | test-team-registration | test-major-profile | test-major-prestart | test-major-roster-safety | test-major-result-recovery | test-invite-concurrency | test-discipline | test-postevent | test-season-governance | bootstrap | reset | stop | studio | dev",
       );
   }
 } catch (error) {

--- a/scripts/db/major-roster-safety-integration.ts
+++ b/scripts/db/major-roster-safety-integration.ts
@@ -290,9 +290,15 @@ async function prepareFixture(pool: Pool, label: string): Promise<RosterSafetyFi
       }
     }
 
-    // Frozen StageRun carrying the affiliation rules accepted at launch.
+    const frozenCompetitiveFacts = allLayouts.flatMap((layout, index) =>
+      layout.frozen
+        ? [{ userId: userIds[index]!, historicalPeak: { rank: "A", rating: 1000 }, previousSeasonPeak: { rank: "A", rating: 1000 }, currentSeasonPeak: { rank: "A", rating: 1000 } }]
+        : [],
+    );
+    // Frozen StageRun carrying the affiliation rules and competitive facts
+    // accepted at launch.
     const ruleSnapshot = {
-      version: 2,
+      version: 3,
       stage: { key: "stage1", type: "swiss", teamCount: 16, matchFormat: "bo1" },
       rosterRules: { minTeamSize: capabilities.minTeamSize, maxTeamSize: capabilities.maxTeamSize, starterCount: capabilities.starterCount },
       affiliationRules: [
@@ -304,6 +310,7 @@ async function prepareFixture(pool: Pool, label: string): Promise<RosterSafetyFi
         },
       ],
       competitiveProfile: { ...COMPETITIVE_PROFILE, rankOrder: [...COMPETITIVE_PROFILE.rankOrder] },
+      frozenCompetitiveFacts,
       tournamentEntrants: [],
       tournamentSeeds: [],
     };
@@ -613,7 +620,8 @@ async function main(): Promise<void> {
       );
     }
 
-    // S12 mutable season 规则被清空后，frozen StageRun 规则仍然生效。
+    // S12 mutable season 规则被清空、live competitive profile 被篡改后，
+    // frozen StageRun 规则与竞技事实仍然生效。
     {
       const mbMatch = await createManagedMatch(pool, fixture, "r1-mb");
       const client = await pool.connect();
@@ -621,6 +629,12 @@ async function main(): Promise<void> {
         // Simulate a legitimate operator mutating the mutable season config.
         await client.query(
           `UPDATE seasons SET affiliation_rules = '[]'::json WHERE id = $1`,
+          [seasonId],
+        );
+        await client.query(
+          `UPDATE competitive_rank_facts SET rank = 'live-mutated' WHERE user_id IN (
+            SELECT user_id FROM team_members WHERE season_id = $1
+          )`,
           [seasonId],
         );
         // A lineup that only satisfies the mutated season row must still be
@@ -634,6 +648,12 @@ async function main(): Promise<void> {
           "S12 mutable 规则清空后冻结规则应继续生效",
         );
         assertCondition(failure.message.includes("南京大学"), "S12 必须按冻结快照给出 NJU shortfall 文案");
+
+        const frozenFactsMatch = await createManagedMatch(pool, fixture, "r1-frozen-facts");
+        await submitLineupProductionLogic(database, {
+          matchId: frozenFactsMatch, teamId: teamAId, source: "participant", submittedBy: null,
+          starterIds: lineupA.starters, substituteIds: [],
+        });
       } finally {
         client.release();
       }

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -258,9 +258,11 @@ export async function claimInviteCode(code: string): Promise<ActionResult<{ role
 
   try {
     const result = await db.transaction(async (tx) => {
-      const invite = await tx.query.adminInvites.findFirst({
-        where: eq(adminInvites.code, code.trim()),
-      });
+      const [invite] = await tx
+        .select()
+        .from(adminInvites)
+        .where(eq(adminInvites.code, code.trim()))
+        .for("update");
 
       if (!invite) {
         return fail({ code: ErrorCode.UNAUTHORIZED, message: "邀请码无效" });

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -263,9 +263,17 @@ export async function claimInviteCode(code: string): Promise<ActionResult<{ role
         .from(adminInvites)
         .where(eq(adminInvites.code, code.trim()))
         .for("update");
+      const [currentUser] = await tx
+        .select()
+        .from(users)
+        .where(eq(users.id, session.userId))
+        .for("update");
 
       if (!invite) {
         return fail({ code: ErrorCode.UNAUTHORIZED, message: "邀请码无效" });
+      }
+      if (!currentUser) {
+        return fail({ code: ErrorCode.UNAUTHORIZED, message: "账号不存在，请重新登录后重试" });
       }
       if (!invite.isActive) {
         return fail({ code: ErrorCode.UNAUTHORIZED, message: "邀请码已失效" });
@@ -282,7 +290,7 @@ export async function claimInviteCode(code: string): Promise<ActionResult<{ role
 
       const targetRole = invite.role === "super_admin" ? "super_admin" : "season_admin";
       // 已有 super_admin 的用户不会被降级
-      const newRole = session.role === "super_admin" ? "super_admin" : targetRole;
+      const newRole = currentUser.role === "super_admin" ? "super_admin" : targetRole;
       const updateSet: {
         role: "user" | "season_admin" | "super_admin";
         updatedAt: Date;

--- a/src/actions/captains.ts
+++ b/src/actions/captains.ts
@@ -43,9 +43,10 @@ export async function castVote(
   try {
     const session = await requireAuth();
     const voteId = await db.transaction(async (tx) => {
-      const voter = await tx.query.seasonRegistrations.findFirst({
-        where: eq(seasonRegistrations.id, parsed.data.voterRegistrationId),
-      });
+      // Serialize count + insert per voter; without this row lock, two tabs
+      // can both observe two votes and exceed the three-vote cap.
+      const [voter] = await tx.select().from(seasonRegistrations)
+        .where(eq(seasonRegistrations.id, parsed.data.voterRegistrationId)).for("update");
       const candidate = await tx.query.seasonRegistrations.findFirst({
         where: eq(seasonRegistrations.id, parsed.data.candidateRegistrationId),
       });

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -17,6 +17,7 @@ import { getMaxMaps, getWinThreshold, isMatchStatus } from "@/types/match";
 import { actionError, getSeasonOrThrow, getMatchOrThrow } from "@/lib/action-utils";
 import {
   applyMatchStatusTransitionInTx,
+  lockMatchInTx,
 } from "@/lib/match-rosters/service";
 import { maybeFinishSeason } from "@/actions/transitions";
 import { revalidateMatchPaths, revalidateSeasonPaths } from "@/lib/revalidation";
@@ -129,19 +130,18 @@ export async function recordMatchResult(
     }
     assertMatchTransition(match.status, "finished");
 
-    const hasVeto = await db.query.matchVetoSteps.findFirst({
-      where: eq(matchVetoSteps.matchId, matchId),
-      columns: { id: true },
-    });
-    if (!hasVeto) {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入比分");
-    }
-
     const season = await getSeasonOrThrow(match.seasonId);
 
     // 事务保护：score 更新 + bracket 推进 + audit 原子化
     await db.transaction(async (tx) => {
-      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
+      const locked = await lockMatchInTx(tx, matchId);
+      if (!isMatchStatus(locked.status)) throw new AppError(ErrorCode.INTERNAL_ERROR, `无效的比赛状态: ${locked.status}`);
+      assertMatchTransition(locked.status, "finished");
+      validateSeriesScore(locked.format, scoreA, scoreB);
+      const hasVeto = await tx.query.matchVetoSteps.findFirst({ where: eq(matchVetoSteps.matchId, matchId), columns: { id: true } });
+      if (!hasVeto) throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入比分");
+      const [lockedSeason] = await tx.select().from(seasons).where(eq(seasons.id, locked.seasonId)).for("update");
+      if (!lockedSeason) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
       await tx
         .update(matches)
         .set({
@@ -154,12 +154,12 @@ export async function recordMatchResult(
         .where(eq(matches.id, matchId));
 
       // 推进 bracket（若 bracket 已初始化）
-      if (season.bracketData && match.bracketNodeId) {
+      if (lockedSeason.bracketData && locked.bracketNodeId) {
         const { updatedData, newResolvedMatches } = await bracketAdvance(
-          match.bracketNodeId,
+          locked.bracketNodeId,
           scoreA,
           scoreB,
-          season.bracketData as Database
+          lockedSeason.bracketData as Database
         );
 
         await tx
@@ -170,14 +170,14 @@ export async function recordMatchResult(
         await insertResolvedBracketMatches(
           tx, match.seasonId, match.stage,
           updatedData as Database, newResolvedMatches,
-          normalizeStagePlan(season.stagePlan),
+          normalizeStagePlan(lockedSeason.stagePlan),
         );
       }
 
       await maybeFinishSeason(tx, match.seasonId);
 
       await tx.insert(auditLogs).values({
-        seasonId: match.seasonId,
+        seasonId: locked.seasonId,
         action: "match.record_result",
         actorId: session.email,
         targetId: matchId,
@@ -220,14 +220,6 @@ export async function recordMapResult(
       throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛状态不允许录入地图结果");
     }
 
-    const hasVeto = await db.query.matchVetoSteps.findFirst({
-      where: eq(matchVetoSteps.matchId, matchId),
-      columns: { id: true },
-    });
-    if (!hasVeto) {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入地图结果");
-    }
-
     const season = await getSeasonOrThrow(match.seasonId);
     const mapPool = normalizeRegistrationConfig(season.registrationConfig).mapPool;
     if (!mapPool.includes(mapName)) {
@@ -244,7 +236,16 @@ export async function recordMapResult(
     let seriesFinished = false;
 
     await db.transaction(async (tx) => {
-      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
+      const locked = await lockMatchInTx(tx, matchId);
+      if (locked.status !== "in_progress") throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "比赛状态不允许录入地图结果");
+      const hasVeto = await tx.query.matchVetoSteps.findFirst({ where: eq(matchVetoSteps.matchId, matchId), columns: { id: true } });
+      if (!hasVeto) throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入地图结果");
+      const [lockedSeason] = await tx.select().from(seasons).where(eq(seasons.id, locked.seasonId)).for("update");
+      if (!lockedSeason) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+      const lockedPool = normalizeRegistrationConfig(lockedSeason.registrationConfig).mapPool;
+      if (!lockedPool.includes(mapName)) throw new AppError(ErrorCode.MATCH_MAP_INVALID, "地图不在当前赛季图池中");
+      const lockedMaxMaps = getMaxMaps(locked.format);
+      if (mapOrder < 1 || mapOrder > lockedMaxMaps) throw new AppError(ErrorCode.VALIDATION_FAILED, `${locked.format.toUpperCase()} 图序号须在 1-${lockedMaxMaps} 之间`);
       // 事务内读快照
       const existingMaps = await tx.query.matchMaps.findMany({
         where: eq(matchMaps.matchId, matchId),
@@ -254,7 +255,7 @@ export async function recordMapResult(
         throw new AppError(ErrorCode.VALIDATION_FAILED, `地图 ${mapName} 已录入比分`);
       }
 
-      const seriesScore = computeSeriesScoreAfterMap(match.format, existingMaps, scoreA, scoreB);
+      const seriesScore = computeSeriesScoreAfterMap(locked.format, existingMaps, scoreA, scoreB);
       const { mapWinsA, mapWinsB } = seriesScore;
       seriesFinished = seriesScore.seriesFinished;
 
@@ -295,18 +296,18 @@ export async function recordMapResult(
           updatedAt: new Date(),
         }).where(eq(matches.id, matchId));
 
-        if (season.bracketData && match.bracketNodeId) {
+        if (lockedSeason.bracketData && locked.bracketNodeId) {
           const { updatedData, newResolvedMatches } = await bracketAdvance(
-            match.bracketNodeId,
+            locked.bracketNodeId,
             mapWinsA,
             mapWinsB,
-            season.bracketData as Database
+            lockedSeason.bracketData as Database
           );
           await tx.update(seasons).set({ bracketData: updatedData as Database, updatedAt: new Date() }).where(eq(seasons.id, match.seasonId));
           await insertResolvedBracketMatches(
             tx, match.seasonId, match.stage,
             updatedData as Database, newResolvedMatches,
-            normalizeStagePlan(season.stagePlan),
+            normalizeStagePlan(lockedSeason.stagePlan),
           );
         }
 
@@ -314,7 +315,7 @@ export async function recordMapResult(
       }
 
       await tx.insert(auditLogs).values({
-        seasonId: match.seasonId,
+        seasonId: locked.seasonId,
         action: "match.record_map_result",
         actorId: session.email,
         targetId: matchId,

--- a/src/actions/matches/schedule.ts
+++ b/src/actions/matches/schedule.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, and, count, asc } from "drizzle-orm";
+import { eq, and, count, asc, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matches, teams, auditLogs } from "@/db/schema";
+import { matches, teams, auditLogs, seasons } from "@/db/schema";
 import { ok, fail } from "@/types/action";
 import type { ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
@@ -27,60 +27,27 @@ export async function generateSchedule(
 ): Promise<ActionResult<{ matchCount: number }>> {
   try {
     const session = await requireSeasonAdmin(seasonId);
-    const season = await getSeasonOrThrow(seasonId);
-
-    if (season.status !== "playing") {
-      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有在赛季进行中才能生成赛程");
-    }
-
-    const [{ value: existingCount }] = await db
-      .select({ value: count() })
-      .from(matches)
-      .where(eq(matches.seasonId, seasonId));
-
-    if (existingCount > 0) {
-      throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "赛程已生成，不可重复生成");
-    }
-
-    // 按 draft_order ASC 取队伍（决定 participantId 顺序）
-    const seasonTeams = await db.query.teams.findMany({
-      where: eq(teams.seasonId, seasonId),
-      orderBy: [asc(teams.draftOrder)],
+    const outcome = await db.transaction(async (tx) => {
+      // Executors still own their writes; this transaction-level advisory lock
+      // serializes all generic schedule requests without coupling them to a
+      // second adapter or allowing two callers to pass the empty-match check.
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`schedule:${seasonId}`}))`);
+      const [season] = await tx.select().from(seasons).where(eq(seasons.id, seasonId));
+      if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+      if (season.status !== "playing") throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "只有在赛季进行中才能生成赛程");
+      const [{ value: existingCount }] = await tx.select({ value: count() }).from(matches).where(eq(matches.seasonId, seasonId));
+      if (existingCount > 0) throw new AppError(ErrorCode.SEASON_INVALID_STATUS, "赛程已生成，不可重复生成");
+      const seasonTeams = await tx.query.teams.findMany({ where: eq(teams.seasonId, seasonId), orderBy: [asc(teams.draftOrder)] });
+      if (seasonTeams.length < 2) throw new AppError(ErrorCode.VALIDATION_FAILED, "队伍数量不足，无法生成赛程");
+      const firstStage = getFirstStage(normalizeStagePlan(season.stagePlan));
+      if (!firstStage) throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季没有可生成的赛程阶段");
+      const stageTeams = firstStage.seeds?.length ? seasonTeams.filter((_, i) => firstStage.seeds!.includes(i + 1)) : seasonTeams.slice(0, firstStage.teamCount);
+      const { matchCount } = await getExecutor(firstStage.type).initialize(seasonId, firstStage, stageTeams);
+      await tx.insert(auditLogs).values({ seasonId, action: "match.generate_schedule", actorId: session.email, targetId: seasonId, targetType: "season", meta: { matchCount, stageKey: firstStage.key } });
+      return { matchCount, slug: season.slug };
     });
-
-    if (seasonTeams.length < 2) {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "队伍数量不足，无法生成赛程");
-    }
-
-    const stagePlan = normalizeStagePlan(season.stagePlan);
-    const firstStage = getFirstStage(stagePlan);
-    if (!firstStage) {
-      throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "该赛季没有可生成的赛程阶段");
-    }
-    // 首阶段参赛队伍：有 seeds 时按 seed 筛选，否则取 top teamCount（draft_order 即种子序）
-    const stageTeams = firstStage.seeds && firstStage.seeds.length > 0
-      ? seasonTeams.filter((_, i) => firstStage.seeds!.includes(i + 1))
-      : seasonTeams.slice(0, firstStage.teamCount);
-
-    const { matchCount } = await getExecutor(firstStage.type).initialize(
-      seasonId,
-      firstStage,
-      stageTeams,
-    );
-
-    // Audit
-    await db.insert(auditLogs).values({
-      seasonId,
-      action: "match.generate_schedule",
-      actorId: session.email,
-      targetId: seasonId,
-      targetType: "season",
-      meta: { matchCount, stageKey: firstStage.key },
-    });
-
-    revalidateSeasonPaths(season.slug, ["matches", "adminMatches"]);
-
-    return ok({ matchCount });
+    revalidateSeasonPaths(outcome.slug, ["matches", "adminMatches"]);
+    return ok({ matchCount: outcome.matchCount });
   } catch (e) {
     return actionError("generateSchedule", e);
   }

--- a/src/actions/matches/scheduling.ts
+++ b/src/actions/matches/scheduling.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, and, isNotNull, isNull, lte } from "drizzle-orm";
+import { eq, and, or, isNotNull, isNull, lte } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matchTimeProposals, matches, auditLogs, seasons } from "@/db/schema";
+import { matchTimeProposals, matches, auditLogs, seasons, teams } from "@/db/schema";
 import { ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
@@ -17,6 +17,7 @@ import {
   getTimeBufferHoursForStage,
 } from "@/lib/matches/time-rules";
 import { getTeamIdForCaptain } from "./_shared";
+import { lockMatchInTx } from "@/lib/match-rosters/service";
 
 const PROPOSAL_AUTO_ACCEPT_HOURS = 24;
 
@@ -89,33 +90,24 @@ export async function respondToTimeProposal(
 ): Promise<ActionResult<void>> {
   try {
     const session = await requireAuth();
-
-    const proposal = await db.query.matchTimeProposals.findFirst({
-      where: eq(matchTimeProposals.id, proposalId),
-    });
-    if (!proposal) {
-      throw new AppError(ErrorCode.NOT_FOUND, "提议不存在");
-    }
-    if (proposal.status !== "pending") {
-      throw new AppError(ErrorCode.VALIDATION_FAILED, "提议已失效");
-    }
-
-    const match = await getMatchOrThrow(proposal.matchId);
-    const season = await getSeasonOrThrow(match.seasonId);
-    const bufferHours = getTimeBufferHoursForStage(season.stagePlan, match.stage);
-    assertBeforeTimeConfirmationCutoff(match.completionDeadline, bufferHours);
-    if (action === "accept") {
-      assertProposedTimeFitsDeadline(proposal.proposedTime, match.completionDeadline);
-    }
-
-    if (proposal.proposedBy === session.userId) {
-      throw new AppError(ErrorCode.FORBIDDEN, "不能回应自己的提议");
-    }
-    if (!(await getTeamIdForCaptain(session.userId, match))) {
-      throw new AppError(ErrorCode.FORBIDDEN, "只有对方队长可以回应");
-    }
-
-    await db.transaction(async (tx) => {
+    const outcome = await db.transaction(async (tx) => {
+      const [proposal] = await tx.select().from(matchTimeProposals)
+        .where(eq(matchTimeProposals.id, proposalId)).for("update");
+      if (!proposal) throw new AppError(ErrorCode.NOT_FOUND, "提议不存在");
+      if (proposal.status !== "pending") throw new AppError(ErrorCode.VALIDATION_FAILED, "提议已失效");
+      const match = await lockMatchInTx(tx, proposal.matchId);
+      const [season] = await tx.select().from(seasons).where(eq(seasons.id, match.seasonId));
+      if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
+      const bufferHours = getTimeBufferHoursForStage(season.stagePlan, match.stage);
+      assertBeforeTimeConfirmationCutoff(match.completionDeadline, bufferHours);
+      if (action === "accept") assertProposedTimeFitsDeadline(proposal.proposedTime, match.completionDeadline);
+      if (proposal.proposedBy === session.userId) throw new AppError(ErrorCode.FORBIDDEN, "不能回应自己的提议");
+      const [captain] = await tx.select({ id: teams.id }).from(teams).where(and(
+        eq(teams.captainUserId, session.userId),
+        eq(teams.seasonId, match.seasonId),
+        or(eq(teams.id, match.teamAId), eq(teams.id, match.teamBId)),
+      ));
+      if (!captain) throw new AppError(ErrorCode.FORBIDDEN, "只有对方队长可以回应");
       const updates: Record<string, unknown> = {
         status: action === "accept" ? "accepted" : "rejected",
         responseAt: new Date(),
@@ -149,18 +141,19 @@ export async function respondToTimeProposal(
             ),
           );
       }
+      return { seasonSlug: season.slug, matchId: match.id, seasonId: match.seasonId };
     });
 
     await db.insert(auditLogs).values({
-      seasonId: match.seasonId,
+      seasonId: outcome.seasonId,
       action: "match.respond_time_proposal",
       actorId: session.userId,
       targetId: proposalId,
       targetType: "match_time_proposal",
-      meta: { matchId: match.id, action, rejectReason: rejectReason ?? null },
+      meta: { matchId: outcome.matchId, action, rejectReason: rejectReason ?? null },
     });
 
-    revalidateMatchPaths(season.slug, proposal.matchId);
+    revalidateMatchPaths(outcome.seasonSlug, outcome.matchId);
 
     return ok(undefined);
   } catch (e) {

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -10,6 +10,38 @@ import { getMatchOrThrow, getSeasonOrThrow, actionError } from "@/lib/action-uti
 import { revalidateMatchPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig } from "@/types/season";
 import type { VetoActionType } from "@/types/match";
+import { lockMatchInTx } from "@/lib/match-rosters/service";
+
+function assertVetoSequence(
+  format: "bo1" | "bo3" | "bo5",
+  steps: readonly VetoStepInput[],
+  teamAId: string,
+  teamBId: string,
+): void {
+  const expected: Record<typeof format, readonly VetoActionType[]> = {
+    bo1: ["ban", "ban", "ban", "ban", "ban", "ban", "decider"],
+    bo3: ["ban", "ban", "pick", "pick", "ban", "ban", "decider"],
+    bo5: ["ban", "ban", "pick", "pick", "pick", "pick", "decider"],
+  };
+  if (steps.length !== expected[format].length || steps.some((step, index) => step.actionType !== expected[format][index])) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, `${format.toUpperCase()} BP 步骤顺序不合法`);
+  }
+  if (steps.some((step) => step.teamId !== null && step.teamId !== teamAId && step.teamId !== teamBId)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "BP 操作队伍必须是本场任一参赛队");
+  }
+  if (format === "bo1") {
+    const expectedTeams = [teamAId, teamAId, teamBId, teamBId, teamBId, teamAId, teamBId];
+    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO1 BP 操作顺序不合法");
+  }
+  if (format === "bo3") {
+    const expectedTeams = [teamAId, teamBId, teamAId, teamBId, teamBId, teamAId, null];
+    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO3 BP 操作顺序不合法");
+  }
+  if (format === "bo5") {
+    const expectedTeams = [teamAId, teamAId, teamBId, teamAId, teamBId, teamAId, null];
+    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO5 BP 操作顺序不合法");
+  }
+}
 
 function resolveTeamASide(selectedSide: string, selectingTeamId: string | null, teamAId: string): "t" | "ct" | null {
   if (!selectedSide || !selectingTeamId) return null;
@@ -70,6 +102,12 @@ export async function saveVetoSteps(
     );
 
     await db.transaction(async (tx) => {
+      const locked = await lockMatchInTx(tx, matchId);
+      const allowedLockedStatuses = ["scheduled", "in_progress", "finished"] as const;
+      if (!(allowedLockedStatuses as readonly string[]).includes(locked.status)) {
+        throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "当前比赛状态不允许录入 BP");
+      }
+      assertVetoSequence(locked.format, steps, locked.teamAId, locked.teamBId);
       // 清除旧 BP 记录（支持重复录入）
       await tx.delete(matchVetoSteps).where(eq(matchVetoSteps.matchId, matchId));
 
@@ -87,7 +125,7 @@ export async function saveVetoSteps(
 
       // 比赛已结束时：仅在无 match_maps 记录时重建（供赛后 OCR 使用），
       // 有记录（含已录入比分的行）时跳过，保护历史数据。
-      if (match.status === "finished") {
+      if (locked.status === "finished") {
         const existingMaps = await tx.query.matchMaps.findMany({
           where: eq(matchMaps.matchId, matchId),
         });
@@ -101,9 +139,9 @@ export async function saveVetoSteps(
               teamAStartSide: resolveTeamASide(
                 s.side ?? "",
                 s.actionType === "pick"
-                  ? (s.teamId === match.teamAId ? match.teamBId : match.teamAId)
+                  ? (s.teamId === locked.teamAId ? locked.teamBId : locked.teamAId)
                   : s.teamId,
-                match.teamAId,
+                locked.teamAId,
               ),
             })),
           );
@@ -130,9 +168,9 @@ export async function saveVetoSteps(
               teamAStartSide: resolveTeamASide(
                 s.side ?? "",
                 s.actionType === "pick"
-                  ? (s.teamId === match.teamAId ? match.teamBId : match.teamAId)
+                  ? (s.teamId === locked.teamAId ? locked.teamBId : locked.teamAId)
                   : s.teamId,
-                match.teamAId,
+                locked.teamAId,
               ),
             })),
           );
@@ -140,12 +178,12 @@ export async function saveVetoSteps(
       }
 
       await tx.insert(auditLogs).values({
-        seasonId: match.seasonId,
+        seasonId: locked.seasonId,
         action: "match.save_veto",
         actorId: auditActorId(session),
         targetId: matchId,
         targetType: "match",
-        meta: { format: match.format, stepCount: steps.length, postMatch: match.status === "finished" },
+        meta: { format: locked.format, stepCount: steps.length, postMatch: locked.status === "finished" },
       });
     });
 

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -11,37 +11,7 @@ import { revalidateMatchPaths } from "@/lib/revalidation";
 import { normalizeRegistrationConfig } from "@/types/season";
 import type { VetoActionType } from "@/types/match";
 import { lockMatchInTx } from "@/lib/match-rosters/service";
-
-function assertVetoSequence(
-  format: "bo1" | "bo3" | "bo5",
-  steps: readonly VetoStepInput[],
-  teamAId: string,
-  teamBId: string,
-): void {
-  const expected: Record<typeof format, readonly VetoActionType[]> = {
-    bo1: ["ban", "ban", "ban", "ban", "ban", "ban", "decider"],
-    bo3: ["ban", "ban", "pick", "pick", "ban", "ban", "decider"],
-    bo5: ["ban", "ban", "pick", "pick", "pick", "pick", "decider"],
-  };
-  if (steps.length !== expected[format].length || steps.some((step, index) => step.actionType !== expected[format][index])) {
-    throw new AppError(ErrorCode.VALIDATION_FAILED, `${format.toUpperCase()} BP 步骤顺序不合法`);
-  }
-  if (steps.some((step) => step.teamId !== null && step.teamId !== teamAId && step.teamId !== teamBId)) {
-    throw new AppError(ErrorCode.VALIDATION_FAILED, "BP 操作队伍必须是本场任一参赛队");
-  }
-  if (format === "bo1") {
-    const expectedTeams = [teamAId, teamAId, teamBId, teamBId, teamBId, teamAId, teamBId];
-    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO1 BP 操作顺序不合法");
-  }
-  if (format === "bo3") {
-    const expectedTeams = [teamAId, teamBId, teamAId, teamBId, teamBId, teamAId, null];
-    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO3 BP 操作顺序不合法");
-  }
-  if (format === "bo5") {
-    const expectedTeams = [teamAId, teamAId, teamBId, teamAId, teamBId, teamAId, null];
-    if (steps.some((step, index) => step.teamId !== expectedTeams[index])) throw new AppError(ErrorCode.VALIDATION_FAILED, "BO5 BP 操作顺序不合法");
-  }
-}
+import { assertVetoSequence } from "@/lib/matches/veto-sequence";
 
 function resolveTeamASide(selectedSide: string, selectingTeamId: string | null, teamAId: string): "t" | "ct" | null {
   if (!selectedSide || !selectingTeamId) return null;

--- a/src/actions/player-stats.ts
+++ b/src/actions/player-stats.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import { eq, desc, sql, inArray } from "drizzle-orm";
+import { and, eq, desc, sql, inArray, isNotNull } from "drizzle-orm";
 import { db } from "@/db/client";
 import { matchMaps } from "@/db/schema/match-maps";
 import { matches } from "@/db/schema/matches";
 import { matchPlayerStats } from "@/db/schema/player-stats";
 import { matchMvpVotes } from "@/db/schema/mvp-votes";
+import { matchRosters, matchRosterPlayers } from "@/db/schema/match-rosters";
 import { auditLogs } from "@/db/schema/audit";
 import { users } from "@/db/schema/users";
 import { teamMembers } from "@/db/schema/teams";
@@ -15,7 +16,7 @@ import { actionError } from "@/lib/action-utils";
 import { MVP_DEADLINE_MS } from "@/lib/utils/date";
 import { extractScoreboardFromBase64 } from "@/lib/ocr";
 import type { PlayerRowOCR } from "@/lib/ocr";
-import { requireAdmin, auditActorId, requireAuth } from "@/lib/auth/session";
+import { requireSeasonAdmin, auditActorId, requireAuth } from "@/lib/auth/session";
 import { revalidatePath } from "next/cache";
 import { isStatOutOfRange } from "@/lib/config/stat-ranges";
 
@@ -41,8 +42,6 @@ export async function extractStatsFromScreenshot(
 ) {
   const { mapId, base64Image, mimeType } = input;
   try {
-    await requireAdmin();
-
     const map = await db.query.matchMaps.findFirst({
       where: eq(matchMaps.id, mapId),
     });
@@ -52,6 +51,7 @@ export async function extractStatsFromScreenshot(
       where: eq(matches.id, map.matchId),
     });
     if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛记录不存在");
+    await requireSeasonAdmin(match.seasonId);
 
     // 仅查询本场比赛两队队员（用于昵称匹配 + 下拉选择）
     const teamMemberRows = await db
@@ -113,9 +113,6 @@ export async function savePlayerStats(
 ) {
   const stats = input.rows;
   try {
-    const session = await requireAdmin();
-    const actor = auditActorId(session);
-
     const map = await db.query.matchMaps.findFirst({
       where: eq(matchMaps.id, mapId),
     });
@@ -125,6 +122,8 @@ export async function savePlayerStats(
       where: eq(matches.id, map.matchId),
     });
     if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛记录不存在");
+    const session = await requireSeasonAdmin(match.seasonId);
+    const actor = auditActorId(session);
 
     const violations: string[] = [];
     for (const s of stats) {
@@ -212,11 +211,11 @@ export async function getPlayerStatsByMap(mapId: string) {
  */
 export async function getMatchPlayerOptions(mapId: string): Promise<PlayerOption[]> {
   try {
-    await requireAdmin();
     const map = await db.query.matchMaps.findFirst({ where: eq(matchMaps.id, mapId) });
     if (!map) return [];
     const match = await db.query.matches.findFirst({ where: eq(matches.id, map.matchId) });
     if (!match) return [];
+    await requireSeasonAdmin(match.seasonId);
 
     const teamMemberRows = await db
       .select({ userId: teamMembers.userId })
@@ -242,8 +241,7 @@ export async function getMatchPlayerOptions(mapId: string): Promise<PlayerOption
 
 export async function castMatchMvpVote(
   matchId: string,
-  playerUserId: string | null,
-  playerName: string,
+  playerUserId: string,
 ) {
   try {
     const session = await requireAuth();
@@ -285,10 +283,40 @@ export async function castMatchMvpVote(
       }
     }
 
+    const confirmedCandidates = await db
+      .select({ userId: users.id, playerName: users.perfectName })
+      .from(matchRosters)
+      .innerJoin(matchRosterPlayers, eq(matchRosterPlayers.rosterId, matchRosters.id))
+      .innerJoin(teamMembers, eq(teamMembers.id, matchRosterPlayers.teamMemberId))
+      .innerJoin(users, eq(users.id, teamMembers.userId))
+      .where(and(
+        eq(matchRosters.matchId, matchId),
+        eq(matchRosters.status, "confirmed"),
+        eq(matchRosterPlayers.isStarter, true),
+      ));
+    // Confirmed match roster is the sole normal-path candidate owner. Older
+    // Rivals records predate it, so only then derive compatible candidates
+    // from verified match stats.
+    const candidates = confirmedCandidates.length > 0
+      ? confirmedCandidates
+      : await db
+          .select({ userId: users.id, playerName: users.perfectName })
+          .from(matchPlayerStats)
+          .innerJoin(users, eq(users.id, matchPlayerStats.userId))
+          .where(and(
+            eq(matchPlayerStats.matchId, matchId),
+            isNotNull(matchPlayerStats.userId),
+            isNotNull(matchPlayerStats.verifiedAt),
+          ));
+    const selected = candidates.find((candidate) => candidate.userId === playerUserId);
+    if (!selected) {
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "该选手不在本场可投票名单中" });
+    }
+
     await db.insert(matchMvpVotes).values({
       matchId,
-      playerUserId: playerUserId ?? undefined,
-      playerName,
+      playerUserId: selected.userId,
+      playerName: selected.playerName ?? "未填写昵称",
       voterUserId: session.userId,
     });
 
@@ -336,11 +364,11 @@ export async function ensureMvpWinner(matchId: string): Promise<string | null> {
  */
 export async function deletePlayerStatsByMap(mapId: string): Promise<ActionResult<void>> {
   try {
-    const session = await requireAdmin();
     const map = await db.query.matchMaps.findFirst({ where: eq(matchMaps.id, mapId) });
     if (!map) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
     const match = await db.query.matches.findFirst({ where: eq(matches.id, map.matchId) });
     if (!match) throw new AppError(ErrorCode.NOT_FOUND, "比赛记录不存在");
+    const session = await requireSeasonAdmin(match.seasonId);
 
     await db.transaction(async (tx) => {
       await tx.delete(matchPlayerStats).where(eq(matchPlayerStats.mapId, mapId));

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -15,6 +15,7 @@ import { getRegistrationWindowState } from "@/lib/registration/window";
 import { normalizeEmail } from "@/lib/utils/email";
 import { compactUndefined } from "@/lib/utils/object";
 import { getSteamAvatar } from "@/lib/steam";
+import { assertUsersNotBlockedInTx } from "@/lib/discipline/service";
 
 const draftSchema = z.object({
   seasonId: z.string().uuid("赛季 ID 格式不正确"),
@@ -219,6 +220,12 @@ export async function submitRegistration(input: RegistrationFormData) {
         message: "账号数据异常，请重新登录后再报名",
       });
     }
+    await assertUsersNotBlockedInTx(db, {
+      seasonId: season.id,
+      userLabels: new Map([[user.id, user.email]]),
+      effect: "registration_block",
+      message: "当前账号处于报名禁赛期",
+    });
 
     const existing = await db.query.seasonRegistrations.findFirst({
       where: and(

--- a/src/components/admin/StagePlanEditor.tsx
+++ b/src/components/admin/StagePlanEditor.tsx
@@ -112,7 +112,14 @@ export function StagePlanEditor({ value, onChange }: StagePlanEditorProps) {
               <Label>赛制类型</Label>
               <Select
                 value={stage.type}
-                onValueChange={(v) => onChange(updateStage(value, index, { type: v as StageType }))}
+                onValueChange={(v) => {
+                  const type = v as StageType;
+                  onChange(updateStage(value, index, {
+                    type,
+                    groupCount: type === "round_robin" ? 1 : undefined,
+                    matchFormat: type === "round_robin" ? "bo1" : type === "double_elim" ? "bo3" : stage.matchFormat,
+                  }));
+                }}
               >
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
@@ -141,7 +148,7 @@ export function StagePlanEditor({ value, onChange }: StagePlanEditorProps) {
               >
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {MATCH_FORMATS.map((f) => (
+                  {(stage.type === "round_robin" ? ["bo1"] : stage.type === "double_elim" ? ["bo3"] : MATCH_FORMATS).map((f) => (
                     <SelectItem key={f} value={f}>{f.toUpperCase()}</SelectItem>
                   ))}
                 </SelectContent>
@@ -183,13 +190,8 @@ export function StagePlanEditor({ value, onChange }: StagePlanEditorProps) {
           {/* Dynamic fields by type */}
           {stage.type === "round_robin" && (
             <div>
-              <Label>分组数</Label>
-              <Input
-                type="number" min={1} max={16}
-                className="w-24"
-                value={stage.groupCount ?? 1}
-                onChange={(e) => onChange(updateStage(value, index, { groupCount: Number(e.target.value) }))}
-              />
+              <Label>分组</Label>
+              <p className="text-sm text-[var(--color-fg-mid)]">当前执行器只支持单组循环赛（BO1）。</p>
             </div>
           )}
 

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -63,9 +63,9 @@ export function MatchMvpVote({
   }, [deadline, votingClosed]);
 
   async function handleVote(playerUserId: string | null, playerName: string) {
-    if (votedName || votingClosed) return;
+    if (!playerUserId || votedName || votingClosed) return;
     startTransition(async () => {
-      const result = await castMatchMvpVote(matchId, playerUserId, playerName);
+      const result = await castMatchMvpVote(matchId, playerUserId);
       if (result.success) {
         setVotedName(playerName);
         setOptimisticVotes((prev) =>
@@ -191,7 +191,7 @@ export function MatchMvpVote({
           return (
             <button
               key={c.perfectName}
-              disabled={!!votedName || isPending}
+              disabled={!c.userId || !!votedName || isPending}
               onClick={() => handleVote(c.userId, c.perfectName)}
               className={[
                 cardStyle(isVoted, !!votedName),

--- a/src/components/matches/VetoInputDialog.tsx
+++ b/src/components/matches/VetoInputDialog.tsx
@@ -101,7 +101,7 @@ function buildTemplate(
         { actionType: "decider", mapName: "", teamId: teamBId, side: null },
       ];
     case "bo3":
-      // A ban, B ban, A pick, B pick, B ban, A ban → decider (leftover)
+      // A ban, B ban, A pick, B pick, B ban, A ban → decider (B picks side)
       return [
         { actionType: "ban", mapName: "", teamId: teamAId, side: null },
         { actionType: "ban", mapName: "", teamId: teamBId, side: null },
@@ -109,18 +109,18 @@ function buildTemplate(
         { actionType: "pick", mapName: "", teamId: teamBId, side: null },
         { actionType: "ban", mapName: "", teamId: teamBId, side: null },
         { actionType: "ban", mapName: "", teamId: teamAId, side: null },
-        { actionType: "decider", mapName: "", teamId: null, side: null },
+        { actionType: "decider", mapName: "", teamId: teamBId, side: null },
       ];
     case "bo5":
-      // A ban×2 → B pick, A pick, B pick, A pick → decider (knife round)
+      // A ban, B ban → A/B/A/B pick → decider (B picks side)
       return [
+        { actionType: "ban", mapName: "", teamId: teamBId, side: null },
         { actionType: "ban", mapName: "", teamId: teamAId, side: null },
-        { actionType: "ban", mapName: "", teamId: teamAId, side: null },
-        { actionType: "pick", mapName: "", teamId: teamBId, side: null },
         { actionType: "pick", mapName: "", teamId: teamAId, side: null },
         { actionType: "pick", mapName: "", teamId: teamBId, side: null },
         { actionType: "pick", mapName: "", teamId: teamAId, side: null },
-        { actionType: "decider", mapName: "", teamId: null, side: null },
+        { actionType: "pick", mapName: "", teamId: teamBId, side: null },
+        { actionType: "decider", mapName: "", teamId: teamBId, side: null },
       ];
   }
 }

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,6 +1,9 @@
 import { getIronSession } from "iron-session";
 import { cookies } from "next/headers";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
+import { db } from "@/db/client";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
 
 // ─── Root 管理员 Session（保留，仅用于紧急登录）───────────────────────────
 
@@ -145,8 +148,9 @@ export async function requireAuth(): Promise<UserSession> {
 /** 任意管理员（season_admin / super_admin / root）。否则抛 UNAUTHORIZED */
 export async function requireAdmin(): Promise<UserSession> {
   const userSession = await getUserSession();
-  if (userSession && userSession.role !== "user") {
-    return userSession;
+  if (userSession) {
+    const current = await loadCurrentPrivileges(userSession);
+    if (current.role !== "user") return current;
   }
 
   // fallback：root 紧急登录
@@ -166,8 +170,9 @@ export async function requireAdmin(): Promise<UserSession> {
 /** super_admin 或 root。否则抛 UNAUTHORIZED */
 export async function requireSuperAdmin(): Promise<UserSession> {
   const userSession = await getUserSession();
-  if (userSession && userSession.role === "super_admin") {
-    return userSession;
+  if (userSession) {
+    const current = await loadCurrentPrivileges(userSession);
+    if (current.role === "super_admin") return current;
   }
 
   const adminSession = await getAdminSession();
@@ -187,12 +192,13 @@ export async function requireSuperAdmin(): Promise<UserSession> {
 export async function requireSeasonAdmin(seasonId: string): Promise<UserSession> {
   const userSession = await getUserSession();
   if (userSession) {
-    if (userSession.role === "super_admin") return userSession;
+    const current = await loadCurrentPrivileges(userSession);
+    if (current.role === "super_admin") return current;
     if (
-      userSession.role === "season_admin" &&
-      userSession.adminSeasonIds.includes(seasonId)
+      current.role === "season_admin" &&
+      current.adminSeasonIds.includes(seasonId)
     ) {
-      return userSession;
+      return current;
     }
   }
 
@@ -207,6 +213,26 @@ export async function requireSeasonAdmin(seasonId: string): Promise<UserSession>
   }
 
   throw new AppError(ErrorCode.UNAUTHORIZED, ERROR_MESSAGES.UNAUTHORIZED);
+}
+
+/**
+ * A 30-day user session identifies the caller, but never authorizes a
+ * privileged operation by itself. Role and season scope are read from the
+ * current users row so revocation takes effect on the next request.
+ */
+async function loadCurrentPrivileges(session: UserSession): Promise<UserSession> {
+  const current = await db.query.users.findFirst({
+    where: eq(users.id, session.userId),
+    columns: { role: true, adminSeasonIds: true },
+  });
+  if (!current) {
+    throw new AppError(ErrorCode.UNAUTHORIZED, ERROR_MESSAGES.UNAUTHORIZED);
+  }
+  return {
+    ...session,
+    role: current.role,
+    adminSeasonIds: current.adminSeasonIds ?? [],
+  };
 }
 
 export interface ActorIdentity {

--- a/src/lib/competition/definition.ts
+++ b/src/lib/competition/definition.ts
@@ -24,7 +24,11 @@ export function validateCompetitionDefinition(capabilities: Pick<SeasonCapabilit
     if (stage.teamCount < 2) issues.push({ path: "stagePlan", message: `${stage.name || "比赛阶段"} 至少需要两支队伍。` });
     if (!stage.matchFormat) issues.push({ path: "stagePlan", message: `${stage.name || "比赛阶段"} 需要设置比赛赛制。` });
     if (stage.advanceTiers.some((tier) => tier.count > stage.teamCount)) issues.push({ path: "stagePlan", message: `${stage.name || "比赛阶段"} 的晋级人数不能超过参赛队伍数。` });
-    if (stage.type === "round_robin" && (!stage.groupCount || stage.teamCount % stage.groupCount !== 0)) issues.push({ path: "stagePlan", message: `${stage.name || "循环赛阶段"} 的队伍数必须能被分组数整除。` });
+    if (stage.type === "round_robin") {
+      if (stage.groupCount !== undefined && stage.groupCount !== 1) issues.push({ path: "stagePlan", message: `${stage.name || "循环赛阶段"} 当前只支持单组运行。` });
+      if (stage.matchFormat !== "bo1") issues.push({ path: "stagePlan", message: `${stage.name || "循环赛阶段"} 当前只支持 BO1。` });
+    }
+    if (stage.type === "double_elim" && stage.matchFormat !== "bo3") issues.push({ path: "stagePlan", message: `${stage.name || "双败淘汰阶段"} 当前只支持 BO3 主赛；总决赛可单独覆写。` });
     if ((stage.type === "single_elim" || stage.type === "double_elim") && (stage.teamCount & (stage.teamCount - 1)) !== 0) issues.push({ path: "stagePlan", message: `${stage.name || "淘汰赛阶段"} 的队伍数必须是 2 的幂。` });
   }
   for (let index = 1; index < stagePlan.length; index++) {

--- a/src/lib/major/start.ts
+++ b/src/lib/major/start.ts
@@ -11,6 +11,7 @@ import {
   majorTournamentSeeds,
   matches,
   seasons,
+  competitiveRankFacts,
 } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { buildMajorOpeningPlan } from "@/lib/major/opening";
@@ -156,10 +157,36 @@ export async function startMajorInTransaction(
   const now = new Date();
   const openingPlan = buildMajorOpeningPlan({ teams: seeds, stageOneMatchFormat: stage.matchFormat });
   const entrantByTeamId = new Map(entrantRows.map((entrant) => [entrant.teamId, entrant]));
+  const competitiveProfile = capabilities.teamRegistrationConfig.requireCompetitiveProfile
+    ? capabilities.teamRegistrationConfig.competitiveProfile ?? null
+    : null;
+  const frozenParticipantIds = [...new Set(rosterRows.map((row) => row.userId))];
+  const competitiveRows = competitiveProfile && frozenParticipantIds.length > 0
+    ? await tx.select().from(competitiveRankFacts).where(and(
+        eq(competitiveRankFacts.platform, competitiveProfile.platform),
+        inArray(competitiveRankFacts.userId, frozenParticipantIds),
+      ))
+    : [];
+  const frozenCompetitiveFacts = frozenParticipantIds.map((userId) => {
+    const facts = competitiveRows.filter((fact) => fact.userId === userId);
+    const serialize = (fact: typeof competitiveRows[number] | undefined) => fact
+      ? { rank: fact.rank, rating: Number(fact.rating) }
+      : null;
+    return {
+      userId,
+      historicalPeak: serialize(facts.find((fact) => fact.kind === "historical_peak" && fact.platformSeasonKey === null)),
+      previousSeasonPeak: competitiveProfile
+        ? serialize(facts.find((fact) => fact.kind === "season_peak" && fact.platformSeasonKey === competitiveProfile.previousSeasonKey))
+        : null,
+      currentSeasonPeak: competitiveProfile
+        ? serialize(facts.find((fact) => fact.kind === "season_peak" && fact.platformSeasonKey === competitiveProfile.currentSeasonKey))
+        : null,
+    };
+  });
   const ruleSnapshot = {
     // StageRun is the immutable tournament rule owner. Match-roster (G1)
     // must consume this frozen value rather than seasons.affiliationRules.
-    version: 2,
+    version: 3,
     stagePlan: capabilities.stagePlan.map((configuredStage) => ({
       key: configuredStage.key,
       name: configuredStage.name,
@@ -188,9 +215,10 @@ export async function startMajorInTransaction(
       starterCount: season.starterCount,
     },
     affiliationRules: freezeAffiliationRules(capabilities.affiliationRules),
-    competitiveProfile: capabilities.teamRegistrationConfig.requireCompetitiveProfile
-      ? capabilities.teamRegistrationConfig.competitiveProfile ?? null
-      : null,
+    competitiveProfile,
+    // Immutable participant-level historical / previous / current values.
+    // Match lineup validation must never consult mutable rank facts again.
+    frozenCompetitiveFacts,
     tournamentEntrants: openingPlan.tournamentTeams.map((team) => {
       const entrant = entrantByTeamId.get(team.teamId);
       if (!entrant) throw new AppError(ErrorCode.INTERNAL_ERROR, "赛事种子缺少已锁定的正式参赛队。");

--- a/src/lib/match-rosters/service.ts
+++ b/src/lib/match-rosters/service.ts
@@ -1,8 +1,7 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { TxDb } from "@/db/client";
 import {
   auditLogs,
-  competitiveRankFacts,
   educationVerifications,
   institutions,
   majorPrestartEntrants,
@@ -37,6 +36,7 @@ export interface TeamLineupContext {
   frozenRosterUserIds: ReadonlySet<string> | null;
   memberFacts: Map<string, LineupMemberFact>;
   competitiveProfile: CompetitiveProfileConfig | null;
+  frozenCompetitiveFacts: Map<string, PlayerStrengthInput> | null;
 }
 
 function frozenCompetitiveProfile(ruleSnapshot: unknown): CompetitiveProfileConfig | null {
@@ -47,6 +47,27 @@ function frozenCompetitiveProfile(ruleSnapshot: unknown): CompetitiveProfileConf
   const profile = candidate as Partial<CompetitiveProfileConfig>;
   if (typeof profile.platform !== "string" || typeof profile.currentSeasonKey !== "string" || typeof profile.previousSeasonKey !== "string" || !Array.isArray(profile.rankOrder)) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结的竞技档案规则不可用。");
   return { platform: profile.platform, currentSeasonKey: profile.currentSeasonKey, previousSeasonKey: profile.previousSeasonKey, rankOrder: profile.rankOrder.filter((rank): rank is string => typeof rank === "string") };
+}
+
+function frozenCompetitiveFacts(ruleSnapshot: unknown): Map<string, PlayerStrengthInput> {
+  if (!ruleSnapshot || typeof ruleSnapshot !== "object") throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少冻结竞技事实。");
+  const rows = (ruleSnapshot as { frozenCompetitiveFacts?: unknown }).frozenCompetitiveFacts;
+  if (!Array.isArray(rows)) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 缺少冻结竞技事实。");
+  const result = new Map<string, PlayerStrengthInput>();
+  for (const row of rows) {
+    if (!row || typeof row !== "object") throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结竞技事实不可用。");
+    const value = row as { userId?: unknown; historicalPeak?: unknown; previousSeasonPeak?: unknown; currentSeasonPeak?: unknown };
+    if (typeof value.userId !== "string" || !value.userId) throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结竞技事实不可用。");
+    const rank = (fact: unknown) => {
+      if (fact === null) return null;
+      if (!fact || typeof fact !== "object") throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结竞技事实不可用。");
+      const candidate = fact as { rank?: unknown; rating?: unknown };
+      if (typeof candidate.rank !== "string" || typeof candidate.rating !== "number") throw new AppError(ErrorCode.INTERNAL_ERROR, "StageRun 冻结竞技事实不可用。");
+      return { rank: candidate.rank, rating: candidate.rating };
+    };
+    result.set(value.userId, { userId: value.userId, label: value.userId, historicalPeak: rank(value.historicalPeak), previousSeasonPeak: rank(value.previousSeasonPeak), currentSeasonPeak: rank(value.currentSeasonPeak) });
+  }
+  return result;
 }
 
 /** Row-lock the match so status transitions and roster mutations serialize. */
@@ -137,6 +158,7 @@ export async function loadTeamLineupContextInTx(
   let frozenRosterUserIds: ReadonlySet<string> | null = null;
   let verificationsByUser: Map<string, LineupMemberFact["verification"]> | null = null;
   let competitiveProfile: CompetitiveProfileConfig | null = null;
+  let frozenCompetitiveFactsByUser: Map<string, PlayerStrengthInput> | null = null;
 
   if (match.ownership === "major_stage") {
     if (!match.majorStageRunId) {
@@ -152,6 +174,7 @@ export async function loadTeamLineupContextInTx(
     // Frozen at StageRun creation; never read from mutable season configuration.
     rules = frozenStageRunAffiliationRules(stageRun.ruleSnapshot);
     competitiveProfile = frozenCompetitiveProfile(stageRun.ruleSnapshot);
+    frozenCompetitiveFactsByUser = competitiveProfile ? frozenCompetitiveFacts(stageRun.ruleSnapshot) : null;
     const frozen = await loadFrozenRosterUserIdsInTx(tx, match.seasonId, teamId);
     frozenRosterUserIds = frozen.ids;
     verificationsByUser = frozen.verificationsByUser;
@@ -180,7 +203,7 @@ export async function loadTeamLineupContextInTx(
     });
   }
 
-  return { rules, frozenRosterUserIds, memberFacts, competitiveProfile };
+  return { rules, frozenRosterUserIds, memberFacts, competitiveProfile, frozenCompetitiveFacts: frozenCompetitiveFactsByUser };
 }
 
 export async function assertStartingLineupAllowedInTx(
@@ -214,17 +237,12 @@ export async function getStartingLineupPreflightInTx(
   const blockers = [...result.blockers];
   if (context.competitiveProfile) {
     const starterFacts = args.starterIds.map((id) => context.memberFacts.get(id)).filter((item): item is LineupMemberFact => Boolean(item));
-    const userIds = starterFacts.map((item) => item.userId);
-    const facts = userIds.length === 0 ? [] : await tx.select().from(competitiveRankFacts).where(and(eq(competitiveRankFacts.platform, context.competitiveProfile.platform), inArray(competitiveRankFacts.userId, userIds)));
     const players = starterFacts.map((member) => {
-      const forUser = facts.filter((fact) => fact.userId === member.userId);
-      const strength: PlayerStrengthInput = {
-        userId: member.userId,
-        label: member.userId,
-        historicalPeak: (() => { const fact = forUser.find((item) => item.kind === "historical_peak" && item.platformSeasonKey === null); return fact ? { rank: fact.rank, rating: Number(fact.rating) } : null; })(),
-        previousSeasonPeak: (() => { const fact = forUser.find((item) => item.kind === "season_peak" && item.platformSeasonKey === context.competitiveProfile!.previousSeasonKey); return fact ? { rank: fact.rank, rating: Number(fact.rating) } : null; })(),
-        currentSeasonPeak: (() => { const fact = forUser.find((item) => item.kind === "season_peak" && item.platformSeasonKey === context.competitiveProfile!.currentSeasonKey); return fact ? { rank: fact.rank, rating: Number(fact.rating) } : null; })(),
-      };
+      const strength = context.frozenCompetitiveFacts?.get(member.userId);
+      if (!strength) {
+        blockers.push(`首发 ${member.userId} 缺少本届冻结的竞技档案。`);
+        return { userId: member.userId, label: member.userId, historicalPeak: null, previousSeasonPeak: null, currentSeasonPeak: null, isHome: false };
+      }
       const required = getPlayerStrengthBreakdown(strength, context.competitiveProfile!);
       if (!required.available) blockers.push(`首发 ${member.userId} 的竞技档案不可确认：${required.blockers.join(" ")}`);
       const verification = member.verification;

--- a/src/lib/matches/veto-sequence.ts
+++ b/src/lib/matches/veto-sequence.ts
@@ -1,0 +1,35 @@
+import { AppError, ErrorCode } from "@/lib/errors";
+import type { VetoActionType } from "@/types/match";
+
+export interface VetoSequenceStep {
+  actionType: VetoActionType;
+  teamId: string | null;
+}
+
+export function assertVetoSequence(
+  format: "bo1" | "bo3" | "bo5",
+  steps: readonly VetoSequenceStep[],
+  teamAId: string,
+  teamBId: string,
+): void {
+  const expected: Record<typeof format, readonly VetoActionType[]> = {
+    bo1: ["ban", "ban", "ban", "ban", "ban", "ban", "decider"],
+    bo3: ["ban", "ban", "pick", "pick", "ban", "ban", "decider"],
+    bo5: ["ban", "ban", "pick", "pick", "pick", "pick", "decider"],
+  };
+  if (steps.length !== expected[format].length || steps.some((step, index) => step.actionType !== expected[format][index])) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, `${format.toUpperCase()} BP 步骤顺序不合法`);
+  }
+  if (steps.some((step) => step.teamId !== null && step.teamId !== teamAId && step.teamId !== teamBId)) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, "BP 操作队伍必须是本场任一参赛队");
+  }
+
+  const expectedTeams: Record<typeof format, readonly string[]> = {
+    bo1: [teamAId, teamAId, teamBId, teamBId, teamBId, teamAId, teamBId],
+    bo3: [teamAId, teamBId, teamAId, teamBId, teamBId, teamAId, teamBId],
+    bo5: [teamAId, teamBId, teamAId, teamBId, teamAId, teamBId, teamBId],
+  };
+  if (steps.some((step, index) => step.teamId !== expectedTeams[format][index])) {
+    throw new AppError(ErrorCode.VALIDATION_FAILED, `${format.toUpperCase()} BP 操作顺序不合法`);
+  }
+}

--- a/tests/unit/actions/auth.test.ts
+++ b/tests/unit/actions/auth.test.ts
@@ -505,14 +505,15 @@ describe("claimInviteCode", () => {
     );
   });
 
-  function mockLockedInvite(invite: unknown) {
-    txSelectMock.mockReturnValue({
+  function mockLockedInvite(invite: unknown, currentUser: unknown = { role: "user" }) {
+    const locked = (row: unknown) => ({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          for: vi.fn().mockResolvedValue(invite ? [invite] : []),
+          for: vi.fn().mockResolvedValue(row ? [row] : []),
         }),
       }),
     });
+    txSelectMock.mockReturnValueOnce(locked(invite)).mockReturnValueOnce(locked(currentUser));
   }
 
   it("空邀请码返回 VALIDATION_FAILED", async () => {
@@ -586,5 +587,17 @@ describe("claimInviteCode", () => {
 
     // 校验 createUserSession 以新 role 被调用
     expect(createUserSessionMock).toHaveBeenCalled();
+  });
+
+  it("stale super_admin session cannot retain super-admin after DB revocation", async () => {
+    requireAuthMock.mockResolvedValue({ ...MOCK_SESSION, role: "super_admin" });
+    mockLockedInvite(VALID_INVITE, { role: "user" });
+    makeTxUpdateChain();
+    makeTxInsertChain();
+
+    const result = await claimInviteCode("VALID123");
+
+    expect(result).toMatchObject({ success: true, data: { role: "season_admin" } });
+    expect(updateSetCalls[0]).toMatchObject({ role: "season_admin" });
   });
 });

--- a/tests/unit/actions/auth.test.ts
+++ b/tests/unit/actions/auth.test.ts
@@ -16,7 +16,7 @@ const {
   // db mocks
   dbInsertMock,
   dbTransactionMock,
-  inviteFindFirstMock,
+  txSelectMock,
   txUpdateMock,
   txInsertMock,
   updateSetCalls,
@@ -38,7 +38,7 @@ const {
     normalizeEmailMock: vi.fn((email: string) => email),
     dbInsertMock: vi.fn(),
     dbTransactionMock: vi.fn(),
-    inviteFindFirstMock: vi.fn(),
+    txSelectMock: vi.fn(),
     txUpdateMock: vi.fn(),
     txInsertMock: vi.fn(),
     updateSetCalls,
@@ -81,8 +81,9 @@ vi.mock("@/db/client", () => {
   // tx 对象复用，每次 transaction 调用都会执行回调并传入 tx
   const tx = {
     query: {
-      adminInvites: { findFirst: inviteFindFirstMock },
+      adminInvites: { findFirst: vi.fn() },
     },
+    select: txSelectMock,
     update: txUpdateMock,
     insert: txInsertMock,
   };
@@ -496,12 +497,23 @@ describe("claimInviteCode", () => {
     // 默认让 transaction 正常执行回调
     dbTransactionMock.mockImplementation((callback: (tx: unknown) => unknown) =>
       callback({
-        query: { adminInvites: { findFirst: inviteFindFirstMock } },
+        query: { adminInvites: { findFirst: vi.fn() }, },
+        select: txSelectMock,
         update: txUpdateMock,
         insert: txInsertMock,
       })
     );
   });
+
+  function mockLockedInvite(invite: unknown) {
+    txSelectMock.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          for: vi.fn().mockResolvedValue(invite ? [invite] : []),
+        }),
+      }),
+    });
+  }
 
   it("空邀请码返回 VALIDATION_FAILED", async () => {
     const result = await claimInviteCode("   ");
@@ -512,7 +524,7 @@ describe("claimInviteCode", () => {
   });
 
   it("邀请码不存在返回 UNAUTHORIZED", async () => {
-    inviteFindFirstMock.mockResolvedValue(null);
+    mockLockedInvite(null);
 
     const result = await claimInviteCode("NONEXISTENT");
     expect(result.success).toBe(false);
@@ -522,7 +534,7 @@ describe("claimInviteCode", () => {
   });
 
   it("isActive=false 的邀请码返回 UNAUTHORIZED（已失效）", async () => {
-    inviteFindFirstMock.mockResolvedValue({ ...VALID_INVITE, isActive: false });
+    mockLockedInvite({ ...VALID_INVITE, isActive: false });
 
     const result = await claimInviteCode("VALID123");
     expect(result.success).toBe(false);
@@ -533,7 +545,7 @@ describe("claimInviteCode", () => {
   });
 
   it("usedCount >= maxUses 返回 UNAUTHORIZED（已用完）", async () => {
-    inviteFindFirstMock.mockResolvedValue({
+    mockLockedInvite({
       ...VALID_INVITE,
       usedCount: 5,
       maxUses: 5,
@@ -548,7 +560,7 @@ describe("claimInviteCode", () => {
   });
 
   it("正常使用邀请码：更新 role + 更新 invite usedCount + 写 audit_log", async () => {
-    inviteFindFirstMock.mockResolvedValue(VALID_INVITE);
+    mockLockedInvite(VALID_INVITE);
     makeTxUpdateChain();
     makeTxInsertChain();
 

--- a/tests/unit/actions/captains.test.ts
+++ b/tests/unit/actions/captains.test.ts
@@ -127,19 +127,25 @@ const CAST_INPUT = {
   candidateRegistrationId: CANDIDATE_REG_ID,
 };
 
-// ── 工具：mock tx.query.seasonRegistrations.findFirst 连续两次（voter/candidate）
+// ── 工具：voter 必须经 FOR UPDATE 读取，candidate 保持普通读取 ───────────────
 function mockTxVoterCandidate(
   voter: typeof VOTER_REG | null,
   candidate: typeof CANDIDATE_REG | null,
 ) {
-  txRegFindFirstMock
-    .mockResolvedValueOnce(voter)
-    .mockResolvedValueOnce(candidate);
+  txSelectMock.mockReset();
+  txSelectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        for: vi.fn().mockResolvedValue(voter ? [voter] : []),
+      }),
+    }),
+  });
+  txRegFindFirstMock.mockResolvedValueOnce(candidate);
 }
 
 // ── 工具：mock tx.select count ───────────────────────────────────────────────
 function mockTxSelectCount(n: number) {
-  txSelectMock.mockReturnValue({
+  txSelectMock.mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockResolvedValue([{ count: n }]),
     }),
@@ -175,6 +181,12 @@ function mockRevalidatePaths() {
 describe("castVote()", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    txRegFindFirstMock.mockReset();
+    txSeasonFindFirstMock.mockReset();
+    txCaptainVoteFindFirstMock.mockReset();
+    txSelectMock.mockReset();
+    txInsertMock.mockReset();
+    txDeleteMock.mockReset();
     resetAuditTracking(insertValuesCalls);
     requireAuthMock.mockResolvedValue(SESSION);
     validateCaptainVoteMock.mockReturnValue(null); // 默认：无错误
@@ -249,6 +261,12 @@ describe("retractVote()", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    txRegFindFirstMock.mockReset();
+    txSeasonFindFirstMock.mockReset();
+    txCaptainVoteFindFirstMock.mockReset();
+    txSelectMock.mockReset();
+    txInsertMock.mockReset();
+    txDeleteMock.mockReset();
     resetAuditTracking(insertValuesCalls);
     requireAuthMock.mockResolvedValue(SESSION);
   });

--- a/tests/unit/actions/matches-veto.test.ts
+++ b/tests/unit/actions/matches-veto.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { assertVetoSequence, type VetoSequenceStep } from "@/lib/matches/veto-sequence";
+
+const TEAM_A = "team-a";
+const TEAM_B = "team-b";
+
+function steps(types: VetoSequenceStep["actionType"][], teams: Array<string | null>): VetoSequenceStep[] {
+  return types.map((actionType, index) => ({ actionType, teamId: teams[index]!, mapName: `map-${index + 1}`, side: index === types.length - 1 ? "ct" : null }));
+}
+
+describe("assertVetoSequence", () => {
+  it("accepts the complete BO1 sequence with Team B choosing the decider side", () => {
+    expect(() => assertVetoSequence("bo1", steps(["ban", "ban", "ban", "ban", "ban", "ban", "decider"], [TEAM_A, TEAM_A, TEAM_B, TEAM_B, TEAM_B, TEAM_A, TEAM_B]), TEAM_A, TEAM_B)).not.toThrow();
+  });
+
+  it("accepts the complete BO3 sequence with Team B choosing Map 3's side", () => {
+    expect(() => assertVetoSequence("bo3", steps(["ban", "ban", "pick", "pick", "ban", "ban", "decider"], [TEAM_A, TEAM_B, TEAM_A, TEAM_B, TEAM_B, TEAM_A, TEAM_B]), TEAM_A, TEAM_B)).not.toThrow();
+  });
+
+  it("accepts the complete BO5 sequence with Team B choosing Map 5's side", () => {
+    expect(() => assertVetoSequence("bo5", steps(["ban", "ban", "pick", "pick", "pick", "pick", "decider"], [TEAM_A, TEAM_B, TEAM_A, TEAM_B, TEAM_A, TEAM_B, TEAM_B]), TEAM_A, TEAM_B)).not.toThrow();
+  });
+});

--- a/tests/unit/actions/register.test.ts
+++ b/tests/unit/actions/register.test.ts
@@ -23,6 +23,7 @@ const {
   buildRegistrationSchemaMock,
   getSteamAvatarMock,
   revalidatePathMock,
+  assertUsersNotBlockedInTxMock,
 } = vi.hoisted(() => {
   const insertValuesCalls: unknown[] = [];
   return {
@@ -40,6 +41,7 @@ const {
     buildRegistrationSchemaMock: vi.fn(),
     getSteamAvatarMock: vi.fn(),
     revalidatePathMock: vi.fn(),
+    assertUsersNotBlockedInTxMock: vi.fn(),
   };
 });
 
@@ -85,6 +87,10 @@ vi.mock("@/lib/utils/object", () => ({
 
 vi.mock("@/lib/steam", () => ({
   getSteamAvatar: getSteamAvatarMock,
+}));
+
+vi.mock("@/lib/discipline/service", () => ({
+  assertUsersNotBlockedInTx: assertUsersNotBlockedInTxMock,
 }));
 
 vi.mock("next/cache", () => ({
@@ -185,6 +191,7 @@ describe("submitRegistration()", () => {
     vi.clearAllMocks();
     resetAuditTracking(insertValuesCalls);
     getSteamAvatarMock.mockResolvedValue(null);
+    assertUsersNotBlockedInTxMock.mockResolvedValue(undefined);
   });
 
   it("seedSchema 校验失败（缺少 seasonId）返回 fieldErrors", async () => {

--- a/tests/unit/competition/definition.test.ts
+++ b/tests/unit/competition/definition.test.ts
@@ -37,13 +37,12 @@ describe("custom competition definition validation", () => {
     expect(issues.some((issue) => issue.message.includes("自定义赛事当前支持循环赛、单败淘汰和双败淘汰"))).toBe(true);
   });
 
-  it("computes grouped round-robin qualification as tier.count × groupCount", () => {
-    // 4 groups × 4 teams; top 2 of each group advance → 8 into elimination.
+  it("refuses grouped round-robin because the executor only runs one group", () => {
     const issues = validateCompetitionDefinition(capabilities([
       { ...baseStage, teamCount: 16, groupCount: 4, advanceTiers: [{ placement: "*", count: 2 }] },
       { ...baseStage, key: "elim", name: "淘汰赛", type: "single_elim", teamCount: 8, advanceTiers: [{ placement: "1st", count: 1 }], matchFormat: "bo3" },
     ]));
-    expect(issues).toEqual([]);
+    expect(issues.some((issue) => issue.message.includes("只支持单组"))).toBe(true);
   });
 
   it("multiplies only by the explicit groupCount (undefined counts as a single group)", () => {
@@ -69,11 +68,20 @@ describe("custom competition definition validation", () => {
     expect(issues.some((issue) => issue.message.includes("2 的幂"))).toBe(true);
   });
 
-  it("accepts a fully valid grouped round-robin into elimination definition", () => {
+  it("accepts a single-group BO1 round-robin into elimination definition", () => {
     const issues = validateCompetitionDefinition(capabilities([
-      { ...baseStage, teamCount: 8, groupCount: 2, advanceTiers: [{ placement: "*", count: 2 }] },
+      { ...baseStage, teamCount: 8, groupCount: 1, advanceTiers: [{ placement: "*", count: 4 }] },
       { ...baseStage, key: "elim", name: "淘汰赛", type: "double_elim", teamCount: 4, advanceTiers: [{ placement: "1st", count: 1 }], matchFormat: "bo3", finalFormat: "bo5" },
     ]));
     expect(issues).toEqual([]);
+  });
+
+  it("refuses unsupported round-robin and double-elim primary formats", () => {
+    const issues = validateCompetitionDefinition(capabilities([
+      { ...baseStage, matchFormat: "bo3" },
+      { ...baseStage, key: "elim", name: "淘汰赛", type: "double_elim", teamCount: 4, advanceTiers: [{ placement: "1st", count: 1 }], matchFormat: "bo1" },
+    ]));
+    expect(issues.map((issue) => issue.message).join(" ")).toContain("BO1");
+    expect(issues.map((issue) => issue.message).join(" ")).toContain("BO3");
   });
 });

--- a/tests/unit/lib/auth-session.test.ts
+++ b/tests/unit/lib/auth-session.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCode } from "@/lib/errors";
 
-const { cookiesMock, getIronSessionMock } = vi.hoisted(() => ({
+const { cookiesMock, getIronSessionMock, userFindFirstMock } = vi.hoisted(() => ({
   cookiesMock: vi.fn(),
   getIronSessionMock: vi.fn(),
+  userFindFirstMock: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({ cookies: cookiesMock }));
 vi.mock("iron-session", () => ({ getIronSession: getIronSessionMock }));
+vi.mock("@/db/client", () => ({
+  db: { query: { users: { findFirst: userFindFirstMock } } },
+}));
 
 import {
   auditActorId,
@@ -40,6 +44,7 @@ describe("auth session guards", () => {
     process.env.ADMIN_SESSION_SECRET = "local-test-session-secret-that-is-long-enough";
     vi.clearAllMocks();
     cookiesMock.mockResolvedValue({});
+    userFindFirstMock.mockResolvedValue({ role: "user", adminSeasonIds: [] });
   });
 
   it("reads valid user data, rejects partial data, and persists a user session", async () => {
@@ -79,6 +84,7 @@ describe("auth session guards", () => {
   it("allows regular admin, falls back to root, and fails closed otherwise", async () => {
     const seasonAdmin = { ...user, role: "season_admin" as const, adminSeasonIds: ["season-1"] };
     getIronSessionMock.mockResolvedValueOnce(session(seasonAdmin));
+    userFindFirstMock.mockResolvedValueOnce({ role: "season_admin", adminSeasonIds: ["season-1"] });
     await expect(requireAdmin()).resolves.toEqual(seasonAdmin);
 
     getIronSessionMock
@@ -92,15 +98,26 @@ describe("auth session guards", () => {
 
   it("enforces super-admin and season scopes without elevating ordinary users", async () => {
     getIronSessionMock.mockResolvedValueOnce(session({ ...user, role: "super_admin" }));
+    userFindFirstMock.mockResolvedValueOnce({ role: "super_admin", adminSeasonIds: [] });
     await expect(requireSuperAdmin()).resolves.toMatchObject({ role: "super_admin" });
 
     getIronSessionMock.mockResolvedValueOnce(session(user)).mockResolvedValueOnce(session());
     await expect(requireSuperAdmin()).rejects.toMatchObject({ code: ErrorCode.UNAUTHORIZED });
 
     getIronSessionMock.mockResolvedValueOnce(session({ ...user, role: "season_admin", adminSeasonIds: ["season-1"] }));
+    userFindFirstMock.mockResolvedValueOnce({ role: "season_admin", adminSeasonIds: ["season-1"] });
     await expect(requireSeasonAdmin("season-1")).resolves.toMatchObject({ role: "season_admin" });
 
     getIronSessionMock.mockResolvedValueOnce(session({ ...user, role: "season_admin", adminSeasonIds: ["other-season"] })).mockResolvedValueOnce(session());
+    userFindFirstMock.mockResolvedValueOnce({ role: "season_admin", adminSeasonIds: ["other-season"] });
+    await expect(requireSeasonAdmin("season-1")).rejects.toMatchObject({ code: ErrorCode.UNAUTHORIZED });
+  });
+
+  it("revokes privileged access immediately even when the old session is still valid", async () => {
+    const staleSeasonAdmin = { ...user, role: "season_admin" as const, adminSeasonIds: ["season-1"] };
+    getIronSessionMock.mockResolvedValueOnce(session(staleSeasonAdmin)).mockResolvedValueOnce(session());
+    userFindFirstMock.mockResolvedValueOnce({ role: "user", adminSeasonIds: [] });
+
     await expect(requireSeasonAdmin("season-1")).rejects.toMatchObject({ code: ErrorCode.UNAUTHORIZED });
   });
 


### PR DESCRIPTION
## Scope

Release-hardening only for the 2.0 RC candidate. No product features, Major creation, rule changes, version bump, tag, or production mutation.

## Included

- Fresh DB-backed privileged guards; Root fallback unchanged.
- Locked invite redemption, captain votes, match results/maps, BP, and time-proposal response.
- StageRun competitive-fact snapshots consumed by Major lineup checks.
- MVP server-owned candidate resolution, solo registration sanctions, and executor-aligned custom format gates.
- Updated RC validation policy and targeted unit/local integration coverage.

## Validation

- pnpm install --frozen-lockfile
- pnpm type-check
- pnpm lint
- pnpm db:check
- pnpm test (892 passed)
- pnpm build
- pnpm test:season-governance:local
- pnpm test:major-roster-safety:local
- pnpm test:major-result-recovery:local
- pnpm test:invite-concurrency:local
- pnpm audit --prod (non-zero; classified in handoff)