### PR TITLE
[Infra] 建立 Expand / Contract migration 与 N/N+1 发布兼容门禁

### DIFF
--- a/.changeset/bright-release-contracts.md
+++ b/.changeset/bright-release-contracts.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+在 PostgreSQL CI 与 production migration 前增加 previous stable release → next schema 的兼容性门禁，阻止未完成 Expand → Switch → Contract 的破坏性数据库变更进入发布流程。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           echo "PostgreSQL service did not become ready within 120 seconds" >&2
           exit 1
       - run: pnpm db:check
+      - run: pnpm db:release-compat
       - run: pnpm test:integration:pg17
 
   dependency-review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
           pnpm db:check
           pnpm db:local:start
 
+      - name: Validate previous release compatibility
+        run: pnpm db:release-compat
+
       - name: Migrate and verify production database
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,6 +95,17 @@ ALTER TABLE ... DROP COLUMN ...;
 
 本地要复现 CI 的 changed-surface 判定，应显式使用当前 `dev` 基线，例如：`RIVALHUB_MIGRATION_BASE_SHA=$(git merge-base HEAD origin/dev) RIVALHUB_MIGRATION_HEAD_SHA=HEAD pnpm db:migration-risk`。CI 在 checkout 完整历史后传入 PR base/head SHA；没有 active migration 变化时，checker 明确输出 no changed active migrations。
 
+`pnpm db:release-compat` 是独立于 `db:migration-risk` 的 N/N+1 兼容性门禁。它默认从当前 revision 可达的 stable `vX.Y.Z` tag 中选择最新且不在 candidate HEAD 上的 tag 作为 previous production baseline，并忽略 `-rc` 等 prerelease；CI/测试可用 `RIVALHUB_PREVIOUS_RELEASE_TAG` 显式指定 tag 或 revision，显式值无法解析时直接 fail closed。PR CI 通过 `RIVALHUB_MIGRATION_BASE_SHA` / `RIVALHUB_MIGRATION_HEAD_SHA` 限定 candidate changed surface；release tag workflow 在没有这两个覆盖值时，以 previous stable commit 到 candidate HEAD 的 active migration surface 复核一次。需要 source 证明时，checker 只读取 previous stable tag 中的 `src/db/schema/**`、`src/actions/**`、`src/lib/**`、`src/app/**`、`src/components/**` 与 `scripts/**`，并输出 migration `path:line` 及 previous source `path:line` evidence。
+
+DROP/RENAME 的 relation、column、type owner 若仍被 previous stable shipped code 以 Drizzle schema/property 或带 table context 的 SQL 使用则拒绝；migration-risk annotation 只表示 cleanup 意图，不能绕过该证明。`ALTER TYPE` 与 `SET NOT NULL` 第一版始终 fail closed；`rewrite-or-exclusive-lock` 仍由 migration-risk 和 migration review 负责，不被误当作 app contract 证明。无法安全解析 owner 或无法判断 schema context 时同样拒绝猜测。
+
+发布顺序固定为：
+
+```text
+Release N+1: expand + backfill + app switch；保留 N 仍依赖的旧 owner
+Release N+2: previous stable 已不再读写 old owner 后才允许 contract
+```
+
 ### Protected staging migration
 
 `pnpm db:staging:migrate` 和 `pnpm db:staging:verify` 只服务受保护的 `rivalhub-dev` staging workflow。命令拒绝继承 `DATABASE_URL` 或 `.env.local`，并对 project ref、Transaction Pooler shape 和写入授权 fail closed。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,6 +37,7 @@ RivalHub 以最高已完成的验证层级描述能力证据：
 | `pnpm db:local:verify-db` / `pnpm db:local:verify-supabase` | 分别验证 PostgreSQL contract 或 Auth/Storage/Data API |
 | `pnpm db:check` | Drizzle active migration chain |
 | `pnpm db:migration-risk` | active migration SQL 的 compatibility/locking risk classifier |
+| `pnpm db:release-compat` | previous stable shipped app → next active migration 的 N/N+1 compatibility gate |
 | `pnpm knip` | default module graph 的 dead-code/dependency/export hygiene |
 | `pnpm knip --production` | shipped production graph 的 dead-code/dependency hygiene |
 | `pnpm db:production:verify` | 严格只读校验明确确认的 production ledger、SQL SHA 与 terminal schema contract |
@@ -63,6 +64,8 @@ pnpm verify:local
 所有 real-PG 套件通过 `scripts/db/local.ts` 注入 loopback Local PostgreSQL。integration runner 先从 `template1` 创建基线库，使用现有 Drizzle runner、seed 和 verify 回放 active chain，再为每个 Vitest worker 创建独立 template clone；migration replay 的 scratch database 仍单独串行执行，不使用 testcontainers，也不以 mock 代替事务、约束或并发证据。Vitest 保持 `pool: forks` 与 `isolate: true`；需要缩小调试范围时直接使用 Vitest 文件或 `-t` pattern filter。
 
 CI 的 `postgres` job 使用官方 `postgres:17` service container，不启动 Supabase CLI 或任何 Auth、Storage、Kong、PostgREST、Studio、Realtime 等服务；`scripts/db/prepare-pg17.ts` 只在 vanilla PostgreSQL 缺少时建立 `anon` 与 `authenticated` 两个 `NOLOGIN` 角色，并验证 `gen_random_uuid()`，不修改 active migrations。随后 `test:integration:pg17` 依次完成 33 条 migration、seed、fixture、`verify-db`、worker clone 和完整 integration suite。开发者的 `db:local:start-db` 仍保留为 Local Supabase 兼容入口，不是 CI migration authority。
+
+PostgreSQL CI 在现有 service container 中按 `db:check → db:release-compat → test:integration:pg17` 执行；release workflow 在 production migrate 前再次执行 `db:release-compat`，不创建重复的 PostgreSQL/Supabase job。`tests/unit/db/release-compat.test.ts` 使用临时 git repository、stable/prerelease tags、previous source 与 candidate migration 覆盖 DROP/RENAME owner 依赖、annotation 不得绕过、ALTER TYPE/SET NOT NULL fail closed、additive/no-change pass、explicit invalid ref 与可定位 evidence 输出。
 
 ## PR CI graph
 

--- a/knip.json
+++ b/knip.json
@@ -41,6 +41,7 @@
     "scripts/db/verify-supabase.ts!",
     "scripts/db/verify-migrations.ts!",
     "scripts/db/migration-risk.ts!",
+    "scripts/db/release-compat.ts!",
     "scripts/db/staging.ts!",
     "scripts/db/production.ts!",
     "scripts/db/production-preflight.ts!",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:generate": "drizzle-kit generate",
     "db:check": "corepack pnpm db:migration-risk && drizzle-kit check",
     "db:migration-risk": "tsx scripts/db/migration-risk.ts",
+    "db:release-compat": "tsx scripts/db/release-compat.ts",
     "db:push": "tsx scripts/db/block-drizzle-push.ts",
     "db:staging:migrate": "tsx scripts/db/staging.ts migrate",
     "db:staging:verify": "tsx scripts/db/staging.ts verify",

--- a/scripts/db/migration-risk.ts
+++ b/scripts/db/migration-risk.ts
@@ -18,7 +18,23 @@ export interface MigrationRiskFinding {
   filePath: string;
   line: number;
   statement: string;
+  statementText?: string;
   annotation?: string;
+}
+
+export interface MigrationRiskClassifierOptions {
+  includeStatementText?: boolean;
+}
+
+export type MigrationContractOwnerKind = "relation" | "column" | "type";
+
+export interface MigrationContractOwner {
+  kind: MigrationContractOwnerKind;
+  identifier: string;
+  relation?: string;
+  schema?: string;
+  renamedTo?: string;
+  displayName: string;
 }
 
 interface SqlStatement {
@@ -28,8 +44,11 @@ interface SqlStatement {
 
 const RISK_PATTERNS: ReadonlyArray<readonly [MigrationRiskCategory, RegExp]> = [
   ["drop", /\bDROP\s+(?:TABLE|COLUMN|TYPE)\b/i],
-  ["rename", /\bALTER\s+TABLE\b[\s\S]*?\bRENAME\s+(?:COLUMN\b[\s\S]*?\bTO\b|TO\b)/i],
-  ["alter-type", /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+COLUMN\b[\s\S]*?\b(?:SET\s+DATA\s+TYPE|TYPE)\b/i],
+  ["rename", /\bALTER\s+(?:TABLE|TYPE)\b[\s\S]*?\bRENAME\s+(?:COLUMN\b[\s\S]*?\bTO\b|TO\b)/i],
+  [
+    "alter-type",
+    /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+COLUMN\b[\s\S]*?\b(?:SET\s+DATA\s+TYPE|TYPE)\b|\bALTER\s+TYPE\b(?![\s\S]*?\bRENAME\s+TO\b)/i,
+  ],
   ["set-not-null", /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+COLUMN\b[\s\S]*?\bSET\s+NOT\s+NULL\b/i],
   [
     "rewrite-or-exclusive-lock",
@@ -47,6 +66,7 @@ const ANNOTATION_PATTERN = /^\s*--\s*rivalhub:migration-risk:\s*(contract cleanu
 export function classifyMigrationSql(
   sql: string,
   filePath = "<inline migration>",
+  options: MigrationRiskClassifierOptions = {},
 ): MigrationRiskFinding[] {
   const findings: MigrationRiskFinding[] = [];
 
@@ -66,6 +86,7 @@ export function classifyMigrationSql(
           filePath,
           line,
           statement: statementPreview,
+          ...(options.includeStatementText ? { statementText: statement.text } : {}),
           ...(annotation ? { annotation } : {}),
         });
       }
@@ -75,8 +96,9 @@ export function classifyMigrationSql(
   return findings;
 }
 
-export function changedMigrationFiles(cwd = process.cwd()): string[] {
-  const base = process.env.RIVALHUB_MIGRATION_BASE_SHA?.trim();
+export function changedMigrationFiles(cwd = process.cwd(), defaultBase?: string): string[] {
+  const configuredBase = process.env.RIVALHUB_MIGRATION_BASE_SHA?.trim();
+  const base = configuredBase && !isZeroRevision(configuredBase) ? configuredBase : defaultBase;
   const head = process.env.RIVALHUB_MIGRATION_HEAD_SHA?.trim() || "HEAD";
   const paths = new Set<string>();
 
@@ -100,6 +122,13 @@ export function changedMigrationFiles(cwd = process.cwd()): string[] {
   }
 
   return [...paths].sort();
+}
+
+export function extractMigrationContractOwners(finding: MigrationRiskFinding): MigrationContractOwner[] {
+  const statement = finding.statementText ?? finding.statement;
+  if (finding.category === "drop") return extractDropOwners(statement);
+  if (finding.category === "rename") return extractRenameOwners(statement);
+  return [];
 }
 
 function main(): void {
@@ -225,6 +254,238 @@ function splitSqlStatements(sql: string): SqlStatement[] {
 
   if (sql.slice(start).trim()) statements.push({ text: sql.slice(start), start });
   return statements;
+}
+
+interface SqlToken {
+  kind: "identifier" | "punctuation";
+  value: string;
+  quoted: boolean;
+}
+
+function extractDropOwners(sql: string): MigrationContractOwner[] {
+  const tokens = tokenizeSql(sql);
+  const dropIndex = findKeyword(tokens, "DROP");
+  if (dropIndex < 0) return [];
+  const objectKind = tokens[dropIndex + 1]?.value.toUpperCase();
+  if (objectKind === "COLUMN") {
+    const tableIndex = findKeywordBefore(tokens, "TABLE", dropIndex);
+    if (tableIndex < 0) return [];
+    const relation = readQualifiedName(tokens, skipKeyword(tokens, tableIndex + 1, "ONLY"));
+    if (!relation) return [];
+    const owners: MigrationContractOwner[] = [];
+    let columnStart = skipKeywords(tokens, dropIndex + 2, ["IF", "EXISTS"]);
+    while (columnStart < tokens.length) {
+      const column = readQualifiedName(tokens, columnStart);
+      if (!column || column.schema) return [];
+      owners.push({
+        kind: "column",
+        identifier: column.name,
+        relation: relation.name,
+        ...(relation.schema ? { schema: relation.schema } : {}),
+        displayName: `${relation.displayName}.${column.name}`,
+      });
+      const next = column.next;
+      if (tokens[next]?.value !== "," || !tokens[next + 1] || !tokens[next + 2] || !isKeyword(tokens[next + 1], "DROP") || !isKeyword(tokens[next + 2], "COLUMN")) break;
+      columnStart = skipKeywords(tokens, next + 3, ["IF", "EXISTS"]);
+    }
+    return owners;
+  }
+
+  const kind = objectKind === "TYPE" ? "type" : objectKind === "TABLE" ? "relation" : undefined;
+  if (!kind) return [];
+  let cursor = skipKeywords(tokens, dropIndex + 2, ["IF", "EXISTS"]);
+  const owners: MigrationContractOwner[] = [];
+  while (cursor < tokens.length) {
+    const name = readQualifiedName(tokens, cursor);
+    if (!name) break;
+    owners.push({
+      kind,
+      identifier: name.name,
+      ...(name.schema ? { schema: name.schema } : {}),
+      displayName: name.displayName,
+    });
+    cursor = name.next;
+    if (tokens[cursor]?.value !== ",") break;
+    cursor = skipKeywords(tokens, cursor + 1, ["IF", "EXISTS"]);
+  }
+  return owners;
+}
+
+function extractRenameOwners(sql: string): MigrationContractOwner[] {
+  const tokens = tokenizeSql(sql);
+  const renameIndex = findKeyword(tokens, "RENAME");
+  if (renameIndex < 0) return [];
+
+  const tableIndex = findKeywordBefore(tokens, "TABLE", renameIndex);
+  if (tableIndex >= 0) {
+    const relation = readQualifiedName(tokens, skipKeyword(tokens, tableIndex + 1, "ONLY"));
+    if (!relation) return [];
+    if (tokens[renameIndex + 1]?.value.toUpperCase() === "COLUMN") {
+      const oldColumn = readQualifiedName(tokens, renameIndex + 2);
+      const toIndex = findKeywordAfter(tokens, "TO", oldColumn?.next ?? renameIndex + 2);
+      const newColumn = toIndex >= 0 ? readQualifiedName(tokens, toIndex + 1) : undefined;
+      if (!oldColumn || !newColumn || oldColumn.schema || newColumn.schema) return [];
+      if (tokens.slice(newColumn.next).some((token) => isKeyword(token, "RENAME"))) return [];
+      return [{
+        kind: "column",
+        identifier: oldColumn.name,
+        relation: relation.name,
+        ...(relation.schema ? { schema: relation.schema } : {}),
+        renamedTo: newColumn.name,
+        displayName: `${relation.displayName}.${oldColumn.name}`,
+      }];
+    }
+
+    if (tokens[renameIndex + 1]?.value.toUpperCase() === "TO") {
+      const newRelation = readQualifiedName(tokens, renameIndex + 2);
+      if (!newRelation) return [];
+      return [{
+        kind: "relation",
+        identifier: relation.name,
+        ...(relation.schema ? { schema: relation.schema } : {}),
+        renamedTo: newRelation.name,
+        displayName: relation.displayName,
+      }];
+    }
+    return [];
+  }
+
+  const typeIndex = findKeyword(tokens, "TYPE");
+  if (typeIndex < 0 || typeIndex > renameIndex) return [];
+  const type = readQualifiedName(tokens, typeIndex + 1);
+  const toIndex = findKeywordAfter(tokens, "TO", type?.next ?? typeIndex + 1);
+  const newType = toIndex >= 0 ? readQualifiedName(tokens, toIndex + 1) : undefined;
+  if (!type || !newType) return [];
+  return [{
+    kind: "type",
+    identifier: type.name,
+    ...(type.schema ? { schema: type.schema } : {}),
+    renamedTo: newType.name,
+    displayName: type.displayName,
+  }];
+}
+
+function tokenizeSql(sql: string): SqlToken[] {
+  const tokens: SqlToken[] = [];
+  let index = 0;
+  while (index < sql.length) {
+    const char = sql[index];
+    const next = sql[index + 1];
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+    if (char === "-" && next === "-") {
+      index = sql.indexOf("\n", index + 2);
+      if (index < 0) break;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      const end = sql.indexOf("*/", index + 2);
+      index = end < 0 ? sql.length : end + 2;
+      continue;
+    }
+    if (char === "'") {
+      index = skipSingleQuoted(sql, index);
+      continue;
+    }
+    if (char === '"') {
+      let end = index + 1;
+      let value = "";
+      while (end < sql.length) {
+        if (sql[end] === '"' && sql[end + 1] === '"') {
+          value += '"';
+          end += 2;
+        } else if (sql[end] === '"') {
+          break;
+        } else {
+          value += sql[end];
+          end += 1;
+        }
+      }
+      tokens.push({ kind: "identifier", value, quoted: true });
+      index = end < sql.length ? end + 1 : sql.length;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(char)) {
+      let end = index + 1;
+      while (end < sql.length && /[A-Za-z0-9_$]/.test(sql[end])) end += 1;
+      tokens.push({ kind: "identifier", value: sql.slice(index, end), quoted: false });
+      index = end;
+      continue;
+    }
+    tokens.push({ kind: "punctuation", value: char, quoted: false });
+    index += 1;
+  }
+  return tokens;
+}
+
+function skipSingleQuoted(sql: string, start: number): number {
+  let index = start + 1;
+  while (index < sql.length) {
+    if (sql[index] === "'" && sql[index + 1] === "'") index += 2;
+    else if (sql[index] === "'") return index + 1;
+    else index += 1;
+  }
+  return sql.length;
+}
+
+function findKeyword(tokens: readonly SqlToken[], keyword: string): number {
+  return tokens.findIndex((token) => isKeyword(token, keyword));
+}
+
+function findKeywordBefore(tokens: readonly SqlToken[], keyword: string, before: number): number {
+  for (let index = before - 1; index >= 0; index -= 1) {
+    if (tokens[index] && isKeyword(tokens[index], keyword)) return index;
+  }
+  return -1;
+}
+
+function findKeywordAfter(tokens: readonly SqlToken[], keyword: string, after: number): number {
+  for (let index = after; index < tokens.length; index += 1) {
+    if (tokens[index] && isKeyword(tokens[index], keyword)) return index;
+  }
+  return -1;
+}
+
+function skipKeyword(tokens: readonly SqlToken[], index: number, keyword: string): number {
+  return tokens[index] && isKeyword(tokens[index], keyword) ? index + 1 : index;
+}
+
+function skipKeywords(tokens: readonly SqlToken[], index: number, keywords: readonly string[]): number {
+  let cursor = index;
+  while (tokens[cursor] && keywords.some((keyword) => isKeyword(tokens[cursor]!, keyword))) cursor += 1;
+  return cursor;
+}
+
+function isKeyword(token: SqlToken, keyword: string): boolean {
+  return token.kind === "identifier" && !token.quoted && token.value.toUpperCase() === keyword;
+}
+
+function readQualifiedName(tokens: readonly SqlToken[], start: number): { name: string; schema?: string; displayName: string; next: number } | undefined {
+  const first = tokens[start];
+  if (!first || first.kind !== "identifier") return undefined;
+  const parts = [normalizeIdentifier(first)];
+  let cursor = start + 1;
+  while (tokens[cursor]?.value === ".") {
+    const part = tokens[cursor + 1];
+    if (!part || part.kind !== "identifier") return undefined;
+    parts.push(normalizeIdentifier(part));
+    cursor += 2;
+  }
+  if (parts.length > 2) return undefined;
+  const name = parts.at(-1);
+  if (!name) return undefined;
+  return {
+    name,
+    ...(parts.length > 1 ? { schema: parts.at(-2) } : {}),
+    displayName: parts.join("."),
+    next: cursor,
+  };
+}
+
+function normalizeIdentifier(token: SqlToken): string {
+  return token.quoted ? token.value : token.value.toLowerCase();
 }
 
 function maskSql(sql: string): string {

--- a/scripts/db/release-compat.ts
+++ b/scripts/db/release-compat.ts
@@ -1,0 +1,667 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  changedMigrationFiles,
+  classifyMigrationSql,
+  extractMigrationContractOwners,
+  type MigrationContractOwner,
+  type MigrationRiskFinding,
+} from "./migration-risk";
+
+const SHIPPED_SOURCE_ROOTS = [
+  "src/db/schema",
+  "src/actions",
+  "src/lib",
+  "src/app",
+  "src/components",
+  "scripts",
+] as const;
+
+const STABLE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+export interface ReleaseTagResolution {
+  ref: string;
+  commit: string;
+}
+
+export interface SourceEvidence {
+  path: string;
+  line: number;
+  reason: string;
+}
+
+export interface CompatibilityFinding {
+  finding: MigrationRiskFinding;
+  owners: MigrationContractOwner[];
+  evidence: SourceEvidence[];
+  status: "pass" | "fail" | "not-applicable";
+  message?: string;
+}
+
+export interface ReleaseCompatibilityResult {
+  previousRelease: ReleaseTagResolution;
+  changedMigrationFiles: string[];
+  findings: CompatibilityFinding[];
+  failures: string[];
+}
+
+interface ShippedSource {
+  path: string;
+  content: string;
+  searchableContent: string;
+}
+
+interface TableDeclaration {
+  path: string;
+  symbol: string;
+  relation: string;
+  start: number;
+  bodyStart: number;
+  bodyEnd: number;
+  content: string;
+  searchableContent: string;
+}
+
+interface EnumDeclaration {
+  path: string;
+  symbol: string;
+  name: string;
+  content: string;
+  start: number;
+}
+
+export function checkReleaseCompatibility(cwd = process.cwd()): ReleaseCompatibilityResult {
+  const head = process.env.RIVALHUB_MIGRATION_HEAD_SHA?.trim() || "HEAD";
+  const previousRelease = resolvePreviousStableRelease(cwd, head);
+  const files = changedMigrationFiles(cwd, previousRelease.commit);
+  const findings = files.flatMap((filePath) => {
+    const absolutePath = resolve(cwd, filePath);
+    return classifyMigrationSql(readFileSync(absolutePath, "utf8"), filePath, { includeStatementText: true });
+  });
+
+  const sources = findings.some((finding) => finding.category === "drop" || finding.category === "rename")
+    ? readShippedSources(cwd, previousRelease.commit)
+    : [];
+  const checks = findings.map((finding) => evaluateFinding(finding, sources));
+  const failures = checks
+    .filter((check) => check.status === "fail")
+    .map((check) => check.message ?? formatFinding(check.finding));
+
+  return {
+    previousRelease,
+    changedMigrationFiles: files,
+    findings: checks,
+    failures,
+  };
+}
+
+export function resolvePreviousStableRelease(cwd = process.cwd(), head = "HEAD"): ReleaseTagResolution {
+  const configuredExplicit = process.env.RIVALHUB_PREVIOUS_RELEASE_TAG;
+  if (configuredExplicit !== undefined) {
+    const explicit = configuredExplicit.trim();
+    return {
+      ref: explicit,
+      commit: resolveGitRevision(cwd, explicit, "RIVALHUB_PREVIOUS_RELEASE_TAG"),
+    };
+  }
+
+  const headCommit = resolveGitRevision(cwd, head, "RIVALHUB_MIGRATION_HEAD_SHA");
+  const stableTags = git(cwd, ["tag", "--merged", headCommit, "--list", "v*"])
+    .split(/\r?\n/)
+    .map((tag) => tag.trim())
+    .filter((tag) => STABLE_TAG_PATTERN.test(tag))
+    .map((tag) => ({ tag, version: parseStableTag(tag) }))
+    .filter((candidate): candidate is { tag: string; version: [number, number, number] } => Boolean(candidate.version))
+    .sort((left, right) => compareStableVersions(right.version, left.version));
+
+  for (const candidate of stableTags) {
+    const commit = resolveGitRevision(cwd, candidate.tag, "stable release tag");
+    if (commit === headCommit) continue;
+    return { ref: candidate.tag, commit };
+  }
+
+  throw new Error(
+    `无法从当前 revision ${head} 解析 previous stable release；需要可达的 vX.Y.Z tag，且会忽略 prerelease tag。`,
+  );
+}
+
+function evaluateFinding(finding: MigrationRiskFinding, sources: readonly ShippedSource[]): CompatibilityFinding {
+  if (finding.category === "alter-type" || finding.category === "set-not-null") {
+    return {
+      finding,
+      owners: [],
+      evidence: [],
+      status: "fail",
+      message: `${formatFinding(finding)} fail closed：${finding.category} 无法仅凭 previous stable source 证明 N/N+1 兼容；请改写为 Expand → Switch → Contract。annotation 不能绕过此 gate。`,
+    };
+  }
+
+  if (finding.category !== "drop" && finding.category !== "rename") {
+    return { finding, owners: [], evidence: [], status: "not-applicable" };
+  }
+
+  const owners = extractMigrationContractOwners(finding);
+  if (owners.length === 0) {
+    return {
+      finding,
+      owners,
+      evidence: [],
+      status: "fail",
+      message: `${formatFinding(finding)} 无法安全解析被 contract 的 relation/column/type owner；拒绝猜测，请明确拆分为可验证的 Expand → Switch → Contract migration。`,
+    };
+  }
+
+  const evidence = owners.flatMap((owner) => findOwnerEvidence(sources, owner));
+  const unsupportedSchema = owners.find((owner) => owner.schema && owner.schema !== "public");
+  if (unsupportedSchema && evidence.length === 0) {
+    return {
+      finding,
+      owners,
+      evidence,
+      status: "fail",
+      message: `${formatFinding(finding)} 无法安全证明非 public schema owner ${unsupportedSchema.displayName} 已停止被 previous stable 使用；拒绝猜测，请提供 Expand → Switch → Contract migration。`,
+    };
+  }
+  if (evidence.length > 0) {
+    const evidenceText = evidence.map((item) => `${item.path}:${item.line} (${item.reason})`).join(", ");
+    return {
+      finding,
+      owners,
+      evidence,
+      status: "fail",
+      message: `${formatFinding(finding)} previous stable 仍依赖 ${owners.map((owner) => owner.displayName).join(", ")}：${evidenceText}。annotation 只声明 cleanup 意图，不能替代兼容性证明；请延后 contract 到下一 release。`,
+    };
+  }
+
+  return {
+    finding,
+    owners,
+    evidence,
+    status: "pass",
+    message: `${formatFinding(finding)} previous stable source 未发现 ${owners.map((owner) => owner.displayName).join(", ")} 的 DB contract 依赖。`,
+  };
+}
+
+function readShippedSources(cwd: string, revision: string): ShippedSource[] {
+  const paths = git(cwd, ["ls-tree", "-r", "--name-only", revision, "--", ...SHIPPED_SOURCE_ROOTS])
+    .split(/\r?\n/)
+    .map((path) => path.trim())
+    .filter(Boolean);
+
+  return paths.map((path) => {
+    const content = git(cwd, ["show", `${revision}:${path}`]);
+    return { path, content, searchableContent: maskSourceComments(content) };
+  });
+}
+
+function findOwnerEvidence(sources: readonly ShippedSource[], owner: MigrationContractOwner): SourceEvidence[] {
+  const tableDeclarations = sources.flatMap((source) => collectTableDeclarations(source));
+  const enumDeclarations = sources.flatMap((source) => collectEnumDeclarations(source));
+  const evidence: SourceEvidence[] = [];
+
+  for (const source of sources) {
+    if (owner.kind === "relation") {
+      for (const declaration of tableDeclarations) {
+        if (matchesRelation(declaration, owner) && declaration.path === source.path) {
+          addEvidence(evidence, {
+            path: source.path,
+            line: lineNumberAt(source.content, declaration.start),
+            reason: `Drizzle pgTable(${owner.identifier}) declaration`,
+          });
+        }
+      }
+      addRegexEvidence(
+        evidence,
+        source,
+        sqlRelationReferencePattern(owner.identifier, owner.schema),
+        "SQL relation reference",
+      );
+      for (const declaration of tableDeclarations.filter((item) => matchesRelation(item, owner))) {
+        addRegexEvidence(
+          evidence,
+          source,
+          tableUsagePattern(tableSymbolsForSource(declaration, source)),
+          "Drizzle table consumer",
+        );
+      }
+    }
+
+    if (owner.kind === "column") {
+      for (const declaration of tableDeclarations.filter((item) => matchesRelation(item, owner))) {
+        if (declaration.path === source.path) {
+          for (const match of columnMappingMatches(declaration, owner.identifier)) {
+            addEvidence(evidence, {
+              path: source.path,
+              line: lineNumberAt(source.content, match),
+              reason: `Drizzle ${owner.relation}.${owner.identifier} column mapping`,
+            });
+          }
+        }
+        const symbols = tableSymbolsForSource(declaration, source);
+        const propertyNames = ownerPropertyNames(owner.identifier);
+        for (const propertyName of propertyNames) {
+          addRegexEvidence(
+            evidence,
+            source,
+            propertyAccessPattern(symbols, propertyName),
+            `Drizzle ${owner.relation}.${propertyName} consumer`,
+          );
+        }
+        if (symbols.length > 0 && tableUsagePattern(symbols).test(source.searchableContent)) {
+          addRegexEvidence(
+            evidence,
+            source,
+            objectPropertyPattern(propertyNames),
+            `DB object property in ${owner.relation} consumer`,
+          );
+        }
+      }
+      addRegexEvidence(
+        evidence,
+        source,
+        qualifiedColumnReferencePattern(owner),
+        "qualified SQL column reference",
+      );
+      addUnqualifiedSqlColumnEvidence(evidence, source, owner, tableDeclarations);
+    }
+
+    if (owner.kind === "type") {
+      for (const declaration of enumDeclarations) {
+        if (sameIdentifier(declaration.name, owner.identifier) && declaration.path === source.path) {
+          addEvidence(evidence, {
+            path: source.path,
+            line: lineNumberAt(source.content, declaration.start),
+            reason: `Drizzle pgEnum(${owner.identifier}) declaration`,
+          });
+        }
+      }
+      addRegexEvidence(
+        evidence,
+        source,
+        sqlTypeReferencePattern(owner.identifier, owner.schema),
+        "SQL type reference",
+      );
+      for (const declaration of enumDeclarations.filter((item) => sameIdentifier(item.name, owner.identifier))) {
+        addRegexEvidence(
+          evidence,
+          source,
+          new RegExp(`\\b${escapeRegExp(declaration.symbol)}\\b`, "g"),
+          "Drizzle enum consumer",
+        );
+      }
+    }
+  }
+
+  return dedupeEvidence(evidence);
+}
+
+function collectTableDeclarations(source: ShippedSource): TableDeclaration[] {
+  const declarations: TableDeclaration[] = [];
+  const pattern = /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*pgTable\s*\(\s*(["'`])([^"'`]+)\2\s*,/g;
+  for (const match of source.searchableContent.matchAll(pattern)) {
+    const matchIndex = match.index ?? 0;
+    const openBrace = source.content.indexOf("{", matchIndex + match[0].length);
+    const closeBrace = openBrace >= 0 ? findMatchingBrace(source.content, openBrace) : -1;
+    if (openBrace < 0 || closeBrace < 0) continue;
+    declarations.push({
+      path: source.path,
+      symbol: match[1] ?? "",
+      relation: normalizeSourceIdentifier(match[3] ?? ""),
+      start: matchIndex,
+      bodyStart: openBrace + 1,
+      bodyEnd: closeBrace,
+      content: source.content,
+      searchableContent: source.searchableContent,
+    });
+  }
+  return declarations;
+}
+
+function collectEnumDeclarations(source: ShippedSource): EnumDeclaration[] {
+  const declarations: EnumDeclaration[] = [];
+  const pattern = /\b(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*pgEnum\s*\(\s*(["'`])([^"'`]+)\2\s*,/g;
+  for (const match of source.searchableContent.matchAll(pattern)) {
+    declarations.push({
+      path: source.path,
+      symbol: match[1] ?? "",
+      name: normalizeSourceIdentifier(match[3] ?? ""),
+      content: source.content,
+      start: match.index ?? 0,
+    });
+  }
+  return declarations;
+}
+
+function columnMappingMatches(declaration: TableDeclaration, identifier: string): number[] {
+  const body = declaration.searchableContent.slice(declaration.bodyStart, declaration.bodyEnd);
+  const properties = ownerPropertyNames(identifier)
+    .map((property) => `(?:"${escapeRegExp(property)}"|${escapeRegExp(property)})`)
+    .join("|");
+  const literal = escapeRegExp(identifier);
+  const pattern = new RegExp(
+    "(?:^|[\\n,])\\s*(?:" + properties + ")\\s*:\\s*[^,}]*[\"'`]" + literal + "[\"'`]",
+    "g",
+  );
+  return [...body.matchAll(pattern)].map((match) => declaration.bodyStart + (match.index ?? 0));
+}
+
+function matchesRelation(declaration: TableDeclaration, owner: MigrationContractOwner): boolean {
+  const relation = owner.kind === "relation" ? owner.identifier : owner.relation;
+  return Boolean(relation && sameIdentifier(relation, declaration.relation)) && (!owner.schema || owner.schema === "public");
+}
+
+function tableSymbolsForSource(declaration: TableDeclaration, source: ShippedSource): string[] {
+  const symbols = new Set<string>();
+  const symbol = declaration.symbol;
+  if (source.path === declaration.path || new RegExp(`\\b${escapeRegExp(symbol)}\\b`).test(source.searchableContent)) symbols.add(symbol);
+  const aliasPattern = new RegExp(`\\b${escapeRegExp(symbol)}\\s+as\\s+([A-Za-z_$][\\w$]*)`, "g");
+  for (const match of source.searchableContent.matchAll(aliasPattern)) {
+    if (match[1]) symbols.add(match[1]);
+  }
+  return [...symbols];
+}
+
+function tableUsagePattern(symbols: readonly string[]): RegExp {
+  if (symbols.length === 0) return /(?!)/g;
+  const names = symbols.map(escapeRegExp).join("|");
+  return new RegExp(
+    `(?:\\b(?:${names})\\s*\\.|\\.(?:from|insert|update|delete)\\s*\\(\\s*(?:${names})\\b|\\b(?:db|tx)\\s*\\.\\s*query\\s*\\.\\s*(?:${names})\\b)`,
+    "g",
+  );
+}
+
+function propertyAccessPattern(symbols: readonly string[], propertyName: string): RegExp {
+  if (symbols.length === 0) return /(?!)/g;
+  return new RegExp(`\\b(?:${symbols.map(escapeRegExp).join("|")})\\s*\\.\\s*${escapeRegExp(propertyName)}\\b`, "g");
+}
+
+function objectPropertyPattern(propertyNames: readonly string[]): RegExp {
+  return new RegExp(`\\b(?:${propertyNames.map(escapeRegExp).join("|")})\\s*:`, "g");
+}
+
+function sqlRelationReferencePattern(identifier: string, schema?: string): RegExp {
+  return new RegExp(
+    `\\b(?:from|join|update|into|references|truncate(?:\\s+table)?|delete\\s+from)\\s+(?:only\\s+)?${sqlNamePattern(identifier, schema)}(?![A-Za-z0-9_$])`,
+    "gi",
+  );
+}
+
+function qualifiedColumnReferencePattern(owner: MigrationContractOwner): RegExp {
+  const relation = owner.relation ?? owner.identifier;
+  return new RegExp(
+    `${sqlNamePattern(relation, owner.schema)}\\s*\\.\\s*${sqlIdentifierPattern(owner.identifier)}(?![A-Za-z0-9_$])`,
+    "gi",
+  );
+}
+
+function sqlTypeReferencePattern(identifier: string, schema?: string): RegExp {
+  return new RegExp(`::\\s*${sqlNamePattern(identifier, schema)}(?![A-Za-z0-9_$])`, "gi");
+}
+
+function addUnqualifiedSqlColumnEvidence(
+  evidence: SourceEvidence[],
+  source: ShippedSource,
+  owner: MigrationContractOwner,
+  declarations: readonly TableDeclaration[],
+): void {
+  const matchingDeclarations = declarations.filter((declaration) => matchesRelation(declaration, owner));
+  const relationContext = sqlRelationReferencePattern(owner.relation ?? "", owner.schema).test(source.searchableContent)
+    || matchingDeclarations.some((declaration) => tableUsagePattern(tableSymbolsForSource(declaration, source)).test(source.searchableContent));
+  if (!relationContext) return;
+
+  const pattern = new RegExp(sqlIdentifierPattern(owner.identifier), "gi");
+  for (const match of source.searchableContent.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    const window = source.content.slice(Math.max(0, index - 400), Math.min(source.content.length, index + 400));
+    if (/(?:select|where|set|values|returning|order\s+by|group\s+by|insert|update|delete|from)/i.test(window)) {
+      addEvidence(evidence, {
+        path: source.path,
+        line: lineNumberAt(source.content, index),
+        reason: `SQL column ${owner.relation}.${owner.identifier} in relation context`,
+      });
+    }
+  }
+}
+
+function addRegexEvidence(
+  evidence: SourceEvidence[],
+  source: ShippedSource,
+  pattern: RegExp,
+  reason: string,
+): void {
+  pattern.lastIndex = 0;
+  for (const match of source.searchableContent.matchAll(pattern)) {
+    addEvidence(evidence, {
+      path: source.path,
+      line: lineNumberAt(source.content, match.index ?? 0),
+      reason,
+    });
+  }
+}
+
+function addEvidence(evidence: SourceEvidence[], item: SourceEvidence): void {
+  if (!evidence.some((existing) => existing.path === item.path && existing.line === item.line && existing.reason === item.reason)) {
+    evidence.push(item);
+  }
+}
+
+function dedupeEvidence(evidence: readonly SourceEvidence[]): SourceEvidence[] {
+  const unique = new Map<string, SourceEvidence>();
+  for (const item of evidence) unique.set(`${item.path}:${item.line}:${item.reason}`, item);
+  return [...unique.values()];
+}
+
+function findMatchingBrace(source: string, openBrace: number): number {
+  let depth = 0;
+  let quote: "single" | "double" | "template" | "line-comment" | "block-comment" | null = null;
+  for (let index = openBrace; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (quote === "line-comment") {
+      if (char === "\n") quote = null;
+      continue;
+    }
+    if (quote === "block-comment") {
+      if (char === "*" && next === "/") {
+        quote = null;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote === "single" || quote === "double" || quote === "template") {
+      if (char === "\\") {
+        index += 1;
+      } else if ((quote === "single" && char === "'") || (quote === "double" && char === '"') || (quote === "template" && char === "`")) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      quote = "line-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      quote = "block-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "'") {
+      quote = "single";
+      continue;
+    }
+    if (char === '"') {
+      quote = "double";
+      continue;
+    }
+    if (char === "`") {
+      quote = "template";
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function maskSourceComments(source: string): string {
+  const chars = source.split("");
+  let state: "single" | "double" | "template" | "line-comment" | "block-comment" | null = null;
+  const blank = (index: number): void => {
+    if (chars[index] !== "\n" && chars[index] !== "\r") chars[index] = " ";
+  };
+
+  for (let index = 0; index < chars.length; index += 1) {
+    const char = chars[index];
+    const next = chars[index + 1];
+    if (state === "line-comment") {
+      blank(index);
+      if (char === "\n") state = null;
+      continue;
+    }
+    if (state === "block-comment") {
+      blank(index);
+      if (char === "*" && next === "/") {
+        blank(index + 1);
+        state = null;
+        index += 1;
+      }
+      continue;
+    }
+    if (state === "single" || state === "double" || state === "template") {
+      if (char === "\\") index += 1;
+      else if ((state === "single" && char === "'") || (state === "double" && char === '"') || (state === "template" && char === "`")) state = null;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      blank(index);
+      blank(index + 1);
+      state = "line-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blank(index);
+      blank(index + 1);
+      state = "block-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "'") state = "single";
+    else if (char === '"') state = "double";
+    else if (char === "`") state = "template";
+  }
+  return chars.join("");
+}
+
+function ownerPropertyNames(identifier: string): string[] {
+  const camel = identifier.replace(/_([a-z0-9])/gi, (_match, character: string) => character.toUpperCase());
+  return [...new Set([identifier, camel])];
+}
+
+function sqlNamePattern(identifier: string, schema?: string): string {
+  const relation = sqlIdentifierPattern(identifier);
+  if (schema && schema !== "public") return `${sqlIdentifierPattern(schema)}\\s*\\.\\s*${relation}`;
+  return `(?:${sqlIdentifierPattern("public")}\\s*\\.\\s*)?${relation}`;
+}
+
+function sqlIdentifierPattern(identifier: string): string {
+  const escaped = escapeRegExp(identifier);
+  return `(?:"${escaped}"|${escaped})`;
+}
+
+function normalizeSourceIdentifier(identifier: string): string {
+  return identifier.toLowerCase();
+}
+
+function sameIdentifier(left: string, right: string): boolean {
+  return left === right || left.toLowerCase() === right.toLowerCase();
+}
+
+function lineNumberAt(source: string, offset: number): number {
+  return source.slice(0, offset).split(/\r?\n/).length;
+}
+
+function formatFinding(finding: MigrationRiskFinding): string {
+  return `${finding.filePath}:${finding.line} [${finding.category}]`;
+}
+
+function parseStableTag(tag: string): [number, number, number] | undefined {
+  const match = tag.match(STABLE_TAG_PATTERN);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareStableVersions(left: readonly number[], right: readonly number[]): number {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return (left[index] ?? 0) - (right[index] ?? 0);
+  }
+  return 0;
+}
+
+function resolveGitRevision(cwd: string, value: string, label: string): string {
+  const ref = value.trim();
+  if (!ref || ref.startsWith("-") || ref.includes("\0")) {
+    throw new Error(`${label} 不是可解析的 git tag/revision：${value}`);
+  }
+  try {
+    const revision = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!/^[0-9a-f]{40}$/i.test(revision)) throw new Error("not a commit");
+    return revision;
+  } catch {
+    throw new Error(`${label} 无法解析为 git tag/revision：${value}`);
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trimEnd();
+  } catch (error) {
+    throw new Error(`release-compat 无法读取 git history：${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function main(): void {
+  try {
+    const result = checkReleaseCompatibility();
+    console.log(
+      `release-compat: previous stable ${result.previousRelease.ref} (${result.previousRelease.commit.slice(0, 12)}); ${result.changedMigrationFiles.length} changed active migration file(s).`,
+    );
+    for (const check of result.findings) {
+      if (check.status === "not-applicable") continue;
+      const output = check.message ?? formatFinding(check.finding);
+      if (check.status === "fail") console.error(`release-compat: FAIL ${output}`);
+      else console.log(`release-compat: PASS ${output}`);
+    }
+    if (result.failures.length > 0) {
+      console.error(`release-compat: compatibility gate failed with ${result.failures.length} finding(s).`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log("release-compat: previous stable → next schema compatibility gate passed.");
+  } catch (error) {
+    console.error(`release-compat: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/unit/db/migration-risk.test.ts
+++ b/tests/unit/db/migration-risk.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyMigrationSql,
+  extractMigrationContractOwners,
   MIGRATION_RISK_ANNOTATION,
 } from "../../../scripts/db/migration-risk";
 
@@ -16,6 +17,7 @@ describe("migration risk classifier", () => {
     ["drop", `DROP TABLE old_teams;`],
     ["rename", `ALTER TABLE teams RENAME COLUMN old_name TO name;`],
     ["alter-type", `ALTER TABLE teams ALTER COLUMN name TYPE varchar(160);`],
+    ["alter-type", `ALTER TYPE team_status ADD VALUE 'paused';`],
     ["set-not-null", `ALTER TABLE teams ALTER COLUMN name SET NOT NULL;`],
     ["rewrite-or-exclusive-lock", `CREATE INDEX teams_name_idx ON teams (name);`],
     ["rewrite-or-exclusive-lock", `ALTER TABLE teams ADD CONSTRAINT teams_name_key UNIQUE (name);`],
@@ -59,5 +61,21 @@ ALTER TABLE teams DROP COLUMN old_name;
       END
       $$;
     `)).toEqual([]);
+  });
+
+  it("extracts quoted owners without treating keyword-shaped identifiers as SQL keywords", () => {
+    const finding = classifyMigrationSql(`ALTER TABLE "drop" RENAME TO "table";`)[0];
+    expect(finding?.category).toBe("rename");
+    expect(finding ? extractMigrationContractOwners(finding) : []).toMatchObject([
+      { kind: "relation", identifier: "drop", renamedTo: "table" },
+    ]);
+  });
+
+  it("extracts every column owner from a multi-action DROP statement", () => {
+    const finding = classifyMigrationSql(`ALTER TABLE teams DROP COLUMN old_name, DROP COLUMN old_code;`)[0];
+    expect(finding ? extractMigrationContractOwners(finding) : []).toMatchObject([
+      { kind: "column", relation: "teams", identifier: "old_name" },
+      { kind: "column", relation: "teams", identifier: "old_code" },
+    ]);
   });
 });

--- a/tests/unit/db/release-compat.test.ts
+++ b/tests/unit/db/release-compat.test.ts
@@ -1,0 +1,206 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { MIGRATION_RISK_ANNOTATION } from "../../../scripts/db/migration-risk";
+import { checkReleaseCompatibility } from "../../../scripts/db/release-compat";
+
+const ENVIRONMENT_KEYS = [
+  "RIVALHUB_MIGRATION_BASE_SHA",
+  "RIVALHUB_MIGRATION_HEAD_SHA",
+  "RIVALHUB_PREVIOUS_RELEASE_TAG",
+] as const;
+const originalEnvironment = new Map(ENVIRONMENT_KEYS.map((key) => [key, process.env[key]]));
+const fixtureDirectories: string[] = [];
+
+const OLD_TEAMS_SOURCE = `export const teams = pgTable("teams", {
+  oldColumn: text("old_column"),
+});
+`;
+const NEW_TEAMS_SOURCE = `export const teams = pgTable("teams", {
+  newColumn: text("new_column"),
+});
+`;
+
+afterEach(() => {
+  for (const key of ENVIRONMENT_KEYS) {
+    const value = originalEnvironment.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  while (fixtureDirectories.length > 0) {
+    const directory = fixtureDirectories.pop();
+    if (directory) rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("release compatibility gate", () => {
+  it.each([
+    ["DROP", `DROP TABLE "old_teams";`],
+    ["RENAME", `ALTER TABLE "teams" RENAME COLUMN "old_column" TO "new_column";`],
+  ])("fails when previous stable source still owns a %s contract", (_label, sql) => {
+    const source = _label === "DROP"
+      ? `export const oldTeams = pgTable("old_teams", { id: uuid("id") });\n`
+      : OLD_TEAMS_SOURCE;
+    const fixture = createFixture({ migration: `${MIGRATION_RISK_ANNOTATION}\n${sql}`, source });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatch(/drizzle\/migrations\/0002_next\.sql:2 \[(?:drop|rename)\]/);
+    expect(result.failures[0]).toContain("src/db/schema/teams.ts:");
+    expect(result.failures[0]).toContain("previous stable");
+  });
+
+  it("fails a column contract even when migration-risk annotation exists", () => {
+    const fixture = createFixture({
+      migration: `${MIGRATION_RISK_ANNOTATION}\nALTER TABLE "teams" DROP COLUMN "old_column";`,
+      source: OLD_TEAMS_SOURCE,
+    });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.findings[0]).toMatchObject({ status: "fail", finding: { category: "drop" } });
+    expect(result.failures[0]).toContain("annotation 只声明 cleanup 意图");
+  });
+
+  it("passes after previous stable has switched to the new column owner", () => {
+    const fixture = createFixture({
+      migration: `${MIGRATION_RISK_ANNOTATION}\nALTER TABLE "teams" DROP COLUMN "old_column";`,
+      source: NEW_TEAMS_SOURCE,
+    });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.failures).toEqual([]);
+    expect(result.findings[0]).toMatchObject({ status: "pass", finding: { category: "drop" } });
+  });
+
+  it("finds a previous stable Drizzle property consumer outside the schema directory", () => {
+    const fixture = createFixture({
+      migration: `${MIGRATION_RISK_ANNOTATION}\nALTER TABLE "teams" DROP COLUMN "old_column";`,
+      source: NEW_TEAMS_SOURCE,
+      extraFiles: {
+        "src/actions/legacy-reader.ts": `import { teams } from "@/db/schema";\nexport const read = (value: string) => eq(teams.oldColumn, value);\n`,
+      },
+    });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.failures[0]).toContain("src/actions/legacy-reader.ts:");
+  });
+
+  it.each([
+    ["alter-type", `ALTER TABLE "teams" ALTER COLUMN "old_column" TYPE text;`],
+    ["set-not-null", `ALTER TABLE "teams" ALTER COLUMN "old_column" SET NOT NULL;`],
+  ])("fails closed for %s", (_category, sql) => {
+    const fixture = createFixture({ migration: `${MIGRATION_RISK_ANNOTATION}\n${sql}`, source: NEW_TEAMS_SOURCE });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatch(/fail closed/);
+    expect(result.failures[0]).toContain("annotation 不能绕过此 gate");
+  });
+
+  it("passes additive migrations", () => {
+    const fixture = createFixture({
+      migration: `ALTER TABLE "teams" ADD COLUMN "new_column" text;`,
+      source: OLD_TEAMS_SOURCE,
+    });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.changedMigrationFiles).toEqual(["drizzle/migrations/0002_next.sql"]);
+    expect(result.findings).toEqual([]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("passes when no active migration changed", () => {
+    const fixture = createFixture({ source: OLD_TEAMS_SOURCE });
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.changedMigrationFiles).toEqual([]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("rejects an explicitly invalid previous release ref instead of falling back", () => {
+    const fixture = createFixture({ migration: `ALTER TABLE "teams" ADD COLUMN "new_column" text;` });
+    process.env.RIVALHUB_PREVIOUS_RELEASE_TAG = "v9.9.9";
+
+    expect(() => checkReleaseCompatibility(fixture.directory)).toThrow(/RIVALHUB_PREVIOUS_RELEASE_TAG/);
+  });
+
+  it("rejects an explicitly empty previous release ref instead of falling back", () => {
+    const fixture = createFixture({ migration: `ALTER TABLE "teams" ADD COLUMN "new_column" text;` });
+    process.env.RIVALHUB_PREVIOUS_RELEASE_TAG = "   ";
+
+    expect(() => checkReleaseCompatibility(fixture.directory)).toThrow(/RIVALHUB_PREVIOUS_RELEASE_TAG/);
+  });
+
+  it("uses an explicit previous revision when it is resolvable", () => {
+    const fixture = createFixture({ migration: `ALTER TABLE "teams" ADD COLUMN "new_column" text;` });
+    process.env.RIVALHUB_PREVIOUS_RELEASE_TAG = fixture.baselineCommit;
+
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.previousRelease.ref).toBe(fixture.baselineCommit);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("selects the latest reachable stable tag and ignores prereleases", () => {
+    const fixture = createFixture({
+      migration: `ALTER TABLE "teams" ADD COLUMN "new_column" text;`,
+      stableTags: ["v1.1.0"],
+      prereleaseTag: "v1.2.0-rc.1",
+    });
+
+    const result = checkReleaseCompatibility(fixture.directory);
+
+    expect(result.previousRelease.ref).toBe("v1.1.0");
+  });
+});
+
+interface FixtureOptions {
+  migration?: string;
+  source?: string;
+  extraFiles?: Record<string, string>;
+  stableTags?: string[];
+  prereleaseTag?: string;
+}
+
+interface Fixture {
+  directory: string;
+  baselineCommit: string;
+}
+
+function createFixture(options: FixtureOptions): Fixture {
+  const directory = mkdtempSync(join(tmpdir(), "rivalhub-release-compat-"));
+  fixtureDirectories.push(directory);
+  runGit(directory, ["init", "-q"]);
+  runGit(directory, ["config", "user.email", "release-compat@example.test"]);
+  runGit(directory, ["config", "user.name", "Release Compat Test"]);
+
+  writeFixtureFile(directory, "src/db/schema/teams.ts", options.source ?? NEW_TEAMS_SOURCE);
+  for (const [path, content] of Object.entries(options.extraFiles ?? {})) writeFixtureFile(directory, path, content);
+  writeFixtureFile(directory, "drizzle/migrations/0001_base.sql", "CREATE TABLE teams (id uuid);\n");
+  runGit(directory, ["add", "."]);
+  runGit(directory, ["commit", "-q", "-m", "baseline"]);
+  const baselineCommit = runGit(directory, ["rev-parse", "HEAD"]);
+  runGit(directory, ["tag", "v1.0.0"]);
+  for (const tag of options.stableTags ?? []) runGit(directory, ["tag", tag]);
+
+  if (options.migration) writeFixtureFile(directory, "drizzle/migrations/0002_next.sql", options.migration);
+  else writeFixtureFile(directory, "README.md", "candidate\n");
+  runGit(directory, ["add", "."]);
+  runGit(directory, ["commit", "-q", "-m", "candidate"]);
+  if (options.prereleaseTag) runGit(directory, ["tag", options.prereleaseTag]);
+
+  expect(readFileSync(join(directory, "src/db/schema/teams.ts"), "utf8")).toBe(options.source ?? NEW_TEAMS_SOURCE);
+  return { directory, baselineCommit };
+}
+
+function writeFixtureFile(directory: string, path: string, content: string): void {
+  const absolutePath = join(directory, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function runGit(directory: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: directory, encoding: "utf8" }).trim();
+}

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -46,6 +46,22 @@ describe("deployment and operations contracts", () => {
     expect(workflow).not.toMatch(/\bproduction\b/i);
   });
 
+  it("runs the previous-release compatibility gate in the existing PostgreSQL and release lanes", () => {
+    const ci = readProjectFile(".github/workflows/ci.yml");
+    const release = readProjectFile(".github/workflows/release.yml");
+
+    expect(ci).toContain("fetch-depth: 0");
+    expect(ci).toContain("RIVALHUB_MIGRATION_BASE_SHA:");
+    expect(ci).toContain("- run: pnpm db:check");
+    expect(ci).toContain("- run: pnpm db:release-compat");
+    expect(ci.indexOf("- run: pnpm db:release-compat")).toBeGreaterThan(ci.indexOf("- run: pnpm db:check"));
+    expect(ci.indexOf("- run: pnpm test:integration:pg17")).toBeGreaterThan(ci.indexOf("- run: pnpm db:release-compat"));
+
+    expect(release).toContain("fetch-depth: 0");
+    expect(release).toContain("run: pnpm db:release-compat");
+    expect(release.indexOf("run: pnpm db:release-compat")).toBeLessThan(release.indexOf("pnpm db:production:migrate"));
+  });
+
   it("runs each production Cron endpoint independently with bounded retries", () => {
     const workflow = readProjectFile(".github/workflows/cron.yml");
     const paths = [


### PR DESCRIPTION
## 摘要

- 新增独立 `pnpm db:release-compat`，从最新可达 stable tag 或显式 revision 解析 previous stable baseline。
- 复用 `migration-risk` 的 changed migration surface 与 SQL 分类器，对 DROP/RENAME 做 previous stable shipped source dependency proof；`ALTER TYPE` / `SET NOT NULL` fail closed，annotation 不能绕过。
- 接入既有 PostgreSQL CI 与 release production migrate 前置门禁，补 deterministic git fixture tests、运行时 contract tests、文档与 patch changeset。

## 验证

- `pnpm test`：192 files / 1215 tests 通过（首轮并行资源抖动后复跑通过）。
- `pnpm type-check`
- `pnpm lint`
- `pnpm knip && pnpm knip --production`
- `pnpm db:check`
- `pnpm db:release-compat`
- `env -u DATABASE_URL pnpm build`
- 本地 `pnpm test:integration:pg17` 未执行：Docker-compatible runtime 未运行；PR PostgreSQL 17 required job 负责真实数据库证据。

Closes #348