### PR TITLE
[2.x] 修复重复注册的 auth_id 错误绑定

### DIFF
--- a/.changeset/fix-issue-417-auth-id.md
+++ b/.changeset/fix-issue-417-auth-id.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复重复注册已确认账号时错误绑定 `auth_id` 的问题，并将注册结果统一为不泄露账号状态的账号设置提示；同时安全修复历史 dangling identity mapping。

--- a/docs/auth-and-permissions.md
+++ b/docs/auth-and-permissions.md
@@ -10,7 +10,7 @@ login  → password authentication → application session
 forgot password → recovery email → /reset-password
 ```
 
-注册与登录采用 email/password；邮件链接用于注册确认、既有邮箱重新验证和密码恢复。注册不会立即创建应用 session；确认页的 GET 不验证 token，而由用户显式确认后的 POST 同步 `users.emailVerifiedAt` 并建立 session。登录路径会同步应用账号，并在必要时检查 owner bootstrap。
+注册与登录采用 email/password；邮件链接用于注册确认、既有邮箱重新验证和密码恢复。注册 action 只消费 Auth 的结果并返回不泄露账号状态的统一提示，不根据 signup response 的 user id 写入 `public.users` 或绑定 `auth_id`。注册不会立即创建应用 session；确认页的 GET 不验证 token，而由用户显式确认后的 POST 在确认 `email_confirmed_at` 后同步 `users.emailVerifiedAt`、绑定 `auth_id` 并建立 session。已存在账号则由成功密码登录同步或修复应用账号，并在必要时检查 owner bootstrap。
 
 ## Owner bootstrap
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,7 @@ Knip 的 `knip.json` 只把 package scripts、CI/config entrypoints 与测试 sh
 
 Local PostgreSQL / migration evidence：
 
-多个 worktree 共享同一个 Local Supabase project/端口时，scripts/db/local.ts 会对 bootstrap、migration、seed、verify、real-PG integration、browser E2E、reset 和 verify:local 持有跨 worktree 的 OS 临时目录锁；占用者结束后才继续，异常退出留下的锁会按 PID 存活状态回收。普通 type-check、unit test 与 build 不经过该锁。`auth-permissions.test.ts` 回放 active migration 的旧权限数据并检查成功 backfill 与 fail-closed；`invite-concurrency.test.ts` 直接调用生产 `claimAdminInviteInTx`，用真实 PostgreSQL 事务证明 invite 锁、claim ledger、maxUses、grant 与 audit 的并发收敛。
+多个 worktree 共享同一个 Local Supabase project/端口时，scripts/db/local.ts 会对 bootstrap、migration、seed、verify、real-PG integration、browser E2E、reset 和 verify:local 持有跨 worktree 的 OS 临时目录锁；占用者结束后才继续，异常退出留下的锁会按 PID 存活状态回收。普通 type-check、unit test 与 build 不经过该锁。`auth-permissions.test.ts` 回放 active migration 的旧权限数据并检查成功 backfill 与 fail-closed；`auth-id-reconciliation.test.ts` 覆盖 normalized email 的唯一修复、有效映射保留、幂等重跑及 unmatched/ambiguous/duplicate target 的 fail-closed；`invite-concurrency.test.ts` 直接调用生产 `claimAdminInviteInTx`，用真实 PostgreSQL 事务证明 invite 锁、claim ledger、maxUses、grant 与 audit 的并发收敛。
 
 ```bash
 pnpm test:integration

--- a/drizzle/migrations/0036_auth_id_reconciliation.sql
+++ b/drizzle/migrations/0036_auth_id_reconciliation.sql
@@ -1,0 +1,153 @@
+-- Reconcile only the dangling application/Auth mappings that can be proven by
+-- one normalized email match. The whole preflight runs before any update.
+DO $$
+DECLARE
+  dangling_count bigint;
+  unmatched_count bigint;
+  ambiguous_count bigint;
+  duplicate_target_count bigint;
+  occupied_target_count bigint;
+  updated_count bigint;
+BEGIN
+  -- Vanilla PostgreSQL CI has no Supabase Auth schema. It is safe to no-op
+  -- only when there are no mappings whose identity could need reconciliation;
+  -- candidates without an Auth source fail closed below.
+  IF to_regclass('auth.users') IS NULL THEN
+    SELECT count(*)
+    INTO dangling_count
+    FROM public.users
+    WHERE auth_id IS NOT NULL;
+
+    IF dangling_count > 0 THEN
+      RAISE EXCEPTION 'auth identity reconciliation refused: auth.users is unavailable for % mapping(s)', dangling_count
+        USING ERRCODE = '23514';
+    END IF;
+
+    RETURN;
+  END IF;
+
+  SELECT count(*)
+  INTO dangling_count
+  FROM public.users AS application_user
+  WHERE application_user.auth_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM auth.users AS auth_user
+      WHERE auth_user.id = application_user.auth_id
+    );
+
+  IF dangling_count = 0 THEN
+    RETURN;
+  END IF;
+
+  WITH dangling AS (
+    SELECT application_user.id, lower(btrim(application_user.email)) AS normalized_email
+    FROM public.users AS application_user
+    WHERE application_user.auth_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.users AS auth_user
+        WHERE auth_user.id = application_user.auth_id
+      )
+  ), match_counts AS (
+    SELECT dangling.id, count(auth_user.id) AS match_count
+    FROM dangling
+    LEFT JOIN auth.users AS auth_user
+      ON lower(btrim(auth_user.email)) = dangling.normalized_email
+    GROUP BY dangling.id
+  )
+  SELECT
+    count(*) FILTER (WHERE match_count = 0),
+    count(*) FILTER (WHERE match_count > 1)
+  INTO unmatched_count, ambiguous_count
+  FROM match_counts;
+
+  WITH dangling AS (
+    SELECT application_user.id, lower(btrim(application_user.email)) AS normalized_email
+    FROM public.users AS application_user
+    WHERE application_user.auth_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.users AS auth_user
+        WHERE auth_user.id = application_user.auth_id
+      )
+  ), unique_matches AS (
+    SELECT dangling.id, (array_agg(auth_user.id ORDER BY auth_user.id))[1] AS matched_auth_id
+    FROM dangling
+    JOIN auth.users AS auth_user
+      ON lower(btrim(auth_user.email)) = dangling.normalized_email
+    GROUP BY dangling.id
+    HAVING count(auth_user.id) = 1
+  )
+  SELECT count(*)
+  INTO duplicate_target_count
+  FROM (
+    SELECT matched_auth_id
+    FROM unique_matches
+    GROUP BY matched_auth_id
+    HAVING count(*) > 1
+  ) AS duplicate_targets;
+
+  WITH dangling AS (
+    SELECT application_user.id, lower(btrim(application_user.email)) AS normalized_email
+    FROM public.users AS application_user
+    WHERE application_user.auth_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.users AS auth_user
+        WHERE auth_user.id = application_user.auth_id
+      )
+  ), unique_matches AS (
+    SELECT dangling.id, (array_agg(auth_user.id ORDER BY auth_user.id))[1] AS matched_auth_id
+    FROM dangling
+    JOIN auth.users AS auth_user
+      ON lower(btrim(auth_user.email)) = dangling.normalized_email
+    GROUP BY dangling.id
+    HAVING count(auth_user.id) = 1
+  )
+  SELECT count(*)
+  INTO occupied_target_count
+  FROM unique_matches
+  JOIN public.users AS already_bound
+    ON already_bound.auth_id = unique_matches.matched_auth_id
+   AND already_bound.id <> unique_matches.id;
+
+  IF unmatched_count > 0
+     OR ambiguous_count > 0
+     OR duplicate_target_count > 0
+     OR occupied_target_count > 0 THEN
+    RAISE EXCEPTION 'auth identity reconciliation refused: dangling=% unmatched=% ambiguous=% duplicate_targets=% occupied_targets=%',
+      dangling_count, unmatched_count, ambiguous_count, duplicate_target_count, occupied_target_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  WITH dangling AS (
+    SELECT application_user.id, lower(btrim(application_user.email)) AS normalized_email
+    FROM public.users AS application_user
+    WHERE application_user.auth_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.users AS auth_user
+        WHERE auth_user.id = application_user.auth_id
+      )
+  ), unique_matches AS (
+    SELECT dangling.id, (array_agg(auth_user.id ORDER BY auth_user.id))[1] AS matched_auth_id
+    FROM dangling
+    JOIN auth.users AS auth_user
+      ON lower(btrim(auth_user.email)) = dangling.normalized_email
+    GROUP BY dangling.id
+    HAVING count(auth_user.id) = 1
+  )
+  UPDATE public.users AS application_user
+  SET auth_id = unique_matches.matched_auth_id,
+      updated_at = now()
+  FROM unique_matches
+  WHERE application_user.id = unique_matches.id;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count <> dangling_count THEN
+    RAISE EXCEPTION 'auth identity reconciliation refused: expected=% updated=%', dangling_count, updated_count
+      USING ERRCODE = '23514';
+  END IF;
+END
+$$;

--- a/drizzle/migrations/meta/0036_snapshot.json
+++ b/drizzle/migrations/meta/0036_snapshot.json
@@ -1,0 +1,9270 @@
+{
+  "id": "f28aafa8-dae5-4f5f-839a-e8f9eaed7c45",
+  "prevId": "29315212-9d87-46b5-a656-004ab2fea5a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invite_claims": {
+      "name": "admin_invite_claims",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_invite_claims_invite_id_idx": {
+          "name": "admin_invite_claims_invite_id_idx",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "admin_invite_claims_user_id_idx": {
+          "name": "admin_invite_claims_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "admin_invite_claims_invite_id_admin_invites_id_fk": {
+          "name": "admin_invite_claims_invite_id_admin_invites_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "tableTo": "admin_invites",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "admin_invite_claims_user_id_users_id_fk": {
+          "name": "admin_invite_claims_user_id_users_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invite_claims_invite_user_unique": {
+          "name": "admin_invite_claims_invite_user_unique",
+          "columns": [
+            "invite_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_invite_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'season_admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invites_max_uses_positive": {
+          "name": "admin_invites_max_uses_positive",
+          "value": "\"admin_invites\".\"max_uses\" > 0"
+        },
+        "admin_invites_role_season_scope": {
+          "name": "admin_invites_role_season_scope",
+          "value": "(\"admin_invites\".\"role\" = 'season_admin' AND \"admin_invites\".\"season_id\" IS NOT NULL) OR (\"admin_invites\".\"role\" = 'super_admin' AND \"admin_invites\".\"season_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_season_id_created_at_idx": {
+          "name": "audit_logs_season_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_award_evidence": {
+      "name": "community_award_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_user_id": {
+          "name": "candidate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_award_evidence_award_id_idx": {
+          "name": "community_award_evidence_award_id_idx",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "community_award_evidence_award_id_community_awards_id_fk": {
+          "name": "community_award_evidence_award_id_community_awards_id_fk",
+          "tableFrom": "community_award_evidence",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "tableTo": "community_awards",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "community_award_evidence_submitted_by_user_id_users_id_fk": {
+          "name": "community_award_evidence_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "community_award_evidence_candidate_user_id_users_id_fk": {
+          "name": "community_award_evidence_candidate_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "columnsFrom": [
+            "candidate_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "community_award_evidence_match_id_matches_id_fk": {
+          "name": "community_award_evidence_match_id_matches_id_fk",
+          "tableFrom": "community_award_evidence",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_award_evidence_non_blank_explanation_check": {
+          "name": "community_award_evidence_non_blank_explanation_check",
+          "value": "length(trim(\"community_award_evidence\".\"explanation\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_awards": {
+      "name": "community_awards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize": {
+          "name": "prize",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplementary_note": {
+          "name": "supplementary_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_note": {
+          "name": "public_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "community_award_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_note": {
+          "name": "outcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_by_user_id": {
+          "name": "outcome_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_at": {
+          "name": "outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_awards_season_id_status_idx": {
+          "name": "community_awards_season_id_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "community_awards_season_id_seasons_id_fk": {
+          "name": "community_awards_season_id_seasons_id_fk",
+          "tableFrom": "community_awards",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "community_awards_submitted_by_user_id_users_id_fk": {
+          "name": "community_awards_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "community_awards_reviewed_by_user_id_users_id_fk": {
+          "name": "community_awards_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "community_awards_recipient_user_id_users_id_fk": {
+          "name": "community_awards_recipient_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "community_awards_outcome_by_user_id_users_id_fk": {
+          "name": "community_awards_outcome_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "columnsFrom": [
+            "outcome_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_awards_non_blank_fields_check": {
+          "name": "community_awards_non_blank_fields_check",
+          "value": "length(trim(\"community_awards\".\"name\")) > 0 AND length(trim(\"community_awards\".\"condition\")) > 0 AND length(trim(\"community_awards\".\"prize\")) > 0"
+        },
+        "community_awards_review_check": {
+          "name": "community_awards_review_check",
+          "value": "(\"community_awards\".\"status\" = 'pending_review' AND ((\"community_awards\".\"reviewed_by_user_id\" IS NULL AND \"community_awards\".\"reviewed_at\" IS NULL) OR (\"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)))\n      OR (\"community_awards\".\"status\" IN ('rejected', 'approved', 'awarded', 'not_awarded', 'cancelled') AND \"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" = 'withdrawn')"
+        },
+        "community_awards_outcome_check": {
+          "name": "community_awards_outcome_check",
+          "value": "(\"community_awards\".\"status\" = 'awarded' AND \"community_awards\".\"recipient_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('not_awarded', 'cancelled', 'withdrawn') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('pending_review', 'rejected', 'approved') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NULL AND \"community_awards\".\"outcome_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_bracket_states": {
+      "name": "competition_bracket_states",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_bracket_states_competition_id_seasons_id_fk": {
+          "name": "competition_bracket_states_competition_id_seasons_id_fk",
+          "tableFrom": "competition_bracket_states",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entries": {
+      "name": "competition_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "competition_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_registration_id": {
+          "name": "source_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formation_order": {
+          "name": "formation_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_user_id": {
+          "name": "representative_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "competition_entry_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "perfect_team_id": {
+          "name": "perfect_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_roster_revision_id": {
+          "name": "current_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_roster_revision_id": {
+          "name": "approved_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entries_competition_status_idx": {
+          "name": "competition_entries_competition_status_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competition_entries_team_history_idx": {
+          "name": "competition_entries_team_history_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competition_entries_one_effective_team_per_competition": {
+          "name": "competition_entries_one_effective_team_per_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"competition_entries\".\"team_id\" IS NOT NULL AND \"competition_entries\".\"registration_status\" NOT IN ('rejected', 'withdrawn')",
+          "concurrently": false
+        },
+        "competition_entries_competition_formation_order_unique": {
+          "name": "competition_entries_competition_formation_order_unique",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formation_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"competition_entries\".\"formation_order\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entries_competition_id_seasons_id_fk": {
+          "name": "competition_entries_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entries",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entries_team_id_teams_id_fk": {
+          "name": "competition_entries_team_id_teams_id_fk",
+          "tableFrom": "competition_entries",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entries_source_registration_id_season_registrations_id_fk": {
+          "name": "competition_entries_source_registration_id_season_registrations_id_fk",
+          "tableFrom": "competition_entries",
+          "columnsFrom": [
+            "source_registration_id"
+          ],
+          "tableTo": "season_registrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entries_representative_user_id_users_id_fk": {
+          "name": "competition_entries_representative_user_id_users_id_fk",
+          "tableFrom": "competition_entries",
+          "columnsFrom": [
+            "representative_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entries_id_competition_id_unique": {
+          "name": "competition_entries_id_competition_id_unique",
+          "columns": [
+            "id",
+            "competition_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entries_source_shape_check": {
+          "name": "competition_entries_source_shape_check",
+          "value": "(\"competition_entries\".\"source\" = 'linked_team' AND \"competition_entries\".\"team_id\" IS NOT NULL) OR (\"competition_entries\".\"source\" = 'event_native' AND \"competition_entries\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_active_claims": {
+      "name": "competition_entry_active_claims",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_active_claims_entry_idx": {
+          "name": "competition_entry_active_claims_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_active_claims_competition_id_seasons_id_fk": {
+          "name": "competition_entry_active_claims_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_active_claims_user_id_users_id_fk": {
+          "name": "competition_entry_active_claims_user_id_users_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_active_claims_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_active_claims_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "tableTo": "competition_entry_participants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_active_claims_entry_competition_scope_fk": {
+          "name": "competition_entry_active_claims_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_active_claims_participant_scope_fk": {
+          "name": "competition_entry_active_claims_participant_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "columnsFrom": [
+            "participant_id",
+            "entry_id",
+            "user_id"
+          ],
+          "tableTo": "competition_entry_participants",
+          "columnsTo": [
+            "id",
+            "entry_id",
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_active_claims_competition_user_unique": {
+          "name": "competition_entry_active_claims_competition_user_unique",
+          "columns": [
+            "competition_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "competition_entry_active_claims_participant_unique": {
+          "name": "competition_entry_active_claims_participant_unique",
+          "columns": [
+            "participant_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_legacy_identities": {
+      "name": "competition_entry_legacy_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_type": {
+          "name": "legacy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_legacy_identities_entry_idx": {
+          "name": "competition_entry_legacy_identities_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_legacy_identities_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_legacy_identities_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_legacy_identities",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_legacy_identities_type_id_unique": {
+          "name": "competition_entry_legacy_identities_type_id_unique",
+          "columns": [
+            "legacy_type",
+            "legacy_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_participants": {
+      "name": "competition_entry_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_participant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_participants_user_status_idx": {
+          "name": "competition_entry_participants_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_participants_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_participants_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_participants_user_id_users_id_fk": {
+          "name": "competition_entry_participants_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_participants_invited_by_user_id_users_id_fk": {
+          "name": "competition_entry_participants_invited_by_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_participants_entry_user_unique": {
+          "name": "competition_entry_participants_entry_user_unique",
+          "columns": [
+            "entry_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "competition_entry_participants_id_entry_user_unique": {
+          "name": "competition_entry_participants_id_entry_user_unique",
+          "columns": [
+            "id",
+            "entry_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_participants_confirmation_shape_check": {
+          "name": "competition_entry_participants_confirmation_shape_check",
+          "value": "(\"competition_entry_participants\".\"status\" = 'confirmed' AND \"competition_entry_participants\".\"confirmed_at\" IS NOT NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)\n      OR (\"competition_entry_participants\".\"status\" = 'withdrawn' AND \"competition_entry_participants\".\"withdrawn_at\" IS NOT NULL)\n      OR (\"competition_entry_participants\".\"status\" IN ('invited', 'declined') AND \"competition_entry_participants\".\"confirmed_at\" IS NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_representative_changes": {
+      "name": "competition_entry_representative_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "competition_entry_representative_changes_entry_changed_at_idx": {
+          "name": "competition_entry_representative_changes_entry_changed_at_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_representative_changes_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_representative_changes_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_representative_changes_from_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_from_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_representative_changes_to_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_to_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_members": {
+      "name": "competition_entry_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_membership_id": {
+          "name": "team_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "tableTo": "competition_entry_participants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_roster_members_user_id_users_id_fk": {
+          "name": "competition_entry_roster_members_user_id_users_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_roster_members_team_membership_id_team_memberships_id_fk": {
+          "name": "competition_entry_roster_members_team_membership_id_team_memberships_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "columnsFrom": [
+            "team_membership_id"
+          ],
+          "tableTo": "team_memberships",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_members_revision_participant_unique": {
+          "name": "competition_entry_roster_members_revision_participant_unique",
+          "columns": [
+            "revision_id",
+            "participant_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "competition_entry_roster_members_revision_user_unique": {
+          "name": "competition_entry_roster_members_revision_user_unique",
+          "columns": [
+            "revision_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_revisions": {
+      "name": "competition_entry_roster_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_roster_revision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "competition_entry_roster_revision_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initial'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_revisions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_roster_revisions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_revisions_entry_revision_number_unique": {
+          "name": "competition_entry_roster_revisions_entry_revision_number_unique",
+          "columns": [
+            "entry_id",
+            "revision_number"
+          ],
+          "nullsNotDistinct": false
+        },
+        "competition_entry_roster_revisions_id_entry_id_unique": {
+          "name": "competition_entry_roster_revisions_id_entry_id_unique",
+          "columns": [
+            "id",
+            "entry_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_roster_revisions_positive_check": {
+          "name": "competition_entry_roster_revisions_positive_check",
+          "value": "\"competition_entry_roster_revisions\".\"revision_number\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_submissions": {
+      "name": "competition_entry_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "competition_entry_submission_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_submissions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_submissions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_submissions_roster_revision_entry_scope_fk": {
+          "name": "competition_entry_submissions_roster_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_submissions",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_submissions_entry_sequence_unique": {
+          "name": "competition_entry_submissions_entry_sequence_unique",
+          "columns": [
+            "entry_id",
+            "sequence"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_submissions_positive_check": {
+          "name": "competition_entry_submissions_positive_check",
+          "value": "\"competition_entry_submissions\".\"sequence\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_roster_members": {
+      "name": "event_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_roster_id": {
+          "name": "event_roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_roster_members_roster_idx": {
+          "name": "event_roster_members_roster_idx",
+          "columns": [
+            {
+              "expression": "event_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_roster_members_event_roster_id_event_rosters_id_fk": {
+          "name": "event_roster_members_event_roster_id_event_rosters_id_fk",
+          "tableFrom": "event_roster_members",
+          "columnsFrom": [
+            "event_roster_id"
+          ],
+          "tableTo": "event_rosters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_roster_members_user_id_users_id_fk": {
+          "name": "event_roster_members_user_id_users_id_fk",
+          "tableFrom": "event_roster_members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "event_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "event_roster_members",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "tableTo": "competition_entry_participants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "event_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "event_roster_members",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "tableTo": "education_verifications",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_roster_members_roster_user_unique": {
+          "name": "event_roster_members_roster_user_unique",
+          "columns": [
+            "event_roster_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "event_roster_members_participant_unique": {
+          "name": "event_roster_members_participant_unique",
+          "columns": [
+            "event_roster_id",
+            "participant_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_rosters": {
+      "name": "event_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_roster_revision_id": {
+          "name": "source_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_by": {
+          "name": "frozen_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_rosters_entry_id_competition_entries_id_fk": {
+          "name": "event_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "event_rosters",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "event_rosters",
+          "columnsFrom": [
+            "source_roster_revision_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_rosters_source_roster_revision_entry_scope_fk": {
+          "name": "event_rosters_source_roster_revision_entry_scope_fk",
+          "tableFrom": "event_rosters",
+          "columnsFrom": [
+            "source_roster_revision_id",
+            "entry_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_rosters_entry_unique": {
+          "name": "event_rosters_entry_unique",
+          "columns": [
+            "entry_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "event_rosters_freeze_shape_check": {
+          "name": "event_rosters_freeze_shape_check",
+          "value": "(\"event_rosters\".\"status\" = 'preparing' AND \"event_rosters\".\"confirmed_at\" IS NULL AND \"event_rosters\".\"confirmed_by\" IS NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'confirmed' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'frozen' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NOT NULL AND \"event_rosters\".\"frozen_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_restriction_overrides": {
+      "name": "competition_entry_restriction_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_code": {
+          "name": "restriction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_snapshot": {
+          "name": "finding_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competition_entry_restriction_overrides_active_unique": {
+          "name": "competition_entry_restriction_overrides_active_unique",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "restriction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL",
+          "concurrently": false
+        },
+        "competition_entry_restriction_overrides_entry_idx": {
+          "name": "competition_entry_restriction_overrides_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competition_entry_restriction_overrides_competition_idx": {
+          "name": "competition_entry_restriction_overrides_competition_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_restriction_overrides_competition_id_seasons_id_fk": {
+          "name": "competition_entry_restriction_overrides_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_competition_scope_fk": {
+          "name": "competition_entry_restriction_overrides_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "competition_entry_restriction_overrides_revision_entry_scope_fk": {
+          "name": "competition_entry_restriction_overrides_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_restriction_overrides_revoke_shape_check": {
+          "name": "competition_entry_restriction_overrides_revoke_shape_check",
+          "value": "(\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NULL) OR (\"competition_entry_restriction_overrides\".\"revoked_at\" IS NOT NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NOT NULL)"
+        },
+        "competition_entry_restriction_overrides_code_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_code_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"restriction_code\")) > 0"
+        },
+        "competition_entry_restriction_overrides_reason_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_reason_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_ranks": {
+      "name": "competitive_platform_ranks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_key": {
+          "name": "platform_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_key": {
+          "name": "rank_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "star_min": {
+          "name": "star_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "star_max": {
+          "name": "star_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_ranks_platform_rank_key_unique": {
+          "name": "competitive_platform_ranks_platform_rank_key_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competitive_platform_ranks_platform_sort_order_unique": {
+          "name": "competitive_platform_ranks_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competitive_platform_ranks_platform_order_idx": {
+          "name": "competitive_platform_ranks_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_ranks_platform_key_competitive_platforms_key_fk": {
+          "name": "competitive_platform_ranks_platform_key_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_ranks",
+          "columnsFrom": [
+            "platform_key"
+          ],
+          "tableTo": "competitive_platforms",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_ranks_star_range_shape": {
+          "name": "competitive_platform_ranks_star_range_shape",
+          "value": "(\"competitive_platform_ranks\".\"star_min\" IS NULL AND \"competitive_platform_ranks\".\"star_max\" IS NULL) OR \"competitive_platform_ranks\".\"star_min\" IS NOT NULL"
+        },
+        "competitive_platform_ranks_star_min_non_negative": {
+          "name": "competitive_platform_ranks_star_min_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_min\" IS NULL OR \"competitive_platform_ranks\".\"star_min\" >= 0"
+        },
+        "competitive_platform_ranks_star_max_non_negative": {
+          "name": "competitive_platform_ranks_star_max_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= 0"
+        },
+        "competitive_platform_ranks_star_range_ordered": {
+          "name": "competitive_platform_ranks_star_range_ordered",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= \"competitive_platform_ranks\".\"star_min\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_seasons": {
+      "name": "competitive_platform_seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_key": {
+          "name": "season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_seasons_platform_key_unique": {
+          "name": "competitive_platform_seasons_platform_key_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competitive_platform_seasons_one_current_per_platform": {
+          "name": "competitive_platform_seasons_one_current_per_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"competitive_platform_seasons\".\"is_current\"",
+          "concurrently": false
+        },
+        "competitive_platform_seasons_platform_order_idx": {
+          "name": "competitive_platform_seasons_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competitive_platform_seasons_platform_sort_order_unique": {
+          "name": "competitive_platform_seasons_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_seasons_platform_competitive_platforms_key_fk": {
+          "name": "competitive_platform_seasons_platform_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_seasons",
+          "columnsFrom": [
+            "platform"
+          ],
+          "tableTo": "competitive_platforms",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_seasons_current_must_be_active": {
+          "name": "competitive_platform_seasons_current_must_be_active",
+          "value": "NOT \"competitive_platform_seasons\".\"is_current\" OR \"competitive_platform_seasons\".\"active\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platforms": {
+      "name": "competitive_platforms",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_label": {
+          "name": "rating_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitive_rank_facts": {
+      "name": "competitive_rank_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "competitive_fact_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_season_key": {
+          "name": "platform_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competitive_fact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ranked'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_season_key": {
+          "name": "achieved_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "competitive_fact_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self_declared'"
+        },
+        "declared_at": {
+          "name": "declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_rank_facts_identity_unique": {
+          "name": "competitive_rank_facts_identity_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"platform_season_key\", '')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "competitive_rank_facts_user_platform_idx": {
+          "name": "competitive_rank_facts_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "competitive_rank_facts_user_id_users_id_fk": {
+          "name": "competitive_rank_facts_user_id_users_id_fk",
+          "tableFrom": "competitive_rank_facts",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_rank_facts_stars_non_negative": {
+          "name": "competitive_rank_facts_stars_non_negative",
+          "value": "\"competitive_rank_facts\".\"stars\" IS NULL OR \"competitive_rank_facts\".\"stars\" >= 0"
+        },
+        "competitive_rank_facts_valid_fact_shape": {
+          "name": "competitive_rank_facts_valid_fact_shape",
+          "value": "\n    (\n      \"competitive_rank_facts\".\"kind\" = 'historical_peak'\n      AND \"competitive_rank_facts\".\"status\" = 'ranked'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NULL\n      AND \"competitive_rank_facts\".\"rank\" IS NOT NULL\n      AND \"competitive_rank_facts\".\"rating\" IS NOT NULL\n    ) OR (\n      \"competitive_rank_facts\".\"kind\" = 'season_peak'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NOT NULL\n      AND (\n        (\"competitive_rank_facts\".\"status\" = 'ranked' AND \"competitive_rank_facts\".\"rank\" IS NOT NULL AND \"competitive_rank_facts\".\"rating\" IS NOT NULL)\n        OR (\"competitive_rank_facts\".\"status\" = 'unranked' AND \"competitive_rank_facts\".\"rank\" IS NULL AND \"competitive_rank_facts\".\"stars\" IS NULL)\n      )\n    )\n  "
+        },
+        "competitive_rank_facts_achieved_season_shape": {
+          "name": "competitive_rank_facts_achieved_season_shape",
+          "value": "\n    (\"competitive_rank_facts\".\"kind\" = 'historical_peak') OR \"competitive_rank_facts\".\"achieved_season_key\" IS NULL\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_competitive_roles": {
+      "name": "user_competitive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "cs2_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_competitive_roles_one_primary_per_user": {
+          "name": "user_competitive_roles_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_competitive_roles\".\"is_primary\"",
+          "concurrently": false
+        },
+        "user_competitive_roles_user_idx": {
+          "name": "user_competitive_roles_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_competitive_roles_user_id_users_id_fk": {
+          "name": "user_competitive_roles_user_id_users_id_fk",
+          "tableFrom": "user_competitive_roles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_competitive_roles_user_role_unique": {
+          "name": "user_competitive_roles_user_role_unique",
+          "columns": [
+            "user_id",
+            "role"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_map_preferences": {
+      "name": "user_map_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_map_preferences_user_id_users_id_fk": {
+          "name": "user_map_preferences_user_id_users_id_fk",
+          "tableFrom": "user_map_preferences",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_case_idempotency": {
+      "name": "disciplinary_case_idempotency",
+      "schema": "",
+      "columns": {
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk": {
+          "name": "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk",
+          "tableFrom": "disciplinary_case_idempotency",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "tableTo": "disciplinary_cases",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_cases": {
+      "name": "disciplinary_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_cases_season_subject_idx": {
+          "name": "disciplinary_cases_season_subject_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "disciplinary_cases_status_idx": {
+          "name": "disciplinary_cases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_cases_season_id_seasons_id_fk": {
+          "name": "disciplinary_cases_season_id_seasons_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "disciplinary_cases_subject_user_id_users_id_fk": {
+          "name": "disciplinary_cases_subject_user_id_users_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disciplinary_cases_revocation_consistent_check": {
+          "name": "disciplinary_cases_revocation_consistent_check",
+          "value": "(\"disciplinary_cases\".\"status\" = 'revoked') = (\"disciplinary_cases\".\"revoked_at\" IS NOT NULL)"
+        },
+        "disciplinary_cases_window_sane_check": {
+          "name": "disciplinary_cases_window_sane_check",
+          "value": "\"disciplinary_cases\".\"effective_until\" IS NULL OR \"disciplinary_cases\".\"effective_until\" > \"disciplinary_cases\".\"effective_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "draft_picks_entry_id_competition_entries_id_fk": {
+          "name": "draft_picks_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_picks",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "tableTo": "season_registrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "columns": [
+            "client_request_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "columns": [
+            "season_id",
+            "registration_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_entry_id": {
+          "name": "current_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "draft_state_current_entry_id_competition_entries_id_fk": {
+          "name": "draft_state_current_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_state",
+          "columnsFrom": [
+            "current_entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "columns": [
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_code": {
+          "name": "evidence_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "tableTo": "institutions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "tableTo": "institutions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "columns": [
+            "moe_institution_code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_url": {
+          "name": "live_stream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "columns": [
+            "auth_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_template": {
+          "name": "competition_template",
+          "type": "competition_template",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 9
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "registration_opens_at": {
+          "name": "registration_opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_opened_at": {
+          "name": "registration_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_change_closes_at": {
+          "name": "roster_change_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "columns": [
+            "user_id",
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "columns": [
+            "season_id",
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_captain_changes": {
+      "name": "team_captain_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_captain_changes_team_changed_at_idx": {
+          "name": "team_captain_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_captain_changes_team_id_teams_id_fk": {
+          "name": "team_captain_changes_team_id_teams_id_fk",
+          "tableFrom": "team_captain_changes",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_captain_changes_from_user_id_users_id_fk": {
+          "name": "team_captain_changes_from_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_captain_changes_to_user_id_users_id_fk": {
+          "name": "team_captain_changes_to_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "team_invitation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_team_status_idx": {
+          "name": "team_invitations_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_invitations_user_status_idx": {
+          "name": "team_invitations_user_status_idx",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_invitations_token_hash_unique": {
+          "name": "team_invitations_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_invitations_one_pending_direct_per_user": {
+          "name": "team_invitations_one_pending_direct_per_user",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"status\" = 'pending'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_invitations_invited_user_id_users_id_fk": {
+          "name": "team_invitations_invited_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_invitations_invited_by_user_id_users_id_fk": {
+          "name": "team_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_invitations_responded_by_user_id_users_id_fk": {
+          "name": "team_invitations_responded_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_invitations_kind_shape_check": {
+          "name": "team_invitations_kind_shape_check",
+          "value": "(\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"invited_user_id\" IS NOT NULL AND \"team_invitations\".\"token_hash\" IS NULL) OR (\"team_invitations\".\"kind\" = 'share_link' AND \"team_invitations\".\"invited_user_id\" IS NULL AND \"team_invitations\".\"token_hash\" IS NOT NULL)"
+        },
+        "team_invitations_response_shape_check": {
+          "name": "team_invitations_response_shape_check",
+          "value": "(\"team_invitations\".\"status\" IN ('accepted', 'declined') AND \"team_invitations\".\"responded_at\" IS NOT NULL AND \"team_invitations\".\"responded_by_user_id\" IS NOT NULL)\n      OR (\"team_invitations\".\"status\" IN ('pending', 'revoked', 'expired') AND \"team_invitations\".\"responded_at\" IS NULL AND \"team_invitations\".\"responded_by_user_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "team_membership_end_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_idx": {
+          "name": "team_memberships_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_memberships_user_idx": {
+          "name": "team_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "team_memberships_one_current_period": {
+          "name": "team_memberships_one_current_period",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false
+        },
+        "team_memberships_one_current_team_per_user": {
+          "name": "team_memberships_one_current_team_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "team_memberships_invited_by_user_id_users_id_fk": {
+          "name": "team_memberships_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_memberships_period_shape_check": {
+          "name": "team_memberships_period_shape_check",
+          "value": "(\"team_memberships\".\"ended_at\" IS NULL AND \"team_memberships\".\"ended_reason\" IS NULL AND \"team_memberships\".\"status\" <> 'left') OR (\"team_memberships\".\"ended_at\" IS NOT NULL AND \"team_memberships\".\"ended_reason\" IS NOT NULL AND \"team_memberships\".\"status\" = 'left')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_name_changes": {
+      "name": "team_name_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_name": {
+          "name": "new_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_name_changes_team_changed_at_idx": {
+          "name": "team_name_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "team_name_changes_team_id_teams_id_fk": {
+          "name": "team_name_changes_team_id_teams_id_fk",
+          "tableFrom": "team_name_changes",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_slug_aliases": {
+      "name": "team_slug_aliases",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_slug_aliases_team_id_teams_id_fk": {
+          "name": "team_slug_aliases_team_id_teams_id_fk",
+          "tableFrom": "team_slug_aliases",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disbanded_at": {
+          "name": "disbanded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disbanded_by": {
+          "name": "disbanded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "teams_one_active_captaincy_per_user": {
+          "name": "teams_one_active_captaincy_per_user",
+          "columns": [
+            {
+              "expression": "captain_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"teams\".\"status\" = 'active'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "teams_creator_user_id_users_id_fk": {
+          "name": "teams_creator_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_lifecycle_shape_check": {
+          "name": "teams_lifecycle_shape_check",
+          "value": "(\"teams\".\"status\" = 'active' AND \"teams\".\"disbanded_at\" IS NULL) OR (\"teams\".\"status\" = 'disbanded' AND \"teams\".\"disbanded_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_intents": {
+      "name": "recruitment_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "recruitment_intent_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positions": {
+          "name": "positions",
+          "type": "cs2_role[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::cs2_role[]"
+        },
+        "target_season_id": {
+          "name": "target_season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recruitment_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_intents_one_team_unique": {
+          "name": "recruitment_intents_one_team_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recruitment_intents_one_user_unique": {
+          "name": "recruitment_intents_one_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recruitment_intents_open_discovery_idx": {
+          "name": "recruitment_intents_open_discovery_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recruitment_intents_target_season_idx": {
+          "name": "recruitment_intents_target_season_idx",
+          "columns": [
+            {
+              "expression": "target_season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recruitment_intents_team_id_teams_id_fk": {
+          "name": "recruitment_intents_team_id_teams_id_fk",
+          "tableFrom": "recruitment_intents",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "tableTo": "teams",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recruitment_intents_user_id_users_id_fk": {
+          "name": "recruitment_intents_user_id_users_id_fk",
+          "tableFrom": "recruitment_intents",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recruitment_intents_target_season_id_seasons_id_fk": {
+          "name": "recruitment_intents_target_season_id_seasons_id_fk",
+          "tableFrom": "recruitment_intents",
+          "columnsFrom": [
+            "target_season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recruitment_intents_owner_shape_check": {
+          "name": "recruitment_intents_owner_shape_check",
+          "value": "(\"recruitment_intents\".\"kind\" = 'team_recruiting' AND \"recruitment_intents\".\"team_id\" IS NOT NULL AND \"recruitment_intents\".\"user_id\" IS NULL)\n      OR (\"recruitment_intents\".\"kind\" = 'player_lft' AND \"recruitment_intents\".\"user_id\" IS NOT NULL AND \"recruitment_intents\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_interests": {
+      "name": "recruitment_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recruitment_intent_id": {
+          "name": "recruitment_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_interests_intent_idx": {
+          "name": "recruitment_interests_intent_idx",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recruitment_interests_user_idx": {
+          "name": "recruitment_interests_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recruitment_interests_one_user_per_intent_unique": {
+          "name": "recruitment_interests_one_user_per_intent_unique",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk": {
+          "name": "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk",
+          "tableFrom": "recruitment_interests",
+          "columnsFrom": [
+            "recruitment_intent_id"
+          ],
+          "tableTo": "recruitment_intents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "recruitment_interests_user_id_users_id_fk": {
+          "name": "recruitment_interests_user_id_users_id_fk",
+          "tableFrom": "recruitment_interests",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_at": {
+          "name": "seeds_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_by": {
+          "name": "seeds_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "columns": [
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_prestart_states_seed_confirmation_shape_check": {
+          "name": "major_prestart_states_seed_confirmation_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_confirmed_at\" IS NULL) = (\"major_prestart_states\".\"seeds_confirmed_by\" IS NULL)"
+        },
+        "major_prestart_states_seed_lock_shape_check": {
+          "name": "major_prestart_states_seed_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_locked_at\" IS NULL) = (\"major_prestart_states\".\"seeds_locked_by\" IS NULL)"
+        },
+        "major_prestart_states_entrant_lock_shape_check": {
+          "name": "major_prestart_states_entrant_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"entrants_locked_at\" IS NULL) = (\"major_prestart_states\".\"entrants_locked_by\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_entrants": {
+      "name": "major_tournament_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_entry_id": {
+          "name": "competition_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_entrants_season_idx": {
+          "name": "major_tournament_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_entrants_season_id_seasons_id_fk": {
+          "name": "major_tournament_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_tournament_entrants_competition_entry_id_competition_entries_id_fk": {
+          "name": "major_tournament_entrants_competition_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "columnsFrom": [
+            "competition_entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_tournament_entrants_entry_season_scope_fk": {
+          "name": "major_tournament_entrants_entry_season_scope_fk",
+          "tableFrom": "major_tournament_entrants",
+          "columnsFrom": [
+            "competition_entry_id",
+            "season_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_entrants_season_entry_unique": {
+          "name": "major_tournament_entrants_season_entry_unique",
+          "columns": [
+            "season_id",
+            "competition_entry_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "major_tournament_entrants_id_season_unique": {
+          "name": "major_tournament_entrants_id_season_unique",
+          "columns": [
+            "id",
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "tableTo": "major_tournament_entrants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_tournament_seeds_entrant_season_scope_fk": {
+          "name": "major_tournament_seeds_entrant_season_scope_fk",
+          "tableFrom": "major_tournament_seeds",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "tableTo": "major_tournament_entrants",
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "columns": [
+            "season_id",
+            "tournament_entrant_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "columns": [
+            "season_id",
+            "seed"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_entry_id": {
+          "name": "champion_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_final_results_champion_entry_id_competition_entries_id_fk": {
+          "name": "major_final_results_champion_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_final_results",
+          "columnsFrom": [
+            "champion_entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_final_results_playoff_run_season_scope_fk": {
+          "name": "major_final_results_playoff_run_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "columnsFrom": [
+            "playoff_stage_run_id",
+            "season_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_final_results_champion_entry_season_scope_fk": {
+          "name": "major_final_results_champion_entry_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "columnsFrom": [
+            "champion_entry_id",
+            "season_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "columns": [
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "columns": [
+            "playoff_stage_run_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_final_results_confirmation_shape_check": {
+          "name": "major_final_results_confirmation_shape_check",
+          "value": "(\"major_final_results\".\"status\" = 'pending_confirmation' AND \"major_final_results\".\"confirmed_at\" IS NULL AND \"major_final_results\".\"confirmed_by\" IS NULL) OR (\"major_final_results\".\"status\" = 'confirmed' AND \"major_final_results\".\"confirmed_at\" IS NOT NULL AND \"major_final_results\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "major_stage_entrants_season_id_seasons_id_fk": {
+          "name": "major_stage_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "tableTo": "major_tournament_entrants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_stage_entrants_run_season_scope_fk": {
+          "name": "major_stage_entrants_run_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "columnsFrom": [
+            "stage_run_id",
+            "season_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_season_scope_fk": {
+          "name": "major_stage_entrants_tournament_entrant_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "tableTo": "major_tournament_entrants",
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "columns": [
+            "stage_run_id",
+            "tournament_entrant_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "columns": [
+            "season_id",
+            "stage_key"
+          ],
+          "nullsNotDistinct": false
+        },
+        "major_stage_runs_id_season_unique": {
+          "name": "major_stage_runs_id_season_unique",
+          "columns": [
+            "id",
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "tableTo": "season_registrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "tableTo": "season_registrations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_a_id": {
+          "name": "entry_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_b_id": {
+          "name": "entry_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false
+        },
+        "matches_season_status_scheduled_at_idx": {
+          "name": "matches_season_status_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matches_entry_a_id_idx": {
+          "name": "matches_entry_a_id_idx",
+          "columns": [
+            {
+              "expression": "entry_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "matches_entry_b_id_idx": {
+          "name": "matches_entry_b_id_idx",
+          "columns": [
+            {
+              "expression": "entry_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_entry_a_id_competition_entries_id_fk": {
+          "name": "matches_entry_a_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "entry_a_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_entry_b_id_competition_entries_id_fk": {
+          "name": "matches_entry_b_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "entry_b_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_entry_a_season_scope_fk": {
+          "name": "matches_entry_a_season_scope_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "entry_a_id",
+            "season_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_entry_b_season_scope_fk": {
+          "name": "matches_entry_b_season_scope_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "entry_b_id",
+            "season_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "matches_major_stage_run_season_scope_fk": {
+          "name": "matches_major_stage_run_season_scope_fk",
+          "tableFrom": "matches",
+          "columnsFrom": [
+            "major_stage_run_id",
+            "season_id"
+          ],
+          "tableTo": "major_stage_runs",
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_entries_different": {
+          "name": "matches_entries_different",
+          "value": "\"matches\".\"entry_a_id\" != \"matches\".\"entry_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_entry_id": {
+          "name": "picked_by_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_maps_picked_by_entry_id_competition_entries_id_fk": {
+          "name": "match_maps_picked_by_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_maps",
+          "columnsFrom": [
+            "picked_by_entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "columns": [
+            "match_id",
+            "map_order"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.season_admin_grants": {
+      "name": "season_admin_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "season_admin_grants_user_id_idx": {
+          "name": "season_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "season_admin_grants_season_id_idx": {
+          "name": "season_admin_grants_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "season_admin_grants_user_id_users_id_fk": {
+          "name": "season_admin_grants_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "season_admin_grants_season_id_seasons_id_fk": {
+          "name": "season_admin_grants_season_id_seasons_id_fk",
+          "tableFrom": "season_admin_grants",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "season_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "season_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_admin_grants_user_season_unique": {
+          "name": "season_admin_grants_user_season_unique",
+          "columns": [
+            "user_id",
+            "season_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_player_stats_match_id_idx": {
+          "name": "match_player_stats_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "match_player_stats_user_id_idx": {
+          "name": "match_player_stats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "tableTo": "match_maps",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "swiss_standings_entry_id_competition_entries_id_fk": {
+          "name": "swiss_standings_entry_id_competition_entries_id_fk",
+          "tableFrom": "swiss_standings",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_entry_id_unique": {
+          "name": "swiss_standings_season_id_stage_entry_id_unique",
+          "columns": [
+            "season_id",
+            "stage",
+            "entry_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_time_proposals_match_id_idx": {
+          "name": "match_time_proposals_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_roster_member_id": {
+          "name": "event_roster_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "tableTo": "match_rosters",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "match_roster_players_event_roster_member_id_event_roster_members_id_fk": {
+          "name": "match_roster_players_event_roster_member_id_event_roster_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "columnsFrom": [
+            "event_roster_member_id"
+          ],
+          "tableTo": "event_roster_members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_event_roster_member_id_unique": {
+          "name": "match_roster_players_roster_id_event_roster_member_id_unique",
+          "columns": [
+            "roster_id",
+            "event_roster_member_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "match_roster_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "match_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_rosters_entry_id_competition_entries_id_fk": {
+          "name": "match_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_rosters",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_entry_id_unique": {
+          "name": "match_rosters_match_id_entry_id_unique",
+          "columns": [
+            "match_id",
+            "entry_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_rosters_metadata_shape_check": {
+          "name": "match_rosters_metadata_shape_check",
+          "value": "(\"match_rosters\".\"source\" = 'participant' AND \"match_rosters\".\"submitted_by\" IS NOT NULL) OR (\"match_rosters\".\"source\" = 'admin_select' AND \"match_rosters\".\"submitted_by\" IS NULL)"
+        },
+        "match_rosters_confirmation_shape_check": {
+          "name": "match_rosters_confirmation_shape_check",
+          "value": "(\"match_rosters\".\"status\" = 'submitted' AND \"match_rosters\".\"confirmed_at\" IS NULL AND \"match_rosters\".\"confirmed_by\" IS NULL) OR (\"match_rosters\".\"status\" = 'confirmed' AND \"match_rosters\".\"confirmed_at\" IS NOT NULL AND \"match_rosters\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "match_veto_steps_entry_id_competition_entries_id_fk": {
+          "name": "match_veto_steps_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_veto_steps",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "columns": [
+            "match_id",
+            "step_order"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_adjudications": {
+      "name": "post_event_adjudications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "adjudication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "adjudication_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "adjudication_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impacts": {
+          "name": "impacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_entry_id": {
+          "name": "target_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_match_id": {
+          "name": "target_match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_event_adjudications_season_idx": {
+          "name": "post_event_adjudications_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "post_event_adjudications_season_id_seasons_id_fk": {
+          "name": "post_event_adjudications_season_id_seasons_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "post_event_adjudications_target_entry_id_competition_entries_id_fk": {
+          "name": "post_event_adjudications_target_entry_id_competition_entries_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "columnsFrom": [
+            "target_entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "post_event_adjudications_target_user_id_users_id_fk": {
+          "name": "post_event_adjudications_target_user_id_users_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "post_event_adjudications_target_match_id_matches_id_fk": {
+          "name": "post_event_adjudications_target_match_id_matches_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "columnsFrom": [
+            "target_match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_event_adjudications_client_request_id_unique": {
+          "name": "post_event_adjudications_client_request_id_unique",
+          "columns": [
+            "client_request_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_event_adjudications_target_check": {
+          "name": "post_event_adjudications_target_check",
+          "value": "(\"post_event_adjudications\".\"target\" = 'season' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'entry' AND \"post_event_adjudications\".\"target_entry_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'user' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'match' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NOT NULL)"
+        },
+        "post_event_adjudications_revocation_check": {
+          "name": "post_event_adjudications_revocation_check",
+          "value": "(\"post_event_adjudications\".\"status\" = 'revoked') = (\"post_event_adjudications\".\"revoked_at\" IS NOT NULL)"
+        },
+        "post_event_adjudications_impacts_array_check": {
+          "name": "post_event_adjudications_impacts_array_check",
+          "value": "jsonb_typeof(\"post_event_adjudications\".\"impacts\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament_honors": {
+      "name": "tournament_honors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "honor_key": {
+          "name": "honor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "honor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "honor_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "basis": {
+          "name": "basis",
+          "type": "honor_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_from": {
+          "name": "placement_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_to": {
+          "name": "placement_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_final_result_id": {
+          "name": "source_final_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjudication_id": {
+          "name": "adjudication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tournament_honors_season_idx": {
+          "name": "tournament_honors_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournament_honors_one_valid_slot_unique": {
+          "name": "tournament_honors_one_valid_slot_unique",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "honor_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"tournament_honors\".\"state\" = 'valid'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_honors_season_id_seasons_id_fk": {
+          "name": "tournament_honors_season_id_seasons_id_fk",
+          "tableFrom": "tournament_honors",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "tableTo": "seasons",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournament_honors_entry_id_competition_entries_id_fk": {
+          "name": "tournament_honors_entry_id_competition_entries_id_fk",
+          "tableFrom": "tournament_honors",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "tableTo": "competition_entries",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournament_honors_user_id_users_id_fk": {
+          "name": "tournament_honors_user_id_users_id_fk",
+          "tableFrom": "tournament_honors",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournament_honors_source_final_result_id_major_final_results_id_fk": {
+          "name": "tournament_honors_source_final_result_id_major_final_results_id_fk",
+          "tableFrom": "tournament_honors",
+          "columnsFrom": [
+            "source_final_result_id"
+          ],
+          "tableTo": "major_final_results",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournament_honors_adjudication_id_post_event_adjudications_id_fk": {
+          "name": "tournament_honors_adjudication_id_post_event_adjudications_id_fk",
+          "tableFrom": "tournament_honors",
+          "columnsFrom": [
+            "adjudication_id"
+          ],
+          "tableTo": "post_event_adjudications",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_honors_client_request_id_unique": {
+          "name": "tournament_honors_client_request_id_unique",
+          "columns": [
+            "client_request_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_honors_recipient_check": {
+          "name": "tournament_honors_recipient_check",
+          "value": "(\"tournament_honors\".\"state\" IN ('valid', 'revoked') AND ((\"tournament_honors\".\"entry_id\" IS NOT NULL)::int + (\"tournament_honors\".\"user_id\" IS NOT NULL)::int) = 1)\n      OR (\"tournament_honors\".\"state\" IN ('vacant', 'not_awarded') AND \"tournament_honors\".\"entry_id\" IS NULL AND \"tournament_honors\".\"user_id\" IS NULL)"
+        },
+        "tournament_honors_placement_check": {
+          "name": "tournament_honors_placement_check",
+          "value": "(\"tournament_honors\".\"type\" = 'placement' AND \"tournament_honors\".\"placement_from\" IS NOT NULL AND \"tournament_honors\".\"placement_to\" IS NOT NULL AND \"tournament_honors\".\"placement_from\" > 0 AND \"tournament_honors\".\"placement_to\" >= \"tournament_honors\".\"placement_from\")\n      OR (\"tournament_honors\".\"type\" <> 'placement' AND \"tournament_honors\".\"placement_from\" IS NULL AND \"tournament_honors\".\"placement_to\" IS NULL)"
+        },
+        "tournament_honors_revocation_check": {
+          "name": "tournament_honors_revocation_check",
+          "value": "(\"tournament_honors\".\"state\" = 'revoked') = (\"tournament_honors\".\"revoked_at\" IS NOT NULL)"
+        },
+        "tournament_honors_non_blank_key_check": {
+          "name": "tournament_honors_non_blank_key_check",
+          "value": "length(trim(\"tournament_honors\".\"honor_key\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_commentators": {
+      "name": "match_commentators",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_commentators_user_id_idx": {
+          "name": "match_commentators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "match_commentators_match_id_matches_id_fk": {
+          "name": "match_commentators_match_id_matches_id_fk",
+          "tableFrom": "match_commentators",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "match_commentators_user_id_users_id_fk": {
+          "name": "match_commentators_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "match_commentators_added_by_user_id_users_id_fk": {
+          "name": "match_commentators_added_by_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_commentators_match_id_user_id_pk": {
+          "name": "match_commentators_match_id_user_id_pk",
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_match_reports": {
+      "name": "post_match_reports",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_match_reports_submitted_by_user_id_idx": {
+          "name": "post_match_reports_submitted_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "submitted_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "post_match_reports_match_id_matches_id_fk": {
+          "name": "post_match_reports_match_id_matches_id_fk",
+          "tableFrom": "post_match_reports",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "tableTo": "matches",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "post_match_reports_submitted_by_user_id_users_id_fk": {
+          "name": "post_match_reports_submitted_by_user_id_users_id_fk",
+          "tableFrom": "post_match_reports",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_invite_role": {
+      "name": "admin_invite_role",
+      "schema": "public",
+      "values": [
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.community_award_status": {
+      "name": "community_award_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "rejected",
+        "approved",
+        "withdrawn",
+        "awarded",
+        "not_awarded",
+        "cancelled"
+      ]
+    },
+    "public.competition_entry_participant_status": {
+      "name": "competition_entry_participant_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_registration_status": {
+      "name": "competition_entry_registration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_roster_revision_origin": {
+      "name": "competition_entry_roster_revision_origin",
+      "schema": "public",
+      "values": [
+        "initial",
+        "admin_remediation",
+        "self_roster_change"
+      ]
+    },
+    "public.competition_entry_roster_revision_status": {
+      "name": "competition_entry_roster_revision_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "superseded"
+      ]
+    },
+    "public.competition_entry_source": {
+      "name": "competition_entry_source",
+      "schema": "public",
+      "values": [
+        "linked_team",
+        "event_native"
+      ]
+    },
+    "public.competition_entry_submission_decision": {
+      "name": "competition_entry_submission_decision",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.event_roster_status": {
+      "name": "event_roster_status",
+      "schema": "public",
+      "values": [
+        "preparing",
+        "confirmed",
+        "frozen"
+      ]
+    },
+    "public.competitive_fact_kind": {
+      "name": "competitive_fact_kind",
+      "schema": "public",
+      "values": [
+        "historical_peak",
+        "season_peak"
+      ]
+    },
+    "public.competitive_fact_provenance": {
+      "name": "competitive_fact_provenance",
+      "schema": "public",
+      "values": [
+        "self_declared"
+      ]
+    },
+    "public.competitive_fact_status": {
+      "name": "competitive_fact_status",
+      "schema": "public",
+      "values": [
+        "ranked",
+        "unranked"
+      ]
+    },
+    "public.cs2_role": {
+      "name": "cs2_role",
+      "schema": "public",
+      "values": [
+        "igl",
+        "awper",
+        "opener",
+        "closer",
+        "anchor"
+      ]
+    },
+    "public.sanction_effect": {
+      "name": "sanction_effect",
+      "schema": "public",
+      "values": [
+        "registration_block",
+        "roster_block",
+        "match_participation_block"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "super_admin"
+      ]
+    },
+    "public.competition_template": {
+      "name": "competition_template",
+      "schema": "public",
+      "values": [
+        "rivals",
+        "major",
+        "custom"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_invitation_kind": {
+      "name": "team_invitation_kind",
+      "schema": "public",
+      "values": [
+        "direct",
+        "share_link"
+      ]
+    },
+    "public.team_invitation_status": {
+      "name": "team_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.team_lifecycle": {
+      "name": "team_lifecycle",
+      "schema": "public",
+      "values": [
+        "active",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_end_reason": {
+      "name": "team_membership_end_reason",
+      "schema": "public",
+      "values": [
+        "left",
+        "kicked",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_status": {
+      "name": "team_membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "benched",
+        "left"
+      ]
+    },
+    "public.recruitment_intent_kind": {
+      "name": "recruitment_intent_kind",
+      "schema": "public",
+      "values": [
+        "team_recruiting",
+        "player_lft"
+      ]
+    },
+    "public.recruitment_intent_status": {
+      "name": "recruitment_intent_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.match_roster_source": {
+      "name": "match_roster_source",
+      "schema": "public",
+      "values": [
+        "participant",
+        "admin_select"
+      ]
+    },
+    "public.match_roster_status": {
+      "name": "match_roster_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "confirmed"
+      ]
+    },
+    "public.adjudication_impact": {
+      "name": "adjudication_impact",
+      "schema": "public",
+      "values": [
+        "canonical_matches",
+        "final_result",
+        "official_placements",
+        "honors",
+        "none"
+      ]
+    },
+    "public.adjudication_kind": {
+      "name": "adjudication_kind",
+      "schema": "public",
+      "values": [
+        "team_sanction",
+        "result_statement",
+        "placement_statement",
+        "honor_directive"
+      ]
+    },
+    "public.adjudication_status": {
+      "name": "adjudication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "revoked"
+      ]
+    },
+    "public.adjudication_target": {
+      "name": "adjudication_target",
+      "schema": "public",
+      "values": [
+        "season",
+        "entry",
+        "user",
+        "match"
+      ]
+    },
+    "public.honor_basis": {
+      "name": "honor_basis",
+      "schema": "public",
+      "values": [
+        "final_result",
+        "manual",
+        "adjudication"
+      ]
+    },
+    "public.honor_state": {
+      "name": "honor_state",
+      "schema": "public",
+      "values": [
+        "valid",
+        "revoked",
+        "vacant",
+        "not_awarded"
+      ]
+    },
+    "public.honor_type": {
+      "name": "honor_type",
+      "schema": "public",
+      "values": [
+        "champion",
+        "runner_up",
+        "placement",
+        "manual_award"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1788486357950,
       "tag": "0035_colorful_black_widow",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1788506000969,
+      "tag": "0036_auth_id_reconciliation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -130,7 +130,7 @@ export async function signUp(
 
   try {
     const supabase = createPublicAuthClient();
-    const { data, error } = await supabase.auth.signUp({
+    const { error } = await supabase.auth.signUp({
       email: normalizedEmail,
       password,
       options: { emailRedirectTo: confirmationUrl("signup", next) },
@@ -145,29 +145,10 @@ export async function signUp(
       return fail({ code: ErrorCode.VALIDATION_FAILED, message: "注册失败，请确认信息后重试" });
     }
 
-    if (!data.user) {
-      return fail({ code: ErrorCode.INTERNAL_ERROR, message: "注册失败，请稍后重试" });
-    }
-
-    // 事务保护：auth.users 行已创建，若 public.users 插入失败则回滚会话。
-    // 极端情况下（DB 断开）auth.users 会遗留孤立行，下次登录时 loginWithPassword
-    // 的 upsert 兜底修复，属于可接受的低概率不一致。
-    await db
-      .insert(users)
-      .values({
-        email: normalizedEmail,
-        authId: data.user.id,
-        role: "user",
-        updatedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: users.email,
-        set: { authId: data.user.id, updatedAt: new Date() },
-      })
-      .returning();
-
-    // Never establish an iron-session here: Auth confirmation is the only
-    // path that can create a session for a newly registered account.
+    // Supabase may return an obfuscated user for a repeated signup. The
+    // response id is therefore not proof of a canonical Auth identity.
+    // Binding belongs only to the explicit confirmation or password-login
+    // paths, and signup never creates an application session.
     return ok({ email: normalizedEmail });
   } catch (e) {
     return actionError("signUp", e);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition, useCallback, useEffect, useRef } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
 import { Field } from "@/components/rivalhub";
 import { Button } from "@/components/ui/button";
@@ -78,7 +79,40 @@ export function LoginForm({ initialMode = "login", redirectTo = "/" }: { initial
 
   if (awaitingEmail) {
     const isResendCoolingDown = resendAvailableAt !== null;
-    return <div className="space-y-4"><div className="rounded-sm border border-[var(--color-border)] p-4"><h2 className="font-semibold">验证邮件已发送</h2><p className="mt-2 break-all text-sm text-[var(--color-fg-mid)]">请打开 {awaitingEmail} 中的邮件完成验证。验证前不会登录 RivalHub。</p><p className="mt-2 text-sm text-[var(--color-fg-mid)]">如果收件箱中没有看到邮件，请检查垃圾邮件、广告邮件或其它分类。</p></div><Button type="button" variant="outline" className="w-full" disabled={isPending || isResendCoolingDown} onClick={() => startTransition(async () => { const result = await resendSignupConfirmation(awaitingEmail, redirectRef.current); if (result.success) { setResendAvailableAt(Date.now() + EMAIL_RESEND_COOLDOWN_SECONDS * 1_000); toast.success("验证邮件已重新发送"); } else toast.error(result.error.message); })}>{isResendCoolingDown ? `请等待 ${EMAIL_RESEND_COOLDOWN_SECONDS} 秒后重试` : "重新发送验证邮件"}</Button><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setResendAvailableAt(null); setMode("login"); }}>返回登录</button><button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setResendAvailableAt(null); setMode("register"); setEmail(""); setPassword(""); setConfirmPassword(""); setTurnstileToken(""); setTurnstileResetKey((key) => key + 1); }}>使用其他邮箱</button></div>;
+    return (
+      <div className="space-y-4">
+        <div className="rounded-sm border border-[var(--color-border)] p-4">
+          <h2 className="font-semibold">继续完成账号设置</h2>
+          <p className="mt-2 break-all text-sm text-[var(--color-fg-mid)]">请检查邮箱：{awaitingEmail}</p>
+          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">如果这是你首次使用该邮箱注册，请前往邮箱完成验证。</p>
+          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">如果你此前已经使用这个邮箱注册过 RivalHub，请直接登录；忘记密码可以重新设置。</p>
+          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">为保护账号隐私，我们不会在这里确认该邮箱是否已注册。</p>
+          <p className="mt-2 text-sm text-[var(--color-fg-mid)]">如果收件箱中没有看到邮件，请检查垃圾邮件、广告邮件或其它分类。</p>
+        </div>
+        <div className="space-y-2">
+          <Button type="button" variant="outline" className="w-full" onClick={() => { setAwaitingEmail(null); setResendAvailableAt(null); setMode("login"); }}>
+            去登录
+          </Button>
+          <Link href="/forgot-password" className="block w-full text-center text-sm underline hover:text-[var(--color-fg)]">
+            找回密码
+          </Link>
+          <Button type="button" variant="outline" className="w-full" disabled={isPending || isResendCoolingDown} onClick={() => startTransition(async () => {
+            const result = await resendSignupConfirmation(awaitingEmail, redirectRef.current);
+            if (result.success) {
+              setResendAvailableAt(Date.now() + EMAIL_RESEND_COOLDOWN_SECONDS * 1_000);
+              toast.success("已提交验证邮件重发请求；如果该邮箱仍待验证，请检查收件箱及垃圾邮件等分类。");
+            } else {
+              toast.error(result.error.message);
+            }
+          })}>
+            {isResendCoolingDown ? `请等待 ${EMAIL_RESEND_COOLDOWN_SECONDS} 秒后重试` : "重新发送验证邮件"}
+          </Button>
+        </div>
+        <button type="button" className="w-full text-sm underline" onClick={() => { setAwaitingEmail(null); setResendAvailableAt(null); setMode("register"); setEmail(""); setPassword(""); setConfirmPassword(""); setTurnstileToken(""); setTurnstileResetKey((key) => key + 1); }}>
+          使用其他邮箱
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -3,10 +3,10 @@ import { pgTable, uuid, text, timestamp, pgEnum } from "drizzle-orm/pg-core";
 export const userRoleEnum = pgEnum("user_role", ["user", "super_admin"]);
 export const emailVerificationSourceEnum = pgEnum("email_verification_source", ["signup_confirmation", "existing_account_reverification", "admin_migration"]);
 
-// 全局用户账号 — 通过 auth_id 关联 Supabase Auth
+// 全局用户账号 — auth_id 只在已证明的 Supabase Auth 身份路径绑定
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
-  authId: uuid("auth_id").unique(), // Supabase auth.users FK
+  authId: uuid("auth_id").unique(), // verified Supabase Auth identity; no cross-schema FK
   email: text("email").notNull().unique(),
   /** Null means the RivalHub ownership fact is unknown; do not infer it from Auth history. */
   emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true }),

--- a/tests/integration/db/migrations/auth-id-reconciliation.test.ts
+++ b/tests/integration/db/migrations/auth-id-reconciliation.test.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { describe, expect, it } from "vitest";
+
+import { migrationFiles, replayMigration, withScratchDatabase } from "../harness/migration-replay";
+
+const RECONCILIATION_MIGRATION = "0036_auth_id_reconciliation.sql";
+
+async function replayBeforeReconciliation(client: Client): Promise<void> {
+  for (const migration of migrationFiles((name) => name < RECONCILIATION_MIGRATION)) {
+    await replayMigration(client, migration);
+  }
+}
+
+async function ensureAuthUsersFixture(client: Client): Promise<void> {
+  await client.query("CREATE SCHEMA IF NOT EXISTS auth");
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS auth.users (
+      id uuid PRIMARY KEY,
+      email text
+    )
+  `);
+}
+
+async function runReconciliation(client: Client): Promise<void> {
+  await replayMigration(client, RECONCILIATION_MIGRATION);
+}
+
+async function expectReconciliationFailure(client: Client, expectedCategory: string, privateValues: string[]): Promise<string> {
+  try {
+    await runReconciliation(client);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message).toContain(expectedCategory);
+    for (const privateValue of privateValues) expect(message).not.toContain(privateValue);
+    return message;
+  }
+  throw new Error("auth identity reconciliation should fail closed");
+}
+
+describe("auth identity reconciliation migration", () => {
+  it("repairs a uniquely normalized email match, preserves valid mappings, and is idempotent", async () => {
+    await withScratchDatabase("rivalhub_auth_id_repair", async (client) => {
+      await replayBeforeReconciliation(client);
+      await ensureAuthUsersFixture(client);
+
+      const validAuthId = randomUUID();
+      const repairedAuthId = randomUUID();
+      const danglingAuthId = randomUUID();
+      const validUserId = randomUUID();
+      const danglingUserId = randomUUID();
+      const validUpdatedAt = "2026-09-01T00:00:00.000Z";
+
+      await client.query(
+        "INSERT INTO auth.users (id, email) VALUES ($1, $2), ($3, $4)",
+        [validAuthId, "valid@example.test", repairedAuthId, "Player@Example.Test"],
+      );
+      await client.query(
+        `INSERT INTO public.users (id, auth_id, email, updated_at)
+         VALUES ($1, $2, $3, $4), ($5, $6, $7, $4)`,
+        [
+          validUserId,
+          validAuthId,
+          "valid@example.test",
+          validUpdatedAt,
+          danglingUserId,
+          danglingAuthId,
+          " player@example.test ",
+        ],
+      );
+
+      await runReconciliation(client);
+
+      const repaired = await client.query<{ auth_id: string; email: string; updated_at: Date }>(
+        "SELECT auth_id, email, updated_at FROM public.users WHERE id = $1",
+        [danglingUserId],
+      );
+      const valid = await client.query<{ auth_id: string; updated_at: Date }>(
+        "SELECT auth_id, updated_at FROM public.users WHERE id = $1",
+        [validUserId],
+      );
+      expect(repaired.rows[0]).toMatchObject({ auth_id: repairedAuthId, email: " player@example.test " });
+      const repairedUpdatedAt = repaired.rows[0]?.updated_at;
+      expect(repairedUpdatedAt).toBeInstanceOf(Date);
+      expect(valid.rows[0]).toEqual({ auth_id: validAuthId, updated_at: new Date(validUpdatedAt) });
+
+      await runReconciliation(client);
+      const afterRerun = await client.query<{ auth_id: string; updated_at: Date }>(
+        "SELECT auth_id, updated_at FROM public.users WHERE id = $1",
+        [danglingUserId],
+      );
+      expect(afterRerun.rows[0]).toEqual({ auth_id: repairedAuthId, updated_at: repairedUpdatedAt });
+    });
+  });
+
+  it("fails closed for an unmatched normalized email before changing the row", async () => {
+    await withScratchDatabase("rivalhub_auth_id_unmatched", async (client) => {
+      await replayBeforeReconciliation(client);
+      await ensureAuthUsersFixture(client);
+
+      const danglingAuthId = randomUUID();
+      const userId = randomUUID();
+      const email = `unmatched-${userId}@example.test`;
+      await client.query(
+        "INSERT INTO public.users (id, auth_id, email) VALUES ($1, $2, $3)",
+        [userId, danglingAuthId, email],
+      );
+
+      await expectReconciliationFailure(client, "unmatched=1", [email, danglingAuthId]);
+      const unchanged = await client.query<{ auth_id: string }>(
+        "SELECT auth_id FROM public.users WHERE id = $1",
+        [userId],
+      );
+      expect(unchanged.rows[0]?.auth_id).toBe(danglingAuthId);
+    });
+  });
+
+  it("fails closed for an ambiguous normalized email match", async () => {
+    await withScratchDatabase("rivalhub_auth_id_ambiguous", async (client) => {
+      await replayBeforeReconciliation(client);
+      await ensureAuthUsersFixture(client);
+
+      const firstAuthId = randomUUID();
+      const secondAuthId = randomUUID();
+      const danglingAuthId = randomUUID();
+      const userId = randomUUID();
+      const email = `ambiguous-${userId}@example.test`;
+      await client.query(
+        "INSERT INTO auth.users (id, email) VALUES ($1, $2), ($3, $4)",
+        [firstAuthId, email.toUpperCase(), secondAuthId, ` ${email} `],
+      );
+      await client.query(
+        "INSERT INTO public.users (id, auth_id, email) VALUES ($1, $2, $3)",
+        [userId, danglingAuthId, email],
+      );
+
+      await expectReconciliationFailure(client, "ambiguous=1", [email, firstAuthId, secondAuthId, danglingAuthId]);
+      const unchanged = await client.query<{ auth_id: string }>(
+        "SELECT auth_id FROM public.users WHERE id = $1",
+        [userId],
+      );
+      expect(unchanged.rows[0]?.auth_id).toBe(danglingAuthId);
+    });
+  });
+
+  it("fails closed when multiple dangling rows resolve to one Auth target", async () => {
+    await withScratchDatabase("rivalhub_auth_id_duplicate_target", async (client) => {
+      await replayBeforeReconciliation(client);
+      await ensureAuthUsersFixture(client);
+
+      const matchedAuthId = randomUUID();
+      const firstDanglingAuthId = randomUUID();
+      const secondDanglingAuthId = randomUUID();
+      const firstUserId = randomUUID();
+      const secondUserId = randomUUID();
+      const email = `duplicate-${firstUserId}@example.test`;
+      await client.query("INSERT INTO auth.users (id, email) VALUES ($1, $2)", [matchedAuthId, email]);
+      await client.query(
+        `INSERT INTO public.users (id, auth_id, email) VALUES
+          ($1, $2, $3), ($4, $5, $6)`,
+        [firstUserId, firstDanglingAuthId, email, secondUserId, secondDanglingAuthId, ` ${email} `],
+      );
+
+      await expectReconciliationFailure(client, "duplicate_targets=1", [email, matchedAuthId, firstDanglingAuthId, secondDanglingAuthId]);
+    });
+  });
+});

--- a/tests/unit/actions/auth.test.ts
+++ b/tests/unit/actions/auth.test.ts
@@ -341,7 +341,7 @@ describe("signUp", () => {
     }
   });
 
-  it("siteverify success=true 时流程不受日志扩展影响，正常进入注册", async () => {
+  it("siteverify success=true 时流程不受日志扩展影响，进入统一注册结果", async () => {
     const originalSecret = process.env.TURNSTILE_SECRET_KEY;
     process.env.TURNSTILE_SECRET_KEY = "0xtest-secret-key";
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -350,13 +350,13 @@ describe("signUp", () => {
       vi.fn().mockResolvedValue({ json: () => Promise.resolve({ success: true }) }),
     );
     signUpMock.mockResolvedValue({ data: { user: { id: "auth-uuid-3" } }, error: null });
-    makeInsertChain([MOCK_USER_ROW]);
-
     try {
       const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD, "valid-token");
 
       expect(result.success).toBe(true);
       expect(signUpMock).toHaveBeenCalledOnce();
+      expect(dbInsertMock).not.toHaveBeenCalled();
+      expect(createUserSessionMock).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
@@ -369,20 +369,41 @@ describe("signUp", () => {
     }
   });
 
-  it("正常注册：insert user、发送确认流程且不创建 session", async () => {
+  it("正常注册：只返回统一账号设置结果，不绑定 Auth identity 或创建 session", async () => {
     signUpMock.mockResolvedValue({
       data: { user: { id: "auth-uuid-2" } },
       error: null,
     });
-    makeInsertChain([MOCK_USER_ROW]);
-
     const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD);
 
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.email).toBe(VALID_EMAIL);
     }
+    expect(dbInsertMock).not.toHaveBeenCalled();
     expect(createUserSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("repeated signup 的 obfuscated user 也不写入 public.users.auth_id", async () => {
+    signUpMock.mockResolvedValue({
+      data: { user: { id: "obfuscated-auth-id" } },
+      error: null,
+    });
+
+    const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD);
+
+    expect(result).toEqual({ success: true, data: { email: VALID_EMAIL } });
+    expect(dbInsertMock).not.toHaveBeenCalled();
+    expect(createUserSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("Auth 成功但没有 user payload 时仍不猜测 identity，进入统一结果", async () => {
+    signUpMock.mockResolvedValue({ data: { user: null }, error: null });
+
+    const result = await signUp(VALID_EMAIL, VALID_PASSWORD, VALID_PASSWORD);
+
+    expect(result).toEqual({ success: true, data: { email: VALID_EMAIL } });
+    expect(dbInsertMock).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/components/identity-flow.test.tsx
+++ b/tests/unit/components/identity-flow.test.tsx
@@ -8,8 +8,9 @@ import { LoginForm } from "@/components/auth/LoginForm";
 import { EducationVerificationPanel } from "@/components/settings/EducationVerificationPanel";
 import { EducationVerificationReviewQueue } from "@/components/admin/EducationVerificationReviewQueue";
 
-const { loginWithPasswordMock, resendSignupConfirmationMock, getInstitutionSearchMock, submitEducationVerificationMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+const { loginWithPasswordMock, signUpMock, resendSignupConfirmationMock, getInstitutionSearchMock, submitEducationVerificationMock, toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
   loginWithPasswordMock: vi.fn(),
+  signUpMock: vi.fn(),
   resendSignupConfirmationMock: vi.fn(),
   getInstitutionSearchMock: vi.fn(),
   submitEducationVerificationMock: vi.fn(),
@@ -18,9 +19,14 @@ const { loginWithPasswordMock, resendSignupConfirmationMock, getInstitutionSearc
 }));
 
 vi.mock("sonner", () => ({ toast: { success: toastSuccessMock, error: toastErrorMock } }));
-vi.mock("@/actions/auth", () => ({ loginWithPassword: loginWithPasswordMock, signUp: vi.fn(), resendSignupConfirmation: resendSignupConfirmationMock, resendCurrentEmailVerification: vi.fn() }));
+vi.mock("@/actions/auth", () => ({ loginWithPassword: loginWithPasswordMock, signUp: signUpMock, resendSignupConfirmation: resendSignupConfirmationMock, resendCurrentEmailVerification: vi.fn() }));
 vi.mock("@/actions/education-verifications", () => ({ declareInstitutionalEmailEducation: vi.fn(), getInstitutionSearch: getInstitutionSearchMock, submitEducationVerification: submitEducationVerificationMock, reviewEducationVerification: vi.fn() }));
-vi.mock("@/components/auth/TurnstileWidget", () => ({ TurnstileWidget: () => <div data-testid="turnstile" /> }));
+vi.mock("@/components/auth/TurnstileWidget", () => ({
+  TurnstileWidget: ({ onVerify }: { onVerify: (token: string) => void }) => {
+    React.useEffect(() => onVerify("test-turnstile-token"), [onVerify]);
+    return <div data-testid="turnstile" />;
+  },
+}));
 
 describe("identity flow UI", () => {
   beforeEach(() => { vi.clearAllMocks(); vi.stubGlobal("React", React); vi.stubGlobal("prompt", vi.fn(() => "审核通过")); });
@@ -54,6 +60,27 @@ describe("identity flow UI", () => {
     expect(screen.getByText(/检查垃圾邮件、广告邮件或其它分类/)).toBeInTheDocument();
   });
 
+  it("uses the same anonymous account-setup presentation after signup success", async () => {
+    signUpMock.mockResolvedValue({ success: true, data: { email: "new@example.test" } });
+    render(<LoginForm initialMode="register" />);
+
+    fireEvent.change(screen.getByLabelText("邮箱地址"), { target: { value: "new@example.test" } });
+    fireEvent.change(screen.getByLabelText("密码"), { target: { value: "Aa1!xx" } });
+    fireEvent.change(screen.getByLabelText("确认密码"), { target: { value: "Aa1!xx" } });
+    const submit = screen.getAllByRole("button", { name: "注册" })[1]!;
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    fireEvent.click(submit);
+
+    expect(await screen.findByRole("heading", { name: "继续完成账号设置" })).toBeInTheDocument();
+    expect(screen.getByText("如果这是你首次使用该邮箱注册，请前往邮箱完成验证。")).toBeInTheDocument();
+    expect(screen.getByText("如果你此前已经使用这个邮箱注册过 RivalHub，请直接登录；忘记密码可以重新设置。")).toBeInTheDocument();
+    expect(screen.getByText("为保护账号隐私，我们不会在这里确认该邮箱是否已注册。")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "去登录" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "找回密码" })).toHaveAttribute("href", "/forgot-password");
+    expect(screen.getByRole("button", { name: "请等待 60 秒后重试" })).toBeDisabled();
+    expect(screen.queryByText("验证邮件已发送")).not.toBeInTheDocument();
+  });
+
   it("after a successful resend, disables repeated sends for the configured cooldown", async () => {
     loginWithPasswordMock.mockResolvedValue({
       success: false,
@@ -70,6 +97,7 @@ describe("identity flow UI", () => {
 
     await waitFor(() => expect(resendSignupConfirmationMock).toHaveBeenCalledTimes(1), { timeout: 10_000 });
     await waitFor(() => expect(screen.getByRole("button", { name: "请等待 60 秒后重试" })).toBeDisabled(), { timeout: 5_000 });
+    expect(toastSuccessMock).toHaveBeenCalledWith("已提交验证邮件重发请求；如果该邮箱仍待验证，请检查收件箱及垃圾邮件等分类。");
   });
 
   it("shows current email and education verification states without evidence URLs", () => {


### PR DESCRIPTION
## 变更

- 注册仅返回统一的账号设置结果，不再使用 Supabase `signUp` 返回的 user id 写入 `public.users.auth_id`，也不创建应用 session。
- 保留邮箱确认与密码登录作为已证明身份的绑定 owner，并将注册成功与未确认登录统一为隐私安全的账号设置提示，提供去登录、找回密码、模糊化重发反馈和冷却。
- 新增 0036 一次性、幂等、fail-closed 的历史 dangling identity mapping 修复：只接受唯一 normalized email match，完整预检后更新，保留有效映射。
- 同步 Auth/测试文档，明确绑定 owner 与迁移回放证据。

## 验证

- `pnpm verify`：通过（type-check、lint、db:check、全量 unit、production build）。
- `pnpm knip`：通过。
- `pnpm knip --production`：通过。
- `pnpm exec drizzle-kit check --config=drizzle.config.ts`：通过。
- PR required CI 的 postgres/system lanes 覆盖真实 PostgreSQL migration replay、Auth contract 与浏览器路径。

## 范围

不修改 Auth provider、权限、触发器、外部邮件供应商或生产环境；保留现有 rate-limit/provider error handling。

Refs #417