### PR TITLE
docs: 补充长期 Team 与 CompetitionEntry Changeset

### DIFF
--- a/.changeset/long-lived-team-competition-entry.md
+++ b/.changeset/long-lived-team-competition-entry.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+将 Team 升级为跨赛事长期实体，并以 CompetitionEntry 统一表示赛事参赛身份；Major 报名、名单修订、赛事冻结名单、StageEntrants 与单场比赛阵容拆分为独立事实层，同时迁移既有 Rivals 历史数据而不补造长期 Team。


### PR DESCRIPTION
Refs #269

## 背景

PR #275 已合入 `dev`，但该 PR 未携带 Changeset。根据当前仓库 release workflow，#275 属于明确的 release-relevant 变更，因此在 stable 2.0 release convergence 前补齐对应发布记录。

## 改动

仅新增 `.changeset/long-lived-team-competition-entry.md`：

- `rivalhub: patch`；
- 中文摘要；
- 描述长期 Team、CompetitionEntry、Major 多层名单事实与 Rivals 历史迁移的用户/领域影响。

## 边界

- 不修改 #275 已合入的代码或历史；
- 不修改 `.changeset/pre.json`；
- 不修改 `CHANGELOG.md`；
- 不运行 `changeset version` / `pre exit`；
- 仅补齐未来 stable 2.0 的 release metadata。

本 PR 自身就是对遗漏 Changeset 的补录，因此不再额外新增第二条 Changeset。