### PR TITLE
docs: 收口 v2 stable active technical docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ Major 的正式运行时由 `src/lib/major/` 与 `major_*` persistence owners �
 | Season capabilities / templates | `src/types/season.ts`, `src/actions/seasons.ts`, `src/db/schema/seasons.ts` |
 | Identity / education / competitive profile | `src/actions/account.ts`, `src/actions/education-verifications.ts`, `src/actions/competitive-profile.ts`, matching schema files |
 | Rivals registration / voting / draft | `src/actions/register.ts`, `src/actions/captains.ts`, `src/actions/draft/`, `src/lib/draft/` |
-| Team applications | `src/actions/team-applications.ts`, `src/lib/major/participant-readiness.ts`, `src/db/schema/team-applications.ts` |
+| Long-lived Teams / CompetitionEntry | `src/lib/teams/`, `src/lib/competition-entries/`, corresponding actions and schema files |
 | Major prestart and runtime | `src/actions/major-prestart.ts`, `src/lib/major/`, `src/db/schema/major-prestart.ts`, `src/db/schema/major-stage.ts` |
 | Matches / rosters / results | `src/actions/matches/`, `src/lib/matches/`, `src/db/schema/matches.ts`, `src/db/schema/match-rosters.ts` |
 | Discipline / post-event | `src/actions/discipline.ts`, `src/actions/postevent.ts`, `src/lib/discipline/`, matching schema files |

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -28,7 +28,7 @@
 
 ## 6. Long-lived Teams and CompetitionEntry
 
-`teams` 是独立于赛事的长期队伍；`team_memberships`、队长任期、名称历史和邀请表达其成员与治理事实。Team 不属于 Season。
+`teams` 是独立于赛事的长期队伍；`team_memberships`、append-only `team_captain_changes`、append-only `team_name_changes` 和邀请表达其成员与治理事实。Team 不属于 Season。
 
 `competition_entries` 是从报名草稿到赛事历史的唯一参赛身份。Major 通常由长期 Team 创建 Entry；Rivals 选秀队为 `teamId = null` 的赛事队伍。`competition_entry_participants` 表示本届参赛确认，报名名单 revision 表示审核材料，`event_rosters`/成员表示赛前确认名单，`match_rosters`/成员表示单场出场阵容。三层人员事实不得互相替代。
 
@@ -48,7 +48,7 @@
 
 ## 10. Major prestart
 
-`major_prestart_states`、`major_prestart_entrants`、`event_rosters`/成员、`major_tournament_seeds` 与 `major_prestart_issues` 管理开赛前的 readiness、参赛队、最终名单、种子和 blocker。只有完成相应确认的预启动事实才能被 Major start 消费。
+`major_prestart_states`、`major_tournament_entrants`、`event_rosters`/成员、`major_tournament_seeds` 与 `major_prestart_issues` 管理开赛前的 readiness、参赛队、最终名单、种子和 blocker。只有完成相应确认的预启动事实才能被 Major start 消费。
 
 ## 11. Major stage runtime
 
@@ -78,7 +78,7 @@
 
 | Live fact | Frozen or event-specific fact |
 |---|---|
-| Team application | approved formal team |
+| long-lived Team / mutable Entry roster revision | approved formal EventRoster |
 | live team membership | frozen tournament entrant / roster |
 | mutable season policy | StageRun rule snapshot |
 | current match result | correction / adjudication history |
@@ -114,7 +114,7 @@
 | 发布时的竞技上下文冻结 | `publishSeason` 事务：platform catalog current/previous/ladder → season frozen competitiveProfile（单一 owner：`src/lib/competitive/catalog.ts`） |
 | 队长交接的并发安全 | application/team 行锁 + season 行锁 + 目标成员 `FOR UPDATE`，全部判断基于锁定行 |
 | 赛前名单与已批准报名名单的一致性 | `src/lib/major/prestart-entry.ts`：确认、锁定与正式开赛前校验 Entry 仍 approved、approved revision 存在且 event roster 已同步到该版本 |
-| Major 赛前事务锁顺序 | `season / majorPrestartState → CompetitionEntry → eventRoster → majorPrestartEntrant`；名单显式重同步只放宽 source revision guard，完成写入后再由同一 coherence owner 严格复核 |
+| Major 赛前事务锁顺序 | `season / majorPrestartState → CompetitionEntry → eventRoster → majorTournamentEntrant`；名单显式重同步只放宽 source revision guard，完成写入后再由同一 coherence owner 严格复核 |
 | Major prestart readiness | prestart domain service 与明确 blocker |
 | StageRun 规则与参赛成员冻结 | rule snapshot + managed runtime；开赛时按冻结 competitiveProfile 重验参赛事实后，以同一批读取结果序列化 `frozenCompetitiveFacts` |
 | 一场 Major 比赛恰好 5 名首发 | match-roster service 与 lineup evaluator |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,7 @@ pnpm verify:local
 
 所有 real-PG 套件通过 `scripts/db/local.ts` 注入同一个 loopback Local Supabase 目标，并由 `vitest.integration.config.ts` 关闭文件并发、保持 fixture 顺序独立。migration replay 使用独立 scratch database；不使用 testcontainers，也不以 mock 代替事务、约束或并发证据。需要缩小调试范围时直接使用 Vitest 文件或 `-t` pattern filter。
 
-## Coverage intent
+## Verification contracts
 
 单元测试覆盖 capability、状态和 action input boundary，包括 persisted template identity、custom definition validator（executor registry 与 groupCount 晋级计算）、qualification batch/single parity 与竞技上下文冻结/解冻；本地集成测试覆盖 Major Entry registration（含跨 Entry aggregate invariant）、0017 migration replay、长期 participant profile、browser fixture、prestart（含 prestart↔CompetitionEntry coherence guard）、StageRun lifecycle（含开赛前名单一致性 fail-closed 与开赛时按冻结规则重验竞技资料）、roster safety、result recovery、discipline、post-event、“我的”资料/Team/CompetitionEntry/qualification/sanction 组合 read model、Team 邀请过期生命周期，以及 season governance（空赛季删除/撤回 guard、竞技冻结生命周期、队长交接并发语义、行锁终态转换与原子审计）。所有入口都运行在 CompetitionEntry/event-roster schema 上。历史 Golden Major rehearsal 保存在 [`archive/rehearsals/`](./archive/rehearsals/)，不是当前策略的替代品。
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,6 +1,6 @@
 # RivalHub 工作流
 
-本文件描述当前 RC4 的生命周期与 owner boundary。政策规则由 [`rules/`](./rules/) 定义；精确 action 输入和错误码以 code 为准。
+本文件描述当前 2.0 实现的生命周期与 owner boundary。政策规则由 [`rules/`](./rules/) 定义；精确 action 输入和错误码以 code 为准。
 
 ## 1. Account / Auth
 
@@ -16,7 +16,7 @@
 
 ## 4. Competitive profile
 
-数据 owner 是 `competitive_platform_seasons` 与 `competitive_rank_facts`。`/settings/competitive` 直接读取全局目录，不依赖已发布 RivalHub 赛事；当前赛季、上一赛季置顶，其他仍启用的已编目赛季也可维护，未来赛季可以留空，历史赛季资料可补录。赛事 qualification evaluator 只检查该赛事冻结上下文要求的 exact season keys，因此目录推进不会让冻结了旧赛季的赛事资格失效。
+数据 owner 是 `competitive_platforms`、`competitive_platform_ranks`、`competitive_platform_seasons` 与 `competitive_rank_facts`：平台拥有 rank ladder，平台赛季只表达时间目录，竞技事实引用其中的稳定身份。`/settings/competitive` 直接读取全局目录，不依赖已发布 RivalHub 赛事；当前赛季、上一赛季置顶，其他仍启用的已编目赛季也可维护，未来赛季可以留空，历史赛季资料可补录。赛事 qualification evaluator 只检查该赛事冻结上下文要求的 exact season keys，因此目录推进不会让冻结了旧赛季的赛事资格失效。
 
 ## 5. Rivals solo registration
 
@@ -89,16 +89,6 @@ Rivals 的 voting/drafting 由 capability 启用；Major start 在 readiness、e
 - 撤回（registration → draft）与删除共用“无报名/队伍/赛程事实”guard；通过后撤回会解除 built-in 赛事的竞技冻结，下一次发布重新解析目录。
 - 删除（draft → deleted）拒绝已有 invite claim 的赛季；未领取的邀请码与其 claim ledger 随赛季删除，`season_admin_grants` 通过 season FK cascade 清理，`audit_logs.season_id` 为 SET NULL，并写入全局 `season.deleted` 审计。
 - 已发布赛季的编辑只接受名称、主题、时间等元数据；核心配置与冻结上下文不可被客户端输入或模板 factory 改写。
-
-### Team application
-
-```text
-draft / rejected → submitted
-submitted → approved | waitlisted | rejected
-waitlisted → approved | rejected
-```
-
-成员状态独立为 `invited → confirmed`。只有 draft/rejected application 可由队长编辑；submitted/waitlisted application 的审核与正式队伍物化由服务端控制。`approved` 已物化为正式队伍，不通过普通 review workflow 回退。
 
 ### Match
 


### PR DESCRIPTION
## 变更
- 修正 architecture、domain model、workflow 中已退役 Team application 和 Major prestart 名称
- 明确长期 Team 的 append-only captain/name history 与竞技平台目录 owner
- 将测试文档的 coverage intent 调整为 verification contracts

## 验证
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `env -u DATABASE_URL pnpm build`
- `pnpm verify:local`
- `pnpm audit`
- `pnpm audit --prod`

## Changeset
无需 changeset：仅修正 active technical docs，不改变 shipped runtime 或用户行为。