### PR TITLE
fix(deps): 收敛 tar Critical advisory (GHSA-23hp-3jrh-7fpw)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tar@7.5.7: 7.5.22
+
 importers:
 
   .:
@@ -5314,11 +5317,6 @@ packages:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -7825,7 +7823,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.7
+      tar: 7.5.22
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -10732,14 +10730,6 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.22:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ allowBuilds:
   esbuild: true
   sharp: true
   unrs-resolver: false
+overrides:
+  # GHSA-23hp-3jrh-7fpw: vercel -> @vercel/fun 精确 pin tar@7.5.7（< 7.5.19 patched floor），
+  # 上游 1.3.1 仍未修复，这里只对该 pin 实例收敛到已修复版本。
+  'tar@7.5.7': 7.5.22


### PR DESCRIPTION
Refs #271

## 背景

Issue #271 剩余的 tar Critical advisory：**GHSA-23hp-3jrh-7fpw**（node-tar Decompression/parse DoS via unlimited input），vulnerable `<=7.5.18`，patched floor `>=7.5.19`。

## 修复前基线

- **Advisory**：GHSA-23hp-3jrh-7fpw（critical）
- **Dependency path**：`rivalhub > vercel@59.5.0 (devDependency) > @vercel/fun@1.3.0 > tar@7.5.7`（唯一受影响实例；另一实例 `@mapbox/node-pre-gyp > tar@7.5.22` 已在 floor 之上）
- **pnpm audit**：60 vulnerabilities（5 low / 23 moderate / 31 high / **1 critical**）
- **pnpm audit --prod**：11 vulnerabilities（4 moderate / 7 high，**0 critical**）
- **Dependabot**：42 个 open alert，其中 tar 相关 5 个（#79/#70 medium，#61/#60/#55 high）

## 调查结论（为何不能 lockfile-only / 升级 vercel）

- `@vercel/fun` 对 tar 是**精确 pin `7.5.7`**（无 range），lockfile 层面无法在 fun 声明范围内解析到 patched 版本；
- fun 最新 `1.3.1` 仍 pin tar 7.5.7，即上游尚未修复；
- vercel 59.x 全系列（含最新 `59.10.0`）均依赖 `@vercel/fun@1.3.0`，故 minor 升级 vercel 无效，也没有更新的 major 可去。

因此按最小边界采用 **pnpm override**：在 `pnpm-workspace.yaml` 添加限定选择器 `'tar@7.5.7': 7.5.22`，仅覆盖该精确 pin 实例，并与其余 tar@7.5.22 dedupe 为单一版本。未使用 `pnpm audit fix`，未触碰其他任何依赖。

## 与 #275 的 manifest overlap

**无 overlap。** 本 PR 不修改 `package.json`：override 位于 `pnpm-workspace.yaml`（pnpm 10+ 支持的 overrides 位置），不与 #275 的 package.json 变更冲突，无需等待 #275 合并后 rebase。

## 修复后状态

- **tar resolved**：全树单一版本 `7.5.22`（≥ patched floor 7.5.19）
- **pnpm audit**：51 vulnerabilities（5 low / 20 moderate / 26 high，**0 critical**）
- **pnpm audit --prod**：11 vulnerabilities，**与修复前完全一致**（tar 仅经 devDependency `vercel` 引入，不进 shipped runtime）
- **Dependabot**：alert 在合入默认分支后由 GitHub 重新扫描，预期 5 个 tar alert 随 7.5.22 关闭（届时复核）

## 验证

- [x] `pnpm install --frozen-lockfile`（更新后 lockfile 通过）
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test`（134 files / 900 tests passed）
- [x] `pnpm build`

## Changeset

无需 changeset：tar@7.5.7 仅存在于 development/build tooling 依赖链（`vercel` devDependency），`pnpm audit --prod` 前后一致，shipped runtime 与产品行为不变。与 #281（vitest dev-only 安全修复）先例一致。