### PR TITLE
release: v2.0.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,14 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# Hosted database. The runtime uses a Supabase Transaction Pooler connection.
-# Copy the exact target-project value from the Supabase Dashboard; do not guess the pooler hostname.
+# Hosted database. Runtime and protected production migration/verify use the
+# same Supabase Transaction Pooler DATABASE_URL; do not maintain a second
+# production database password variable.
 DATABASE_URL=
+
+# Staging remains isolated and composes its own fixed target URL from this
+# operational credential rather than inheriting the application's DATABASE_URL.
+RIVALHUB_STAGING_DB_PASSWORD=
 
 # Application sessions and standard first-owner bootstrap
 ADMIN_SESSION_SECRET=at-least-32-chars-random-secret-here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,109 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: rivalhub-production-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      # Fixed non-secret Vercel target. The only credential this workflow needs
+      # is VERCEL_TOKEN; production DATABASE_URL remains owned by Vercel.
+      VERCEL_ORG_ID: team_0eIkBawGTdVjwYHdyrb20ZVV
+      VERCEL_PROJECT_ID: prj_3bjmfKrSqRh4szrkEE4HpavnhI0E
+      RIVALHUB_DB_TARGET: production
+      RIVALHUB_PRODUCTION_PROJECT_CONFIRM: sucokfotkypwqkckfynp
+      RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: aws-0-ap-northeast-1.pooler.supabase.com:6543
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        # 不指定 ref，checkout 当前 tag 指向的 commit。
-        # 创建 tag 前必须确保对应 version 与 CHANGELOG 已随 release commit 进入 main，
-        # 使 tag checkout 包含完整的版本与发布说明。
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+        # 不指定 ref，checkout 当前 tag 指向的 commit。release 的数据库、部署、
+        # changelog 与 GitHub Release 都必须来自同一个不可变 tag commit。
+
+      - name: Require release tag commit on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Release tag $GITHUB_REF_NAME does not point to a commit contained in main." >&2
+            exit 1
+          fi
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.34.5
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install pinned Vercel CLI
+        run: pnpm add --global vercel@59.10.0
+
+      - name: Verify Vercel release credential
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [[ -z "$VERCEL_TOKEN" ]]; then
+            echo "GitHub production environment secret VERCEL_TOKEN is required." >&2
+            exit 1
+          fi
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Validate active migration chain locally
+        run: |
+          pnpm db:check
+          pnpm db:local:start
+
+      - name: Migrate and verify production database
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel env run -e production -- \
+            env \
+              RIVALHUB_DB_TARGET=production \
+              RIVALHUB_PRODUCTION_PROJECT_CONFIRM="$RIVALHUB_PRODUCTION_PROJECT_CONFIRM" \
+              RIVALHUB_PRODUCTION_DB_HOST_CONFIRM="$RIVALHUB_PRODUCTION_DB_HOST_CONFIRM" \
+              RIVALHUB_ALLOW_REMOTE_DB_WRITE=production \
+              pnpm db:production:migrate
+
+          vercel env run -e production -- \
+            env \
+              RIVALHUB_DB_TARGET=production \
+              RIVALHUB_PRODUCTION_PROJECT_CONFIRM="$RIVALHUB_PRODUCTION_PROJECT_CONFIRM" \
+              RIVALHUB_PRODUCTION_DB_HOST_CONFIRM="$RIVALHUB_PRODUCTION_DB_HOST_CONFIRM" \
+              pnpm db:production:verify
+
+      - name: Deploy exact release commit to Vercel Production
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          DEPLOYMENT_URL="$(vercel deploy --prod --yes --token="$VERCEL_TOKEN" \
+            --build-env RIVALHUB_RELEASE_TAG="$GITHUB_REF_NAME" \
+            --build-env RIVALHUB_RELEASE_COMMIT="$GITHUB_SHA")"
+          echo "url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+          echo "Production deployment: $DEPLOYMENT_URL"
+
+      - name: Smoke test production deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          curl --fail --silent --show-error \
+            --retry 8 --retry-all-errors --retry-delay 5 \
+            "$DEPLOYMENT_URL/" >/dev/null
+          curl --fail --silent --show-error \
+            --retry 8 --retry-all-errors --retry-delay 5 \
+            "https://match.starfie1d.top/" >/dev/null
 
       - name: Extract changelog for this version
         run: |
@@ -48,3 +141,7 @@ jobs:
               --notes-file /tmp/release-notes.md \
               "${RELEASE_FLAGS[@]}"
           fi
+
+      - name: Stop Local Supabase
+        if: always()
+        run: pnpm db:local:stop || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- 生产发版改为由 `v*` tag 的 release workflow 串行执行数据库前向迁移、严格校验、精确 Vercel Production 部署与 smoke test；普通 `main` production build 不能绕过 release gate。
+
+### Fixed
+
+- 公开玩家竞技档案改用长期竞技位置与平台目录展示位置、段位、赛季和星数，不再把赛事报名快照当作长期资料。
+
+### Migration & Operations
+
+- Production release 会在应用部署前执行 active Drizzle migration chain 并进行 exact verify；迁移或校验失败会中止新版本部署并保留上一版 production。
+
 ## 2.0.1
 
 ### Fixed

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,6 +51,40 @@ pnpm db:staging:migrate
 
 这些命令不执行 seed 或 `db:push`。缺少 Local 验证、确认值、staging 密码或写入 opt-in 时，命令在任何远程写入前停止。
 
+### Protected production migration and release transaction
+
+Production 的 active chain 仍只有一个 authority：`drizzle/migrations/meta/_journal.json` 与对应 SQL SHA-256。只读核验与前向迁移只能使用以下受保护命令；禁止裸 `drizzle-kit migrate`、手工 `ALTER TABLE`、`db:push`、seed 或 reset。
+
+Production 与应用运行时统一使用同一个 Supabase **Transaction Pooler `DATABASE_URL`**：`aws-0-ap-northeast-1.pooler.supabase.com:6543`。不再维护 `RIVALHUB_PRODUCTION_DB_PASSWORD` 或第二份 production database credential。受保护命令复用运行时 `DATABASE_URL`，但在任何查询或写入前严格验证固定 project ref、host、port、username 和 pooler shape；因此“复用已有 secret”不等于接受任意 inherited connection string。
+
+```bash
+# DATABASE_URL 使用与 production runtime 相同的现有 Transaction Pooler secret。
+# Strictly read-only: rejects a pending, divergent or unexpected ledger entry.
+DATABASE_URL='<existing production runtime DATABASE_URL>' \
+RIVALHUB_DB_TARGET=production \
+RIVALHUB_PRODUCTION_PROJECT_CONFIRM=sucokfotkypwqkckfynp \
+RIVALHUB_PRODUCTION_DB_HOST_CONFIRM=aws-0-ap-northeast-1.pooler.supabase.com:6543 \
+pnpm db:production:verify
+
+# Authorized forward migration only. It first validates the active chain in
+# Local PostgreSQL, reads the production preflight, runs Drizzle migrate, then
+# automatically runs the strict production verifier again.
+DATABASE_URL='<existing production runtime DATABASE_URL>' \
+RIVALHUB_DB_TARGET=production \
+RIVALHUB_PRODUCTION_PROJECT_CONFIRM=sucokfotkypwqkckfynp \
+RIVALHUB_PRODUCTION_DB_HOST_CONFIRM=aws-0-ap-northeast-1.pooler.supabase.com:6543 \
+RIVALHUB_ALLOW_REMOTE_DB_WRITE=production \
+pnpm db:production:migrate
+```
+
+在 Vercel Production 中 `DATABASE_URL` 本来就是应用访问 production DB 的 runtime secret，因此 migration/verify runner 应在能够继承该 Production environment 的受控执行环境中运行；不要把 URL 拆成第二份 password secret。显式 target、project、host 和 write authorization 仍是独立安全门禁。
+
+Production preflight 以 `0024_major_runtime_convergence` 为已确认最低 baseline：早于 0024 的 ledger 直接拒绝；恰好位于 0024 时会在只读事务内验证旧 schema 形态以及 0025 CHSI-code extraction / 0026 role values 的 fail-closed predicates；任何晚于 0024 且仍是 active chain **精确前缀**的状态都允许继续前向执行，因此某个后续 migration 已成功、再后一个 migration 失败时可以安全重试 canonical runner。hash/timestamp divergence、unexpected entry 或超出 active chain 仍然 fail closed。迁移完成后 verify 要求完整 ledger SHA/timestamp sequence，并验证 `evidence_code` present/`evidence_url` absent、`perfect_id` absent 与 canonical `cs2_role` enum。
+
+正式 production release 由 `.github/workflows/release.yml` 的 `v*` tag workflow 独占：tag commit 必须已经包含在 `main`；runner 使用 GitHub `production` Environment 中的 `VERCEL_TOKEN` 访问 Vercel，但 production database credential 仍只存在于 Vercel Production `DATABASE_URL`。workflow 的固定顺序是 **tag/main 校验 → Local migration validation → production migrate → production verify → exact tag Vercel Production deploy → smoke test → GitHub Release**。数据库迁移因此属于 release transaction，而不是发版后的人工补丁。
+
+Vercel production builds 使用 [`scripts/vercel-build.ts`](../scripts/vercel-build.ts)：当 `VERCEL_ENV=production` 时，只有 release workflow 注入合法 `RIVALHUB_RELEASE_TAG` 与 `RIVALHUB_RELEASE_COMMIT` 后才继续；随后它使用现有 runtime Transaction Pooler `DATABASE_URL` 执行 exact production migration verify，再进入 `next build`。普通 `main` Git auto-deploy 即使被 Vercel 创建，也会在没有 release marker 时 fail closed 并保留上一版 production；Preview builds 不读取 production DB。build gate 只验证，不自动执行 migration，从而避免“DB 已前进但 application build 随后失败”的反向半发布状态。
+
 ### Explicit remote seed guard
 
 `pnpm seed` 不从 `.env.local` 读取远程目标。对 staging 或 production 的 seed 必须同时提供：

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,8 @@ RivalHub 以最高已完成的验证层级描述能力证据：
 | `pnpm verify` | check + production build；build 不需要数据库或 fake DB URL |
 | `pnpm verify:local` | 确保 Local ready，bootstrap/verify、verify、real-PG integration 与 browser E2E |
 | `pnpm db:check` | Drizzle active migration chain |
+| `pnpm db:production:verify` | 严格只读校验明确确认的 production ledger、SQL SHA 与 terminal schema contract |
+| `pnpm db:production:migrate` | 先 Local/production preflight，再唯一的 Drizzle 前向迁移与自动 production verify |
 | `pnpm build` | production build |
 | `pnpm build:local` | 注入 loopback Local Supabase 环境的 production build |
 

--- a/drizzle.production.config.ts
+++ b/drizzle.production.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from "drizzle-kit";
+import { assertProductionDatabaseUrl } from "./scripts/db/production-environment";
+
+const databaseUrl = assertProductionDatabaseUrl(process.env.RIVALHUB_PRODUCTION_DATABASE_URL);
+
+export default {
+  schema: "./src/db/schema",
+  out: "./drizzle/migrations",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: databaseUrl,
+    ssl: true,
+  },
+} satisfies Config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
@@ -19,6 +19,8 @@
     "db:push": "tsx scripts/db/block-drizzle-push.ts",
     "db:staging:migrate": "tsx scripts/db/staging.ts migrate",
     "db:staging:verify": "tsx scripts/db/staging.ts verify",
+    "db:production:migrate": "tsx scripts/db/production.ts migrate",
+    "db:production:verify": "tsx scripts/db/production.ts verify",
     "db:studio": "tsx scripts/db/local.ts studio",
     "db:local:start": "tsx scripts/db/local.ts start",
     "db:local:status": "tsx scripts/db/local.ts status",

--- a/scripts/db/production-environment.ts
+++ b/scripts/db/production-environment.ts
@@ -1,0 +1,93 @@
+import {
+  assertProtectedRemoteDatabaseUrl,
+  assertRemoteConfirmations,
+  sanitizedRemoteEnvironment,
+  type Environment,
+  type ProtectedRemoteDatabaseConfig,
+} from "./remote-environment";
+
+export const PRODUCTION_PROJECT_REF = "sucokfotkypwqkckfynp";
+export const PRODUCTION_POOLER_HOST = "aws-0-ap-northeast-1.pooler.supabase.com";
+export const PRODUCTION_POOLER_PORT = "6543";
+
+const productionConfig: ProtectedRemoteDatabaseConfig = {
+  target: "production",
+  projectRef: PRODUCTION_PROJECT_REF,
+  poolerHost: PRODUCTION_POOLER_HOST,
+  poolerPort: PRODUCTION_POOLER_PORT,
+  requiresPgbouncer: true,
+  projectConfirmationKey: "RIVALHUB_PRODUCTION_PROJECT_CONFIRM",
+  hostConfirmationKey: "RIVALHUB_PRODUCTION_DB_HOST_CONFIRM",
+  databaseUrlKey: "RIVALHUB_PRODUCTION_DATABASE_URL",
+  requireExplicitTarget: true,
+};
+
+export function buildProductionEnvironment(
+  env: Environment = process.env,
+  options: { requiresWriteAuthorization: boolean },
+): NodeJS.ProcessEnv {
+  if (env.RIVALHUB_DB_TARGET !== "production") {
+    throw new Error("必须显式设置 RIVALHUB_DB_TARGET=production。");
+  }
+  assertRemoteConfirmations(env, productionConfig);
+  if (options.requiresWriteAuthorization && env.RIVALHUB_ALLOW_REMOTE_DB_WRITE !== "production") {
+    throw new Error("远程 production migration 未授权；必须显式设置 RIVALHUB_ALLOW_REMOTE_DB_WRITE=production。");
+  }
+
+  const databaseUrl = normalizeProductionDatabaseUrl(env.DATABASE_URL);
+  const sanitized = sanitizedRemoteEnvironment(env);
+  return {
+    ...sanitized,
+    NODE_ENV: sanitized.NODE_ENV === "test" ? "test" : "production",
+    DATABASE_URL: databaseUrl,
+    RIVALHUB_PRODUCTION_DATABASE_URL: databaseUrl,
+    RIVALHUB_DB_TARGET: "production",
+    RIVALHUB_PRODUCTION_PROJECT_CONFIRM: PRODUCTION_PROJECT_REF,
+    RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: `${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}`,
+  };
+}
+
+export function assertProductionDatabaseUrl(value: string | undefined): string {
+  return assertProtectedRemoteDatabaseUrl(value, productionConfig);
+}
+
+export function assertProductionConfirmations(env: Environment = process.env): void {
+  if (env.RIVALHUB_DB_TARGET !== "production") {
+    throw new Error("Migration verification 的 production 目标必须显式设置 RIVALHUB_DB_TARGET=production。");
+  }
+  assertRemoteConfirmations(env, productionConfig);
+}
+
+/** Vercel production builds inherit the same runtime Transaction Pooler URL used by the app. */
+export function buildVercelProductionVerificationEnvironment(env: Environment = process.env): NodeJS.ProcessEnv {
+  if (env.VERCEL_ENV !== "production") {
+    throw new Error("Vercel production migration gate 只能在 VERCEL_ENV=production 运行。");
+  }
+  const databaseUrl = normalizeProductionDatabaseUrl(env.DATABASE_URL);
+  return {
+    ...env,
+    NODE_ENV: "production",
+    DATABASE_URL: databaseUrl,
+    RIVALHUB_DB_TARGET: "production",
+    RIVALHUB_PRODUCTION_PROJECT_CONFIRM: PRODUCTION_PROJECT_REF,
+    RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: `${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}`,
+  };
+}
+
+function normalizeProductionDatabaseUrl(value: string | undefined): string {
+  if (!value?.trim()) {
+    throw new Error("DATABASE_URL 未设置；production migration/verify 复用现有 production runtime credential，不维护第二份数据库密码。");
+  }
+
+  let runtimeUrl: URL;
+  try {
+    runtimeUrl = new URL(value.trim());
+  } catch {
+    throw new Error("Production DATABASE_URL 格式无效。");
+  }
+
+  // Supabase runtime Transaction Pooler URLs may omit this marker. Normalize
+  // only its absence; an explicitly conflicting value remains fail-closed.
+  if (!runtimeUrl.searchParams.has("pgbouncer")) runtimeUrl.searchParams.set("pgbouncer", "true");
+  return assertProductionDatabaseUrl(runtimeUrl.toString());
+}

--- a/scripts/db/production-preflight.ts
+++ b/scripts/db/production-preflight.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Pool } from "pg";
+import { assertProductionConfirmations, assertProductionDatabaseUrl } from "./production-environment";
+
+interface MigrationJournalEntry { tag: string; when: number; }
+export interface Migration { hash: string; when: number; }
+export interface ExpectedMigration extends Migration { tag: string; }
+
+export const PRODUCTION_BASELINE_TAG = "0024_major_runtime_convergence";
+
+export async function verifyProductionPreflight(): Promise<void> {
+  assertProductionConfirmations(process.env);
+  const databaseUrl = assertProductionDatabaseUrl(process.env.DATABASE_URL);
+  const expected = readExpectedMigrations();
+  const pool = new Pool({ connectionString: databaseUrl, ssl: { rejectUnauthorized: false }, max: 1 });
+  try {
+    await pool.query("BEGIN TRANSACTION READ ONLY");
+    const ledger = await pool.query<Migration>("SELECT hash, created_at::bigint::text AS when FROM drizzle.__drizzle_migrations ORDER BY created_at");
+    const actual = ledger.rows.map((row) => ({ hash: row.hash, when: Number(row.when) }));
+    const state = assertResumableProductionLedger(actual, expected);
+
+    // At the confirmed 0024 baseline, prove the destructive-data predicates
+    // for the currently pending 0025/0026 pair before Drizzle is permitted to
+    // start the forward write. Once production has advanced beyond 0024, an
+    // exact active-chain prefix is resumable: a failed later migration must
+    // not make the canonical runner reject its own partial progress.
+    if (state.atBaseline) {
+      await assert0024SchemaAndPendingData(pool);
+    }
+    await pool.query("ROLLBACK");
+    console.log(`Production migration preflight passed: ledger is a resumable active-chain prefix (${ledger.rows.length}/${expected.length}).`);
+  } catch (error) {
+    try { await pool.query("ROLLBACK"); } catch { /* no transaction to roll back */ }
+    throw error;
+  } finally {
+    await pool.end();
+  }
+}
+
+export function assertResumableProductionLedger(
+  actual: readonly Migration[],
+  expected: readonly ExpectedMigration[],
+): { baselineLength: number; atBaseline: boolean } {
+  assertActiveChainPrefix(actual, expected);
+  const baselineIndex = expected.findIndex((migration) => migration.tag === PRODUCTION_BASELINE_TAG);
+  if (baselineIndex < 0) {
+    throw new Error(`Active migration chain 缺少已确认的 production baseline ${PRODUCTION_BASELINE_TAG}。`);
+  }
+  const baselineLength = baselineIndex + 1;
+  if (actual.length < baselineLength) {
+    throw new Error(
+      `Production ledger 早于已确认的 ${PRODUCTION_BASELINE_TAG} baseline；实际 ${actual.length}/${expected.length}，拒绝自动前向迁移。`,
+    );
+  }
+  return { baselineLength, atBaseline: actual.length === baselineLength };
+}
+
+export function assertActiveChainPrefix(actual: readonly Migration[], expected: readonly Migration[]): void {
+  if (actual.length > expected.length || actual.some((item, index) => item.hash !== expected[index]?.hash || item.when !== expected[index]?.when)) {
+    throw new Error("Production Drizzle migration ledger 不是 active migration chain 的精确前缀；拒绝迁移。");
+  }
+}
+
+export function readExpectedMigrations(): ExpectedMigration[] {
+  const migrationsDirectory = resolve(process.cwd(), "drizzle/migrations");
+  const journal = JSON.parse(readFileSync(resolve(migrationsDirectory, "meta/_journal.json"), "utf8")) as { entries: MigrationJournalEntry[] };
+  return journal.entries.map((entry) => ({
+    tag: entry.tag,
+    hash: createHash("sha256").update(readFileSync(resolve(migrationsDirectory, `${entry.tag}.sql`), "utf8")).digest("hex"),
+    when: entry.when,
+  }));
+}
+
+async function assert0024SchemaAndPendingData(pool: Pool): Promise<void> {
+  const result = await pool.query<{
+    has_evidence_url: boolean;
+    has_evidence_code: boolean;
+    has_perfect_id: boolean;
+    unsafe_chsi_rows: string;
+    url_evidence_rows: string;
+    noncanonical_roles: string;
+  }>(`
+    SELECT
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'education_verifications' AND column_name = 'evidence_url') AS has_evidence_url,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'education_verifications' AND column_name = 'evidence_code') AS has_evidence_code,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'perfect_id') AS has_perfect_id,
+      (SELECT count(*)::text FROM education_verifications
+       WHERE evidence_type IN ('chsi_enrollment_report', 'chsi_education_report')
+         AND (evidence_url !~* '^https://(www\\.)?chsi\\.com\\.cn(?:/|[?#]|$)'
+           OR (SELECT count(*) FROM regexp_matches(evidence_url, '(?i)[?&]vcode=', 'g')) <> 1
+           OR upper((regexp_match(evidence_url, '(?i)[?&]vcode=([a-z0-9]{12}|[a-z0-9]{16})(?:[&#]|$)'))[1]) !~ '^(?:[A-Z0-9]{16}|[0-9]{12})$')) AS unsafe_chsi_rows,
+      (SELECT count(*)::text FROM education_verifications
+       WHERE evidence_type NOT IN ('chsi_enrollment_report', 'chsi_education_report') AND evidence_url IS NOT NULL) AS url_evidence_rows,
+      (SELECT count(*)::text FROM user_competitive_roles WHERE role::text NOT IN ('igl', 'awper', 'opener', 'closer', 'anchor')) AS noncanonical_roles
+  `);
+  const facts = result.rows[0];
+  if (!facts?.has_evidence_url || facts.has_evidence_code || !facts.has_perfect_id) {
+    throw new Error("Production schema 不符合 0024 基线；拒绝对未知状态执行 0025/0026。");
+  }
+  if (facts.unsafe_chsi_rows !== "0" || facts.url_evidence_rows !== "0" || facts.noncanonical_roles !== "0") {
+    throw new Error(`Production 0025/0026 fail-closed data validation 未通过：unsafe CHSI=${facts.unsafe_chsi_rows}, non-CHSI URL=${facts.url_evidence_rows}, non-canonical roles=${facts.noncanonical_roles}。`);
+  }
+}
+
+if (require.main === module) {
+  verifyProductionPreflight().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/db/production.ts
+++ b/scripts/db/production.ts
@@ -1,0 +1,27 @@
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { buildProductionEnvironment } from "./production-environment";
+import { runProtectedRemoteCommand } from "./remote";
+
+const projectRoot = resolve(process.cwd());
+
+try {
+  runProtectedRemoteCommand(process.argv[2], {
+    drizzleConfig: "drizzle.production.config.ts",
+    buildEnvironment: (options) => buildProductionEnvironment(process.env, options),
+    beforeMigrate: (environment) => {
+      // runProtectedRemoteCommand is synchronous, so the preflight is invoked
+      // by the separate synchronous child below to keep the write ordering exact.
+      const result = spawnSync(
+        resolve(projectRoot, `node_modules/.bin/tsx${process.platform === "win32" ? ".cmd" : ""}`),
+        ["scripts/db/production-preflight.ts"],
+        { cwd: projectRoot, stdio: "inherit", env: environment },
+      );
+      if (result.error) throw result.error;
+      if (result.status !== 0) throw new Error("Production migration preflight 失败；未执行远程写入。");
+    },
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/db/remote-environment.ts
+++ b/scripts/db/remote-environment.ts
@@ -1,0 +1,123 @@
+export type Environment = Readonly<Record<string, string | undefined>>;
+
+export interface ProtectedRemoteDatabaseConfig {
+  target: "staging" | "production";
+  projectRef: string;
+  poolerHost: string;
+  poolerPort: string;
+  requiresPgbouncer: boolean;
+  passwordKey?: string;
+  projectConfirmationKey: string;
+  hostConfirmationKey?: string;
+  databaseUrlKey: string;
+  requireExplicitTarget: boolean;
+}
+
+export function buildProtectedRemoteEnvironment(
+  env: Environment,
+  config: ProtectedRemoteDatabaseConfig,
+  options: { requiresWriteAuthorization: boolean },
+): NodeJS.ProcessEnv {
+  if (env.DATABASE_URL?.trim()) {
+    throw new Error(`db:${config.target}:* 不接受 DATABASE_URL；拒绝从 shell、.env 或其他远程连接串继承目标。`);
+  }
+  if (config.requireExplicitTarget && env.RIVALHUB_DB_TARGET !== config.target) {
+    throw new Error(`必须显式设置 RIVALHUB_DB_TARGET=${config.target}。`);
+  }
+  if (env.RIVALHUB_DB_TARGET && env.RIVALHUB_DB_TARGET !== config.target) {
+    throw new Error(`db:${config.target}:* 只允许 ${config.target} 目标；拒绝其他环境。`);
+  }
+  assertRemoteConfirmations(env, config);
+  if (options.requiresWriteAuthorization && env.RIVALHUB_ALLOW_REMOTE_DB_WRITE !== config.target) {
+    throw new Error(`远程 ${config.target} migration 未授权；必须显式设置 RIVALHUB_ALLOW_REMOTE_DB_WRITE=${config.target}。`);
+  }
+
+  const passwordKey = config.passwordKey;
+  if (!passwordKey) {
+    throw new Error(`db:${config.target}:* 未配置独立密码输入；该目标应使用自己的受保护 credential builder。`);
+  }
+  const password = env[passwordKey];
+  if (!password?.trim()) {
+    throw new Error(`${passwordKey} 未设置；拒绝猜测或回退到其他凭据。`);
+  }
+  const databaseUrl = assertProtectedRemoteDatabaseUrl(
+    `postgresql://postgres.${config.projectRef}:${encodeURIComponent(password.trim())}@${config.poolerHost}:${config.poolerPort}/postgres${config.requiresPgbouncer ? "?pgbouncer=true" : ""}`,
+    config,
+  );
+  const sanitized = sanitizedRemoteEnvironment(env);
+  return {
+    ...sanitized,
+    NODE_ENV: sanitized.NODE_ENV === "test" ? "test" : "production",
+    DATABASE_URL: databaseUrl,
+    [config.databaseUrlKey]: databaseUrl,
+    RIVALHUB_DB_TARGET: config.target,
+  };
+}
+
+export function assertRemoteConfirmations(env: Environment, config: ProtectedRemoteDatabaseConfig): void {
+  if (env[config.projectConfirmationKey] !== config.projectRef) {
+    throw new Error(`必须显式设置 ${config.projectConfirmationKey}=${config.projectRef}。`);
+  }
+  if (config.hostConfirmationKey) {
+    const expectedHost = `${config.poolerHost}:${config.poolerPort}`;
+    if (env[config.hostConfirmationKey] !== expectedHost) {
+      throw new Error(`必须显式设置 ${config.hostConfirmationKey}=${expectedHost}。`);
+    }
+  }
+}
+
+export function assertProtectedRemoteDatabaseUrl(
+  value: string | undefined,
+  config: ProtectedRemoteDatabaseConfig,
+): string {
+  const url = parseUrl(value, config.databaseUrlKey);
+  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+    throw new Error(`${config.databaseUrlKey} 协议不受支持。`);
+  }
+  if (url.hostname !== config.poolerHost || url.port !== config.poolerPort) {
+    const targetLabel = config.target === "staging" ? "rivalhub-dev" : config.target;
+    throw new Error(`${config.databaseUrlKey} 未指向固定的 ${targetLabel} Transaction Pooler。`);
+  }
+  if (decodeURIComponent(url.username) !== `postgres.${config.projectRef}`) {
+    throw new Error(`${config.databaseUrlKey} 的 project ref 不匹配；已拒绝。`);
+  }
+  if (url.pathname !== "/postgres" || (config.requiresPgbouncer && url.searchParams.get("pgbouncer") !== "true")) {
+    throw new Error(`${config.databaseUrlKey} 必须使用固定的 ${config.target} pooler 格式。`);
+  }
+  if (!url.password) {
+    throw new Error(`${config.databaseUrlKey} 缺少数据库密码。`);
+  }
+  return url.toString();
+}
+
+export function sanitizedRemoteEnvironment(env: Environment): Record<string, string | undefined> {
+  const result = { ...env };
+  for (const key of [
+    "DATABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_ACCESS_TOKEN",
+    "SUPABASE_DB_PASSWORD",
+    "SUPABASE_PROJECT_ID",
+    "RIVALHUB_DB_TARGET",
+    "RIVALHUB_DB_HOST_CONFIRM",
+    "RIVALHUB_ALLOW_REMOTE_DB_WRITE",
+    "RIVALHUB_STAGING_DB_PASSWORD",
+    "RIVALHUB_STAGING_DATABASE_URL",
+    "RIVALHUB_PRODUCTION_DB_PASSWORD",
+    "RIVALHUB_PRODUCTION_DATABASE_URL",
+  ]) {
+    delete result[key];
+  }
+  return result;
+}
+
+function parseUrl(value: string | undefined, label: string): URL {
+  if (!value?.trim()) throw new Error(`${label} 未设置。`);
+  try {
+    return new URL(value.trim());
+  } catch {
+    throw new Error(`${label} 格式无效。`);
+  }
+}

--- a/scripts/db/remote.ts
+++ b/scripts/db/remote.ts
@@ -1,0 +1,57 @@
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { resolve } from "node:path";
+
+interface ProtectedRemoteMigrationTarget {
+  drizzleConfig: string;
+  buildEnvironment: (options: { requiresWriteAuthorization: boolean }) => NodeJS.ProcessEnv;
+  beforeMigrate?: (environment: NodeJS.ProcessEnv) => void;
+}
+
+const projectRoot = resolve(process.cwd());
+const binSuffix = process.platform === "win32" ? ".cmd" : "";
+const drizzleBin = resolve(projectRoot, `node_modules/.bin/drizzle-kit${binSuffix}`);
+const tsxBin = resolve(projectRoot, `node_modules/.bin/tsx${binSuffix}`);
+
+export function runProtectedRemoteCommand(
+  command: string | undefined,
+  target: ProtectedRemoteMigrationTarget,
+): void {
+  switch (command) {
+    case "migrate": {
+      const environment = target.buildEnvironment({ requiresWriteAuthorization: true });
+      // The active chain must parse and replay in Local PostgreSQL before any
+      // remote write. This intentionally does not seed, reset or db:push.
+      run(drizzleBin, ["check"]);
+      run(tsxBin, ["scripts/db/local.ts", "migrate"]);
+      run(tsxBin, ["scripts/db/local.ts", "verify-migrations"]);
+      target.beforeMigrate?.(environment);
+      run(drizzleBin, ["migrate", `--config=${target.drizzleConfig}`], { env: environment });
+      run(tsxBin, ["scripts/db/verify-migrations.ts"], { env: environment });
+      return;
+    }
+    case "verify": {
+      const environment = target.buildEnvironment({ requiresWriteAuthorization: false });
+      run(tsxBin, ["scripts/db/verify-migrations.ts"], { env: environment });
+      return;
+    }
+    default:
+      throw new Error("未知命令。可用命令：migrate | verify");
+  }
+}
+
+function run(
+  executable: string,
+  args: readonly string[],
+  options: Pick<SpawnSyncOptions, "env"> = {},
+): void {
+  const result = spawnSync(executable, [...args], {
+    cwd: projectRoot,
+    stdio: "inherit",
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`命令被信号 ${result.signal} 终止。`);
+  if (result.status !== 0) {
+    throw new Error(`命令执行失败（exit ${result.status ?? "unknown"}）。`);
+  }
+}

--- a/scripts/db/staging-environment.ts
+++ b/scripts/db/staging-environment.ts
@@ -1,8 +1,22 @@
-const STAGING_PROJECT_REF = "cueazphyskstwdhnzsxx";
-const STAGING_POOLER_HOST = "aws-0-ap-northeast-1.pooler.supabase.com";
-const STAGING_POOLER_PORT = "6543";
+import {
+  assertProtectedRemoteDatabaseUrl,
+  buildProtectedRemoteEnvironment,
+  type Environment,
+  type ProtectedRemoteDatabaseConfig,
+} from "./remote-environment";
 
-type Environment = Readonly<Record<string, string | undefined>>;
+const STAGING_PROJECT_REF = "cueazphyskstwdhnzsxx";
+const stagingConfig: ProtectedRemoteDatabaseConfig = {
+  target: "staging",
+  projectRef: STAGING_PROJECT_REF,
+  poolerHost: "aws-0-ap-northeast-1.pooler.supabase.com",
+  poolerPort: "6543",
+  requiresPgbouncer: true,
+  passwordKey: "RIVALHUB_STAGING_DB_PASSWORD",
+  projectConfirmationKey: "RIVALHUB_STAGING_PROJECT_CONFIRM",
+  databaseUrlKey: "RIVALHUB_STAGING_DATABASE_URL",
+  requireExplicitTarget: false,
+};
 
 export { STAGING_PROJECT_REF };
 
@@ -10,95 +24,9 @@ export function buildStagingEnvironment(
   env: Environment = process.env,
   options: { requiresWriteAuthorization: boolean },
 ): NodeJS.ProcessEnv {
-  if (env.DATABASE_URL?.trim()) {
-    throw new Error(
-      "db:staging:* 不接受 DATABASE_URL；拒绝从 shell、.env 或生产连接串继承远程目标。",
-    );
-  }
-  if (env.RIVALHUB_DB_TARGET && env.RIVALHUB_DB_TARGET !== "staging") {
-    throw new Error("db:staging:* 只允许 staging 目标；拒绝 production 或未声明目标。");
-  }
-  if (env.RIVALHUB_STAGING_PROJECT_CONFIRM !== STAGING_PROJECT_REF) {
-    throw new Error(
-      `必须显式设置 RIVALHUB_STAGING_PROJECT_CONFIRM=${STAGING_PROJECT_REF}。`,
-    );
-  }
-  if (
-    options.requiresWriteAuthorization &&
-    env.RIVALHUB_ALLOW_REMOTE_DB_WRITE !== "staging"
-  ) {
-    throw new Error(
-      "远程 staging migration 未授权；必须显式设置 RIVALHUB_ALLOW_REMOTE_DB_WRITE=staging。",
-    );
-  }
-
-  const databaseUrl = buildStagingDatabaseUrl(env.RIVALHUB_STAGING_DB_PASSWORD);
-  const sanitized = sanitizedEnvironment(env);
-
-  return {
-    ...sanitized,
-    NODE_ENV: sanitized.NODE_ENV === "test" ? "test" : "production",
-    DATABASE_URL: databaseUrl,
-    RIVALHUB_STAGING_DATABASE_URL: databaseUrl,
-    RIVALHUB_DB_TARGET: "staging",
-  };
+  return buildProtectedRemoteEnvironment(env, stagingConfig, options);
 }
 
 export function assertStagingDatabaseUrl(value: string | undefined): string {
-  const url = parseUrl(value, "RIVALHUB_STAGING_DATABASE_URL");
-  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
-    throw new Error("RIVALHUB_STAGING_DATABASE_URL 协议不受支持。");
-  }
-  if (url.hostname !== STAGING_POOLER_HOST || url.port !== STAGING_POOLER_PORT) {
-    throw new Error("RIVALHUB_STAGING_DATABASE_URL 未指向固定的 rivalhub-dev Transaction Pooler。");
-  }
-  if (decodeURIComponent(url.username) !== `postgres.${STAGING_PROJECT_REF}`) {
-    throw new Error("RIVALHUB_STAGING_DATABASE_URL 的 project ref 不匹配；已拒绝。");
-  }
-  if (url.pathname !== "/postgres" || url.searchParams.get("pgbouncer") !== "true") {
-    throw new Error("RIVALHUB_STAGING_DATABASE_URL 必须使用 rivalhub-dev 的 Transaction Pooler 格式。");
-  }
-  if (!url.password) {
-    throw new Error("RIVALHUB_STAGING_DATABASE_URL 缺少数据库密码。");
-  }
-  return url.toString();
-}
-
-function buildStagingDatabaseUrl(password: string | undefined): string {
-  if (!password?.trim()) {
-    throw new Error("RIVALHUB_STAGING_DB_PASSWORD 未设置；拒绝猜测或回退到其他凭据。");
-  }
-  return assertStagingDatabaseUrl(
-    `postgresql://postgres.${STAGING_PROJECT_REF}:${encodeURIComponent(password.trim())}@${STAGING_POOLER_HOST}:${STAGING_POOLER_PORT}/postgres?pgbouncer=true`,
-  );
-}
-
-function sanitizedEnvironment(env: Environment): Record<string, string | undefined> {
-  const result = { ...env };
-  for (const key of [
-    "DATABASE_URL",
-    "NEXT_PUBLIC_SUPABASE_URL",
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-    "SUPABASE_SERVICE_ROLE_KEY",
-    "SUPABASE_ACCESS_TOKEN",
-    "SUPABASE_DB_PASSWORD",
-    "SUPABASE_PROJECT_ID",
-    "RIVALHUB_DB_TARGET",
-    "RIVALHUB_DB_HOST_CONFIRM",
-    "RIVALHUB_ALLOW_REMOTE_DB_WRITE",
-    "RIVALHUB_STAGING_DB_PASSWORD",
-    "RIVALHUB_STAGING_DATABASE_URL",
-  ]) {
-    delete result[key];
-  }
-  return result;
-}
-
-function parseUrl(value: string | undefined, label: string): URL {
-  if (!value?.trim()) throw new Error(`${label} 未设置。`);
-  try {
-    return new URL(value.trim());
-  } catch {
-    throw new Error(`${label} 格式无效。`);
-  }
+  return assertProtectedRemoteDatabaseUrl(value, stagingConfig);
 }

--- a/scripts/db/staging.ts
+++ b/scripts/db/staging.ts
@@ -1,44 +1,19 @@
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { buildStagingEnvironment } from "./staging-environment";
+import { runProtectedRemoteCommand } from "./remote";
 
 const projectRoot = resolve(process.cwd());
-const binSuffix = process.platform === "win32" ? ".cmd" : "";
-const drizzleBin = resolve(projectRoot, `node_modules/.bin/drizzle-kit${binSuffix}`);
-const tsxBin = resolve(projectRoot, `node_modules/.bin/tsx${binSuffix}`);
 const command = process.argv[2];
 
 try {
-  switch (command) {
-    case "migrate":
-      migrateStagingDatabase();
-      break;
-    case "verify":
-      verifyStagingDatabase();
-      break;
-    default:
-      throw new Error("未知命令。可用命令：migrate | verify");
-  }
+  runProtectedRemoteCommand(command, {
+    drizzleConfig: "drizzle.staging.config.ts",
+    buildEnvironment: (options) => buildStagingEnvironment(stagingProcessEnvironment(), options),
+  });
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
-}
-
-function migrateStagingDatabase(): void {
-  const stagingEnv = buildStagingEnvironment(stagingProcessEnvironment(), { requiresWriteAuthorization: true });
-
-  // 不启动、不重置、不 seed Local Supabase；它必须已由操作者启动，并先通过同一 active chain。
-  run(tsxBin, ["scripts/db/local.ts", "migrate"]);
-  run(tsxBin, ["scripts/db/local.ts", "verify-migrations"]);
-
-  run(drizzleBin, ["migrate", "--config=drizzle.staging.config.ts"], { env: stagingEnv });
-  run(tsxBin, ["scripts/db/verify-migrations.ts"], { env: stagingEnv });
-}
-
-function verifyStagingDatabase(): void {
-  const stagingEnv = buildStagingEnvironment(stagingProcessEnvironment(), { requiresWriteAuthorization: false });
-  run(tsxBin, ["scripts/db/verify-migrations.ts"], { env: stagingEnv });
 }
 
 /**
@@ -56,22 +31,5 @@ function stagingProcessEnvironment(): NodeJS.ProcessEnv {
     return password ? { ...process.env, RIVALHUB_STAGING_DB_PASSWORD: password } : process.env;
   } catch {
     return process.env;
-  }
-}
-
-function run(
-  executable: string,
-  args: readonly string[],
-  options: Pick<SpawnSyncOptions, "env"> = {},
-): void {
-  const result = spawnSync(executable, [...args], {
-    cwd: projectRoot,
-    stdio: "inherit",
-    ...options,
-  });
-  if (result.error) throw result.error;
-  if (result.signal) throw new Error(`命令被信号 ${result.signal} 终止。`);
-  if (result.status !== 0) {
-    throw new Error(`命令执行失败（exit ${result.status ?? "unknown"}）。`);
   }
 }

--- a/scripts/db/verify-migrations.ts
+++ b/scripts/db/verify-migrations.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { Pool } from "pg";
 import { assertLocalDatabaseUrl } from "./local-environment";
 import { assertStagingDatabaseUrl } from "./staging-environment";
+import { assertProductionConfirmations, assertProductionDatabaseUrl } from "./production-environment";
 import { isLegacyStandardMajorWithoutAffiliation } from "../../src/lib/competition/definition";
 import type { SeasonCapabilities } from "../../src/types/season";
 
@@ -18,7 +19,7 @@ async function main(): Promise<void> {
   const expected = readExpectedMigrations();
   const pool = new Pool({
     connectionString: databaseUrl,
-    ssl: target === "staging" ? { rejectUnauthorized: false } : false,
+    ssl: target === "staging" || target === "production" ? { rejectUnauthorized: false } : false,
     max: 1,
   });
 
@@ -71,9 +72,7 @@ async function main(): Promise<void> {
       hash: entry.hash,
       when: Number(entry.created_at),
     }));
-    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-      throw new Error("Drizzle migration ledger 与 active migration chain 不完全一致。");
-    }
+    assertCompleteMigrationLedger(actual, expected);
 
     const legacyStandardRows = facts.seasons.filter((season) =>
       isLegacyStandardMajorWithoutAffiliation({
@@ -94,7 +93,21 @@ async function main(): Promise<void> {
       throw new Error(`发现 ${legacyStandardRows.length} 个 pre-0008 标准 Major 能力行缺少 affiliation_rules；拒绝猜测回填：${legacyStandardRows.map((row) => row.slug).join(", ")}`);
     }
 
-    console.log(`Migration verification passed for ${target}: ${expected.length} active migrations; no legacy standard Major affiliation backfill is required.`);
+    const terminalSchema = await pool.query<{
+      evidence_code: boolean;
+      evidence_url: boolean;
+      perfect_id: boolean;
+      roles: string[];
+    }>(`
+      SELECT
+        EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'education_verifications' AND column_name = 'evidence_code') AS evidence_code,
+        EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'education_verifications' AND column_name = 'evidence_url') AS evidence_url,
+        EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'perfect_id') AS perfect_id,
+        COALESCE((SELECT json_agg(enumlabel ORDER BY enumsortorder) FROM pg_enum WHERE enumtypid = 'public.cs2_role'::regtype), '[]'::json) AS roles
+    `);
+    assertCurrentTerminalSchema(terminalSchema.rows[0]);
+
+    console.log(`Migration verification passed for ${target}: ${expected.length} active migrations; active terminal schema contract is present.`);
   } finally {
     await pool.end();
   }
@@ -103,10 +116,14 @@ async function main(): Promise<void> {
 function databaseUrlFor(target: string | undefined, value: string | undefined): string {
   if (target === "local") return assertLocalDatabaseUrl(value);
   if (target === "staging") return assertStagingDatabaseUrl(value);
-  throw new Error("Migration verification 目标必须由受保护命令声明为 local 或 staging。");
+  if (target === "production") {
+    assertProductionConfirmations(process.env);
+    return assertProductionDatabaseUrl(value);
+  }
+  throw new Error("Migration verification 目标必须由受保护命令声明为 local、staging 或 production。");
 }
 
-function readExpectedMigrations(): Array<{ hash: string; when: number }> {
+export function readExpectedMigrations(): Array<{ hash: string; when: number }> {
   const migrationsDirectory = resolve(process.cwd(), "drizzle/migrations");
   const journal = JSON.parse(
     readFileSync(resolve(migrationsDirectory, "meta/_journal.json"), "utf8"),
@@ -120,7 +137,36 @@ function readExpectedMigrations(): Array<{ hash: string; when: number }> {
   }));
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+export function assertCompleteMigrationLedger(
+  actual: readonly { hash: string; when: number }[],
+  expected: readonly { hash: string; when: number }[],
+): void {
+  if (actual.length < expected.length) {
+    throw new Error("Drizzle migration ledger 落后于 active migration chain；存在 pending migration。");
+  }
+  if (actual.length > expected.length) {
+    throw new Error("Drizzle migration ledger 包含 unexpected migration；拒绝继续。");
+  }
+  if (actual.some((entry, index) => entry.hash !== expected[index]?.hash || entry.when !== expected[index]?.when)) {
+    throw new Error("Drizzle migration ledger hash divergence；拒绝继续。");
+  }
+}
+
+export function assertCurrentTerminalSchema(facts: {
+  evidence_code: boolean;
+  evidence_url: boolean;
+  perfect_id: boolean;
+  roles: readonly string[];
+} | undefined): void {
+  const canonicalRoles = ["igl", "awper", "opener", "closer", "anchor"];
+  if (!facts?.evidence_code || facts.evidence_url || facts.perfect_id || JSON.stringify(facts.roles) !== JSON.stringify(canonicalRoles)) {
+    throw new Error("Active terminal schema contract 不完整：需要 evidence_code、无 evidence_url/perfect_id，且 cs2_role 为 canonical 集合。");
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/release/production-deployment.ts
+++ b/scripts/release/production-deployment.ts
@@ -1,0 +1,25 @@
+export type ReleaseEnvironment = Readonly<Record<string, string | undefined>>;
+
+const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Production Vercel builds are release-only. Git integration may still create
+ * a production build attempt from main, but without the release workflow's
+ * build marker it fails before reading production schema or running Next.js.
+ */
+export function assertProductionReleaseBuild(env: ReleaseEnvironment): void {
+  if (env.VERCEL_ENV !== "production") return;
+
+  const tag = env.RIVALHUB_RELEASE_TAG?.trim();
+  const commit = env.RIVALHUB_RELEASE_COMMIT?.trim();
+  if (!tag || !RELEASE_TAG_PATTERN.test(tag)) {
+    throw new Error(
+      "Vercel production deploy 必须由 tag release workflow 发起；缺少有效 RIVALHUB_RELEASE_TAG。",
+    );
+  }
+  if (!commit || !/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(
+      "Vercel production deploy 必须携带 release commit SHA；缺少有效 RIVALHUB_RELEASE_COMMIT。",
+    );
+  }
+}

--- a/scripts/vercel-build.ts
+++ b/scripts/vercel-build.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { buildVercelProductionVerificationEnvironment } from "./db/production-environment";
+import { assertProductionReleaseBuild } from "./release/production-deployment";
+
+const projectRoot = resolve(process.cwd());
+const binSuffix = process.platform === "win32" ? ".cmd" : "";
+
+try {
+  if (process.env.VERCEL_ENV === "production") {
+    // Production is release-only. Ordinary Git integration builds do not carry
+    // these workflow-injected markers and therefore fail before Next.js build.
+    assertProductionReleaseBuild(process.env);
+    const productionEnvironment = buildVercelProductionVerificationEnvironment(process.env);
+    run(resolve(projectRoot, `node_modules/.bin/tsx${binSuffix}`), ["scripts/db/verify-migrations.ts"], productionEnvironment);
+  }
+  run(resolve(projectRoot, `node_modules/.bin/next${binSuffix}`), ["build"], process.env);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+function run(executable: string, args: readonly string[], env: NodeJS.ProcessEnv): void {
+  const result = spawnSync(executable, [...args], { cwd: projectRoot, stdio: "inherit", env });
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`Vercel build 被信号 ${result.signal} 终止。`);
+  if (result.status !== 0) throw new Error(`Vercel build gate 失败（exit ${result.status ?? "unknown"}）。`);
+}

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { eq, and, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client";
-import { competitionEntries, eventRosterMembers, eventRosters, users, seasonRegistrations, seasons, matches, matchMaps, competitiveRankFacts } from "@/db/schema";
+import { competitionEntries, eventRosterMembers, eventRosters, users, seasonRegistrations, seasons, matches, matchMaps, competitiveRankFacts, userCompetitiveRoles } from "@/db/schema";
 import { resolveAvatarUrl } from "@/lib/steam";
 import { PUBLIC_PLAYER_INFO_FIELDS } from "@/lib/utils/player-info-fields";
 import { getPublicDisplayName } from "@/lib/identity/display-name";
@@ -15,6 +15,8 @@ import { wAvg } from "@/lib/utils/stats";
 import { getSeasonHexagonScores } from "@/actions/hexagon";
 import type { HexagonScores } from "@/lib/utils/hexagon";
 import { PlayerRadarChart } from "@/components/matches/PlayerRadarChart";
+import { loadCompetitivePlatformCatalog } from "@/lib/competitive/catalog";
+import { presentCompetitiveRole, presentPublicCompetitiveProfile } from "@/lib/competitive/presentation";
 
 /**
  * 统计玩家 MVP 获胜次数（从 matches.mvp_winner_user_id 直读，已持久化缓存）。
@@ -62,19 +64,16 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   if (!user) notFound();
 
   // ── 并行：报名记录 / MVP 胜场 / 个人数据 / Steam 头像 ──────────────────
-  const [registrations, mvpWinCount, playerStats, avatarUrl] = await Promise.all([
+  const [registrations, mvpWinCount, playerStats, avatarUrl, competitiveFacts, competitiveRoles, competitiveCatalog] = await Promise.all([
     db
       .select({
         id: seasonRegistrations.id,
         seasonId: seasonRegistrations.seasonId,
         primaryPosition: seasonRegistrations.primaryPosition,
-        secondaryPosition: seasonRegistrations.secondaryPosition,
         peakRank: seasonRegistrations.peakRank,
         peakRankSeason: seasonRegistrations.peakRankSeason,
         peakRating: seasonRegistrations.peakRating,
         peakWe: seasonRegistrations.peakWe,
-        currentSeasonPeakRank: seasonRegistrations.currentSeasonPeakRank,
-        currentRating: seasonRegistrations.currentRating,
         mapPreferences: seasonRegistrations.mapPreferences,
         highlightVideoUrl: seasonRegistrations.highlightVideoUrl,
         gameplayStyle: seasonRegistrations.gameplayStyle,
@@ -128,6 +127,9 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
       .groupBy(seasons.id, seasons.name, seasons.slug, seasons.createdAt)
       .orderBy(asc(seasons.createdAt)),
     resolveAvatarUrl({ avatarUrl: user.avatarUrl, steam64: user.steam64 }),
+    db.select().from(competitiveRankFacts).where(eq(competitiveRankFacts.userId, userId)),
+    db.select().from(userCompetitiveRoles).where(eq(userCompetitiveRoles.userId, userId)),
+    loadCompetitivePlatformCatalog(db),
   ]);
 
   // ── 六维数据：仅对有数据的赛季查询 ──────────────────────────────────
@@ -155,7 +157,11 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
     .where(eq(eventRosterMembers.userId, userId));
 
   const teamBySeasonId = new Map(teamMemberRows.map((r) => [r.seasonId, r]));
-  const competitiveFacts = await db.select().from(competitiveRankFacts).where(eq(competitiveRankFacts.userId, userId));
+  const publicCompetitiveProfile = presentPublicCompetitiveProfile(competitiveCatalog, competitiveFacts);
+  const publicCompetitiveRoles = competitiveRoles
+    .sort((a, b) => Number(b.isPrimary) - Number(a.isPrimary))
+    .map((role) => presentCompetitiveRole(role.role))
+    .filter((role): role is string => role !== null);
 
   // ── 跨赛季比赛战绩（以个人 OCR 出场记录为准）───────────────────────
   const teamIds = [...new Set(teamMemberRows.map((r) => r.teamId).filter(Boolean))];
@@ -198,7 +204,8 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
 
   const played = totalWins + totalLosses;
 
-  // 最新报名的主位置
+  // Registration snapshots remain event history only; the header's current
+  // long-lived role preferences come from user_competitive_roles above.
   const latestReg = registrations[registrations.length - 1];
 
   // ── 生涯总计预计算 ──────────────────────────────────────────────────
@@ -239,12 +246,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
           )}
 
           <div className="flex flex-wrap items-center gap-2">
-            {latestReg && (
-              <>
-                <PosChip pos={POSITION_LABELS[latestReg.primaryPosition as keyof typeof POSITION_LABELS]?.cn ?? latestReg.primaryPosition} />
-                <PosChip pos={POSITION_LABELS[latestReg.secondaryPosition as keyof typeof POSITION_LABELS]?.cn ?? latestReg.secondaryPosition} />
-              </>
-            )}
+            {publicCompetitiveRoles.map((role) => <PosChip key={role} pos={role} />)}
             {user.steamProfileUrl && (
               <a
                 href={user.steamProfileUrl}
@@ -259,7 +261,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         </div>
       </div>
 
-      {competitiveFacts.length > 0 && <section className="space-y-3"><SectionHeading>公开竞技档案</SectionHeading><Panel pad={16}><div className="space-y-2 text-sm">{competitiveFacts.map((fact) => <p key={fact.id}><span className="text-[var(--color-fg-mid)]">{fact.kind === "historical_peak" ? "历史最高" : `赛季 ${fact.platformSeasonKey ?? "—"} 最高`}</span> · {fact.rank} · Rating {String(fact.rating)}</p>)}</div></Panel></section>}
+      {publicCompetitiveProfile.length > 0 && <section className="space-y-3"><SectionHeading>公开竞技档案</SectionHeading><Panel pad={16}><div className="space-y-4 text-sm">{publicCompetitiveProfile.map((platform) => <div key={platform.displayName} className="space-y-2"><p className="font-semibold text-[var(--color-fg)]">{platform.displayName}</p>{platform.facts.map((fact) => <p key={`${platform.displayName}-${fact.label}`}><span className="text-[var(--color-fg-mid)]">{fact.label}</span> · {fact.rankLabel}{fact.stars !== null ? ` ${fact.stars} 星` : ""} · {fact.ratingLabel} {fact.rating}</p>)}</div>)}</div></Panel></section>}
 
       {latestReg && (
         <section className="space-y-3">
@@ -448,7 +450,7 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
         </section>
       )}
 
-      {/* 赛季记录 */}
+      {/* Immutable event-registration snapshots, deliberately separate from the long-lived profile above. */}
       {registrations.length > 0 && (
         <section className="space-y-3">
           <SectionHeading>参赛记录</SectionHeading>

--- a/src/lib/competitive/presentation.ts
+++ b/src/lib/competitive/presentation.ts
@@ -1,0 +1,62 @@
+import { CS2_POSITION_LABELS } from "@/lib/config/cs2-positions";
+import type { CompetitivePlatformCatalogEntry } from "./catalog";
+
+export interface CompetitiveProfileFactForPresentation {
+  id: string;
+  platform: string;
+  kind: "historical_peak" | "season_peak";
+  platformSeasonKey: string | null;
+  rank: string;
+  rating: string | number;
+  stars: number | null;
+}
+
+export interface PublicCompetitiveProfileFact {
+  label: string;
+  rankLabel: string;
+  stars: number | null;
+  ratingLabel: string;
+  rating: string;
+}
+
+export interface PublicCompetitiveProfilePlatform {
+  displayName: string;
+  facts: PublicCompetitiveProfileFact[];
+}
+
+/** Public presentation is catalog-backed: no persisted platform, season or rank key may leak into the player page. */
+export function presentPublicCompetitiveProfile(
+  catalog: readonly CompetitivePlatformCatalogEntry[],
+  facts: readonly CompetitiveProfileFactForPresentation[],
+): PublicCompetitiveProfilePlatform[] {
+  return catalog.flatMap((platform) => {
+    const ranks = new Map(platform.ranks.map((rank) => [rank.rankKey, rank]));
+    const seasons = new Map(platform.seasons.map((season) => [season.seasonKey, season]));
+    const visible = facts
+      .filter((fact) => fact.platform === platform.key)
+      .flatMap((fact): Array<PublicCompetitiveProfileFact & { order: number }> => {
+        const rank = ranks.get(fact.rank);
+        if (!rank) return [];
+        if (fact.kind === "historical_peak") {
+          return [{ label: "历史最高", rankLabel: rank.label, stars: rank.starMin === null ? null : fact.stars, ratingLabel: platform.ratingLabel, rating: String(fact.rating), order: Number.POSITIVE_INFINITY }];
+        }
+        const season = fact.platformSeasonKey ? seasons.get(fact.platformSeasonKey) : undefined;
+        if (!season) return [];
+        return [{ label: `${season.label} · 最高`, rankLabel: rank.label, stars: rank.starMin === null ? null : fact.stars, ratingLabel: platform.ratingLabel, rating: String(fact.rating), order: season.sortOrder }];
+      })
+      .sort((a, b) => b.order - a.order)
+      .map((fact) => ({
+        label: fact.label,
+        rankLabel: fact.rankLabel,
+        stars: fact.stars,
+        ratingLabel: fact.ratingLabel,
+        rating: fact.rating,
+      }));
+    return visible.length > 0 ? [{ displayName: platform.displayName, facts: visible }] : [];
+  });
+}
+
+/** Long-lived roles use the shared CS2 taxonomy, never a registration snapshot label. */
+export function presentCompetitiveRole(role: string): string | null {
+  return CS2_POSITION_LABELS[role as keyof typeof CS2_POSITION_LABELS]?.full ?? null;
+}

--- a/tests/unit/db/production-environment.test.ts
+++ b/tests/unit/db/production-environment.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRODUCTION_POOLER_HOST,
+  PRODUCTION_POOLER_PORT,
+  PRODUCTION_PROJECT_REF,
+  assertProductionDatabaseUrl,
+  buildProductionEnvironment,
+  buildVercelProductionVerificationEnvironment,
+} from "../../../scripts/db/production-environment";
+
+const runtimeUrl = `postgresql://postgres.${PRODUCTION_PROJECT_REF}:pw@${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}/postgres`;
+const confirmation = {
+  RIVALHUB_DB_TARGET: "production",
+  RIVALHUB_PRODUCTION_PROJECT_CONFIRM: PRODUCTION_PROJECT_REF,
+  RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: `${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}`,
+  DATABASE_URL: runtimeUrl,
+};
+
+describe("production database target guard", () => {
+  it("reuses only the validated runtime DATABASE_URL", () => {
+    const env = buildProductionEnvironment(confirmation, { requiresWriteAuthorization: false });
+    expect(env.DATABASE_URL).toContain(`postgres.${PRODUCTION_PROJECT_REF}`);
+    expect(env.DATABASE_URL).toContain(`${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}`);
+    expect(env.DATABASE_URL).toContain("pgbouncer=true");
+    expect(env.RIVALHUB_PRODUCTION_DATABASE_URL).toBe(env.DATABASE_URL);
+    expect(env.RIVALHUB_DB_TARGET).toBe("production");
+    expect(env.RIVALHUB_PRODUCTION_DB_PASSWORD).toBeUndefined();
+  });
+
+  it("fails closed for missing target confirmation, missing credential, staging targets and unapproved writes", () => {
+    expect(() => buildProductionEnvironment({}, { requiresWriteAuthorization: false })).toThrow(/RIVALHUB_DB_TARGET=production/);
+    expect(() => buildProductionEnvironment({ ...confirmation, DATABASE_URL: undefined }, { requiresWriteAuthorization: false })).toThrow(/不维护第二份数据库密码/);
+    expect(() => buildProductionEnvironment({ ...confirmation, RIVALHUB_DB_TARGET: "staging" }, { requiresWriteAuthorization: false })).toThrow(/RIVALHUB_DB_TARGET=production/);
+    expect(() => buildProductionEnvironment({ ...confirmation, RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: `${PRODUCTION_POOLER_HOST}:5432` }, { requiresWriteAuthorization: false })).toThrow(/DB_HOST_CONFIRM/);
+    expect(() => buildProductionEnvironment(confirmation, { requiresWriteAuthorization: true })).toThrow(/ALLOW_REMOTE_DB_WRITE=production/);
+  });
+
+  it("rejects non-production DATABASE_URL values and only lets Vercel production builds inherit the runtime URL", () => {
+    expect(() => buildProductionEnvironment({ ...confirmation, DATABASE_URL: "postgresql://prod.example.com/postgres" }, { requiresWriteAuthorization: false })).toThrow(/固定的 production/);
+    expect(() => assertProductionDatabaseUrl(`postgresql://postgres.cueazphyskstwdhnzsxx:pw@${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}/postgres?pgbouncer=true`)).toThrow(/project ref/);
+
+    expect(() => buildVercelProductionVerificationEnvironment({ VERCEL_ENV: "preview", DATABASE_URL: runtimeUrl })).toThrow(/VERCEL_ENV=production/);
+    const vercelEnv = buildVercelProductionVerificationEnvironment({ VERCEL_ENV: "production", DATABASE_URL: runtimeUrl });
+    expect(vercelEnv).toMatchObject({
+      RIVALHUB_DB_TARGET: "production",
+      RIVALHUB_PRODUCTION_PROJECT_CONFIRM: PRODUCTION_PROJECT_REF,
+      RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: `${PRODUCTION_POOLER_HOST}:${PRODUCTION_POOLER_PORT}`,
+    });
+    expect(vercelEnv.DATABASE_URL).toContain("pgbouncer=true");
+  });
+});

--- a/tests/unit/db/production-preflight.test.ts
+++ b/tests/unit/db/production-preflight.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRODUCTION_BASELINE_TAG,
+  assertResumableProductionLedger,
+  type ExpectedMigration,
+  type Migration,
+} from "../../../scripts/db/production-preflight";
+
+const expected: ExpectedMigration[] = [
+  { tag: "0022_example", hash: "h22", when: 22 },
+  { tag: "0023_example", hash: "h23", when: 23 },
+  { tag: PRODUCTION_BASELINE_TAG, hash: "h24", when: 24 },
+  { tag: "0025_example", hash: "h25", when: 25 },
+  { tag: "0026_example", hash: "h26", when: 26 },
+  { tag: "0027_example", hash: "h27", when: 27 },
+];
+
+const prefix = (length: number): Migration[] =>
+  expected.slice(0, length).map(({ hash, when }) => ({ hash, when }));
+
+describe("production migration preflight ledger policy", () => {
+  it("accepts the exact confirmed baseline and requests baseline-specific predicates", () => {
+    expect(assertResumableProductionLedger(prefix(3), expected)).toEqual({
+      baselineLength: 3,
+      atBaseline: true,
+    });
+  });
+
+  it("accepts partial progress after the baseline so a failed migration can be retried", () => {
+    expect(assertResumableProductionLedger(prefix(4), expected)).toEqual({
+      baselineLength: 3,
+      atBaseline: false,
+    });
+  });
+
+  it("accepts any newer incomplete exact active-chain prefix", () => {
+    expect(assertResumableProductionLedger(prefix(5), expected)).toEqual({
+      baselineLength: 3,
+      atBaseline: false,
+    });
+  });
+
+  it("accepts an already complete active chain", () => {
+    expect(assertResumableProductionLedger(prefix(expected.length), expected)).toEqual({
+      baselineLength: 3,
+      atBaseline: false,
+    });
+  });
+
+  it("rejects a ledger older than the confirmed production baseline", () => {
+    expect(() => assertResumableProductionLedger(prefix(2), expected)).toThrow(/早于已确认/);
+  });
+
+  it("rejects hash or timestamp divergence even after the baseline", () => {
+    const divergent = prefix(4);
+    divergent[3] = { ...divergent[3], hash: "unexpected" };
+    expect(() => assertResumableProductionLedger(divergent, expected)).toThrow(/精确前缀/);
+  });
+
+  it("fails closed when the active chain no longer contains the configured baseline tag", () => {
+    const missingBaseline = expected.map((migration) => ({
+      ...migration,
+      tag: migration.tag === PRODUCTION_BASELINE_TAG ? "0024_other" : migration.tag,
+    }));
+    expect(() => assertResumableProductionLedger(prefix(3), missingBaseline)).toThrow(/缺少已确认/);
+  });
+});

--- a/tests/unit/db/verify-migrations.test.ts
+++ b/tests/unit/db/verify-migrations.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { assertCompleteMigrationLedger, assertCurrentTerminalSchema } from "../../../scripts/db/verify-migrations";
+import { assertActiveChainPrefix } from "../../../scripts/db/production-preflight";
+
+const expected = [
+  { hash: "first", when: 1 },
+  { hash: "second", when: 2 },
+];
+
+describe("active Drizzle ledger verification", () => {
+  it("accepts only the complete expected ledger", () => {
+    expect(() => assertCompleteMigrationLedger(expected, expected)).not.toThrow();
+  });
+
+  it("fails closed for a pending migration, a divergent hash, or an unexpected ledger entry", () => {
+    expect(() => assertCompleteMigrationLedger([expected[0]!], expected)).toThrow(/pending migration/);
+    expect(() => assertCompleteMigrationLedger([{ hash: "other", when: 1 }, expected[1]!], expected)).toThrow(/hash divergence/);
+    expect(() => assertCompleteMigrationLedger([...expected, { hash: "third", when: 3 }], expected)).toThrow(/unexpected migration/);
+    expect(() => assertActiveChainPrefix([{ hash: "other", when: 1 }], expected)).toThrow(/精确前缀/);
+  });
+
+  it("requires the active terminal schema contract", () => {
+    expect(() => assertCurrentTerminalSchema({ evidence_code: true, evidence_url: false, perfect_id: false, roles: ["igl", "awper", "opener", "closer", "anchor"] })).not.toThrow();
+    expect(() => assertCurrentTerminalSchema({ evidence_code: false, evidence_url: true, perfect_id: true, roles: ["igl"] })).toThrow(/terminal schema contract/);
+  });
+});

--- a/tests/unit/lib/competitive/presentation.test.ts
+++ b/tests/unit/lib/competitive/presentation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { presentCompetitiveRole, presentPublicCompetitiveProfile } from "@/lib/competitive/presentation";
+
+const catalog = [{
+  key: "perfect_world",
+  displayName: "完美平台",
+  ratingLabel: "Rating Pro",
+  ranks: [
+    { id: "bronze", rankKey: "bronze_s", label: "青铜 S", sortOrder: 1, starMin: 0, starMax: 9 },
+    { id: "gold", rankKey: "gold_s", label: "黄金 S", sortOrder: 2, starMin: 10, starMax: 24 },
+  ],
+  seasons: [
+    { id: "s1", seasonKey: "2026s1", label: "2026 第一赛季", sortOrder: 202601, active: true, isCurrent: false },
+    { id: "s2", seasonKey: "2026s2", label: "2026 第二赛季", sortOrder: 202602, active: true, isCurrent: true },
+  ],
+}];
+
+describe("public competitive profile presentation", () => {
+  it("uses catalog display labels, preserves stars and never exposes stored keys", () => {
+    const profile = presentPublicCompetitiveProfile(catalog, [
+      { id: "history", platform: "perfect_world", kind: "historical_peak", platformSeasonKey: null, rank: "gold_s", rating: "1.17", stars: 10 },
+      { id: "s1", platform: "perfect_world", kind: "season_peak", platformSeasonKey: "2026s1", rank: "bronze_s", rating: "1.10", stars: 8 },
+      { id: "s2", platform: "perfect_world", kind: "season_peak", platformSeasonKey: "2026s2", rank: "gold_s", rating: "1.17", stars: 10 },
+      { id: "unknown", platform: "unknown", kind: "season_peak", platformSeasonKey: "raw-season", rank: "raw-rank", rating: "9", stars: null },
+    ]);
+    expect(profile).toEqual([{
+      displayName: "完美平台",
+      facts: [
+        { label: "历史最高", rankLabel: "黄金 S", stars: 10, ratingLabel: "Rating Pro", rating: "1.17" },
+        { label: "2026 第二赛季 · 最高", rankLabel: "黄金 S", stars: 10, ratingLabel: "Rating Pro", rating: "1.17" },
+        { label: "2026 第一赛季 · 最高", rankLabel: "青铜 S", stars: 8, ratingLabel: "Rating Pro", rating: "1.10" },
+      ],
+    }]);
+  });
+
+  it("uses the shared long-lived role taxonomy and hides unknown persisted keys", () => {
+    expect(presentCompetitiveRole("igl")).toBe("IGL（指挥）");
+    expect(presentCompetitiveRole("legacy_position")).toBeNull();
+  });
+});

--- a/tests/unit/release/production-deployment.test.ts
+++ b/tests/unit/release/production-deployment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { assertProductionReleaseBuild } from "../../../scripts/release/production-deployment";
+
+describe("production deployment provenance gate", () => {
+  it("does not constrain preview builds", () => {
+    expect(() => assertProductionReleaseBuild({ VERCEL_ENV: "preview" })).not.toThrow();
+  });
+
+  it("accepts a tagged release build with an exact commit sha", () => {
+    expect(() => assertProductionReleaseBuild({
+      VERCEL_ENV: "production",
+      RIVALHUB_RELEASE_TAG: "v2.0.1",
+      RIVALHUB_RELEASE_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+    })).not.toThrow();
+  });
+
+  it("rejects ordinary production Git builds and malformed release markers", () => {
+    expect(() => assertProductionReleaseBuild({ VERCEL_ENV: "production" })).toThrow(/tag release workflow/);
+    expect(() => assertProductionReleaseBuild({
+      VERCEL_ENV: "production",
+      RIVALHUB_RELEASE_TAG: "main",
+      RIVALHUB_RELEASE_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+    })).toThrow(/RIVALHUB_RELEASE_TAG/);
+    expect(() => assertProductionReleaseBuild({
+      VERCEL_ENV: "production",
+      RIVALHUB_RELEASE_TAG: "v2.0.1",
+      RIVALHUB_RELEASE_COMMIT: "not-a-sha",
+    })).toThrow(/RIVALHUB_RELEASE_COMMIT/);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,4 @@
-{}
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "tsx scripts/vercel-build.ts"
+}


### PR DESCRIPTION
## 发布内容

- 将 production database migration 纳入正式 `v*` tag release transaction：迁移前做 active-chain / baseline preflight，迁移后 exact verify，再部署精确 release commit；普通 `main` production build 不能绕过 release gate。
- production migration/verify 复用 Vercel Production 现有 `DATABASE_URL`，GitHub `production` Environment 的 `VERCEL_TOKEN` 仅用于受控读取 Production env 与执行 Vercel production deploy，不维护第二份数据库密码。
- 修复公开玩家竞技档案的数据 owner：长期位置、平台赛季、段位与星数来自长期竞技资料和平台目录，赛事报名快照只保留在参赛历史。

## Release bookkeeping

- 已通过 Changesets 消费本轮唯一 patch changeset，将版本从 `2.0.1` 升至 `2.0.2`。
- 已完成 stable patch 的 CHANGELOG editorial review。
- 为避免 `dev` / `main` squash-history 造成 three-dot diff 污染，本 release commit 直接以当前 `main` `fc3ef79` 为 parent，并使用已验证的 release tree；相对 `main` 只有本轮 #318 + release bookkeeping 的 25 个文件。

## 验证

- #318 CI：quality / Local PostgreSQL integration / Playwright E2E 全绿，Vercel Preview 成功。
- release preparation workflow 成功执行 `pnpm exec changeset version` 并自动删除一次性 workflow。
- 本 PR 的 required CI / Vercel Preview 全绿后才合入 `main`。

## 发布后

合入 `main` 后创建 `v2.0.2` tag；tag workflow 自动执行 production migration（已知 baseline 0024）→ exact verify → Vercel Production deploy → smoke test → GitHub Release。tag 前不手工修改 production schema。

Refs #318