### PR TITLE
[2.x] 收口失效的 CI branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, feat/major-2027-integration]
+    branches: [main, dev]
   pull_request:
-    branches: [main, dev, feat/major-2027-integration]
+    branches: [main, dev]
   merge_group:
   release:
     types: [published]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,7 +70,7 @@ plan → static ─┐
 
 `scripts/ci/plan.mjs` 根据 changed surface 选择 capability：文档-only 只运行 `plan + ci-gate`；代码域分别进入 `static`、`postgres` 或 `system`；rename/delete、未分类、toolchain、workflow、release、merge queue 和手动运行 fail closed 到 full。`ci-gate` 会区分预期 skipped 与 required failure/skipped/cancelled，只有 planner 明确声明的 capability 可以跳过。
 
-只有 pull request 使用上述 selective graph；`push` 到 `dev`、`main` 或 Major integration branch、`merge_group`、已发布 `release` 以及 `workflow_dispatch` 都将 `FORCE_FULL`，运行 `static + postgres + system + ci-gate` 的完整 convergence gate。
+只有 pull request 使用上述 selective graph；`push` 到 `dev` 或 `main`、`merge_group`、已发布 `release` 以及 `workflow_dispatch` 都将 `FORCE_FULL`，运行 `static + postgres + system + ci-gate` 的完整 convergence gate。
 
 当前 planner contract 如下：
 


### PR DESCRIPTION
## 摘要

- 从 CI 的 push / pull_request branch filter 移除已不存在的 feat/major-2027-integration。
- 将 docs/testing.md 的 CI branch 说明收敛到当前 main / dev governance。

## 保留的 CI contract

- pull request 继续使用 changed-surface selective graph。
- dev / main push、merge_group、已发布 release 与 workflow_dispatch 继续执行 FULL gate。
- planner capability map、static / postgres / system graph、ci-gate semantics 与现有 toolchain 未修改。
- 历史 GitHub Actions sidebar / one-shot workflow runs 未处理。

## 验证

- planner/gate unit tests：26/26 通过。
- workflow YAML 事件与 branch 语义检查通过。
- active repo 旧 branch contract 扫描无残留。
- git diff --check 通过。

CI/docs-only 变更，无需 changeset。

Refs #354