### PR TITLE
chore: 收敛 v2 stable 依赖与安全基线

### DIFF
--- a/.changeset/security-dependencies-convergence.md
+++ b/.changeset/security-dependencies-convergence.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+收敛 v2 stable 依赖安全边界：移除无实际 consumer 的数据库/环境加载与未使用 Radix direct dependencies；保留仍被当前依赖路径需要的精确 security overrides 与 patched lock graph；不改变赛事领域数据或产品行为。

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
-    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -46,8 +45,6 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
-    "@radix-ui/react-toast": "^1.2.14",
-    "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.112.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
@@ -72,7 +69,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@eslint/eslintrc": "^3.3.6",
-    "@neondatabase/serverless": "^0.10.4",
     "@playwright/test": "^1.52.0",
     "@tailwindcss/postcss": "^4.1.6",
     "@testing-library/jest-dom": "^6.6.3",
@@ -83,7 +79,6 @@
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.4",
     "@vitest/coverage-v8": "^3.2.7",
-    "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.1",
     "eslint": "^9.39.5",
     "eslint-config-next": "15.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
-      '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -41,12 +38,6 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toast':
-        specifier: ^1.2.14
-        version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.7
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@supabase/supabase-js':
         specifier: ^2.112.4
         version: 2.112.4
@@ -114,9 +105,6 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.6
         version: 3.3.6
-      '@neondatabase/serverless':
-        specifier: ^0.10.4
-        version: 0.10.4
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.59.1
@@ -147,9 +135,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.7
         version: 3.2.7(vitest@3.2.7(@types/node@24.13.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.23.13))
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       drizzle-kit:
         specifier: ^0.31.1
         version: 0.31.10
@@ -1051,19 +1036,6 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
-  '@radix-ui/react-alert-dialog@1.1.15':
-    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -1337,32 +1309,6 @@ packages:
 
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toast@1.2.15':
-    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2443,10 +2389,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -4983,6 +4925,7 @@ snapshots:
   '@neondatabase/serverless@0.10.4':
     dependencies:
       '@types/pg': 8.11.6
+    optional: true
 
   '@next/env@15.5.24': {}
 
@@ -5046,20 +4989,6 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
-
-  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -5344,46 +5273,6 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -5730,6 +5619,7 @@ snapshots:
       '@types/node': 24.13.3
       pg-protocol: 1.13.0
       pg-types: 4.1.0
+    optional: true
 
   '@types/pg@8.20.0':
     dependencies:
@@ -6304,8 +6194,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dotenv@17.4.2: {}
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -7458,7 +7346,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obuf@1.1.2: {}
+  obuf@1.1.2:
+    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -7542,7 +7431,8 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-numeric@1.0.2: {}
+  pg-numeric@1.0.2:
+    optional: true
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
@@ -7567,6 +7457,7 @@ snapshots:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
+    optional: true
 
   pg@8.20.0:
     dependencies:
@@ -7614,25 +7505,30 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
-  postgres-array@3.0.4: {}
+  postgres-array@3.0.4:
+    optional: true
 
   postgres-bytea@1.0.1: {}
 
   postgres-bytea@3.0.0:
     dependencies:
       obuf: 1.1.2
+    optional: true
 
   postgres-date@1.0.7: {}
 
-  postgres-date@2.1.0: {}
+  postgres-date@2.1.0:
+    optional: true
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
 
-  postgres-interval@3.0.0: {}
+  postgres-interval@3.0.0:
+    optional: true
 
-  postgres-range@1.1.4: {}
+  postgres-range@1.1.4:
+    optional: true
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## 变更范围

基于 foundation / `origin/dev@45361d9e4d06d3da5def9b19fd5ecdb355ff1486`，仅处理 security-dependencies task：

- 删除无实际 consumer 的 `@neondatabase/serverless`、`dotenv`、`@radix-ui/react-alert-dialog`、`@radix-ui/react-toast`、`@radix-ui/react-tooltip` direct dependencies。
- 由 pnpm 10.34.5 重写 lockfile，移除对应 importer/package/snapshot 残留。
- 保留 `iron-session` 及所有仍被当前依赖路径需要的 security overrides。
- 添加 `.changeset/security-dependencies-convergence.md`。
- 不改业务代码、schema、migration、Next major、CI、production 或其他 stable convergence task。

## Canonical owner 与 dependency evidence

- `package.json` 是 root direct dependency owner，`pnpm-lock.yaml` 是解析结果。
- import scan 覆盖 `src/`、`scripts/`、`tests/` 与配置文件：上述五个 direct dependency 均无 import/require consumer。
- `pnpm why`：删除前三类 Radix 与 `dotenv` 只归因到 root；`@neondatabase/serverless` 删除 root direct 后仅由 `drizzle-orm@0.45.2` 的 optional peer 自动解析，当前不在 root direct 列表且无应用代码 import。
- `iron-session@8.0.4` 仍由 `src/lib/auth/session.ts` 与 auth action 使用，保留。
- 当前仍需要的精确 overrides 未删除：
  - `postcss@8.4.31 -> 8.5.23`：Next 15.5.24 的 pinned path，owner upgrade 到 Next 16 不在本 task scope。
  - `uuid@9.0.1 -> 11.1.1`：brackets-manager 当前仍声明 uuid 9，保留 CJS/v4 compatibility。
  - `esbuild@0.18.20 / 0.27.7 -> 0.28.2`：drizzle-kit 内部路径尚未自然到 patched floor。
- `sharp`、`vite`、`js-yaml`、`brace-expansion` 已自然解析到 patched versions，因此没有新增或保留额外 override。

## Security triage

本地当前 dependency graph：

- `pnpm audit --json`：0 vulnerabilities（816 dependencies）。
- `pnpm audit --prod --json`：0 vulnerabilities（203 dependencies）。
- 当前 lock 中的关键版本：sharp 0.35.4、postcss 8.5.23/8.5.26、uuid 11.1.1、vite 7.3.6、esbuild 0.25.12/0.28.2、js-yaml 3.15.2/4.3.1、brace-expansion 2.1.4/5.0.9、nanoid 3.3.18、ws 8.21.3。

Dependabot API snapshot（2026-08-31，default branch ledger）：无开放 Dependabot PR；42 条 open alert，30 development、12 runtime，严重度为 1 critical、19 high、17 moderate、5 low。所有 open alert 均由下表覆盖：

| alerts | 当前路径/版本 | 分类与处置 |
| --- | --- | --- |
| #1, #3 drizzle-orm | direct runtime，0.45.2 | owner upgrade available；已在 patched floor，无 unresolved |
| #4, #40, #41, #46 postcss | runtime path，8.5.23/8.5.26；Next pinned 8.4.31 由 override 处理 | runtime reachable + override mitigated；无 unresolved |
| #31 sharp | runtime path，0.35.4 | runtime reachable，natural patched resolution |
| #19, #23 ws | runtime path，8.21.3 | runtime reachable + transitive，natural patched resolution |
| #20 uuid | brackets-manager -> uuid，override 到 11.1.1 | runtime reachable + override mitigated；owner upgrade unavailable，保留 exit condition |
| #49, #50 nanoid | postcss -> nanoid，3.3.18 | runtime reachable + transitive，patched |
| #27, #28 brace-expansion | development-only，2.1.4/5.0.9 | transitive，patched |
| #2, #22 esbuild | development-only，0.25.12/0.28.2 | transitive + required override paths，patched；dev-server advisory 不可达于当前 drizzle-kit 使用 |
| #21 vitest | development-only，3.2.7 | owner range 已达 patched floor |
| #24, #25 vite | development-only，7.3.6 | natural patched resolution |
| #26, #29, #30, #47, #48, #75 js-yaml | development-only，3.15.2/4.3.1 | transitive，natural patched resolution |
| #59 minimatch | development-only，3.1.5/9.0.9/10.2.5 | transitive，patched |
| #55, #60, #61, #70, #79 tar | development-only | 当前 lock 无 tar；历史 vercel owner path 已不再 reachable |
| #69 @tootallnate/once | development-only | 当前 lock 无 package；历史 vercel owner path 已不再 reachable |
| #52, #53, #62, #63, #71, #73, #74, #81, #82, #83 undici | development-only | 当前 lock 无 undici；历史 vercel owner path 已不再 reachable |

GitHub ledger 中的历史 auto-dismissed alerts 不作为当前 unresolved issue；未执行人工 dismiss，待 default branch dependency graph refresh。

## Local evidence

- `pnpm install --frozen-lockfile`
- `pnpm audit --json`
- `pnpm audit --prod --json`
- `pnpm type-check`
- `pnpm lint`
- `pnpm exec vitest run tests/unit/lib/auth-session.test.ts`（8/8）
- `pnpm exec changeset status --since origin/dev`

未改 schema/migration，因此未运行 `pnpm db:check`；完整 `pnpm test`、`pnpm build`、integration/E2E 由 PR quality/local/Vercel CI 承担。