### PR TITLE
fix(release): 使用 GitHub 生产迁移凭据

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ jobs:
       contents: write
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      # Fixed non-secret Vercel target. The only credential this workflow needs
-      # is VERCEL_TOKEN; production DATABASE_URL remains owned by Vercel.
+      # Fixed non-secret Vercel target. VERCEL_TOKEN authorizes the exact
+      # production deployment; DATABASE_URL is a GitHub production Environment
+      # secret dedicated to the protected migration runner below.
       VERCEL_ORG_ID: team_0eIkBawGTdVjwYHdyrb20ZVV
       VERCEL_PROJECT_ID: prj_3bjmfKrSqRh4szrkEE4HpavnhI0E
       RIVALHUB_DB_TARGET: production
@@ -61,6 +62,8 @@ jobs:
             echo "GitHub production environment secret VERCEL_TOKEN is required." >&2
             exit 1
           fi
+          # This checks project access only. Vercel never exports Sensitive
+          # values to external runners, so it is deliberately not a DB source.
           vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Validate active migration chain locally
@@ -70,22 +73,14 @@ jobs:
 
       - name: Migrate and verify production database
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
-          vercel env run -e production -- \
-            env \
-              RIVALHUB_DB_TARGET=production \
-              RIVALHUB_PRODUCTION_PROJECT_CONFIRM="$RIVALHUB_PRODUCTION_PROJECT_CONFIRM" \
-              RIVALHUB_PRODUCTION_DB_HOST_CONFIRM="$RIVALHUB_PRODUCTION_DB_HOST_CONFIRM" \
-              RIVALHUB_ALLOW_REMOTE_DB_WRITE=production \
-              pnpm db:production:migrate
-
-          vercel env run -e production -- \
-            env \
-              RIVALHUB_DB_TARGET=production \
-              RIVALHUB_PRODUCTION_PROJECT_CONFIRM="$RIVALHUB_PRODUCTION_PROJECT_CONFIRM" \
-              RIVALHUB_PRODUCTION_DB_HOST_CONFIRM="$RIVALHUB_PRODUCTION_DB_HOST_CONFIRM" \
-              pnpm db:production:verify
+          if [[ -z "$DATABASE_URL" || "$DATABASE_URL" == "[SENSITIVE]" ]]; then
+            echo "GitHub production environment secret DATABASE_URL is required." >&2
+            exit 1
+          fi
+          RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:migrate
+          pnpm db:production:verify
 
       - name: Deploy exact release commit to Vercel Production
         id: deploy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,7 +55,7 @@ pnpm db:staging:migrate
 
 Production 的 active chain 仍只有一个 authority：`drizzle/migrations/meta/_journal.json` 与对应 SQL SHA-256。只读核验与前向迁移只能使用以下受保护命令；禁止裸 `drizzle-kit migrate`、手工 `ALTER TABLE`、`db:push`、seed 或 reset。
 
-Production 与应用运行时统一使用同一个 Supabase **Transaction Pooler `DATABASE_URL`**：`aws-0-ap-northeast-1.pooler.supabase.com:6543`。不再维护 `RIVALHUB_PRODUCTION_DB_PASSWORD` 或第二份 production database credential。受保护命令复用运行时 `DATABASE_URL`，但在任何查询或写入前严格验证固定 project ref、host、port、username 和 pooler shape；因此“复用已有 secret”不等于接受任意 inherited connection string。
+Production 与应用运行时统一使用同一个 Supabase **Transaction Pooler `DATABASE_URL`**：`aws-0-ap-northeast-1.pooler.supabase.com:6543`。Vercel 的 Sensitive runtime value 无法被 GitHub-hosted runner 导出，因此 release runner 在 GitHub `production` Environment 维护一份同值的 `DATABASE_URL` secret；它仅用于受保护的 migration/verify，不替代 Vercel runtime credential。受保护命令在任何查询或写入前严格验证固定 project ref、host、port、username 和 pooler shape，不接受任意 inherited connection string。
 
 ```bash
 # DATABASE_URL 使用与 production runtime 相同的现有 Transaction Pooler secret。
@@ -77,11 +77,11 @@ RIVALHUB_ALLOW_REMOTE_DB_WRITE=production \
 pnpm db:production:migrate
 ```
 
-在 Vercel Production 中 `DATABASE_URL` 本来就是应用访问 production DB 的 runtime secret，因此 migration/verify runner 应在能够继承该 Production environment 的受控执行环境中运行；不要把 URL 拆成第二份 password secret。显式 target、project、host 和 write authorization 仍是独立安全门禁。
+Vercel Production 的 `DATABASE_URL` 是应用 runtime secret；GitHub `production` Environment 的同值 `DATABASE_URL` 是 release runner secret。两处均通过环境变量注入，绝不进入 repository、日志、tag 或 release notes。显式 target、project、host 和 write authorization 仍是独立安全门禁。
 
 Production preflight 以 `0024_major_runtime_convergence` 为已确认最低 baseline：早于 0024 的 ledger 直接拒绝；恰好位于 0024 时会在只读事务内验证旧 schema 形态以及 0025 CHSI-code extraction / 0026 role values 的 fail-closed predicates；任何晚于 0024 且仍是 active chain **精确前缀**的状态都允许继续前向执行，因此某个后续 migration 已成功、再后一个 migration 失败时可以安全重试 canonical runner。hash/timestamp divergence、unexpected entry 或超出 active chain 仍然 fail closed。迁移完成后 verify 要求完整 ledger SHA/timestamp sequence，并验证 `evidence_code` present/`evidence_url` absent、`perfect_id` absent 与 canonical `cs2_role` enum。
 
-正式 production release 由 `.github/workflows/release.yml` 的 `v*` tag workflow 独占：tag commit 必须已经包含在 `main`；runner 使用 GitHub `production` Environment 中的 `VERCEL_TOKEN` 访问 Vercel，但 production database credential 仍只存在于 Vercel Production `DATABASE_URL`。workflow 的固定顺序是 **tag/main 校验 → Local migration validation → production migrate → production verify → exact tag Vercel Production deploy → smoke test → GitHub Release**。数据库迁移因此属于 release transaction，而不是发版后的人工补丁。
+正式 production release 由 `.github/workflows/release.yml` 的 `v*` tag workflow 独占：tag commit 必须已经包含在 `main`；runner 从 GitHub `production` Environment 取得 `VERCEL_TOKEN` 与仅用于 migration/verify 的 `DATABASE_URL`。workflow 的固定顺序是 **tag/main 校验 → Local migration validation → production migrate → production verify → exact tag Vercel Production deploy → smoke test → GitHub Release**。数据库迁移因此属于 release transaction，而不是发版后的人工补丁。
 
 Vercel production builds 使用 [`scripts/vercel-build.ts`](../scripts/vercel-build.ts)：当 `VERCEL_ENV=production` 时，只有 release workflow 注入合法 `RIVALHUB_RELEASE_TAG` 与 `RIVALHUB_RELEASE_COMMIT` 后才继续；随后它使用现有 runtime Transaction Pooler `DATABASE_URL` 执行 exact production migration verify，再进入 `next build`。普通 `main` Git auto-deploy 即使被 Vercel 创建，也会在没有 release marker 时 fail closed 并保留上一版 production；Preview builds 不读取 production DB。build gate 只验证，不自动执行 migration，从而避免“DB 已前进但 application build 随后失败”的反向半发布状态。
 


### PR DESCRIPTION
## 变更

- production release runner 改由 GitHub `production` Environment 的 `DATABASE_URL` secret 执行受保护的 migrate/verify。
- 保留 Vercel runtime credential 与 Vercel build 内的 exact verify；不再假设 Sensitive value 可导出给 GitHub runner。
- 更新 production credential boundary 文档。

## 验证

- `pnpm test`（158 files / 991 tests）
- `pnpm type-check`
- `git diff --check`

## Changeset

无需 changeset：仅 CI/release infrastructure 与运行文档调整，不改变已发布应用的用户运行时行为。