### PR TITLE
docs: 规范 2.x Issue 格式与元数据

### DIFF
--- a/.github/ISSUE_TEMPLATE/2x-work-item.yml
+++ b/.github/ISSUE_TEMPLATE/2x-work-item.yml
@@ -1,0 +1,57 @@
+name: 2.x 工作项
+description: 创建 RivalHub 2.x 产品、架构、基础设施、性能或 UX 工作项
+title: "[2.x] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请使用自然中文描述问题。创建后确认该 Issue 存在且仅存在一个 `priority:P0` / `priority:P1` / `priority:P2` / `priority:P3` label；`next` 仅用于当前正在推进或紧接着推进的少数主题。
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景
+      description: 当前发生了什么，为什么值得处理；有真实代码、日志、截图或用户反馈时优先给出证据。
+      placeholder: 描述当前状态、已确认问题和必要上下文。
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: 目标
+      description: 完成后系统或用户应该达到什么状态。
+      placeholder: 描述目标状态，不必提前写死实现方案。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 范围 / 边界
+      description: 可选。仅在需要限制 scope、明确非目标或 canonical owner 时填写。
+      placeholder: 哪些内容属于本 Issue，哪些明确不属于。
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 验收
+      description: 使用可验证结果描述完成条件。
+      placeholder: |
+        - [ ] 可验证结果 1
+        - [ ] 可验证结果 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: 关联
+      description: 可选。只填写真实依赖、前置或相关 Issue / PR。
+      placeholder: "例如：#123、PR #456"
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,16 @@ pnpm db:studio
 - `admin_users` / `rivalhub-admin` 仅是 emergency compatibility path。
 - Fresh deployment 通过配置的 `RIVALHUB_OWNER_EMAIL` 在尚不存在 `super_admin` 时一次性 bootstrap；不得把“第一个注册用户”当作 owner。
 
+## Issue governance
+
+- 2.x Issue 标题统一使用 `[2.x] <问题或目标>`；`Infra`、`Perf`、`UX` 等工作类别不再作为标题前缀，避免与版本线混用。
+- Open 2.x Issue 必须且只能有一个 `priority:P0` / `priority:P1` / `priority:P2` / `priority:P3` label；优先级以 label 为唯一 authority，正文不再重复维护 `## 优先级`。
+- 计划性工作默认使用 `enhancement` 等现有类型 label；`next` 仅用于当前正在推进或紧接着推进的极少数主题，不是新的优先级等级。
+- milestone 与 assignee 默认留空；只有存在真实 release boundary 或明确 owner 时才设置，不为了“元数据完整”机械填写。
+- Issue 正文以 `背景 → 目标 → 验收` 为最小结构；`范围/边界`、`非目标`、`关联` 仅在确实有助于限定实现时增加。小 Issue 不需要为了模板制造空章节，大型产品/架构 Issue 可以按实际规则展开。
+- 通过 GitHub API、ChatGPT、Codex 或其它 agent 创建/修改 Issue 时，必须显式设置标题和 labels；不要假设 GitHub UI 的 Issue Form 会自动应用到 API 写入。
+- 人工从 GitHub UI 创建 2.x 工作项时优先使用 `.github/ISSUE_TEMPLATE/2x-work-item.yml`；创建后确认存在且仅存在一个 `priority:P*` label。
+
 ## Branches and releases
 
 - `main` 是 production branch，`dev` 是下一版本 integration/staging branch；二者均不 force push，只通过 PR 合入。


### PR DESCRIPTION
## 关联

无独立产品 Issue；本 PR 收口仓库级 Issue governance。

## 变更

- 在 `AGENTS.md` 增加 2.x Issue 标题、priority/type/next、milestone/assignee 与正文最小结构约束；
- 明确 agent / API 创建 Issue 时必须显式设置 metadata，不能依赖 GitHub UI template；
- 新增 `.github/ISSUE_TEMPLATE/2x-work-item.yml`，统一 GitHub UI 下的 `[2.x]` 标题与背景 / 目标 / 验收结构。

## 验证

- [x] 纯文档 / repository metadata 变更，无 runtime 代码；
- [x] Issue Form YAML 按 GitHub Issue Forms 结构编写；
- [x] 与 `docs/roadmap.md` 现有 `priority:P*` / `next` authority 保持一致。

## Changeset

- [x] 本 PR 无需 changeset：仅工程文档与 GitHub Issue template，不改变 shipped runtime / 用户行为。