### PR TITLE
[2.x] 修复赛事首页队伍阵容旧路由

### DIFF
--- a/.changeset/quiet-rosters-link.md
+++ b/.changeset/quiet-rosters-link.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复赛事首页“队伍阵容”入口，使其指向 canonical `/teams` 路由。

--- a/src/app/[seasonSlug]/page.tsx
+++ b/src/app/[seasonSlug]/page.tsx
@@ -37,7 +37,7 @@ export default function SeasonPage({ params }: SeasonPageProps) {
   );
 }
 
-async function SeasonPageContent({ params }: SeasonPageProps) {
+export async function SeasonPageContent({ params }: SeasonPageProps) {
   await connection();
   const { seasonSlug } = await params;
 
@@ -194,7 +194,7 @@ async function SeasonPageContent({ params }: SeasonPageProps) {
       show: season.hasDraft,
     },
     {
-      href: `/${seasonSlug}/competitionEntries`,
+      href: `/${seasonSlug}/teams`,
       label: "队伍阵容",
       description: "查看各队选手分布",
       icon: Users,

--- a/tests/unit/app/season-page.test.tsx
+++ b/tests/unit/app/season-page.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  connectionMock,
+  getPublicOrAuthorizedDraftSeasonMock,
+  getParticipantSummaryMock,
+  selectDistinctMock,
+  selectMock,
+} = vi.hoisted(() => ({
+  connectionMock: vi.fn(),
+  getPublicOrAuthorizedDraftSeasonMock: vi.fn(),
+  getParticipantSummaryMock: vi.fn(),
+  selectDistinctMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({ connection: connectionMock }));
+vi.mock("next/navigation", () => ({ notFound: vi.fn() }));
+vi.mock("@/components/layout/AdminShortcutSlot", () => ({ AdminShortcutSlot: () => null }));
+vi.mock("@/db/client", () => ({
+  db: {
+    select: selectMock,
+    selectDistinct: selectDistinctMock,
+  },
+}));
+vi.mock("@/lib/data/public-seasons", () => ({
+  getPublicOrAuthorizedDraftSeason: getPublicOrAuthorizedDraftSeasonMock,
+}));
+vi.mock("@/lib/participants/summary", () => ({ getParticipantSummary: getParticipantSummaryMock }));
+
+import { SeasonPageContent } from "@/app/[seasonSlug]/page";
+
+function chain<T>(value: T) {
+  const result = {
+    from: () => result,
+    where: () => result,
+    then: (resolve: (resolved: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(value).then(resolve, reject),
+  };
+  return result;
+}
+
+describe("season page navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("React", React);
+    connectionMock.mockResolvedValue(undefined);
+    getPublicOrAuthorizedDraftSeasonMock.mockResolvedValue({
+      id: "season-major",
+      slug: "2026-nju-major",
+      name: "2026 NJU Major",
+      status: "registration",
+      registrationMode: "team",
+      stagePlan: [],
+      competitionTemplate: "major",
+      hasCaptainVoting: false,
+      hasDraft: false,
+    });
+    getParticipantSummaryMock.mockResolvedValue({ count: 0, hasPlayers: false });
+    selectDistinctMock.mockReturnValue(chain([]));
+    selectMock
+      .mockImplementationOnce(() => chain([{ value: 4 }]))
+      .mockImplementationOnce(() => chain([{ total: 0, finished: 0 }]));
+  });
+
+  it("routes the visible team roster shortcut to the canonical teams page", async () => {
+    const page = await SeasonPageContent({
+      params: Promise.resolve({ seasonSlug: "2026-nju-major" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toMatch(/href="\/2026-nju-major\/teams"[\s\S]*队伍阵容/);
+    expect(html).not.toContain("/competitionEntries");
+  });
+});


### PR DESCRIPTION
## 关联

Refs #400

## 变更

- 将赛事首页“队伍阵容”入口从旧的 `/competitionEntries` 路由改为 canonical `/{seasonSlug}/teams`。
- 增加首页实际渲染导航 contract 的窄 unit regression，覆盖 `2026-nju-major`。
- 添加 patch changeset。
- 保持 `competitionEntries` 领域实体命名、schema、query 和 route scope 不变。

## 验证

- [x] `pnpm exec vitest run tests/unit/app/season-page.test.tsx`
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `git diff --check`
- [x] 全仓 URL 语义扫描：无 `/competitionEntries` 导航或 URL 生成残留
- [x] PR CI 全绿后合并到 `dev`

## Changeset

- [x] 已提交中文 patch changeset：`.changeset/quiet-rosters-link.md`

Refs #400