### PR TITLE
chore(sync): 回流 v2.0.2 release bookkeeping 到 dev

### DIFF
--- a/.changeset/green-production-schema-gate.md
+++ b/.changeset/green-production-schema-gate.md
@@ -1,5 +1,0 @@
----
-"rivalhub": patch
----
-
-生产发版现在由 tag release workflow 串行执行数据库迁移、严格校验、精确 Vercel Production 部署与 smoke test；普通 main production build 无法绕过 release gate。公开玩家竞技档案改用平台目录与长期位置资料展示段位、赛季和星数。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.2
+
+### Changed
+
+- 生产发版改为由 `v*` tag 的 release workflow 串行执行数据库前向迁移、严格校验、精确 Vercel Production 部署与 smoke test；普通 `main` production build 不能绕过 release gate。
+
+### Fixed
+
+- 公开玩家竞技档案改用长期竞技位置与平台目录展示位置、段位、赛季和星数，不再把赛事报名快照当作长期资料。
+
+### Migration & Operations
+
+- Production release 会在应用部署前执行 active Drizzle migration chain 并进行 exact verify；迁移或校验失败会中止新版本部署并保留上一版 production。
+
 ## 2.0.1
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
## 同步内容

- 回流 `v2.0.2` 的版本号、CHANGELOG 与已消费 changeset。
- runtime/source tree 与 `main` 的 v2.0.2 release source 对齐；#318 的实际实现已经先在 `dev` 合入，本 PR 只补 release bookkeeping。

## 拓扑处理

- 不 force-push `dev`，不重放历史 release commits。
- 本同步 commit 直接以当前 `dev` 为 parent、使用已验证的 v2.0.2 release tree，因此相对 `dev` 仅应出现 `package.json`、`CHANGELOG.md` 与 changeset 删除。

## 验证

- CI / Vercel Preview 全绿后合入。