### PR TITLE
docs: 规范 Changeset 时机、中文摘要与 PR 检查项

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,22 +2,63 @@
 
 本目录由 [changesets](https://github.com/changesets/changesets) 管理 RivalHub 的版本号与 CHANGELOG。
 
-## 日常：记录一次变更
+## 日常：在功能 PR 中记录发布变更
 
-每完成一个改动（feat / fix / refactor 等），运行：
+Changeset 应在实现对应改动的 **feature branch / PR 内创建并随代码一起提交**，而不是等到准备发版时再回忆和补写。
+
+以下变更通常必须写 changeset：
+
+- 用户或管理员可感知的 `feat` / `fix` / `refactor`；
+- production runtime 行为、权限、安全边界或数据 contract 的变化；
+- schema / migration 等会改变正式部署数据模型的变化；
+- production/runtime dependency 的安全或兼容升级。
+
+以下变更通常可以不写 changeset：
+
+- 纯文档；
+- 纯测试；
+- CI / 本地开发工具；
+- 仅 development dependency，且不改变 shipped runtime 或用户/管理员行为的维护性升级。
+
+无需 changeset 时，应在 PR 中明确写出原因。
+
+需要记录时运行：
 
 ```bash
 pnpm changeset
 ```
 
-按提示选择 bump 等级（patch / minor / major）并写一句变更描述，会生成一个 `.changeset/*.md` 文件，**随代码一起提交**。
+按提示选择 bump 等级（patch / minor / major），生成 `.changeset/*.md` 并随本 PR 提交。
 
-## 发版：消费所有 changeset
+### 摘要语言与写法
+
+Changeset 摘要会直接进入后续 `CHANGELOG.md`，因此它不是内部 commit message。
+
+- **默认使用中文**；真实代码名、字段名、协议名、库名等必要技术术语可以保留英文；
+- 描述用户、管理员或运营者能观察到的变化，而不是罗列内部实现步骤；
+- 一条 changeset 聚焦一个可理解的发布主题，避免“misc fixes”“refactor internals”这类不可读描述；
+- `patch` 用于兼容性修复、小功能和体验调整；`minor` / `major` 仅在真实版本语义需要时选择。
+
+示例：
+
+```md
+---
+"rivalhub": patch
+---
+
+将设置页桌面端的参赛资料导航移至左侧，并保留移动端顶部导航体验。
+```
+
+## 发版：只消费，不补写
+
+发版阶段的职责是消费已经随各功能 PR 进入 `dev` 的 changeset，并 review 最终 CHANGELOG：
 
 ```bash
 pnpm exec changeset version   # 自动 bump package.json + 写入 CHANGELOG.md
 # 人工 review CHANGELOG → 提交 → 打 v 前缀 tag → push --follow-tags
 ```
+
+如果 release 前才发现某个已合入的 release-relevant change 缺少 changeset，应先补一个明确的 follow-up changeset，再执行 `changeset version`；不要直接手写版本号或把 release commit 当成日常变更记录入口。
 
 ## RC prerelease
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## 关联
+
+Refs #
+
+## 变更
+
+- 
+
+## 验证
+
+- [ ] `pnpm type-check`
+- [ ] `pnpm lint`
+- [ ] 相关测试 / build 已按变更范围执行
+
+## Changeset
+
+- [ ] 本 PR 属于 release-relevant 变更，已提交中文 `.changeset/*.md`
+- [ ] 本 PR 无需 changeset（仅文档 / 测试 / CI / 开发工具 / development-only 维护），原因：
+
+> feature PR 合入 `dev` 时使用 `Refs #N`；Issue 在对应变更进入 `main` / release convergence 后统一关闭。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ pnpm db:studio
 
 - `main` 是 production branch，`dev` 是下一版本 integration/staging branch；二者均不 force push，只通过 PR 合入。
 - 常规工作从 `dev` 建 `feat/*`、`fix/*`、`docs/*` 等分支，PR base 为 `dev`；production hotfix 从 `main` 开始并回同步到 `dev`。
+- 面向协作者的 Issue / PR 标题与正文、Changeset 摘要和 release note **默认使用中文**；真实代码名、字段名、协议名、库名和其他必要技术术语可保留英文。
+- 会进入版本发布、影响用户/管理员体验或 production runtime/data contract 的 `feat` / `fix` / `refactor` / migration / runtime security 变更，必须在**同一个 feature PR** 中提交对应 `.changeset/*.md`；不要把 changeset 留到发版时补写。
+- 纯文档、纯测试、CI/开发工具，以及仅 development dependency 且不改变 shipped runtime / 用户行为的变更，可以不写 changeset；PR 中应明确写出“无需 changeset”及原因。
+- Changeset 摘要是面向 release/CHANGELOG 的用户可读说明，默认用中文描述可观察影响，不把内部实现细节或 commit message 原样当作 release note。
+- feature PR 合入 `dev` 时关联 Issue 使用 `Refs #N`；不要依赖 `Closes #N` 在非默认分支自动关 Issue。Issue 在对应变更进入 `main` / release convergence 后统一关闭。
 - 版本、CHANGELOG 与 release path 由 Changesets 和 `.claude/skills/release.md` 共同定义。禁止手改 `package.json` version，且仅在 release commit 已进入 `main` 后创建 release tag。
 
 ## Documentation authority


### PR DESCRIPTION
## 目标

把 Changeset 约定从口头习惯落实为仓库级工作流，避免 release 时漏写或生成英文 CHANGELOG 条目。

## 变更

- `AGENTS.md`：明确 release-relevant 变更必须在 feature PR 内提交 changeset；纯文档/测试/CI/dev-only 维护可豁免；Issue/PR/changeset/release note 默认中文；`dev` PR 使用 `Refs #N`。
- `.changeset/README.md`：补充 Changeset 的适用范围、编写时机、中文摘要规范和示例，明确“发版阶段只消费，不临时补写”。
- `.github/pull_request_template.md`：增加验证与 Changeset checklist，要求 PR 明确选择“已添加 changeset”或“无需 changeset并说明原因”。

## Changeset

无需 changeset：本 PR 仅修改工程文档与 PR 模板，不改变 shipped runtime 或用户/管理员产品行为。