### PR TITLE
refactor(matches): 统一 BO1 与系列赛赛果持久化语义

### DIFF
--- a/.changeset/match-score-semantics.md
+++ b/.changeset/match-score-semantics.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+统一 BO1、BO3 与 BO5 的比赛赛果持久化语义：`matches` 保存官方系列赛比分，`match_maps` 保存实际地图回合比分。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ Major 的正式运行时由 `src/lib/major/` 与 `major_*` persistence owners �
 
 ## Match lifecycle and recovery
 
-比赛、地图、BP、阵容、时间协商和结果由各自 schema/action owner 维护。Major match 带有 managed ownership 与 `stageRunId` 归属，结果结算推进同一 StageRun 的完整事实。更正必须遵守已冻结的规则和后续阶段边界；当恢复会改变后续配对时，使用 Major recovery 逻辑而不是直接改 projection。
+比赛、地图、BP、阵容、时间协商和结果由各自 schema/action owner 维护。`matches.scoreA/scoreB` 是所有 format 的官方系列赛比分，`match_maps.scoreA/scoreB` 是实际进行地图的回合比分；正常比赛结果只能由 map-level owner 写入，弃赛不制造虚构地图。Major match 带有 managed ownership 与 `stageRunId` 归属，结果结算推进同一 StageRun 的完整事实。更正必须遵守已冻结的规则和后续阶段边界；当恢复会改变后续配对时，使用 Major recovery 逻辑而不是直接改 projection。
 
 纪律与赛后领域保持独立：sanction、adjudication、placement 与 honor 不相互暗示结果。无季军赛时保留 3–4 placement group；最终结果先进入 `pending_confirmation`，确认后才形成可归档的历史事实。
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -46,7 +46,7 @@ CS2 地图也分为相互独立的事实 owner：`CS2_MAP_CATALOG` 是保留历�
 
 ## 8. Matches
 
-`matches` 表示赛程和比赛状态，并区分 `manual` 与 `major_stage` ownership。`match_maps`、`match_veto_steps`、`match_time_proposals`、`match_mvp_votes` 与 `match_player_stats` 记录比赛细节。结果更正必须保留 audit 与适用的运行时边界。
+`matches` 表示赛程、比赛状态和官方系列赛结果；`scoreA/scoreB` 在 BO1、BO3、BO5 中始终是系列赛地图胜场比分。`match_maps` 持有所有实际进行地图的回合比分，正常 BO1 也必须有一行 scored map；弃赛不制造虚构地图。`match_veto_steps`、`match_time_proposals`、`match_mvp_votes` 与 `match_player_stats` 记录比赛细节。结果更正必须保留 audit 与适用的运行时边界。
 
 ## 9. Match rosters
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -56,7 +56,7 @@ Entry 为具体比赛提交或由管理员选定阵容；阵容成员必须是�
 
 ## 14. Match execution / result
 
-比赛可进行时间协商、BP、地图结果与赛果录入。结果由对应 Server Action 验证、写审计并在适用时推进赛程。管理的 Major match 必须通过其 runtime owner 结算。
+比赛可进行时间协商、BP、地图结果与赛果录入。正常比赛先由 BP 确定实际地图并建立 pending `match_maps`，再由 `recordMapResult` 写入实际地图回合比分，并从已完成地图推导 `matches` 的官方系列赛比分；弃赛只写官方系列赛结果，不制造未进行的地图。结果由对应 Server Action 验证、写审计并在适用时推进赛程。管理的 Major match 必须通过其 runtime owner 结算。
 
 ## 15. Result correction
 

--- a/drizzle/migrations/0037_match_score_semantics.sql
+++ b/drizzle/migrations/0037_match_score_semantics.sql
@@ -1,0 +1,214 @@
+-- Normalize the legacy BO1 score unit before enforcing the all-format series contract.
+-- This migration deliberately does not identify or print individual match data.
+DO $$
+DECLARE
+  incomplete_matches bigint;
+  incomplete_maps bigint;
+  malformed_bo1 bigint;
+  malformed_series bigint;
+BEGIN
+  SELECT count(*) INTO incomplete_matches
+  FROM "matches"
+  WHERE ("score_a" IS NULL) <> ("score_b" IS NULL);
+
+  SELECT count(*) INTO incomplete_maps
+  FROM "match_maps"
+  WHERE ("score_a" IS NULL) <> ("score_b" IS NULL);
+
+  WITH bo1_facts AS (
+    SELECT
+      m."id",
+      m."score_a",
+      m."score_b",
+      m."status",
+      m."is_forfeit",
+      count(mm."id")::integer AS map_count,
+      count(mm."id") FILTER (WHERE mm."score_a" IS NOT NULL AND mm."score_b" IS NOT NULL)::integer AS scored_count,
+      count(mm."id") FILTER (WHERE (mm."score_a" IS NULL) <> (mm."score_b" IS NULL))::integer AS partial_count,
+      count(mm."id") FILTER (WHERE mm."score_a" > mm."score_b")::integer AS scored_a_wins,
+      count(mm."id") FILTER (WHERE mm."score_b" > mm."score_a")::integer AS scored_b_wins,
+      COALESCE(
+        m."score_a" IS NOT NULL
+        AND m."score_b" IS NOT NULL
+        AND (
+          (GREATEST(m."score_a", m."score_b") = 1 AND LEAST(m."score_a", m."score_b") = 0)
+        ),
+        false
+      ) AS canonical_series,
+      COALESCE(
+        m."score_a" IS NOT NULL
+        AND m."score_b" IS NOT NULL
+        AND GREATEST(m."score_a", m."score_b") >= 13
+        AND (GREATEST(m."score_a", m."score_b") - 13) % 3 = 0
+        AND LEAST(m."score_a", m."score_b") >= 0
+        AND LEAST(m."score_a", m."score_b") < GREATEST(m."score_a", m."score_b"),
+        false
+      ) AS legacy_round,
+      COALESCE(
+        m."is_forfeit"
+        AND m."score_a" IS NOT NULL
+        AND m."score_b" IS NOT NULL
+        AND GREATEST(m."score_a", m."score_b") = 13
+        AND LEAST(m."score_a", m."score_b") = 0,
+        false
+      ) AS legacy_forfeit
+    FROM "matches" m
+    LEFT JOIN "match_maps" mm ON mm."match_id" = m."id"
+    WHERE m."format" = 'bo1'
+    GROUP BY m."id", m."score_a", m."score_b", m."status", m."is_forfeit"
+  )
+  SELECT count(*) INTO malformed_bo1
+  FROM bo1_facts
+  WHERE
+    ("status" = 'finished' AND "score_a" IS NULL AND "score_b" IS NULL)
+    OR (
+      "score_a" IS NOT NULL
+      AND "score_b" IS NOT NULL
+      AND NOT "canonical_series"
+      AND NOT (
+        "status" = 'finished'
+        AND (
+          (NOT "is_forfeit" AND "legacy_round" AND map_count = 1 AND scored_count = 0 AND partial_count = 0)
+          OR ("is_forfeit" AND "legacy_forfeit" AND scored_count = 0 AND partial_count = 0)
+        )
+      )
+    )
+    OR (
+      "status" = 'finished'
+    AND NOT "is_forfeit"
+    AND "canonical_series"
+      AND (
+        map_count <> 1
+        OR scored_count <> 1
+        OR partial_count <> 0
+        OR NOT (
+          ("score_a" = 1 AND "score_b" = 0 AND scored_a_wins = 1)
+          OR ("score_a" = 0 AND "score_b" = 1 AND scored_b_wins = 1)
+        )
+      )
+    )
+    OR (
+      "status" = 'finished'
+      AND "is_forfeit"
+      AND "legacy_forfeit"
+      AND (scored_count <> 0 OR partial_count <> 0)
+    );
+
+  SELECT count(*) INTO malformed_series
+  FROM "matches" m
+  WHERE m."score_a" IS NOT NULL
+    AND m."score_b" IS NOT NULL
+    AND (
+      (m."format" = 'bo3' AND NOT (
+        GREATEST(m."score_a", m."score_b") = 2
+        AND LEAST(m."score_a", m."score_b") BETWEEN 0 AND 1
+      ))
+      OR (m."format" = 'bo5' AND NOT (
+        GREATEST(m."score_a", m."score_b") = 3
+        AND LEAST(m."score_a", m."score_b") BETWEEN 0 AND 2
+      ))
+    );
+
+  IF incomplete_matches > 0 OR incomplete_maps > 0 OR malformed_bo1 > 0 OR malformed_series > 0 THEN
+    RAISE EXCEPTION
+      'match score semantics preflight failed (incomplete_matches=%, incomplete_maps=%, malformed_bo1=%, malformed_series=%)',
+      incomplete_matches, incomplete_maps, malformed_bo1, malformed_series;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+
+-- Legacy non-forfeit BO1: preserve the existing map row and move its round fact
+-- out of matches before converting matches to a 1:0/0:1 series result.
+UPDATE "match_maps" mm
+SET
+  "score_a" = m."score_a",
+  "score_b" = m."score_b",
+  "completed_at" = COALESCE(mm."completed_at", m."completed_at")
+FROM "matches" m
+WHERE m."id" = mm."match_id"
+  AND m."format" = 'bo1'
+  AND m."status" = 'finished'
+  AND NOT m."is_forfeit"
+  AND m."score_a" IS NOT NULL
+  AND m."score_b" IS NOT NULL
+  AND GREATEST(m."score_a", m."score_b") >= 13
+  AND (GREATEST(m."score_a", m."score_b") - 13) % 3 = 0
+  AND LEAST(m."score_a", m."score_b") >= 0
+  AND LEAST(m."score_a", m."score_b") < GREATEST(m."score_a", m."score_b")
+  AND mm."score_a" IS NULL
+  AND mm."score_b" IS NULL;--> statement-breakpoint
+
+UPDATE "matches"
+SET
+  "score_a" = CASE WHEN "score_a" > "score_b" THEN 1 ELSE 0 END,
+  "score_b" = CASE WHEN "score_b" > "score_a" THEN 1 ELSE 0 END
+WHERE "format" = 'bo1'
+  AND "status" = 'finished'
+  AND NOT "is_forfeit"
+  AND "score_a" IS NOT NULL
+  AND "score_b" IS NOT NULL
+  AND GREATEST("score_a", "score_b") >= 13
+  AND (GREATEST("score_a", "score_b") - 13) % 3 = 0
+  AND LEAST("score_a", "score_b") >= 0
+  AND LEAST("score_a", "score_b") < GREATEST("score_a", "score_b");--> statement-breakpoint
+
+-- Legacy BO1 forfeits become official series results only; no map row is created.
+UPDATE "matches"
+SET
+  "score_a" = CASE WHEN "score_a" > "score_b" THEN 1 ELSE 0 END,
+  "score_b" = CASE WHEN "score_b" > "score_a" THEN 1 ELSE 0 END
+WHERE "format" = 'bo1'
+  AND "status" = 'finished'
+  AND "is_forfeit"
+  AND "score_a" IS NOT NULL
+  AND "score_b" IS NOT NULL
+  AND GREATEST("score_a", "score_b") = 13
+  AND LEAST("score_a", "score_b") = 0;--> statement-breakpoint
+
+-- A forfeited match keeps scored real maps but drops only pending/unscored rows.
+DELETE FROM "match_maps" mm
+USING "matches" m
+WHERE m."id" = mm."match_id"
+  AND m."format" = 'bo1'
+  AND m."status" = 'finished'
+  AND m."is_forfeit"
+  AND mm."score_a" IS NULL
+  AND mm."score_b" IS NULL;--> statement-breakpoint
+
+-- The three constraints are guarded so the data migration logic is safe to
+-- replay in a scratch database after the row values are already canonical.
+-- rivalhub:migration-risk: locking-reviewed short constraint validation is performed after the fail-closed preflight and data normalization above
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'matches_score_pair_complete'
+      AND conrelid = 'public.matches'::regclass
+  ) THEN
+    ALTER TABLE "matches" ADD CONSTRAINT "matches_score_pair_complete"
+      CHECK (("score_a" IS NULL AND "score_b" IS NULL) OR ("score_a" IS NOT NULL AND "score_b" IS NOT NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'matches_series_score_shape'
+      AND conrelid = 'public.matches'::regclass
+  ) THEN
+    ALTER TABLE "matches" ADD CONSTRAINT "matches_series_score_shape"
+      CHECK (("score_a" IS NULL AND "score_b" IS NULL)
+        OR ("format" = 'bo1' AND GREATEST("score_a", "score_b") = 1 AND LEAST("score_a", "score_b") = 0)
+        OR ("format" = 'bo3' AND GREATEST("score_a", "score_b") = 2 AND LEAST("score_a", "score_b") BETWEEN 0 AND 1)
+        OR ("format" = 'bo5' AND GREATEST("score_a", "score_b") = 3 AND LEAST("score_a", "score_b") BETWEEN 0 AND 2));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'match_maps_score_pair_complete'
+      AND conrelid = 'public.match_maps'::regclass
+  ) THEN
+    ALTER TABLE "match_maps" ADD CONSTRAINT "match_maps_score_pair_complete"
+      CHECK (("score_a" IS NULL AND "score_b" IS NULL) OR ("score_a" IS NOT NULL AND "score_b" IS NOT NULL));
+  END IF;
+END
+$$;

--- a/drizzle/migrations/meta/0037_snapshot.json
+++ b/drizzle/migrations/meta/0037_snapshot.json
@@ -1,0 +1,9282 @@
+{
+  "id": "854123f4-37f7-4218-a479-1a78bbe3534a",
+  "prevId": "f28aafa8-dae5-4f5f-839a-e8f9eaed7c45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invite_claims": {
+      "name": "admin_invite_claims",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_invite_claims_invite_id_idx": {
+          "name": "admin_invite_claims_invite_id_idx",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_invite_claims_user_id_idx": {
+          "name": "admin_invite_claims_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invite_claims_invite_id_admin_invites_id_fk": {
+          "name": "admin_invite_claims_invite_id_admin_invites_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "tableTo": "admin_invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_invite_claims_user_id_users_id_fk": {
+          "name": "admin_invite_claims_user_id_users_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invite_claims_invite_user_unique": {
+          "name": "admin_invite_claims_invite_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_invite_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'season_admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invites_max_uses_positive": {
+          "name": "admin_invites_max_uses_positive",
+          "value": "\"admin_invites\".\"max_uses\" > 0"
+        },
+        "admin_invites_role_season_scope": {
+          "name": "admin_invites_role_season_scope",
+          "value": "(\"admin_invites\".\"role\" = 'season_admin' AND \"admin_invites\".\"season_id\" IS NOT NULL) OR (\"admin_invites\".\"role\" = 'super_admin' AND \"admin_invites\".\"season_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_season_id_created_at_idx": {
+          "name": "audit_logs_season_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_award_evidence": {
+      "name": "community_award_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_user_id": {
+          "name": "candidate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_award_evidence_award_id_idx": {
+          "name": "community_award_evidence_award_id_idx",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_award_evidence_award_id_community_awards_id_fk": {
+          "name": "community_award_evidence_award_id_community_awards_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "community_awards",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_submitted_by_user_id_users_id_fk": {
+          "name": "community_award_evidence_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_candidate_user_id_users_id_fk": {
+          "name": "community_award_evidence_candidate_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "candidate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_match_id_matches_id_fk": {
+          "name": "community_award_evidence_match_id_matches_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_award_evidence_non_blank_explanation_check": {
+          "name": "community_award_evidence_non_blank_explanation_check",
+          "value": "length(trim(\"community_award_evidence\".\"explanation\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_awards": {
+      "name": "community_awards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize": {
+          "name": "prize",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplementary_note": {
+          "name": "supplementary_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_note": {
+          "name": "public_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "community_award_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_note": {
+          "name": "outcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_by_user_id": {
+          "name": "outcome_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_at": {
+          "name": "outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_awards_season_id_status_idx": {
+          "name": "community_awards_season_id_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_awards_season_id_seasons_id_fk": {
+          "name": "community_awards_season_id_seasons_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_awards_submitted_by_user_id_users_id_fk": {
+          "name": "community_awards_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "community_awards_reviewed_by_user_id_users_id_fk": {
+          "name": "community_awards_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_awards_recipient_user_id_users_id_fk": {
+          "name": "community_awards_recipient_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_awards_outcome_by_user_id_users_id_fk": {
+          "name": "community_awards_outcome_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "outcome_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_awards_non_blank_fields_check": {
+          "name": "community_awards_non_blank_fields_check",
+          "value": "length(trim(\"community_awards\".\"name\")) > 0 AND length(trim(\"community_awards\".\"condition\")) > 0 AND length(trim(\"community_awards\".\"prize\")) > 0"
+        },
+        "community_awards_review_check": {
+          "name": "community_awards_review_check",
+          "value": "(\"community_awards\".\"status\" = 'pending_review' AND ((\"community_awards\".\"reviewed_by_user_id\" IS NULL AND \"community_awards\".\"reviewed_at\" IS NULL) OR (\"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)))\n      OR (\"community_awards\".\"status\" IN ('rejected', 'approved', 'awarded', 'not_awarded', 'cancelled') AND \"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" = 'withdrawn')"
+        },
+        "community_awards_outcome_check": {
+          "name": "community_awards_outcome_check",
+          "value": "(\"community_awards\".\"status\" = 'awarded' AND \"community_awards\".\"recipient_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('not_awarded', 'cancelled', 'withdrawn') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('pending_review', 'rejected', 'approved') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NULL AND \"community_awards\".\"outcome_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_bracket_states": {
+      "name": "competition_bracket_states",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_bracket_states_competition_id_seasons_id_fk": {
+          "name": "competition_bracket_states_competition_id_seasons_id_fk",
+          "tableFrom": "competition_bracket_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entries": {
+      "name": "competition_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "competition_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_registration_id": {
+          "name": "source_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formation_order": {
+          "name": "formation_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_user_id": {
+          "name": "representative_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "competition_entry_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "perfect_team_id": {
+          "name": "perfect_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_roster_revision_id": {
+          "name": "current_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_roster_revision_id": {
+          "name": "approved_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entries_competition_status_idx": {
+          "name": "competition_entries_competition_status_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_team_history_idx": {
+          "name": "competition_entries_team_history_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_one_effective_team_per_competition": {
+          "name": "competition_entries_one_effective_team_per_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entries\".\"team_id\" IS NOT NULL AND \"competition_entries\".\"registration_status\" NOT IN ('rejected', 'withdrawn')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_competition_formation_order_unique": {
+          "name": "competition_entries_competition_formation_order_unique",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formation_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entries\".\"formation_order\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entries_competition_id_seasons_id_fk": {
+          "name": "competition_entries_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_team_id_teams_id_fk": {
+          "name": "competition_entries_team_id_teams_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_source_registration_id_season_registrations_id_fk": {
+          "name": "competition_entries_source_registration_id_season_registrations_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "source_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_representative_user_id_users_id_fk": {
+          "name": "competition_entries_representative_user_id_users_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "representative_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entries_id_competition_id_unique": {
+          "name": "competition_entries_id_competition_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "competition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entries_source_shape_check": {
+          "name": "competition_entries_source_shape_check",
+          "value": "(\"competition_entries\".\"source\" = 'linked_team' AND \"competition_entries\".\"team_id\" IS NOT NULL) OR (\"competition_entries\".\"source\" = 'event_native' AND \"competition_entries\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_active_claims": {
+      "name": "competition_entry_active_claims",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_active_claims_entry_idx": {
+          "name": "competition_entry_active_claims_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_active_claims_competition_id_seasons_id_fk": {
+          "name": "competition_entry_active_claims_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_user_id_users_id_fk": {
+          "name": "competition_entry_active_claims_user_id_users_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_active_claims_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_entry_competition_scope_fk": {
+          "name": "competition_entry_active_claims_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_participant_scope_fk": {
+          "name": "competition_entry_active_claims_participant_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id",
+            "entry_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_active_claims_competition_user_unique": {
+          "name": "competition_entry_active_claims_competition_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        },
+        "competition_entry_active_claims_participant_unique": {
+          "name": "competition_entry_active_claims_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_legacy_identities": {
+      "name": "competition_entry_legacy_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_type": {
+          "name": "legacy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_legacy_identities_entry_idx": {
+          "name": "competition_entry_legacy_identities_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_legacy_identities_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_legacy_identities_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_legacy_identities",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_legacy_identities_type_id_unique": {
+          "name": "competition_entry_legacy_identities_type_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_type",
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_participants": {
+      "name": "competition_entry_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_participant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_participants_user_status_idx": {
+          "name": "competition_entry_participants_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_participants_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_participants_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_participants_user_id_users_id_fk": {
+          "name": "competition_entry_participants_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_participants_invited_by_user_id_users_id_fk": {
+          "name": "competition_entry_participants_invited_by_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_participants_entry_user_unique": {
+          "name": "competition_entry_participants_entry_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "user_id"
+          ]
+        },
+        "competition_entry_participants_id_entry_user_unique": {
+          "name": "competition_entry_participants_id_entry_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "entry_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_participants_confirmation_shape_check": {
+          "name": "competition_entry_participants_confirmation_shape_check",
+          "value": "(\"competition_entry_participants\".\"status\" = 'confirmed' AND \"competition_entry_participants\".\"confirmed_at\" IS NOT NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)\n      OR (\"competition_entry_participants\".\"status\" = 'withdrawn' AND \"competition_entry_participants\".\"withdrawn_at\" IS NOT NULL)\n      OR (\"competition_entry_participants\".\"status\" IN ('invited', 'declined') AND \"competition_entry_participants\".\"confirmed_at\" IS NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_representative_changes": {
+      "name": "competition_entry_representative_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "competition_entry_representative_changes_entry_changed_at_idx": {
+          "name": "competition_entry_representative_changes_entry_changed_at_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_representative_changes_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_representative_changes_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_representative_changes_from_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_from_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_representative_changes_to_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_to_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_members": {
+      "name": "competition_entry_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_membership_id": {
+          "name": "team_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_user_id_users_id_fk": {
+          "name": "competition_entry_roster_members_user_id_users_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_team_membership_id_team_memberships_id_fk": {
+          "name": "competition_entry_roster_members_team_membership_id_team_memberships_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "team_memberships",
+          "columnsFrom": [
+            "team_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_members_revision_participant_unique": {
+          "name": "competition_entry_roster_members_revision_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision_id",
+            "participant_id"
+          ]
+        },
+        "competition_entry_roster_members_revision_user_unique": {
+          "name": "competition_entry_roster_members_revision_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_revisions": {
+      "name": "competition_entry_roster_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_roster_revision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "competition_entry_roster_revision_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initial'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_revisions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_roster_revisions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_roster_revisions",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_revisions_entry_revision_number_unique": {
+          "name": "competition_entry_roster_revisions_entry_revision_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "revision_number"
+          ]
+        },
+        "competition_entry_roster_revisions_id_entry_id_unique": {
+          "name": "competition_entry_roster_revisions_id_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_roster_revisions_positive_check": {
+          "name": "competition_entry_roster_revisions_positive_check",
+          "value": "\"competition_entry_roster_revisions\".\"revision_number\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_submissions": {
+      "name": "competition_entry_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "competition_entry_submission_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_submissions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_submissions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_submissions_roster_revision_entry_scope_fk": {
+          "name": "competition_entry_submissions_roster_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_submissions_entry_sequence_unique": {
+          "name": "competition_entry_submissions_entry_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_submissions_positive_check": {
+          "name": "competition_entry_submissions_positive_check",
+          "value": "\"competition_entry_submissions\".\"sequence\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_roster_members": {
+      "name": "event_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_roster_id": {
+          "name": "event_roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_roster_members_roster_idx": {
+          "name": "event_roster_members_roster_idx",
+          "columns": [
+            {
+              "expression": "event_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_roster_members_event_roster_id_event_rosters_id_fk": {
+          "name": "event_roster_members_event_roster_id_event_rosters_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "event_rosters",
+          "columnsFrom": [
+            "event_roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_user_id_users_id_fk": {
+          "name": "event_roster_members_user_id_users_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "event_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "event_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "education_verifications",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_roster_members_roster_user_unique": {
+          "name": "event_roster_members_roster_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_roster_id",
+            "user_id"
+          ]
+        },
+        "event_roster_members_participant_unique": {
+          "name": "event_roster_members_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_roster_id",
+            "participant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_rosters": {
+      "name": "event_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_roster_revision_id": {
+          "name": "source_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_by": {
+          "name": "frozen_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_rosters_entry_id_competition_entries_id_fk": {
+          "name": "event_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "source_roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_rosters_source_roster_revision_entry_scope_fk": {
+          "name": "event_rosters_source_roster_revision_entry_scope_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "source_roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_rosters_entry_unique": {
+          "name": "event_rosters_entry_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "event_rosters_freeze_shape_check": {
+          "name": "event_rosters_freeze_shape_check",
+          "value": "(\"event_rosters\".\"status\" = 'preparing' AND \"event_rosters\".\"confirmed_at\" IS NULL AND \"event_rosters\".\"confirmed_by\" IS NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'confirmed' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'frozen' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NOT NULL AND \"event_rosters\".\"frozen_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_restriction_overrides": {
+      "name": "competition_entry_restriction_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_code": {
+          "name": "restriction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_snapshot": {
+          "name": "finding_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competition_entry_restriction_overrides_active_unique": {
+          "name": "competition_entry_restriction_overrides_active_unique",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "restriction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entry_restriction_overrides_entry_idx": {
+          "name": "competition_entry_restriction_overrides_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entry_restriction_overrides_competition_idx": {
+          "name": "competition_entry_restriction_overrides_competition_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_restriction_overrides_competition_id_seasons_id_fk": {
+          "name": "competition_entry_restriction_overrides_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_competition_scope_fk": {
+          "name": "competition_entry_restriction_overrides_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_revision_entry_scope_fk": {
+          "name": "competition_entry_restriction_overrides_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_restriction_overrides_revoke_shape_check": {
+          "name": "competition_entry_restriction_overrides_revoke_shape_check",
+          "value": "(\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NULL) OR (\"competition_entry_restriction_overrides\".\"revoked_at\" IS NOT NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NOT NULL)"
+        },
+        "competition_entry_restriction_overrides_code_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_code_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"restriction_code\")) > 0"
+        },
+        "competition_entry_restriction_overrides_reason_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_reason_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_ranks": {
+      "name": "competitive_platform_ranks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_key": {
+          "name": "platform_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_key": {
+          "name": "rank_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "star_min": {
+          "name": "star_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "star_max": {
+          "name": "star_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_ranks_platform_rank_key_unique": {
+          "name": "competitive_platform_ranks_platform_rank_key_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_ranks_platform_sort_order_unique": {
+          "name": "competitive_platform_ranks_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_ranks_platform_order_idx": {
+          "name": "competitive_platform_ranks_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_ranks_platform_key_competitive_platforms_key_fk": {
+          "name": "competitive_platform_ranks_platform_key_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_ranks",
+          "tableTo": "competitive_platforms",
+          "columnsFrom": [
+            "platform_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_ranks_star_range_shape": {
+          "name": "competitive_platform_ranks_star_range_shape",
+          "value": "(\"competitive_platform_ranks\".\"star_min\" IS NULL AND \"competitive_platform_ranks\".\"star_max\" IS NULL) OR \"competitive_platform_ranks\".\"star_min\" IS NOT NULL"
+        },
+        "competitive_platform_ranks_star_min_non_negative": {
+          "name": "competitive_platform_ranks_star_min_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_min\" IS NULL OR \"competitive_platform_ranks\".\"star_min\" >= 0"
+        },
+        "competitive_platform_ranks_star_max_non_negative": {
+          "name": "competitive_platform_ranks_star_max_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= 0"
+        },
+        "competitive_platform_ranks_star_range_ordered": {
+          "name": "competitive_platform_ranks_star_range_ordered",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= \"competitive_platform_ranks\".\"star_min\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_seasons": {
+      "name": "competitive_platform_seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_key": {
+          "name": "season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_seasons_platform_key_unique": {
+          "name": "competitive_platform_seasons_platform_key_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_one_current_per_platform": {
+          "name": "competitive_platform_seasons_one_current_per_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competitive_platform_seasons\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_platform_order_idx": {
+          "name": "competitive_platform_seasons_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_platform_sort_order_unique": {
+          "name": "competitive_platform_seasons_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_seasons_platform_competitive_platforms_key_fk": {
+          "name": "competitive_platform_seasons_platform_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_seasons",
+          "tableTo": "competitive_platforms",
+          "columnsFrom": [
+            "platform"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_seasons_current_must_be_active": {
+          "name": "competitive_platform_seasons_current_must_be_active",
+          "value": "NOT \"competitive_platform_seasons\".\"is_current\" OR \"competitive_platform_seasons\".\"active\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platforms": {
+      "name": "competitive_platforms",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_label": {
+          "name": "rating_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitive_rank_facts": {
+      "name": "competitive_rank_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "competitive_fact_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_season_key": {
+          "name": "platform_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competitive_fact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ranked'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_season_key": {
+          "name": "achieved_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "competitive_fact_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self_declared'"
+        },
+        "declared_at": {
+          "name": "declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_rank_facts_identity_unique": {
+          "name": "competitive_rank_facts_identity_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"platform_season_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_rank_facts_user_platform_idx": {
+          "name": "competitive_rank_facts_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_rank_facts_user_id_users_id_fk": {
+          "name": "competitive_rank_facts_user_id_users_id_fk",
+          "tableFrom": "competitive_rank_facts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_rank_facts_stars_non_negative": {
+          "name": "competitive_rank_facts_stars_non_negative",
+          "value": "\"competitive_rank_facts\".\"stars\" IS NULL OR \"competitive_rank_facts\".\"stars\" >= 0"
+        },
+        "competitive_rank_facts_valid_fact_shape": {
+          "name": "competitive_rank_facts_valid_fact_shape",
+          "value": "\n    (\n      \"competitive_rank_facts\".\"kind\" = 'historical_peak'\n      AND \"competitive_rank_facts\".\"status\" = 'ranked'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NULL\n      AND \"competitive_rank_facts\".\"rank\" IS NOT NULL\n      AND \"competitive_rank_facts\".\"rating\" IS NOT NULL\n    ) OR (\n      \"competitive_rank_facts\".\"kind\" = 'season_peak'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NOT NULL\n      AND (\n        (\"competitive_rank_facts\".\"status\" = 'ranked' AND \"competitive_rank_facts\".\"rank\" IS NOT NULL AND \"competitive_rank_facts\".\"rating\" IS NOT NULL)\n        OR (\"competitive_rank_facts\".\"status\" = 'unranked' AND \"competitive_rank_facts\".\"rank\" IS NULL AND \"competitive_rank_facts\".\"stars\" IS NULL)\n      )\n    )\n  "
+        },
+        "competitive_rank_facts_achieved_season_shape": {
+          "name": "competitive_rank_facts_achieved_season_shape",
+          "value": "\n    (\"competitive_rank_facts\".\"kind\" = 'historical_peak') OR \"competitive_rank_facts\".\"achieved_season_key\" IS NULL\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_competitive_roles": {
+      "name": "user_competitive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "cs2_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_competitive_roles_one_primary_per_user": {
+          "name": "user_competitive_roles_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_competitive_roles\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_competitive_roles_user_idx": {
+          "name": "user_competitive_roles_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_competitive_roles_user_id_users_id_fk": {
+          "name": "user_competitive_roles_user_id_users_id_fk",
+          "tableFrom": "user_competitive_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_competitive_roles_user_role_unique": {
+          "name": "user_competitive_roles_user_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "role"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_map_preferences": {
+      "name": "user_map_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_map_preferences_user_id_users_id_fk": {
+          "name": "user_map_preferences_user_id_users_id_fk",
+          "tableFrom": "user_map_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_case_idempotency": {
+      "name": "disciplinary_case_idempotency",
+      "schema": "",
+      "columns": {
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk": {
+          "name": "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk",
+          "tableFrom": "disciplinary_case_idempotency",
+          "tableTo": "disciplinary_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_cases": {
+      "name": "disciplinary_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_cases_season_subject_idx": {
+          "name": "disciplinary_cases_season_subject_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_cases_status_idx": {
+          "name": "disciplinary_cases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_cases_season_id_seasons_id_fk": {
+          "name": "disciplinary_cases_season_id_seasons_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disciplinary_cases_subject_user_id_users_id_fk": {
+          "name": "disciplinary_cases_subject_user_id_users_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disciplinary_cases_revocation_consistent_check": {
+          "name": "disciplinary_cases_revocation_consistent_check",
+          "value": "(\"disciplinary_cases\".\"status\" = 'revoked') = (\"disciplinary_cases\".\"revoked_at\" IS NOT NULL)"
+        },
+        "disciplinary_cases_window_sane_check": {
+          "name": "disciplinary_cases_window_sane_check",
+          "value": "\"disciplinary_cases\".\"effective_until\" IS NULL OR \"disciplinary_cases\".\"effective_until\" > \"disciplinary_cases\".\"effective_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_entry_id_competition_entries_id_fk": {
+          "name": "draft_picks_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_entry_id": {
+          "name": "current_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_entry_id_competition_entries_id_fk": {
+          "name": "draft_state_current_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "current_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_code": {
+          "name": "evidence_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "moe_institution_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_url": {
+          "name": "live_stream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_template": {
+          "name": "competition_template",
+          "type": "competition_template",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 9
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "registration_opens_at": {
+          "name": "registration_opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_opened_at": {
+          "name": "registration_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_change_closes_at": {
+          "name": "roster_change_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_captain_changes": {
+      "name": "team_captain_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_captain_changes_team_changed_at_idx": {
+          "name": "team_captain_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_captain_changes_team_id_teams_id_fk": {
+          "name": "team_captain_changes_team_id_teams_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_captain_changes_from_user_id_users_id_fk": {
+          "name": "team_captain_changes_from_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_captain_changes_to_user_id_users_id_fk": {
+          "name": "team_captain_changes_to_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "team_invitation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_team_status_idx": {
+          "name": "team_invitations_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_user_status_idx": {
+          "name": "team_invitations_user_status_idx",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_token_hash_unique": {
+          "name": "team_invitations_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_one_pending_direct_per_user": {
+          "name": "team_invitations_one_pending_direct_per_user",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_user_id_users_id_fk": {
+          "name": "team_invitations_invited_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_user_id_users_id_fk": {
+          "name": "team_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_responded_by_user_id_users_id_fk": {
+          "name": "team_invitations_responded_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_invitations_kind_shape_check": {
+          "name": "team_invitations_kind_shape_check",
+          "value": "(\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"invited_user_id\" IS NOT NULL AND \"team_invitations\".\"token_hash\" IS NULL) OR (\"team_invitations\".\"kind\" = 'share_link' AND \"team_invitations\".\"invited_user_id\" IS NULL AND \"team_invitations\".\"token_hash\" IS NOT NULL)"
+        },
+        "team_invitations_response_shape_check": {
+          "name": "team_invitations_response_shape_check",
+          "value": "(\"team_invitations\".\"status\" IN ('accepted', 'declined') AND \"team_invitations\".\"responded_at\" IS NOT NULL AND \"team_invitations\".\"responded_by_user_id\" IS NOT NULL)\n      OR (\"team_invitations\".\"status\" IN ('pending', 'revoked', 'expired') AND \"team_invitations\".\"responded_at\" IS NULL AND \"team_invitations\".\"responded_by_user_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "team_membership_end_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_idx": {
+          "name": "team_memberships_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_user_idx": {
+          "name": "team_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_one_current_period": {
+          "name": "team_memberships_one_current_period",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_one_current_team_per_user": {
+          "name": "team_memberships_one_current_team_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_invited_by_user_id_users_id_fk": {
+          "name": "team_memberships_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_memberships_period_shape_check": {
+          "name": "team_memberships_period_shape_check",
+          "value": "(\"team_memberships\".\"ended_at\" IS NULL AND \"team_memberships\".\"ended_reason\" IS NULL AND \"team_memberships\".\"status\" <> 'left') OR (\"team_memberships\".\"ended_at\" IS NOT NULL AND \"team_memberships\".\"ended_reason\" IS NOT NULL AND \"team_memberships\".\"status\" = 'left')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_name_changes": {
+      "name": "team_name_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_name": {
+          "name": "new_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_name_changes_team_changed_at_idx": {
+          "name": "team_name_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_name_changes_team_id_teams_id_fk": {
+          "name": "team_name_changes_team_id_teams_id_fk",
+          "tableFrom": "team_name_changes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_slug_aliases": {
+      "name": "team_slug_aliases",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_slug_aliases_team_id_teams_id_fk": {
+          "name": "team_slug_aliases_team_id_teams_id_fk",
+          "tableFrom": "team_slug_aliases",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disbanded_at": {
+          "name": "disbanded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disbanded_by": {
+          "name": "disbanded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_one_active_captaincy_per_user": {
+          "name": "teams_one_active_captaincy_per_user",
+          "columns": [
+            {
+              "expression": "captain_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"teams\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_creator_user_id_users_id_fk": {
+          "name": "teams_creator_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_lifecycle_shape_check": {
+          "name": "teams_lifecycle_shape_check",
+          "value": "(\"teams\".\"status\" = 'active' AND \"teams\".\"disbanded_at\" IS NULL) OR (\"teams\".\"status\" = 'disbanded' AND \"teams\".\"disbanded_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_intents": {
+      "name": "recruitment_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "recruitment_intent_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positions": {
+          "name": "positions",
+          "type": "cs2_role[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::cs2_role[]"
+        },
+        "target_season_id": {
+          "name": "target_season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recruitment_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_intents_one_team_unique": {
+          "name": "recruitment_intents_one_team_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_one_user_unique": {
+          "name": "recruitment_intents_one_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_open_discovery_idx": {
+          "name": "recruitment_intents_open_discovery_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_target_season_idx": {
+          "name": "recruitment_intents_target_season_idx",
+          "columns": [
+            {
+              "expression": "target_season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recruitment_intents_team_id_teams_id_fk": {
+          "name": "recruitment_intents_team_id_teams_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_intents_user_id_users_id_fk": {
+          "name": "recruitment_intents_user_id_users_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_intents_target_season_id_seasons_id_fk": {
+          "name": "recruitment_intents_target_season_id_seasons_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "target_season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recruitment_intents_owner_shape_check": {
+          "name": "recruitment_intents_owner_shape_check",
+          "value": "(\"recruitment_intents\".\"kind\" = 'team_recruiting' AND \"recruitment_intents\".\"team_id\" IS NOT NULL AND \"recruitment_intents\".\"user_id\" IS NULL)\n      OR (\"recruitment_intents\".\"kind\" = 'player_lft' AND \"recruitment_intents\".\"user_id\" IS NOT NULL AND \"recruitment_intents\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_interests": {
+      "name": "recruitment_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recruitment_intent_id": {
+          "name": "recruitment_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_interests_intent_idx": {
+          "name": "recruitment_interests_intent_idx",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_interests_user_idx": {
+          "name": "recruitment_interests_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_interests_one_user_per_intent_unique": {
+          "name": "recruitment_interests_one_user_per_intent_unique",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk": {
+          "name": "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk",
+          "tableFrom": "recruitment_interests",
+          "tableTo": "recruitment_intents",
+          "columnsFrom": [
+            "recruitment_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_interests_user_id_users_id_fk": {
+          "name": "recruitment_interests_user_id_users_id_fk",
+          "tableFrom": "recruitment_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_at": {
+          "name": "seeds_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_by": {
+          "name": "seeds_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_prestart_states_seed_confirmation_shape_check": {
+          "name": "major_prestart_states_seed_confirmation_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_confirmed_at\" IS NULL) = (\"major_prestart_states\".\"seeds_confirmed_by\" IS NULL)"
+        },
+        "major_prestart_states_seed_lock_shape_check": {
+          "name": "major_prestart_states_seed_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_locked_at\" IS NULL) = (\"major_prestart_states\".\"seeds_locked_by\" IS NULL)"
+        },
+        "major_prestart_states_entrant_lock_shape_check": {
+          "name": "major_prestart_states_entrant_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"entrants_locked_at\" IS NULL) = (\"major_prestart_states\".\"entrants_locked_by\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_entrants": {
+      "name": "major_tournament_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_entry_id": {
+          "name": "competition_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_entrants_season_idx": {
+          "name": "major_tournament_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_entrants_season_id_seasons_id_fk": {
+          "name": "major_tournament_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_entrants_competition_entry_id_competition_entries_id_fk": {
+          "name": "major_tournament_entrants_competition_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "competition_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_entrants_entry_season_scope_fk": {
+          "name": "major_tournament_entrants_entry_season_scope_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "competition_entry_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_entrants_season_entry_unique": {
+          "name": "major_tournament_entrants_season_entry_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "competition_entry_id"
+          ]
+        },
+        "major_tournament_entrants_id_season_unique": {
+          "name": "major_tournament_entrants_id_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_season_scope_fk": {
+          "name": "major_tournament_seeds_entrant_season_scope_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_entry_id": {
+          "name": "champion_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_entry_id_competition_entries_id_fk": {
+          "name": "major_final_results_champion_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "champion_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_run_season_scope_fk": {
+          "name": "major_final_results_playoff_run_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_entry_season_scope_fk": {
+          "name": "major_final_results_champion_entry_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "champion_entry_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_final_results_confirmation_shape_check": {
+          "name": "major_final_results_confirmation_shape_check",
+          "value": "(\"major_final_results\".\"status\" = 'pending_confirmation' AND \"major_final_results\".\"confirmed_at\" IS NULL AND \"major_final_results\".\"confirmed_by\" IS NULL) OR (\"major_final_results\".\"status\" = 'confirmed' AND \"major_final_results\".\"confirmed_at\" IS NOT NULL AND \"major_final_results\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_season_id_seasons_id_fk": {
+          "name": "major_stage_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_run_season_scope_fk": {
+          "name": "major_stage_entrants_run_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_season_scope_fk": {
+          "name": "major_stage_entrants_tournament_entrant_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "tournament_entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        },
+        "major_stage_runs_id_season_unique": {
+          "name": "major_stage_runs_id_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_a_id": {
+          "name": "entry_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_b_id": {
+          "name": "entry_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_season_status_scheduled_at_idx": {
+          "name": "matches_season_status_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_entry_a_id_idx": {
+          "name": "matches_entry_a_id_idx",
+          "columns": [
+            {
+              "expression": "entry_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_entry_b_id_idx": {
+          "name": "matches_entry_b_id_idx",
+          "columns": [
+            {
+              "expression": "entry_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_a_id_competition_entries_id_fk": {
+          "name": "matches_entry_a_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_b_id_competition_entries_id_fk": {
+          "name": "matches_entry_b_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_a_season_scope_fk": {
+          "name": "matches_entry_a_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_a_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_b_season_scope_fk": {
+          "name": "matches_entry_b_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_b_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_season_scope_fk": {
+          "name": "matches_major_stage_run_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_entries_different": {
+          "name": "matches_entries_different",
+          "value": "\"matches\".\"entry_a_id\" != \"matches\".\"entry_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_score_pair_complete": {
+          "name": "matches_score_pair_complete",
+          "value": "(\"matches\".\"score_a\" IS NULL AND \"matches\".\"score_b\" IS NULL) OR (\"matches\".\"score_a\" IS NOT NULL AND \"matches\".\"score_b\" IS NOT NULL)"
+        },
+        "matches_series_score_shape": {
+          "name": "matches_series_score_shape",
+          "value": "(\"matches\".\"score_a\" IS NULL AND \"matches\".\"score_b\" IS NULL)\n      OR (\"matches\".\"format\" = 'bo1' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 1 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 0)\n      OR (\"matches\".\"format\" = 'bo3' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 2 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") BETWEEN 0 AND 1)\n      OR (\"matches\".\"format\" = 'bo5' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 3 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") BETWEEN 0 AND 2)"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_entry_id": {
+          "name": "picked_by_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_entry_id_competition_entries_id_fk": {
+          "name": "match_maps_picked_by_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "picked_by_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        },
+        "match_maps_score_pair_complete": {
+          "name": "match_maps_score_pair_complete",
+          "value": "(\"match_maps\".\"score_a\" IS NULL AND \"match_maps\".\"score_b\" IS NULL) OR (\"match_maps\".\"score_a\" IS NOT NULL AND \"match_maps\".\"score_b\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.season_admin_grants": {
+      "name": "season_admin_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "season_admin_grants_user_id_idx": {
+          "name": "season_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "season_admin_grants_season_id_idx": {
+          "name": "season_admin_grants_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "season_admin_grants_user_id_users_id_fk": {
+          "name": "season_admin_grants_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "season_admin_grants_season_id_seasons_id_fk": {
+          "name": "season_admin_grants_season_id_seasons_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "season_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "season_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_admin_grants_user_season_unique": {
+          "name": "season_admin_grants_user_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_player_stats_match_id_idx": {
+          "name": "match_player_stats_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_player_stats_user_id_idx": {
+          "name": "match_player_stats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_entry_id_competition_entries_id_fk": {
+          "name": "swiss_standings_entry_id_competition_entries_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_entry_id_unique": {
+          "name": "swiss_standings_season_id_stage_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_time_proposals_match_id_idx": {
+          "name": "match_time_proposals_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_roster_member_id": {
+          "name": "event_roster_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_event_roster_member_id_event_roster_members_id_fk": {
+          "name": "match_roster_players_event_roster_member_id_event_roster_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "event_roster_members",
+          "columnsFrom": [
+            "event_roster_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_event_roster_member_id_unique": {
+          "name": "match_roster_players_roster_id_event_roster_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "event_roster_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "match_roster_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "match_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_entry_id_competition_entries_id_fk": {
+          "name": "match_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_entry_id_unique": {
+          "name": "match_rosters_match_id_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_rosters_metadata_shape_check": {
+          "name": "match_rosters_metadata_shape_check",
+          "value": "(\"match_rosters\".\"source\" = 'participant' AND \"match_rosters\".\"submitted_by\" IS NOT NULL) OR (\"match_rosters\".\"source\" = 'admin_select' AND \"match_rosters\".\"submitted_by\" IS NULL)"
+        },
+        "match_rosters_confirmation_shape_check": {
+          "name": "match_rosters_confirmation_shape_check",
+          "value": "(\"match_rosters\".\"status\" = 'submitted' AND \"match_rosters\".\"confirmed_at\" IS NULL AND \"match_rosters\".\"confirmed_by\" IS NULL) OR (\"match_rosters\".\"status\" = 'confirmed' AND \"match_rosters\".\"confirmed_at\" IS NOT NULL AND \"match_rosters\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_entry_id_competition_entries_id_fk": {
+          "name": "match_veto_steps_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_adjudications": {
+      "name": "post_event_adjudications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "adjudication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "adjudication_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "adjudication_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impacts": {
+          "name": "impacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_entry_id": {
+          "name": "target_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_match_id": {
+          "name": "target_match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_event_adjudications_season_idx": {
+          "name": "post_event_adjudications_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_event_adjudications_season_id_seasons_id_fk": {
+          "name": "post_event_adjudications_season_id_seasons_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_entry_id_competition_entries_id_fk": {
+          "name": "post_event_adjudications_target_entry_id_competition_entries_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "target_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_user_id_users_id_fk": {
+          "name": "post_event_adjudications_target_user_id_users_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_match_id_matches_id_fk": {
+          "name": "post_event_adjudications_target_match_id_matches_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "target_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_event_adjudications_client_request_id_unique": {
+          "name": "post_event_adjudications_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_event_adjudications_target_check": {
+          "name": "post_event_adjudications_target_check",
+          "value": "(\"post_event_adjudications\".\"target\" = 'season' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'entry' AND \"post_event_adjudications\".\"target_entry_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'user' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'match' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NOT NULL)"
+        },
+        "post_event_adjudications_revocation_check": {
+          "name": "post_event_adjudications_revocation_check",
+          "value": "(\"post_event_adjudications\".\"status\" = 'revoked') = (\"post_event_adjudications\".\"revoked_at\" IS NOT NULL)"
+        },
+        "post_event_adjudications_impacts_array_check": {
+          "name": "post_event_adjudications_impacts_array_check",
+          "value": "jsonb_typeof(\"post_event_adjudications\".\"impacts\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament_honors": {
+      "name": "tournament_honors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "honor_key": {
+          "name": "honor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "honor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "honor_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "basis": {
+          "name": "basis",
+          "type": "honor_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_from": {
+          "name": "placement_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_to": {
+          "name": "placement_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_final_result_id": {
+          "name": "source_final_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjudication_id": {
+          "name": "adjudication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tournament_honors_season_idx": {
+          "name": "tournament_honors_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tournament_honors_one_valid_slot_unique": {
+          "name": "tournament_honors_one_valid_slot_unique",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "honor_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament_honors\".\"state\" = 'valid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_honors_season_id_seasons_id_fk": {
+          "name": "tournament_honors_season_id_seasons_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_entry_id_competition_entries_id_fk": {
+          "name": "tournament_honors_entry_id_competition_entries_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_user_id_users_id_fk": {
+          "name": "tournament_honors_user_id_users_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_source_final_result_id_major_final_results_id_fk": {
+          "name": "tournament_honors_source_final_result_id_major_final_results_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "major_final_results",
+          "columnsFrom": [
+            "source_final_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_adjudication_id_post_event_adjudications_id_fk": {
+          "name": "tournament_honors_adjudication_id_post_event_adjudications_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "post_event_adjudications",
+          "columnsFrom": [
+            "adjudication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_honors_client_request_id_unique": {
+          "name": "tournament_honors_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_honors_recipient_check": {
+          "name": "tournament_honors_recipient_check",
+          "value": "(\"tournament_honors\".\"state\" IN ('valid', 'revoked') AND ((\"tournament_honors\".\"entry_id\" IS NOT NULL)::int + (\"tournament_honors\".\"user_id\" IS NOT NULL)::int) = 1)\n      OR (\"tournament_honors\".\"state\" IN ('vacant', 'not_awarded') AND \"tournament_honors\".\"entry_id\" IS NULL AND \"tournament_honors\".\"user_id\" IS NULL)"
+        },
+        "tournament_honors_placement_check": {
+          "name": "tournament_honors_placement_check",
+          "value": "(\"tournament_honors\".\"type\" = 'placement' AND \"tournament_honors\".\"placement_from\" IS NOT NULL AND \"tournament_honors\".\"placement_to\" IS NOT NULL AND \"tournament_honors\".\"placement_from\" > 0 AND \"tournament_honors\".\"placement_to\" >= \"tournament_honors\".\"placement_from\")\n      OR (\"tournament_honors\".\"type\" <> 'placement' AND \"tournament_honors\".\"placement_from\" IS NULL AND \"tournament_honors\".\"placement_to\" IS NULL)"
+        },
+        "tournament_honors_revocation_check": {
+          "name": "tournament_honors_revocation_check",
+          "value": "(\"tournament_honors\".\"state\" = 'revoked') = (\"tournament_honors\".\"revoked_at\" IS NOT NULL)"
+        },
+        "tournament_honors_non_blank_key_check": {
+          "name": "tournament_honors_non_blank_key_check",
+          "value": "length(trim(\"tournament_honors\".\"honor_key\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_commentators": {
+      "name": "match_commentators",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_commentators_user_id_idx": {
+          "name": "match_commentators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_commentators_match_id_matches_id_fk": {
+          "name": "match_commentators_match_id_matches_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_commentators_user_id_users_id_fk": {
+          "name": "match_commentators_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "match_commentators_added_by_user_id_users_id_fk": {
+          "name": "match_commentators_added_by_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_commentators_match_id_user_id_pk": {
+          "name": "match_commentators_match_id_user_id_pk",
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_match_reports": {
+      "name": "post_match_reports",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_match_reports_submitted_by_user_id_idx": {
+          "name": "post_match_reports_submitted_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "submitted_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_match_reports_match_id_matches_id_fk": {
+          "name": "post_match_reports_match_id_matches_id_fk",
+          "tableFrom": "post_match_reports",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_match_reports_submitted_by_user_id_users_id_fk": {
+          "name": "post_match_reports_submitted_by_user_id_users_id_fk",
+          "tableFrom": "post_match_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_invite_role": {
+      "name": "admin_invite_role",
+      "schema": "public",
+      "values": [
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.community_award_status": {
+      "name": "community_award_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "rejected",
+        "approved",
+        "withdrawn",
+        "awarded",
+        "not_awarded",
+        "cancelled"
+      ]
+    },
+    "public.competition_entry_participant_status": {
+      "name": "competition_entry_participant_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_registration_status": {
+      "name": "competition_entry_registration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_roster_revision_origin": {
+      "name": "competition_entry_roster_revision_origin",
+      "schema": "public",
+      "values": [
+        "initial",
+        "admin_remediation",
+        "self_roster_change"
+      ]
+    },
+    "public.competition_entry_roster_revision_status": {
+      "name": "competition_entry_roster_revision_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "superseded"
+      ]
+    },
+    "public.competition_entry_source": {
+      "name": "competition_entry_source",
+      "schema": "public",
+      "values": [
+        "linked_team",
+        "event_native"
+      ]
+    },
+    "public.competition_entry_submission_decision": {
+      "name": "competition_entry_submission_decision",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.event_roster_status": {
+      "name": "event_roster_status",
+      "schema": "public",
+      "values": [
+        "preparing",
+        "confirmed",
+        "frozen"
+      ]
+    },
+    "public.competitive_fact_kind": {
+      "name": "competitive_fact_kind",
+      "schema": "public",
+      "values": [
+        "historical_peak",
+        "season_peak"
+      ]
+    },
+    "public.competitive_fact_provenance": {
+      "name": "competitive_fact_provenance",
+      "schema": "public",
+      "values": [
+        "self_declared"
+      ]
+    },
+    "public.competitive_fact_status": {
+      "name": "competitive_fact_status",
+      "schema": "public",
+      "values": [
+        "ranked",
+        "unranked"
+      ]
+    },
+    "public.cs2_role": {
+      "name": "cs2_role",
+      "schema": "public",
+      "values": [
+        "igl",
+        "awper",
+        "opener",
+        "closer",
+        "anchor"
+      ]
+    },
+    "public.sanction_effect": {
+      "name": "sanction_effect",
+      "schema": "public",
+      "values": [
+        "registration_block",
+        "roster_block",
+        "match_participation_block"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "super_admin"
+      ]
+    },
+    "public.competition_template": {
+      "name": "competition_template",
+      "schema": "public",
+      "values": [
+        "rivals",
+        "major",
+        "custom"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_invitation_kind": {
+      "name": "team_invitation_kind",
+      "schema": "public",
+      "values": [
+        "direct",
+        "share_link"
+      ]
+    },
+    "public.team_invitation_status": {
+      "name": "team_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.team_lifecycle": {
+      "name": "team_lifecycle",
+      "schema": "public",
+      "values": [
+        "active",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_end_reason": {
+      "name": "team_membership_end_reason",
+      "schema": "public",
+      "values": [
+        "left",
+        "kicked",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_status": {
+      "name": "team_membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "benched",
+        "left"
+      ]
+    },
+    "public.recruitment_intent_kind": {
+      "name": "recruitment_intent_kind",
+      "schema": "public",
+      "values": [
+        "team_recruiting",
+        "player_lft"
+      ]
+    },
+    "public.recruitment_intent_status": {
+      "name": "recruitment_intent_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.match_roster_source": {
+      "name": "match_roster_source",
+      "schema": "public",
+      "values": [
+        "participant",
+        "admin_select"
+      ]
+    },
+    "public.match_roster_status": {
+      "name": "match_roster_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "confirmed"
+      ]
+    },
+    "public.adjudication_impact": {
+      "name": "adjudication_impact",
+      "schema": "public",
+      "values": [
+        "canonical_matches",
+        "final_result",
+        "official_placements",
+        "honors",
+        "none"
+      ]
+    },
+    "public.adjudication_kind": {
+      "name": "adjudication_kind",
+      "schema": "public",
+      "values": [
+        "team_sanction",
+        "result_statement",
+        "placement_statement",
+        "honor_directive"
+      ]
+    },
+    "public.adjudication_status": {
+      "name": "adjudication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "revoked"
+      ]
+    },
+    "public.adjudication_target": {
+      "name": "adjudication_target",
+      "schema": "public",
+      "values": [
+        "season",
+        "entry",
+        "user",
+        "match"
+      ]
+    },
+    "public.honor_basis": {
+      "name": "honor_basis",
+      "schema": "public",
+      "values": [
+        "final_result",
+        "manual",
+        "adjudication"
+      ]
+    },
+    "public.honor_state": {
+      "name": "honor_state",
+      "schema": "public",
+      "values": [
+        "valid",
+        "revoked",
+        "vacant",
+        "not_awarded"
+      ]
+    },
+    "public.honor_type": {
+      "name": "honor_type",
+      "schema": "public",
+      "values": [
+        "champion",
+        "runner_up",
+        "placement",
+        "manual_award"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1788506000969,
       "tag": "0036_auth_id_reconciliation",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1788522422678,
+      "tag": "0037_match_score_semantics",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/hexagon.ts
+++ b/src/actions/hexagon.ts
@@ -17,24 +17,24 @@ import type { PlayerMetrics, HexagonScores } from "@/lib/utils/hexagon";
 export async function getSeasonHexagonScores(
   seasonId: string
 ): Promise<Map<string, HexagonScores>> {
-  // 回合数：优先 map 级（BO3/BO5），BO1 fallback 到 match 级
+  // 回合数只来自实际打过的地图；matches 仅保存系列赛比分。
   const { rows } = await db.execute(sql`
     SELECT
       mps.user_id,
-      sum(mps.kills)::float        / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS kpr,
-      sum(mps.deaths)::float       / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS dpr,
-      sum(mps.assists)::float      / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS apr,
-      sum(mps.first_kills)::float  / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS fkpr,
-      sum(mps.multi_kills)::float  / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS mkpr,
-      sum(mps.clutches)::float     / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)  AS cpr,
-      sum(mps.adr * COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b))
-        / NULLIF(sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)), 0)                             AS adr,
+      sum(mps.kills)::float        / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS kpr,
+      sum(mps.deaths)::float       / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS dpr,
+      sum(mps.assists)::float      / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS apr,
+      sum(mps.first_kills)::float  / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS fkpr,
+      sum(mps.multi_kills)::float  / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS mkpr,
+      sum(mps.clutches)::float     / NULLIF(sum(mm.score_a + mm.score_b), 0)  AS cpr,
+      sum(mps.adr * (mm.score_a + mm.score_b))
+        / NULLIF(sum(mm.score_a + mm.score_b), 0)                             AS adr,
       avg(mps.rws)                                                                                             AS rws,
       avg(mps.we)                                                                                              AS we,
       avg(mps.rating_pro)                                                                                      AS rating_pro,
       sum(mps.kills)::float        / NULLIF(sum(mps.deaths), 0)                                               AS kd,
       (sum(mps.kills) + sum(mps.assists))::float / NULLIF(sum(mps.deaths), 0)                                 AS kda,
-      sum(COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b))::int                                      AS total_rounds
+      sum(mm.score_a + mm.score_b)::int                                      AS total_rounds
     FROM match_player_stats mps
     JOIN matches m  ON m.id  = mps.match_id
     JOIN match_maps mm ON mm.id = mps.map_id

--- a/src/actions/matches/index.ts
+++ b/src/actions/matches/index.ts
@@ -1,3 +1,3 @@
 export { generateSchedule, initializeStage, createMatch } from "./schedule";
-export { recordMatchResult, recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMatchScore, correctMapScore, updateMatchCompletedAt, forfeitMatch, syncBracketMatches } from "./results";
+export { recordMapResult, updateMatchStatus, updateMatchScheduledAt, updateMatchCompletionDeadline, batchSetCompletionDeadline, deleteMatch, correctMapScore, updateMatchCompletedAt, forfeitMatch, syncBracketMatches } from "./results";
 export { runMatchTimeAutoAwardCron } from "./scheduling";

--- a/src/actions/matches/results.ts
+++ b/src/actions/matches/results.ts
@@ -13,7 +13,7 @@ import {
   assertMatchTransition,
   resolveMatchFormat,
 } from "@/lib/match-transitions";
-import { getMaxMaps, getWinThreshold, isMatchStatus } from "@/types/match";
+import { getMaxMaps, isMatchStatus } from "@/types/match";
 import { actionError, getSeasonOrThrow, getMatchOrThrow } from "@/lib/action-utils";
 import {
   applyMatchStatusTransitionInTx,
@@ -25,14 +25,12 @@ import { normalizeRegistrationConfig, normalizeStagePlan } from "@/types/season"
 import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard";
 import {
   computeSeriesScoreAfterMap,
-  isValidCS2RoundScore,
   validateMapScore,
-  validateSeriesScore,
 } from "@/lib/matches/result-rules";
 
 /**
  * 将 bracket 推进后解析出的新对阵批量写入 matches 表。
- * recordMatchResult 和 recordMapResult 共用。
+ * recordMapResult 使用。
  */
 async function insertResolvedBracketMatches(
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
@@ -110,94 +108,12 @@ export async function updateMatchStatus(
   }
 }
 
-// ── 录入比赛结果 ──────────────────────────────────────────────────────────
-
-/**
- * 录入系列赛比分，将比赛标记为 finished，并推进 bracket。
- * 若 bracket 中因此产生新的已确定对阵，自动创建对应 DB match 记录。
- */
-export async function recordMatchResult(
-  matchId: string,
-  scoreA: number,
-  scoreB: number
-): Promise<ActionResult<void>> {
-  try {
-    const match = await getMatchOrThrow(matchId);
-    validateSeriesScore(match.format, scoreA, scoreB);
-    const session = await requireSeasonAdmin(match.seasonId);
-    if (!isMatchStatus(match.status)) {
-      throw new AppError(ErrorCode.INTERNAL_ERROR, `无效的比赛状态: ${match.status}`);
-    }
-    assertMatchTransition(match.status, "finished");
-
-    const season = await getSeasonOrThrow(match.seasonId);
-
-    // 事务保护：score 更新 + bracket 推进 + audit 原子化
-    await db.transaction(async (tx) => {
-      const locked = await lockMatchInTx(tx, matchId);
-      if (!isMatchStatus(locked.status)) throw new AppError(ErrorCode.INTERNAL_ERROR, `无效的比赛状态: ${locked.status}`);
-      assertMatchTransition(locked.status, "finished");
-      validateSeriesScore(locked.format, scoreA, scoreB);
-      const hasVeto = await tx.query.matchVetoSteps.findFirst({ where: eq(matchVetoSteps.matchId, matchId), columns: { id: true } });
-      if (!hasVeto) throw new AppError(ErrorCode.VALIDATION_FAILED, "请先录入 BP 再录入比分");
-      const [lockedSeason] = await tx.select().from(seasons).where(eq(seasons.id, locked.seasonId)).for("update");
-      if (!lockedSeason) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在");
-      const bracketState = await loadBracketState(tx, locked.seasonId);
-      await tx
-        .update(matches)
-        .set({
-          scoreA,
-          scoreB,
-          status: "finished",
-          completedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(matches.id, matchId));
-
-      // 推进 bracket（若 bracket 已初始化）
-      if (bracketState && locked.bracketNodeId) {
-        const { updatedData, newResolvedMatches } = await bracketAdvance(
-          locked.bracketNodeId,
-          scoreA,
-          scoreB,
-          bracketState,
-        );
-
-        await saveBracketState(tx, match.seasonId, updatedData);
-
-        await insertResolvedBracketMatches(
-          tx, match.seasonId, match.stage,
-          updatedData as Database, newResolvedMatches,
-          normalizeStagePlan(lockedSeason.stagePlan),
-        );
-      }
-
-      await maybeFinishSeason(tx, match.seasonId);
-
-      await tx.insert(auditLogs).values({
-        seasonId: locked.seasonId,
-        action: "match.record_result",
-        actorId: session.email,
-        targetId: matchId,
-        targetType: "match",
-        meta: { scoreA, scoreB },
-      });
-    }); // end db.transaction
-
-    revalidateMatchPaths(season.slug, matchId);
-
-    return ok(undefined);
-  } catch (e) {
-    return actionError("recordMatchResult", e);
-  }
-}
-
 // ── 录入单图结果（BO1/BO3/BO5） ───────────────────────────────────────────────
 
 /**
  * 录入一张地图的比赛结果。
  * 系统根据已完成地图自动计算大比分，达到 maxWins 时自动结束系列赛并推进 bracket。
- * 支持 BO1/BO3/BO5；BO1 也可继续走 recordMatchResult 直接录入总分。
+ * 支持 BO1/BO3/BO5；matches 只保存由实际地图胜负推导出的系列赛比分。
  */
 export async function recordMapResult(
   matchId: string,
@@ -250,6 +166,9 @@ export async function recordMapResult(
         where: eq(matchMaps.matchId, matchId),
       });
       const existingRow = existingMaps.find((m) => m.mapName === mapName);
+      if (existingMaps.some((m) => (m.scoreA === null) !== (m.scoreB === null))) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "地图比分数据不完整，无法继续录入");
+      }
       if (existingRow && existingRow.scoreA !== null) {
         throw new AppError(ErrorCode.VALIDATION_FAILED, `地图 ${mapName} 已录入比分`);
       }
@@ -284,7 +203,7 @@ export async function recordMapResult(
 
       if (seriesFinished) {
         await tx.delete(matchMaps).where(
-          and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA))
+          and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA), isNull(matchMaps.scoreB))
         );
 
         await tx.update(matches).set({
@@ -518,96 +437,6 @@ export async function batchSetCompletionDeadline(input: {
   }
 }
 
-// ── 修正已完成比赛的比分 ──────────────────────────────────────────────────
-
-/**
- * 修正已完成比赛的比分（只允许不改变胜者的纠错）。
- * 改变胜者的修正会与已推进的 bracket 结果矛盾，当前版本无法安全重建后续赛程，一律拒绝。
- * BO1 合法胜者回合数：13、16、19、22、…（MR12 公式：13 + 3k，k ≥ 0）。
- */
-export async function correctMatchScore(
-  matchId: string,
-  scoreA: number,
-  scoreB: number
-): Promise<ActionResult<void>> {
-  try {
-    if (!Number.isInteger(scoreA) || !Number.isInteger(scoreB) || scoreA < 0 || scoreB < 0) {
-      throw new AppError(ErrorCode.MATCH_INVALID_SCORE, "比分必须为非负整数");
-    }
-    if (scoreA === scoreB) {
-      throw new AppError(ErrorCode.MATCH_INVALID_SCORE, "系列赛不能平局，必须分出胜负");
-    }
-
-    const match = await getMatchOrThrow(matchId);
-    if (match.status !== "finished") {
-      throw new AppError(ErrorCode.MATCH_INVALID_TRANSITION, "只能修正已完成比赛的比分");
-    }
-
-    if (match.format === "bo1") {
-      const winner = Math.max(scoreA, scoreB);
-      const loser = Math.min(scoreA, scoreB);
-      if (!isValidCS2RoundScore(winner, loser)) {
-        throw new AppError(
-          ErrorCode.MATCH_INVALID_SCORE,
-          "BO1 比分不合法，胜者回合数须满足 13 + 3k（如 13、16、19、22…）"
-        );
-      }
-    } else {
-      const maxWins = getWinThreshold(match.format);
-      const winner = Math.max(scoreA, scoreB);
-      const loser = Math.min(scoreA, scoreB);
-      if (winner !== maxWins || loser >= maxWins) {
-        throw new AppError(
-          ErrorCode.MATCH_INVALID_SCORE,
-          `${match.format.toUpperCase()} 系列赛比分不合法（胜者须恰好赢 ${maxWins} 图）`
-        );
-      }
-    }
-
-    // winner guard：拒绝改变胜者的纠错（当前版本无法安全重建 downstream bracket）
-    const prevWinner =
-      match.scoreA !== null && match.scoreB !== null
-        ? match.scoreA > match.scoreB
-          ? match.entryAId
-          : match.entryBId
-        : null;
-    const nextWinner = scoreA > scoreB ? match.entryAId : match.entryBId;
-    if (prevWinner !== null && prevWinner !== nextWinner) {
-      throw new AppError(
-        ErrorCode.VALIDATION_FAILED,
-        "该修正会改变比赛胜者。当前版本无法安全重建后续赛程，请勿直接修改；需通过赛事事故处理流程解决。"
-      );
-    }
-
-    const session = await requireSeasonAdmin(match.seasonId);
-    const season = await getSeasonOrThrow(match.seasonId);
-    const prevScoreA = match.scoreA;
-    const prevScoreB = match.scoreB;
-
-    await db.transaction(async (tx) => {
-      await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
-      await tx
-        .update(matches)
-        .set({ scoreA, scoreB, updatedAt: new Date() })
-        .where(eq(matches.id, matchId));
-
-      await tx.insert(auditLogs).values({
-        seasonId: match.seasonId,
-        action: "match.correct_score",
-        actorId: session.email,
-        targetId: matchId,
-        targetType: "match",
-        meta: { prevScoreA, prevScoreB, scoreA, scoreB },
-      });
-    });
-
-    revalidateMatchPaths(season.slug, matchId);
-    return ok(undefined);
-  } catch (e) {
-    return actionError("correctMatchScore", e);
-  }
-}
-
 // ── 删除比赛 ──────────────────────────────────────────────────────────────
 
 /**
@@ -733,7 +562,7 @@ export async function correctMapScore(
       where: eq(matchMaps.id, mapId),
     });
     if (!mapRecord) throw new AppError(ErrorCode.NOT_FOUND, "地图记录不存在");
-    if (mapRecord.scoreA === null) {
+    if (mapRecord.scoreA === null || mapRecord.scoreB === null) {
       throw new AppError(ErrorCode.VALIDATION_FAILED, "该图尚未录入比分，无法修正");
     }
 
@@ -752,6 +581,9 @@ export async function correctMapScore(
       const allMaps = await tx.query.matchMaps.findMany({
         where: eq(matchMaps.matchId, mapRecord.matchId),
       });
+      if (allMaps.some((m) => (m.scoreA === null) !== (m.scoreB === null))) {
+        throw new AppError(ErrorCode.VALIDATION_FAILED, "地图比分数据不完整，无法修正");
+      }
       const otherMaps = allMaps.filter((m) => m.id !== mapId);
       const { mapWinsA, mapWinsB, seriesFinished } = computeSeriesScoreAfterMap(
         match.format,
@@ -896,7 +728,7 @@ export async function syncBracketMatches(seasonId: string): Promise<ActionResult
 // ── 弃赛判负 ─────────────────────────────────────────────────────────────────
 
 const FORFEIT_WINNER_SCORE: Record<"bo1" | "bo3" | "bo5", number> = {
-  bo1: 13,
+  bo1: 1,
   bo3: 2,
   bo5: 3,
 };
@@ -932,7 +764,7 @@ export async function forfeitMatch(
     await db.transaction(async (tx) => {
       await assertSeasonAllowsTournamentMutationInTx(tx, match.seasonId);
       await tx.delete(matchMaps).where(
-        and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA))
+        and(eq(matchMaps.matchId, matchId), isNull(matchMaps.scoreA), isNull(matchMaps.scoreB))
       );
 
       await tx

--- a/src/actions/matches/veto.ts
+++ b/src/actions/matches/veto.ts
@@ -121,7 +121,7 @@ export async function saveVetoSteps(
         const existingMaps = await tx.query.matchMaps.findMany({
           where: eq(matchMaps.matchId, matchId),
         });
-        if (existingMaps.some((m) => m.scoreA != null)) {
+        if (existingMaps.some((m) => (m.scoreA === null) !== (m.scoreB === null) || m.scoreA != null)) {
           throw new AppError(
             ErrorCode.VALIDATION_FAILED,
             "已有地图录入了比分，无法重新录入 BP。如需补录请在赛后操作。",

--- a/src/app/[seasonSlug]/matches/page.tsx
+++ b/src/app/[seasonSlug]/matches/page.tsx
@@ -24,6 +24,7 @@ import { presentStageMarker } from "@/lib/seasons/presentation";
 import { MatchTabsSection } from "@/components/matches/MatchTabsSection";
 import { AdminShortcutSlot } from "@/components/layout/AdminShortcutSlot";
 import { getPublicOrAuthorizedDraftSeason } from "@/lib/data/public-seasons";
+import { getMatchMapRoundScores } from "@/lib/data/standings";
 
 interface MatchesPageProps {
   params: Promise<{ seasonSlug: string }>;
@@ -51,6 +52,9 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
   ]);
 
   const teamMap = new Map(allTeams.map((team) => [team.id, team.name]));
+  const roundScoresByMatchId = await getMatchMapRoundScores(
+    allMatches.filter((match) => match.status === "finished").map((match) => match.id),
+  );
   const stagePlan = normalizeStagePlan(season.stagePlan);
   const { views: stageViews, unconfiguredMatches } = buildStageViews(stagePlan, allMatches);
   const matchFilter = (match: { entryAId: string; entryBId: string }) =>
@@ -153,6 +157,7 @@ export default async function MatchesPage({ params, searchParams }: MatchesPageP
                 ? calculateStandings(
                     getTeamsReferencedByMatches(allTeams, allStageMatches),
                     allStageMatches.filter((match) => match.status === "finished"),
+                    roundScoresByMatchId,
                   )
                 : [];
               const isPlayoff = stage.type === "double_elim" || stage.type === "single_elim";

--- a/src/app/admin/[seasonSlug]/matches/page.tsx
+++ b/src/app/admin/[seasonSlug]/matches/page.tsx
@@ -29,6 +29,7 @@ import { presentSeasonStatus } from "@/lib/seasons/presentation";
 import { getDisplayName } from "@/lib/identity/display-name";
 import { getPostMatchCompletion, POST_MATCH_COMPLETION_LABEL } from "@/lib/postmatch/service";
 import { presentMatchLabel } from "@/lib/matches/presentation";
+import { getMatchMapRoundScores } from "@/lib/data/standings";
 
 const STATUS_SORT_ORDER: Record<string, number> = {
   in_progress: 0,
@@ -39,7 +40,7 @@ const STATUS_SORT_ORDER: Record<string, number> = {
 
 function mapCompletedMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; scoreB: number | null; pickedByEntryId: string | null; teamAStartSide: string | null }[]) {
   return records
-    .filter((r) => r.scoreA !== null)
+    .filter((r) => r.scoreA !== null && r.scoreB !== null)
     .map((r) => ({
       mapOrder: r.mapOrder,
       mapName: r.mapName,
@@ -50,9 +51,9 @@ function mapCompletedMaps(records: { mapOrder: number; mapName: string; scoreA: 
     }));
 }
 
-function mapPendingMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; pickedByEntryId: string | null; teamAStartSide: string | null }[]) {
+function mapPendingMaps(records: { mapOrder: number; mapName: string; scoreA: number | null; scoreB: number | null; pickedByEntryId: string | null; teamAStartSide: string | null }[]) {
   return records
-    .filter((r) => r.scoreA === null)
+    .filter((r) => r.scoreA === null && r.scoreB === null)
     .map((r) => ({
       mapOrder: r.mapOrder,
       mapName: r.mapName,
@@ -174,6 +175,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
     arr.push(map);
     mapsByMatch.set(map.matchId, arr);
   }
+  const roundScoresByMatchId = await getMatchMapRoundScores(finishedMatchIds);
 
   const matchCount = allMatches.length;
   const hasSwissStage = stagePlan.some((stage) => stage.type === "swiss");
@@ -205,6 +207,7 @@ export default async function AdminMatchesPage({ params, searchParams }: AdminMa
         calculateStandings(
           getTeamsReferencedByMatches(allTeams, view.matches),
           view.matches.filter((match) => match.status === "finished"),
+          roundScoresByMatchId,
         ),
       ]),
   );

--- a/src/app/players/[userId]/page.tsx
+++ b/src/app/players/[userId]/page.tsx
@@ -123,7 +123,7 @@ export async function PlayerPageContent({ params }: PlayerPageProps) {
         totalFirstKills: sql<number>`sum(${matchPlayerStats.firstKills})::int`,
         totalMultiKills: sql<number>`sum(${matchPlayerStats.multiKills})::int`,
         totalClutches: sql<number>`sum(${matchPlayerStats.clutches})::int`,
-        totalRounds: sql<number>`sum(COALESCE(${matchMaps.scoreA} + ${matchMaps.scoreB}, ${matches.scoreA} + ${matches.scoreB}))::int`,
+        totalRounds: sql<number>`sum(${matchMaps.scoreA} + ${matchMaps.scoreB})::int`,
       })
       .from(matchPlayerStats)
       .innerJoin(matches, eq(matchPlayerStats.matchId, matches.id))

--- a/src/components/matches/AdminMatchRow.tsx
+++ b/src/components/matches/AdminMatchRow.tsx
@@ -169,7 +169,7 @@ export function AdminMatchRow({
         </div>
       </div>
 
-      {match.status === "scheduled" && <><PreMatchOperatorChecklist requiresPreflight={requiresPreflight} teamA={{ name: teamAName, submitted: Boolean(teamARoster), confirmed: teamARoster?.status === "confirmed", starters: teamARoster?.starters.length ?? 0, preflight: teamAPreflight }} teamB={{ name: teamBName, submitted: Boolean(teamBRoster), confirmed: teamBRoster?.status === "confirmed", starters: teamBRoster?.starters.length ?? 0, preflight: teamBPreflight }} mapState={match.format === "bo1" ? "not_required" : completedMaps.length + pendingMaps.length > 0 ? "recorded" : "not_recorded"} /><p className="text-xs leading-5 text-[var(--color-fg-mid)]">默认宽限为 15 分钟，不会自动判负。延长宽限或重新排期请使用赛程时间；需要判负时请在下方“裁决与弃赛”记录原因。</p></>}
+      {match.status === "scheduled" && <><PreMatchOperatorChecklist requiresPreflight={requiresPreflight} teamA={{ name: teamAName, submitted: Boolean(teamARoster), confirmed: teamARoster?.status === "confirmed", starters: teamARoster?.starters.length ?? 0, preflight: teamAPreflight }} teamB={{ name: teamBName, submitted: Boolean(teamBRoster), confirmed: teamBRoster?.status === "confirmed", starters: teamBRoster?.starters.length ?? 0, preflight: teamBPreflight }} mapState={completedMaps.length + pendingMaps.length > 0 ? "recorded" : "not_recorded"} /><p className="text-xs leading-5 text-[var(--color-fg-mid)]">默认宽限为 15 分钟，不会自动判负。延长宽限或重新排期请使用赛程时间；需要判负时请在下方“裁决与弃赛”记录原因。</p></>}
 
       {/* Operations */}
       {match.status !== "cancelled" && (
@@ -212,7 +212,7 @@ export function AdminMatchRow({
                   currentScheduledAt={match.scheduledAt}
                   currentCompletionDeadline={match.completionDeadline}
                 />
-                {(match.format === "bo3" || match.format === "bo5") && match.status === "in_progress" ? (
+                {match.status === "in_progress" ? (
                   <MapByMapInput
                     matchId={match.id}
                     format={match.format}
@@ -227,10 +227,7 @@ export function AdminMatchRow({
                 ) : (
                   <ScoreInput
                     matchId={match.id}
-                    teamAName={teamAName}
-                    teamBName={teamBName}
                     currentStatus={match.status}
-                    format={match.format}
                     startBlockers={startBlockers}
                   />
                 )}
@@ -273,15 +270,9 @@ export function AdminMatchRow({
                     ))}
                   </div>
                 ) : (
-                  <ScoreInput
-                    matchId={match.id}
-                    teamAName={teamAName}
-                    teamBName={teamBName}
-                    currentStatus="finished"
-                    format={match.format}
-                    currentScoreA={match.scoreA}
-                    currentScoreB={match.scoreB}
-                  />
+                  <p className="text-xs leading-5 text-[var(--color-fg-mid)]">
+                    {match.isForfeit ? "本场为弃赛，无实际进行的地图，不提供地图比分或 Stats OCR。" : "本场没有已记录的实际地图比分，不能通过系列赛比分直接修改。"}
+                  </p>
                 )}
                 <ResultCorrectionPanel
                   matchId={match.id}

--- a/src/components/matches/PreMatchOperatorChecklist.tsx
+++ b/src/components/matches/PreMatchOperatorChecklist.tsx
@@ -6,7 +6,7 @@ import { Checklist, type ChecklistItem, Panel, StatusBanner } from "@/components
 
 export interface PreMatchTeamState { name: string; submitted: boolean; confirmed: boolean; starters: number; preflight: { valid: boolean; blockers: string[] } | null; }
 
-export function PreMatchOperatorChecklist({ teamA, teamB, mapState, requiresPreflight = false }: { teamA: PreMatchTeamState; teamB: PreMatchTeamState; mapState: "not_recorded" | "recorded" | "not_required"; requiresPreflight?: boolean }) {
+export function PreMatchOperatorChecklist({ teamA, teamB, mapState, requiresPreflight = false }: { teamA: PreMatchTeamState; teamB: PreMatchTeamState; mapState: "not_recorded" | "recorded"; requiresPreflight?: boolean }) {
   const [manual, setManual] = useState({ room: false, server: false, bp: false, ready: false });
   const teamItems = (team: PreMatchTeamState): ChecklistItem[] => [
     { label: `${team.name} · 首发名单`, state: team.submitted ? "complete" : "blocked", detail: team.submitted ? "名单已提交。" : "尚未提交首发名单。" },
@@ -17,7 +17,7 @@ export function PreMatchOperatorChecklist({ teamA, teamB, mapState, requiresPref
   const manualItems: Array<{ key: keyof typeof manual; label: string; detail: string }> = [
     { key: "room", label: "Perfect 房间已创建", detail: "请在完美平台完成创建并通知双方。" },
     { key: "server", label: "服务器与裁判已就绪", detail: "确认比赛服务器、裁判安排和通讯渠道。" },
-    { key: "bp", label: "地图 BP 已处理", detail: mapState === "recorded" ? "RivalHub 中已记录地图信息；请核对双方执行结果。" : mapState === "not_required" ? "本场无需额外地图 BP。" : "需要时通过地图 BP 录入操作记录。" },
+    { key: "bp", label: "地图 BP 已处理", detail: mapState === "recorded" ? "RivalHub 中已记录地图信息；请核对双方执行结果。" : "先通过地图 BP 录入实际比赛地图。" },
     { key: "ready", label: "双方已 ready", detail: "人工确认双方选手和裁判可以开始。" },
   ];
   const rosterBlockers = [teamA, teamB].flatMap((team) => !team.submitted ? [`${team.name} 尚未提交首发`] : team.starters !== 5 ? [`${team.name} 当前不是 5 名首发`] : !team.confirmed ? [`${team.name} 首发尚未确认`] : requiresPreflight && !team.preflight?.valid ? team.preflight?.blockers.map((blocker) => `${team.name}：${blocker}`) ?? [`${team.name} 尚未完成首发资格检查`] : []);

--- a/src/components/matches/README.md
+++ b/src/components/matches/README.md
@@ -10,13 +10,13 @@
 | `MatchDetail` | 比赛详情（系列赛比分 + 单图列表 + 双方阵容） |
 | `MapResultRow` | 单图结果行（地图 + 双方比分 + picked-by 标记 + 起始边） |
 | `BracketView` | `brackets-viewer` 封装组件（注入 theme_color，多 stage 支持） |
-| `ScoreInput` | 管理员录入系列赛比分（admin only） |
+| `ScoreInput` | 管理员控制 scheduled 比赛开始/取消（admin only） |
 | `MapResultInput` | 管理员录入单图结果（admin only，BO3/BO5 多次提交） |
 
 ## v1 范围
 
 - 展示 BO1/BO3/BO5 的比赛详情（依赖 `match_maps`）
-- 管理员后台录入比分（系列赛 + 每张图）
+- 管理员后台按地图录入实际回合比分；系列赛比分由已完成地图自动推导
 - Bracket 视图（排位赛排名表 + 正赛 brackets-viewer 双视图）
 
 ## 推到后续阶段

--- a/src/components/matches/ResultCorrectionPanel.tsx
+++ b/src/components/matches/ResultCorrectionPanel.tsx
@@ -135,6 +135,9 @@ export function ResultCorrectionPanel({
       <p className="text-xs text-[var(--color-fg-mid)]">
         先计算影响清单并审阅；改变胜者会要求显式确认恢复。已开始/完成的下游比赛不会被自动改写。
       </p>
+      <p className="text-xs text-[var(--color-fg-mid)]">
+        这里填写官方系列赛比分（BO1 为 1:0 / 0:1；BO3、BO5 为地图胜场比分），实际单图回合比分请在逐图修正中处理。
+      </p>
 
       {!plan ? (
         <>

--- a/src/components/matches/ScoreInput.tsx
+++ b/src/components/matches/ScoreInput.tsx
@@ -3,46 +3,24 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { InlineConfirm } from "@/components/rivalhub";
-import { recordMatchResult, updateMatchStatus, correctMatchScore } from "@/actions/matches";
+import { updateMatchStatus } from "@/actions/matches";
 
 interface ScoreInputProps {
   matchId: string;
-  teamAName: string;
-  teamBName: string;
   currentStatus: "scheduled" | "in_progress" | "finished" | "cancelled";
-  format: "bo1" | "bo3" | "bo5";
-  currentScoreA?: number | null;
-  currentScoreB?: number | null;
   startBlockers?: string[];
 }
 
-const MAX_WINS: Record<string, number | null> = { bo1: null, bo3: 2, bo5: 3 };
-const SCORE_LABELS: Record<string, string> = { bo1: "回合数", bo3: "系列赛比分（地图胜场）", bo5: "系列赛比分（地图胜场）" };
-
-function validateSeriesScore(format: string, a: number, b: number): string | null {
-  if (isNaN(a) || isNaN(b) || a < 0 || b < 0) return "请输入有效的非负整数";
-  if (a === b) return "系列赛不能平局";
-  const maxWins = MAX_WINS[format];
-  if (maxWins !== null) {
-    const winner = Math.max(a, b);
-    const loser = Math.min(a, b);
-    if (winner !== maxWins || loser >= maxWins) {
-      return `${format.toUpperCase()} 比分不合法（胜者须恰好赢 ${maxWins} 图，如 ${maxWins}:0 或 ${maxWins}:${maxWins - 1}）`;
-    }
-  }
-  return null;
-}
-
-export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, format, currentScoreA, currentScoreB, startBlockers = [] }: ScoreInputProps) {
-  const [scoreA, setScoreA] = useState("");
-  const [scoreB, setScoreB] = useState("");
+/**
+ * Scheduled-match controls only.
+ *
+ * Normal results are entered through MapByMapInput so every format writes the
+ * actual round score to match_maps before matches receives the derived series
+ * score.
+ */
+export function ScoreInput({ matchId, currentStatus, startBlockers = [] }: ScoreInputProps) {
   const [showStartConfirm, setShowStartConfirm] = useState(false);
-  const [showCorrect, setShowCorrect] = useState(false);
-  const [correctA, setCorrectA] = useState("");
-  const [correctB, setCorrectB] = useState("");
   const [isPending, startTransition] = useTransition();
 
   function handleStart() {
@@ -50,27 +28,6 @@ export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, forma
       const result = await updateMatchStatus(matchId, "in_progress");
       if (result.success) {
         toast.success("比赛已开始");
-      } else {
-        toast.error(result.error.message);
-      }
-    });
-  }
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const a = parseInt(scoreA, 10);
-    const b = parseInt(scoreB, 10);
-    const err = validateSeriesScore(format, a, b);
-    if (err) {
-      toast.error(err);
-      return;
-    }
-    startTransition(async () => {
-      const result = await recordMatchResult(matchId, a, b);
-      if (result.success) {
-        toast.success("比分已录入");
-        setScoreA("");
-        setScoreB("");
       } else {
         toast.error(result.error.message);
       }
@@ -88,166 +45,35 @@ export function ScoreInput({ matchId, teamAName, teamBName, currentStatus, forma
     });
   }
 
-  function handleCorrect(e: React.FormEvent) {
-    e.preventDefault();
-    const a = parseInt(correctA, 10);
-    const b = parseInt(correctB, 10);
-    if (isNaN(a) || isNaN(b) || a < 0 || b < 0) {
-      toast.error("请输入有效的非负整数");
-      return;
-    }
-    if (a === b) {
-      toast.error("系列赛不能平局");
-      return;
-    }
-    startTransition(async () => {
-      const result = await correctMatchScore(matchId, a, b);
-      if (result.success) {
-        toast.success("比分已修正");
-        setShowCorrect(false);
-        setCorrectA("");
-        setCorrectB("");
-      } else {
-        toast.error(result.error.message);
-      }
-    });
-  }
-
-  if (currentStatus === "finished") {
-    return (
-      <div className="space-y-2">
-        {!showCorrect ? (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setCorrectA(currentScoreA != null ? String(currentScoreA) : "");
-              setCorrectB(currentScoreB != null ? String(currentScoreB) : "");
-              setShowCorrect(true);
-            }}
-          >
-            修改比分
-          </Button>
-        ) : (
-          <form onSubmit={handleCorrect} className="space-y-3">
-            <p className="text-xs text-[var(--color-fg-mid)]">
-              {format === "bo1" ? "回合数（MR12：13 / 16 / 19 / 22）" : SCORE_LABELS[format]}
-            </p>
-            <p className="text-xs text-[var(--color-accent)]">仅修正比分数字，不影响胜负判定和晋级结果</p>
-            <div className="flex items-end gap-3">
-              <div className="space-y-1">
-                <Label className="text-xs text-[var(--color-fg-mid)]">{teamAName}</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  value={correctA}
-                  onChange={(e) => setCorrectA(e.target.value)}
-                  className="w-20 text-center"
-                  placeholder="0"
-                />
-              </div>
-              <span className="text-[var(--color-fg-mid)] mb-2">:</span>
-              <div className="space-y-1">
-                <Label className="text-xs text-[var(--color-fg-mid)]">{teamBName}</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  value={correctB}
-                  onChange={(e) => setCorrectB(e.target.value)}
-                  className="w-20 text-center"
-                  placeholder="0"
-                />
-              </div>
-              <Button type="submit" size="sm" disabled={isPending} className="mb-0.5">
-                确认修改
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={isPending}
-                className="mb-0.5"
-                onClick={() => setShowCorrect(false)}
-              >
-                取消
-              </Button>
-            </div>
-          </form>
-        )}
-      </div>
-    );
-  }
-
-  if (currentStatus === "cancelled") {
-    return null;
-  }
+  if (currentStatus !== "scheduled") return null;
 
   return (
     <div className="space-y-3">
-      {currentStatus === "scheduled" && (
-        <div className="space-y-3">
-          {showStartConfirm ? (
-            <InlineConfirm
-              title="确认开始比赛？"
-              sub="开始后比赛状态将变为「进行中」"
-              onConfirm={handleStart}
-              onCancel={() => setShowStartConfirm(false)}
-            />
-          ) : (
-            <div className="flex gap-2">
-              <Button size="sm" onClick={() => setShowStartConfirm(true)} disabled={isPending || startBlockers.length > 0}>
-                开始比赛
-              </Button>
-              <Button size="sm" variant="outline" onClick={handleCancel} disabled={isPending}>
-                取消比赛
-              </Button>
-            </div>
-          )}
-          {startBlockers.length > 0 && <p className="text-xs leading-5 text-[var(--color-warn)]">无法开始：{startBlockers.join("；")}</p>}
-        </div>
-      )}
-
-      {currentStatus === "in_progress" && (
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <p className="text-xs text-[var(--color-fg-mid)]">{SCORE_LABELS[format]}</p>
-          <div className="flex items-end gap-3">
-            <div className="space-y-1">
-              <Label className="text-xs text-[var(--color-fg-mid)]">{teamAName}</Label>
-              <Input
-                type="number"
-                min="0"
-                value={scoreA}
-                onChange={(e) => setScoreA(e.target.value)}
-                className="w-20 text-center"
-                placeholder="0"
-              />
-            </div>
-            <span className="text-[var(--color-fg-mid)] mb-2">:</span>
-            <div className="space-y-1">
-              <Label className="text-xs text-[var(--color-fg-mid)]">{teamBName}</Label>
-              <Input
-                type="number"
-                min="0"
-                value={scoreB}
-                onChange={(e) => setScoreB(e.target.value)}
-                className="w-20 text-center"
-                placeholder="0"
-              />
-            </div>
-            <Button type="submit" size="sm" disabled={isPending} className="mb-0.5">
-              录入结果
-            </Button>
-          </div>
+      {showStartConfirm ? (
+        <InlineConfirm
+          title="确认开始比赛？"
+          sub="开始后比赛状态将变为「进行中」，正常赛果请按地图录入"
+          onConfirm={handleStart}
+          onCancel={() => setShowStartConfirm(false)}
+        />
+      ) : (
+        <div className="flex gap-2">
           <Button
-            type="button"
             size="sm"
-            variant="outline"
-            onClick={handleCancel}
-            disabled={isPending}
+            onClick={() => setShowStartConfirm(true)}
+            disabled={isPending || startBlockers.length > 0}
           >
+            开始比赛
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleCancel} disabled={isPending}>
             取消比赛
           </Button>
-        </form>
+        </div>
+      )}
+      {startBlockers.length > 0 && (
+        <p className="text-xs leading-5 text-[var(--color-warn)]">
+          无法开始：{startBlockers.join("；")}
+        </p>
       )}
     </div>
   );

--- a/src/components/matches/VetoInputDialog.tsx
+++ b/src/components/matches/VetoInputDialog.tsx
@@ -114,8 +114,8 @@ function buildTemplate(
     case "bo5":
       // A ban, B ban → A/B/A/B pick → decider (B picks side)
       return [
-        { actionType: "ban", mapName: "", entryId: entryBId, side: null },
         { actionType: "ban", mapName: "", entryId: entryAId, side: null },
+        { actionType: "ban", mapName: "", entryId: entryBId, side: null },
         { actionType: "pick", mapName: "", entryId: entryAId, side: null },
         { actionType: "pick", mapName: "", entryId: entryBId, side: null },
         { actionType: "pick", mapName: "", entryId: entryAId, side: null },

--- a/src/db/schema/match-maps.ts
+++ b/src/db/schema/match-maps.ts
@@ -33,7 +33,7 @@ export const matchMaps = pgTable(
     /** Team A 上半场起始边（决胜图由刀赛决定，结果填入此字段）*/
     teamAStartSide: sideEnum("team_a_start_side"),
 
-    /** 单图比分（未开始为 null）*/
+    /** 实际单图回合比分（未开始为 null）*/
     scoreA: integer("score_a"),
     scoreB: integer("score_b"),
 
@@ -48,6 +48,10 @@ export const matchMaps = pgTable(
     // 单图比分非负（无上限，兼容加时赛）
     scoreANonNeg: check("match_maps_score_a_nonneg", sql`${t.scoreA} IS NULL OR ${t.scoreA} >= 0`),
     scoreBNonNeg: check("match_maps_score_b_nonneg", sql`${t.scoreB} IS NULL OR ${t.scoreB} >= 0`),
+    scorePairComplete: check(
+      "match_maps_score_pair_complete",
+      sql`(${t.scoreA} IS NULL AND ${t.scoreB} IS NULL) OR (${t.scoreA} IS NOT NULL AND ${t.scoreB} IS NOT NULL)`,
+    ),
   })
 );
 

--- a/src/db/schema/matches.ts
+++ b/src/db/schema/matches.ts
@@ -28,8 +28,8 @@ export const matches = pgTable("matches", {
   entryRound: text("entry_round"),                                       // bracket entry round; null for non-elimination stages
   // ──────────────────────────────────────────────────────────────────────
 
-  // 整场系列赛比分（如 BO3 中 2:1）
-  // 单图比分见 match_maps 表
+  // 官方系列赛比分（所有 format；BO1 为 1:0 / 0:1）
+  // 实际单图回合比分见 match_maps 表
   scoreA: integer("score_a"),
   scoreB: integer("score_b"),
 
@@ -58,6 +58,17 @@ export const matches = pgTable("matches", {
   // 系列赛比分非负
   scoreANonNegative: check("matches_score_a_nonneg", sql`${t.scoreA} IS NULL OR ${t.scoreA} >= 0`),
   scoreBNonNegative: check("matches_score_b_nonneg", sql`${t.scoreB} IS NULL OR ${t.scoreB} >= 0`),
+  scorePairComplete: check(
+    "matches_score_pair_complete",
+    sql`(${t.scoreA} IS NULL AND ${t.scoreB} IS NULL) OR (${t.scoreA} IS NOT NULL AND ${t.scoreB} IS NOT NULL)`,
+  ),
+  seriesScoreShape: check(
+    "matches_series_score_shape",
+    sql`(${t.scoreA} IS NULL AND ${t.scoreB} IS NULL)
+      OR (${t.format} = 'bo1' AND GREATEST(${t.scoreA}, ${t.scoreB}) = 1 AND LEAST(${t.scoreA}, ${t.scoreB}) = 0)
+      OR (${t.format} = 'bo3' AND GREATEST(${t.scoreA}, ${t.scoreB}) = 2 AND LEAST(${t.scoreA}, ${t.scoreB}) BETWEEN 0 AND 1)
+      OR (${t.format} = 'bo5' AND GREATEST(${t.scoreA}, ${t.scoreB}) = 3 AND LEAST(${t.scoreA}, ${t.scoreB}) BETWEEN 0 AND 2)`,
+  ),
   managedMajorMatchShape: check(
     "matches_managed_major_match_shape",
     sql`(${t.ownership} = 'manual' AND ${t.majorStageRunId} IS NULL AND ${t.managedKey} IS NULL)

--- a/src/lib/audit/presentation.test.ts
+++ b/src/lib/audit/presentation.test.ts
@@ -77,8 +77,8 @@ describe("audit presentation owner", () => {
 
   it("summarizes only approved low-sensitivity metadata", () => {
     const summary = summarizeAuditMeta("match.record_result", {
-      scoreA: 13,
-      scoreB: 9,
+      scoreA: 1,
+      scoreB: 0,
       token: "secret-token",
       evidenceCode: "secret-code",
       internalEvidence: "private evidence",
@@ -86,7 +86,7 @@ describe("audit presentation owner", () => {
       note: "private note",
       email: "player@example.test",
     });
-    expect(summary).toContain("比分 13:9");
+    expect(summary).toContain("比分 1:0");
     expect(summary).not.toContain("secret-token");
     expect(summary).not.toContain("secret-code");
     expect(summary).not.toContain("private evidence");

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -1,8 +1,27 @@
 import "server-only";
-import { and, eq, asc } from "drizzle-orm";
+import { and, eq, asc, inArray, isNotNull } from "drizzle-orm";
 import { db } from "@/db/client";
-import { matches, competitionEntries } from "@/db/schema";
-import { calculateStandings, type TeamStanding } from "@/lib/standings";
+import { matches, matchMaps, competitionEntries } from "@/db/schema";
+import { calculateStandings, type MatchRoundScore, type TeamStanding } from "@/lib/standings";
+
+export async function getMatchMapRoundScores(
+  matchIds: readonly string[],
+): Promise<Map<string, MatchRoundScore[]>> {
+  if (matchIds.length === 0) return new Map();
+
+  const rows = await db
+    .select({ matchId: matchMaps.matchId, scoreA: matchMaps.scoreA, scoreB: matchMaps.scoreB })
+    .from(matchMaps)
+    .where(and(inArray(matchMaps.matchId, [...matchIds]), isNotNull(matchMaps.scoreA), isNotNull(matchMaps.scoreB)));
+  const result = new Map<string, MatchRoundScore[]>();
+  for (const row of rows) {
+    if (row.scoreA == null || row.scoreB == null) continue;
+    const list = result.get(row.matchId) ?? [];
+    list.push({ scoreA: row.scoreA, scoreB: row.scoreB });
+    result.set(row.matchId, list);
+  }
+  return result;
+}
 
 export async function getStandings(seasonId: string): Promise<TeamStanding[]> {
   const [allTeams, finished] = await Promise.all([
@@ -16,5 +35,6 @@ export async function getStandings(seasonId: string): Promise<TeamStanding[]> {
     }),
   ]);
 
-  return calculateStandings(allTeams, finished);
+  const roundScores = await getMatchMapRoundScores(finished.map((match) => match.id));
+  return calculateStandings(allTeams, finished, roundScores);
 }

--- a/src/lib/formats/double-elim.ts
+++ b/src/lib/formats/double-elim.ts
@@ -4,6 +4,7 @@ import { matches, seasons } from "@/db/schema";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { generateBracket, loadBracketState, saveBracketState, seedPlayoff, type BracketStageRef, type BracketParticipantRef } from "@/lib/bracket";
 import { calculateStandings } from "@/lib/standings";
+import { getMatchMapRoundScores } from "@/lib/data/standings";
 import { getPreviousStage, normalizeStagePlan } from "@/types/season";
 import type { StageExecutor } from "./types";
 import type { QualifiedTeam } from "@/types/season";
@@ -63,7 +64,8 @@ export const doubleElimExecutor: StageExecutor = {
         eq(matches.status, "finished"),
       ),
     });
-    const standings = calculateStandings(teams, finishedMatches);
+    const roundScores = await getMatchMapRoundScores(finishedMatches.map((match) => match.id));
+    const standings = calculateStandings(teams, finishedMatches, roundScores);
 
     if (!bracketState) {
       // Fallback: qualifier matches were created manually, so the bracket skeleton

--- a/src/lib/formats/round-robin.ts
+++ b/src/lib/formats/round-robin.ts
@@ -4,6 +4,7 @@ import { matches, seasons, competitionEntries } from "@/db/schema";
 import { AppError, ErrorCode, ERROR_MESSAGES } from "@/lib/errors";
 import { generateBracket, saveBracketState, type BracketStageRef } from "@/lib/bracket";
 import { calculateStandings } from "@/lib/standings";
+import { getMatchMapRoundScores } from "@/lib/data/standings";
 import { getFirstStageOfType, normalizeStagePlan } from "@/types/season";
 import type { StageExecutor } from "./types";
 import { isStageComplete } from "./_shared";
@@ -72,7 +73,8 @@ export const roundRobinExecutor: StageExecutor = {
         eq(matches.status, "finished"),
       ),
     });
-    const standings = calculateStandings(seasonTeams, finishedMatches);
+    const roundScores = await getMatchMapRoundScores(finishedMatches.map((match) => match.id));
+    const standings = calculateStandings(seasonTeams, finishedMatches, roundScores);
     const advanceCount = config.advanceTiers.reduce((sum, t) => sum + t.count, 0);
     return standings.slice(0, advanceCount).map((s) => ({
       teamId: s.teamId,

--- a/src/lib/match-corrections/service.test.ts
+++ b/src/lib/match-corrections/service.test.ts
@@ -135,24 +135,24 @@ describe("deriveSwissFinalizedRollback", () => {
 });
 
 describe("validateResultCorrectionProposal", () => {
-  it("accepts a legal BO1 13:x score and resolves the winner", () => {
-    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 13, scoreB: 9 });
+  it("accepts a legal BO1 series score and resolves the winner", () => {
+    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 1, scoreB: 0 });
     expect(result.winnerTeamId).toBe(TEAM_A);
     expect(result.isForfeit).toBe(false);
   });
 
   it("resolves a B-side winner", () => {
-    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 4, scoreB: 13 });
+    const result = validateResultCorrectionProposal(baseMatch(), { scoreA: 0, scoreB: 1 });
     expect(result.winnerTeamId).toBe(TEAM_B);
   });
 
   it("rejects negative and non-integer scores", () => {
-    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: -1, scoreB: 13 })).toThrow(AppError);
-    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 12.5, scoreB: 13 })).toThrow(AppError);
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: -1, scoreB: 1 })).toThrow(AppError);
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 1.5, scoreB: 1 })).toThrow(AppError);
   });
 
   it("rejects ties", () => {
-    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 9, scoreB: 9 })).toThrow(/平局/);
+    expect(() => validateResultCorrectionProposal(baseMatch(), { scoreA: 1, scoreB: 1 })).toThrow(/平局/);
   });
 
   it("enforces exact series thresholds for non-forfeit corrections", () => {
@@ -163,11 +163,11 @@ describe("validateResultCorrectionProposal", () => {
 
   it("requires the canonical forfeit shape when marked as forfeit", () => {
     expect(
-      validateResultCorrectionProposal(baseMatch(), { scoreA: 13, scoreB: 0, isForfeit: true }).isForfeit,
+      validateResultCorrectionProposal(baseMatch(), { scoreA: 1, scoreB: 0, isForfeit: true }).isForfeit,
     ).toBe(true);
     expect(() =>
-      validateResultCorrectionProposal(baseMatch(), { scoreA: 16, scoreB: 3, isForfeit: true }),
-    ).toThrow(/弃赛判负的标准比分为 13:0/);
+      validateResultCorrectionProposal(baseMatch(), { scoreA: 2, scoreB: 0, isForfeit: true }),
+    ).toThrow(/弃赛判负的标准比分为 1:0/);
     const bo3 = { ...baseMatch(), format: "bo3" as const };
     expect(() =>
       validateResultCorrectionProposal(bo3, { scoreA: 1, scoreB: 2, isForfeit: false }),
@@ -179,7 +179,7 @@ describe("validateResultCorrectionProposal", () => {
 
   it("inherits forfeit semantics from the existing fact when the proposal omits the flag", () => {
     const forfeited = { ...baseMatch(), isForfeit: true };
-    expect(() => validateResultCorrectionProposal(forfeited, { scoreA: 7, scoreB: 13 })).toThrow(/弃赛判负/);
+    expect(() => validateResultCorrectionProposal(forfeited, { scoreA: 0, scoreB: 2 })).toThrow(/弃赛判负/);
   });
 });
 

--- a/src/lib/match-corrections/service.ts
+++ b/src/lib/match-corrections/service.ts
@@ -25,7 +25,7 @@ import { assertSeasonAllowsTournamentMutationInTx } from "@/lib/postevent/guard"
 export interface ResultCorrectionProposal {
   scoreA: number;
   scoreB: number;
-  /** Marks the corrected fact as a forfeit result (skips normal series shape). */
+  /** Marks the corrected fact as an official forfeit series result. */
   isForfeit?: boolean;
 }
 
@@ -224,7 +224,7 @@ export function resolveWinnerTeamId(match: Pick<Match, "entryAId" | "entryBId" |
 }
 
 const FORFEIT_WINNER_SCORE: Record<"bo1" | "bo3" | "bo5", number> = {
-  bo1: 13,
+  bo1: 1,
   bo3: 2,
   bo5: 3,
 };

--- a/src/lib/matches/detail-stats.test.ts
+++ b/src/lib/matches/detail-stats.test.ts
@@ -44,8 +44,8 @@ describe("match detail stats", () => {
   it("computes team record from finished scores", () => {
     expect(
       computeRecord("team-a", [
-        { entryAId: "team-a", entryBId: "team-b", scoreA: 13, scoreB: 8 },
-        { entryAId: "team-c", entryBId: "team-a", scoreA: 13, scoreB: 11 },
+        { entryAId: "team-a", entryBId: "team-b", scoreA: 1, scoreB: 0 },
+        { entryAId: "team-c", entryBId: "team-a", scoreA: 1, scoreB: 0 },
         { entryAId: "team-a", entryBId: "team-d", scoreA: null, scoreB: null },
       ]),
     ).toEqual({ wins: 1, losses: 1 });

--- a/src/lib/matches/result-rules.test.ts
+++ b/src/lib/matches/result-rules.test.ts
@@ -9,6 +9,12 @@ describe("match result rules", () => {
   describe("validateSeriesScore", () => {
     it("accepts a BO1 decisive score", () => {
       expect(validateSeriesScore("bo1", 1, 0)).toEqual({ scoreA: 1, scoreB: 0 });
+      expect(validateSeriesScore("bo1", 0, 1)).toEqual({ scoreA: 0, scoreB: 1 });
+    });
+
+    it("rejects BO1 round scores because series scores are map wins", () => {
+      expect(() => validateSeriesScore("bo1", 13, 8)).toThrow("BO1 系列赛比分不合法");
+      expect(() => validateSeriesScore("bo1", 7, 3)).toThrow("BO1 系列赛比分不合法");
     });
 
     it("rejects draws and negative scores", () => {
@@ -32,13 +38,23 @@ describe("match result rules", () => {
     });
 
     it("rejects invalid map scores", () => {
+      expect(validateMapScore(13, 8)).toEqual({ winner: 13, loser: 8 });
       expect(() => validateMapScore(12, 10)).toThrow("单图比分不合法");
+      expect(() => validateMapScore(7, 3)).toThrow("单图比分不合法");
       expect(() => validateMapScore(13, 13)).toThrow("单图不能平局");
       expect(() => validateMapScore(13, -1)).toThrow("比分必须为非负整数");
     });
   });
 
   describe("computeSeriesScoreAfterMap", () => {
+    it("turns a BO1 map result into a 1:0 series result", () => {
+      expect(computeSeriesScoreAfterMap("bo1", [], 13, 8)).toEqual({
+        mapWinsA: 1,
+        mapWinsB: 0,
+        seriesFinished: true,
+      });
+    });
+
     it("adds the new map score and reports whether the series is finished", () => {
       expect(
         computeSeriesScoreAfterMap("bo3", [
@@ -60,6 +76,17 @@ describe("match result rules", () => {
           { scoreA: null, scoreB: null },
         ], 13, 10),
       ).toEqual({ mapWinsA: 2, mapWinsB: 0, seriesFinished: false });
+    });
+
+    it("derives a BO5 series score from played map winners", () => {
+      expect(
+        computeSeriesScoreAfterMap("bo5", [
+          { scoreA: 13, scoreB: 8 },
+          { scoreA: 10, scoreB: 13 },
+          { scoreA: 13, scoreB: 7 },
+          { scoreA: 8, scoreB: 13 },
+        ], 13, 10),
+      ).toEqual({ mapWinsA: 3, mapWinsB: 2, seriesFinished: true });
     });
   });
 });

--- a/src/lib/matches/result-rules.ts
+++ b/src/lib/matches/result-rules.ts
@@ -17,16 +17,14 @@ export function validateSeriesScore(
     throw new AppError(ErrorCode.MATCH_INVALID_SCORE, "系列赛不能平局，必须分出胜负");
   }
 
-  const maxWins = format === "bo1" ? null : getWinThreshold(format);
-  if (maxWins !== null) {
-    const winner = Math.max(scoreA, scoreB);
-    const loser = Math.min(scoreA, scoreB);
-    if (winner !== maxWins || loser >= maxWins) {
-      throw new AppError(
-        ErrorCode.MATCH_INVALID_SCORE,
-        `${format.toUpperCase()} 系列赛比分不合法（胜者须恰好赢 ${maxWins} 图）`,
-      );
-    }
+  const maxWins = getWinThreshold(format);
+  const winner = Math.max(scoreA, scoreB);
+  const loser = Math.min(scoreA, scoreB);
+  if (winner !== maxWins || loser >= maxWins) {
+    throw new AppError(
+      ErrorCode.MATCH_INVALID_SCORE,
+      `${format.toUpperCase()} 系列赛比分不合法（胜者须恰好赢 ${maxWins} 图）`,
+    );
   }
 
   return { scoreA, scoreB };
@@ -59,7 +57,7 @@ export function computeSeriesScoreAfterMap(
   scoreB: number,
 ): { mapWinsA: number; mapWinsB: number; seriesFinished: boolean } {
   const maxWins = getWinThreshold(format);
-  const scoredMaps = existingMaps.filter((m) => m.scoreA !== null);
+  const scoredMaps = existingMaps.filter((m) => m.scoreA !== null && m.scoreB !== null);
   const allMaps = [...scoredMaps, { scoreA, scoreB }];
   let mapWinsA = 0;
   let mapWinsB = 0;

--- a/src/lib/standings.test.ts
+++ b/src/lib/standings.test.ts
@@ -3,7 +3,6 @@ import type { Match } from "@/db/schema/matches";
 import type { CompetitionEntry } from "@/db/schema/competition-entries";
 import { calculateStandings } from "@/lib/standings";
 
-// Helper to construct a minimal CompetitionEntry-like object
 function t(id: string, name: string, draftOrder: number) {
   return {
     id,
@@ -14,14 +13,7 @@ function t(id: string, name: string, draftOrder: number) {
   } as CompetitionEntry;
 }
 
-// Helper to construct a minimal finished Match-like object
-function m(
-  id: string,
-  entryAId: string,
-  entryBId: string,
-  scoreA: number,
-  scoreB: number,
-) {
+function m(id: string, entryAId: string, entryBId: string, scoreA: number, scoreB: number) {
   return {
     id,
     seasonId: "s1",
@@ -42,52 +34,54 @@ function m(
   } as Match;
 }
 
+function mapScores(...scores: [string, number, number][]) {
+  return new Map(scores.map(([matchId, scoreA, scoreB]) => [matchId, [{ scoreA, scoreB }]]));
+}
+
 describe("calculateStandings", () => {
-  it("scores wins and losses correctly", () => {
+  it("uses series scores for wins and map scores for round tiebreakers", () => {
     const teams = [t("t1", "Alpha", 1), t("t2", "Bravo", 2)];
-    const matches = [m("m1", "t1", "t2", 13, 8)];
-    const result = calculateStandings(teams, matches);
+    const matches = [m("m1", "t1", "t2", 1, 0)];
+    const result = calculateStandings(teams, matches, mapScores(["m1", 13, 8]));
     expect(result[0].teamName).toBe("Alpha");
     expect(result[0].wins).toBe(1);
     expect(result[0].losses).toBe(0);
+    expect(result[0].netRounds).toBe(5);
+    expect(result[0].totalRoundsWon).toBe(13);
     expect(result[1].wins).toBe(0);
     expect(result[1].losses).toBe(1);
+    expect(result[1].netRounds).toBe(-5);
+    expect(result[1].totalRoundsWon).toBe(8);
   });
 
-  it("calculates netRounds and totalRoundsWon", () => {
-    const teams = [t("t1", "A", 1), t("t2", "B", 2)];
-    const matches = [m("m1", "t1", "t2", 13, 8)];
-    const result = calculateStandings(teams, matches);
-    const a = result.find((r) => r.teamName === "A")!;
-    expect(a.netRounds).toBe(5);
-    expect(a.totalRoundsWon).toBe(13);
-  });
-
-  it("breaks ties with netRounds before totalRoundsWon", () => {
+  it("breaks ties with map-level net rounds before total rounds", () => {
     const teams = [t("t1", "A", 1), t("t2", "B", 2), t("t3", "C", 3)];
     const matches = [
-      m("m1", "t1", "t2", 13, 10),
-      m("m2", "t1", "t3", 10, 13),
-      m("m3", "t2", "t3", 13, 8),
+      m("m1", "t1", "t2", 1, 0),
+      m("m2", "t1", "t3", 0, 1),
+      m("m3", "t2", "t3", 1, 0),
     ];
-    const result = calculateStandings(teams, matches);
-    expect(result[0].teamName).toBe("B"); // best netRounds (+2)
-    expect(result[1].teamName).toBe("A"); // next netRounds (0)
-    expect(result[2].teamName).toBe("C"); // lowest (-2)
+    const result = calculateStandings(
+      teams,
+      matches,
+      mapScores(["m1", 13, 10], ["m2", 10, 13], ["m3", 13, 8]),
+    );
+    expect(result[0].teamName).toBe("B");
+    expect(result[1].teamName).toBe("A");
+    expect(result[2].teamName).toBe("C");
   });
 
   it("falls back to draftOrder when all else is equal", () => {
     const teams = [t("t1", "A", 3), t("t2", "B", 1)];
-    const matches: Match[] = [];
-    const result = calculateStandings(teams, matches);
+    const result = calculateStandings(teams, [], new Map());
     expect(result[0].draftOrder).toBe(1);
     expect(result[1].draftOrder).toBe(3);
   });
 
   it("assigns seeds 1-based", () => {
     const teams = [t("t1", "A", 1), t("t2", "B", 2)];
-    const matches = [m("m1", "t1", "t2", 13, 8)];
-    const result = calculateStandings(teams, matches);
+    const matches = [m("m1", "t1", "t2", 1, 0)];
+    const result = calculateStandings(teams, matches, mapScores(["m1", 13, 8]));
     expect(result[0].seed).toBe(1);
     expect(result[1].seed).toBe(2);
   });

--- a/src/lib/standings.ts
+++ b/src/lib/standings.ts
@@ -7,11 +7,16 @@
 //   4. 相互战绩（head-to-head胜负）
 //   5. 抽签（原始 draftOrder）
 //
-// BO1 场景下：matches.scoreA/scoreB 存储的是回合数（如 13、8），
-// 胜者 = 回合数更高的一方（不允许平局）。
+// matches.scoreA/scoreB 始终是系列赛比分；排名中的回合项只消费
+// match_maps 中实际完成地图的回合事实。弃赛没有实际地图，因此不贡献回合数。
 
 import type { CompetitionEntry } from "@/db/schema/competition-entries";
 import type { Match } from "@/db/schema/matches";
+
+export interface MatchRoundScore {
+  scoreA: number;
+  scoreB: number;
+}
 
 export interface TeamStanding {
   teamId: string;
@@ -36,6 +41,7 @@ export interface TeamStanding {
 export function calculateStandings(
   competitionEntries: CompetitionEntry[],
   finishedMatches: Match[],
+  roundScoresByMatchId: ReadonlyMap<string, readonly MatchRoundScore[]>,
 ): TeamStanding[] {
   // 初始化每支队伍的数据
   const stats = new Map<string, { wins: number; losses: number; netRounds: number; totalRoundsWon: number }>();
@@ -51,10 +57,12 @@ export function calculateStandings(
     const scoreA = m.scoreA;
     const scoreB = m.scoreB;
 
-    a.totalRoundsWon += scoreA;
-    b.totalRoundsWon += scoreB;
-    a.netRounds += scoreA - scoreB;
-    b.netRounds += scoreB - scoreA;
+    for (const mapScore of roundScoresByMatchId.get(m.id) ?? []) {
+      a.totalRoundsWon += mapScore.scoreA;
+      b.totalRoundsWon += mapScore.scoreB;
+      a.netRounds += mapScore.scoreA - mapScore.scoreB;
+      b.netRounds += mapScore.scoreB - mapScore.scoreA;
+    }
     if (scoreA > scoreB) { a.wins++; b.losses++; }
     else { b.wins++; a.losses++; }
   }
@@ -75,7 +83,7 @@ export function calculateStandings(
         (m.entryAId === a.teamId && m.entryBId === b.teamId) ||
         (m.entryAId === b.teamId && m.entryBId === a.teamId),
     );
-    if (h2h) {
+    if (h2h && h2h.scoreA !== null && h2h.scoreB !== null && h2h.scoreA !== h2h.scoreB) {
       const aWonH2H =
         (h2h.entryAId === a.teamId && (h2h.scoreA ?? 0) > (h2h.scoreB ?? 0)) ||
         (h2h.entryBId === a.teamId && (h2h.scoreB ?? 0) > (h2h.scoreA ?? 0));

--- a/src/lib/stats/sql.ts
+++ b/src/lib/stats/sql.ts
@@ -2,14 +2,14 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 /**
- * 回合数表达式：优先图级比分（BO3/BO5），BO1 fallback 到赛事级比分。
- * 依赖 SQL 别名：mm = match_maps, m = matches
+ * 回合数表达式：所有 format 均只从实际已记录地图的回合比分计算。
+ * 依赖 SQL 别名：mm = match_maps
  */
-export const roundsExpr: SQL = sql`COALESCE(mm.score_a + mm.score_b, m.score_a + m.score_b)`;
+export const roundsExpr: SQL = sql`mm.score_a + mm.score_b`;
 
 /**
  * 回合加权均值 — ADR 跨图聚合的正确方式
- * 依赖别名：mm, m
+ * 依赖别名：mm
  */
 export function roundWeightedAvg(col: string): SQL {
   return sql`CASE WHEN sum(${roundsExpr}) > 0
@@ -29,7 +29,7 @@ export function killWeightedAvg(col: string): SQL {
 
 /**
  * 每回合率 — KPR / FKPR / MKPR / CPR 的正确聚合方式
- * 依赖别名：mm, m
+ * 依赖别名：mm
  */
 export function perRound(col: string): SQL {
   return sql`CASE WHEN sum(${roundsExpr}) > 0

--- a/src/lib/teams/data.ts
+++ b/src/lib/teams/data.ts
@@ -16,58 +16,30 @@ export interface MapWinStats {
   played: number;
 }
 
-/** 每图胜率，兼容 BO1（via decider veto step）和 BO3/BO5（via matchMaps） */
+/** 每图胜率：所有 format 均只统计 matchMaps 中实际完成的地图。 */
 export async function getTeamMapWinStats(
   entryId: string,
   teamMatches: MatchRef[],
 ): Promise<Map<string, MapWinStats>> {
   if (!teamMatches.length) return new Map();
   const matchRef = new Map(teamMatches.map((m) => [m.id, m]));
-  const bo1Matches = teamMatches.filter((m) => m.format === "bo1");
-  const bo35Matches = teamMatches.filter((m) => m.format !== "bo1");
   const mapStats = new Map<string, MapWinStats>();
 
-  if (bo35Matches.length) {
-    const maps = await db.query.matchMaps.findMany({
-      where: inArray(matchMaps.matchId, bo35Matches.map((m) => m.id)),
+  const maps = await db.query.matchMaps.findMany({
+    where: inArray(matchMaps.matchId, teamMatches.map((m) => m.id)),
+  });
+  for (const mp of maps) {
+    if (mp.scoreA === null || mp.scoreB === null) continue;
+    const match = matchRef.get(mp.matchId);
+    if (!match) continue;
+    const isA = match.entryAId === entryId;
+    const myScore = isA ? mp.scoreA : mp.scoreB;
+    const oppScore = isA ? mp.scoreB : mp.scoreA;
+    const prev = mapStats.get(mp.mapName) ?? { wins: 0, played: 0 };
+    mapStats.set(mp.mapName, {
+      wins: prev.wins + (myScore > oppScore ? 1 : 0),
+      played: prev.played + 1,
     });
-    for (const mp of maps) {
-      if (mp.scoreA === null || mp.scoreB === null) continue;
-      const match = matchRef.get(mp.matchId);
-      if (!match) continue;
-      const isA = match.entryAId === entryId;
-      const myScore = isA ? mp.scoreA : mp.scoreB;
-      const oppScore = isA ? mp.scoreB : mp.scoreA;
-      const prev = mapStats.get(mp.mapName) ?? { wins: 0, played: 0 };
-      mapStats.set(mp.mapName, {
-        wins: prev.wins + (myScore > oppScore ? 1 : 0),
-        played: prev.played + 1,
-      });
-    }
-  }
-
-  if (bo1Matches.length) {
-    const deciders = await db
-      .select({ matchId: matchVetoSteps.matchId, mapName: matchVetoSteps.mapName })
-      .from(matchVetoSteps)
-      .where(
-        and(
-          inArray(matchVetoSteps.matchId, bo1Matches.map((m) => m.id)),
-          eq(matchVetoSteps.actionType, "decider"),
-        ),
-      );
-    for (const d of deciders) {
-      const match = matchRef.get(d.matchId);
-      if (!match) continue;
-      const isA = match.entryAId === entryId;
-      const myScore = isA ? (match.scoreA ?? 0) : (match.scoreB ?? 0);
-      const oppScore = isA ? (match.scoreB ?? 0) : (match.scoreA ?? 0);
-      const prev = mapStats.get(d.mapName) ?? { wins: 0, played: 0 };
-      mapStats.set(d.mapName, {
-        wins: prev.wins + (myScore > oppScore ? 1 : 0),
-        played: prev.played + 1,
-      });
-    }
   }
 
   return mapStats;

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -15,7 +15,7 @@ export interface Match {
   stage: MatchStage;
   round: number | null;
   format: MatchFormat;
-  /** 系列赛比分（如 BO3 中 2:1）；单图比分见 MatchMap */
+  /** 官方系列赛比分（所有 format；BO1 为 1:0 / 0:1）；单图回合比分见 MatchMap */
   scoreA: number | null;
   scoreB: number | null;
   status: MatchStatus;

--- a/tests/integration/db/major-result-recovery.test.ts
+++ b/tests/integration/db/major-result-recovery.test.ts
@@ -6,7 +6,7 @@
  *  B/C. started or finished final/third-place blocks automatic recovery
  *  D. quarterfinal correction invalidates only its actual semifinal path
  *  B. 下游生成前的胜者更正（无需作废任何比赛，修正后 finalize 可重建）
- *  A. 同胜者比分笔误最小更正（含弃赛形态）
+ *  A. BO1 官方系列赛结果与弃赛形态更正
  *  C. 下游已生成但未开始：plan 展示影响 → 显式确认恢复 → 作废未开始下游
  *     + 回滚 finalizedRound → 经既有 finalize 确定性重建
  *  E. 重复更正请求幂等；重复 finalize 幂等
@@ -370,8 +370,8 @@ async function finishRound1Matches(
     await client.query("BEGIN");
     for (let index = 0; index < ctx.matchIdsByIndex.length; index += 1) {
       const matchId = ctx.matchIdsByIndex[index]!;
-      // flipped: 高种子(A) 9 : 低种子(B) 13 —— 爆冷；否则 A 13:4。
-      const [scoreA, scoreB] = flips.has(index) ? [9, 13] : [13, 4];
+      // flipped: 高种子(A) 0 : 低种子(B) 1 —— 爆冷；否则 A 1:0。
+      const [scoreA, scoreB] = flips.has(index) ? [0, 1] : [1, 0];
       await client.query(
         `UPDATE matches SET score_a = $2, score_b = $3, status = 'finished', completed_at = now(), updated_at = now()
          WHERE id = $1`,
@@ -626,7 +626,7 @@ async function main(): Promise<void> {
       fixtures.push(fixture);
       const run = fixture.stageKeysWithRuns[0]!;
       const r1 = await generateAndInsertRound1(pool, fixture);
-      // m0 爆冷：低种子 13:9 取胜，随后管理员更正回高种子获胜。
+      // m0 爆冷：低种子以 0:1 取胜，随后管理员更正回高种子获胜。
       await finishRound1Matches(pool, r1, { flipMatchIndexes: [0] });
 
       const m0 = r1.matchIdsByIndex[0]!;
@@ -634,7 +634,7 @@ async function main(): Promise<void> {
         () => database.transaction((tx) =>
           applyResultCorrectionInTx(tx, {
             matchId: m0,
-            proposal: { scoreA: 13, scoreB: 4 },
+            proposal: { scoreA: 1, scoreB: 0 },
             actorId: ACTOR,
           }),
         ),
@@ -646,7 +646,7 @@ async function main(): Promise<void> {
       const applied = await database.transaction((tx) =>
         applyResultCorrectionInTx(tx, {
           matchId: m0,
-          proposal: { scoreA: 13, scoreB: 4 },
+          proposal: { scoreA: 1, scoreB: 0 },
           actorId: ACTOR,
           confirmRecovery: true,
         }),
@@ -657,7 +657,7 @@ async function main(): Promise<void> {
       const client = await pool.connect();
       try {
         const fact = await getMatchFact(client, m0);
-        expect(fact.scoreA === 13 && fact.scoreB === 4,  "B2 更正事实必须落库").toBe(true);
+        expect(fact.scoreA === 1 && fact.scoreB === 0,  "B2 更正事实必须落库").toBe(true);
         expect(await auditCount(client, "match.result.corrected", m0) === 1,  "B2 更正审计恰好一条").toBe(true);
 
         // 修正后经既有 finalize 路径重建第 2 轮。
@@ -687,22 +687,22 @@ async function main(): Promise<void> {
 
       const client = await pool.connect();
 
-      // A. 同胜者笔误最小更正。
+      // A. 已 canonical 的 BO1 系列赛结果重复提交时应幂等。
       const typoTarget = r1.matchIdsByIndex[1]!;
       const typoApplied = await database.transaction((tx) =>
         applyResultCorrectionInTx(tx, {
           matchId: typoTarget,
-          proposal: { scoreA: 13, scoreB: 9 },
+          proposal: { scoreA: 1, scoreB: 0 },
           actorId: ACTOR,
         }),
       );
-      expect(!typoApplied.winnerChanged && !typoApplied.alreadyApplied,  "A 同胜者笔误应为普通更正").toBe(true);
+      expect(!typoApplied.winnerChanged && typoApplied.alreadyApplied,  "A canonical BO1 结果重复提交应幂等").toBe(true);
 
       // A2. 弃赛形态同胜者更正。
       await database.transaction((tx) =>
         applyResultCorrectionInTx(tx, {
           matchId: r1.matchIdsByIndex[2]!,
-          proposal: { scoreA: 13, scoreB: 0, isForfeit: true },
+          proposal: { scoreA: 1, scoreB: 0, isForfeit: true },
           actorId: ACTOR,
         }),
       );
@@ -714,7 +714,7 @@ async function main(): Promise<void> {
       // C. 计划层展示影响并要求显式确认。
       const m0 = r1.matchIdsByIndex[0]!;
       const plan = await database.transaction((tx) =>
-        planResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 } }),
+        planResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 1, scoreB: 0 } }),
       );
       expect(plan.winnerChanges,  "C 计划必须识别胜者变更").toBe(true);
       expect(plan.blockedReasons.length === 0,  "C 全部下游未开始时不应有 fail-closed 理由").toBe(true);
@@ -725,7 +725,7 @@ async function main(): Promise<void> {
 
       await expectAppError(
         () => database.transaction((tx) =>
-          applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR }),
+          applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 1, scoreB: 0 }, actorId: ACTOR }),
         ),
         ErrorCode.VALIDATION_FAILED,
         "显式确认恢复流程",
@@ -733,7 +733,7 @@ async function main(): Promise<void> {
       );
 
       const applied = await database.transaction((tx) =>
-        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR, confirmRecovery: true }),
+        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 1, scoreB: 0 }, actorId: ACTOR, confirmRecovery: true }),
       );
       expect(applied.winnerChanged,  "C2 应用必须成功").toBe(true);
       expect(applied.invalidatedDownstreamMatches.length === 8,  "C2 应作废全部 8 场第 2 轮").toBe(true);
@@ -747,7 +747,7 @@ async function main(): Promise<void> {
 
       // E. 重复提交同一更正请求：alreadyApplied 且不新增审计/不再作废。
       const repeat = await database.transaction((tx) =>
-        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 13, scoreB: 4 }, actorId: ACTOR, confirmRecovery: true }),
+        applyResultCorrectionInTx(tx, { matchId: m0, proposal: { scoreA: 1, scoreB: 0 }, actorId: ACTOR, confirmRecovery: true }),
       );
       expect(repeat.alreadyApplied,  "E 重复更正应 alreadyApplied").toBe(true);
       expect(repeat.invalidatedDownstreamMatches.length === 0,  "E 重复更正不得再作废任何比赛").toBe(true);
@@ -790,14 +790,14 @@ async function main(): Promise<void> {
         const mLast = r1.matchIdsByIndex[r1.matchIdsByIndex.length - 1]!;
         await expectAppError(
           () => database.transaction((tx) =>
-            applyResultCorrectionInTx(tx, { matchId: mLast, proposal: { scoreA: 4, scoreB: 13 }, actorId: ACTOR, confirmRecovery: true }),
+            applyResultCorrectionInTx(tx, { matchId: mLast, proposal: { scoreA: 0, scoreB: 1 }, actorId: ACTOR, confirmRecovery: true }),
           ),
           ErrorCode.VALIDATION_FAILED,
           "已经开始或完成",
           "D 已开始下游必须硬阻断",
         );
         const untouched = await getMatchFact(client, mLast);
-        expect(untouched.scoreA === 13 && untouched.scoreB === 4,  "D 阻断后原结果不变").toBe(true);
+        expect(untouched.scoreA === 1 && untouched.scoreB === 0,  "D 阻断后原结果不变").toBe(true);
         expect(await getFinalizedRound(client, run.runId) === 1,  "D 阻断后 finalizedRound 不变").toBe(true);
       }
 
@@ -828,7 +828,7 @@ async function main(): Promise<void> {
           expect(Boolean(finalResultCheck.rows[0]?.id),  "F 官方名次夹具注入成功").toBe(true);
           await expectAppError(
             () => database.transaction((tx) =>
-              applyResultCorrectionInTx(tx, { matchId: typoTarget, proposal: { scoreA: 4, scoreB: 13 }, actorId: ACTOR, confirmRecovery: true }),
+              applyResultCorrectionInTx(tx, { matchId: typoTarget, proposal: { scoreA: 0, scoreB: 1 }, actorId: ACTOR, confirmRecovery: true }),
             ),
             ErrorCode.VALIDATION_FAILED,
             "官方名次已经生成",
@@ -910,7 +910,7 @@ async function main(): Promise<void> {
           () => database.transaction((tx) =>
             applyResultCorrectionInTx(tx, {
               matchId: r1Late.matchIdsByIndex[0]!,
-              proposal: { scoreA: 13, scoreB: 4 },
+              proposal: { scoreA: 1, scoreB: 0 },
               actorId: ACTOR,
               confirmRecovery: true,
             }),

--- a/tests/integration/db/major-start.test.ts
+++ b/tests/integration/db/major-start.test.ts
@@ -379,8 +379,8 @@ async function finishSwissRound(pool: Pool, stageRunId: string, round: number): 
     for (let index = 0; index < roundMatches.rows.length; index += 1) {
       const match = roundMatches.rows[index];
       const teamAWins = (round + index) % 2 === 0;
-      const scoreA = match.format === "bo1" ? (teamAWins ? 13 : 11) : (teamAWins ? 2 : 1);
-      const scoreB = match.format === "bo1" ? (teamAWins ? 11 : 13) : (teamAWins ? 1 : 2);
+      const scoreA = match.format === "bo1" ? (teamAWins ? 1 : 0) : (teamAWins ? 2 : 1);
+      const scoreB = match.format === "bo1" ? (teamAWins ? 0 : 1) : (teamAWins ? 1 : 2);
       await client.query(
         `UPDATE matches SET score_a = $2, score_b = $3, status = 'finished', completed_at = now(), updated_at = now() WHERE id = $1`,
         [match.id, scoreA, scoreB],
@@ -534,43 +534,51 @@ async function exerciseSwissRuntime(
 
   await finishSwissRound(pool, stageRunId, 1);
   const client = await pool.connect();
-  let corruptedMatchId: string;
+  let correctionTargetId: string;
+  let correctionProposal: { scoreA: number; scoreB: number };
   try {
-    const invalid = await client.query<{ id: string }>(
-      `SELECT id FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 1 ORDER BY managed_key LIMIT 1`,
+    const target = await client.query<{ id: string; score_a: number | null; score_b: number | null }>(
+      `SELECT id, score_a, score_b FROM matches WHERE season_id = $1 AND ownership = 'major_stage' AND round = 1 ORDER BY managed_key LIMIT 1`,
       [fixture.seasonId],
     );
-    corruptedMatchId = invalid.rows[0]?.id ?? "";
-    if (!corruptedMatchId) throw new Error("缺少用于非法比分验证的 R1 比赛。 ");
-    await client.query("UPDATE matches SET score_a = 0, score_b = 0 WHERE id = $1", [corruptedMatchId]);
+    const row = target.rows[0];
+    if (!row) throw new Error("缺少用于结果更正验证的 R1 比赛。 ");
+    correctionTargetId = row.id;
+    if (row.score_a === null || row.score_b === null || row.score_a === row.score_b) {
+      throw new Error("结果更正验证目标缺少合法的 BO1 系列赛比分。 ");
+    }
+    correctionProposal = row.score_a > row.score_b
+      ? { scoreA: 0, scoreB: 1 }
+      : { scoreA: 1, scoreB: 0 };
+    await client.query("BEGIN");
+    const malformed = await capturePostgresError(client, () =>
+      client.query("UPDATE matches SET score_a = 0, score_b = 0 WHERE id = $1", [correctionTargetId]),
+    );
+    await client.query("ROLLBACK");
+    if (postgresErrorCode(malformed) !== "23514") {
+      throw new Error(`数据库应拒绝非法 BO1 系列赛比分，实际错误：${postgresErrorDetail(malformed)}`);
+    }
   } finally {
     client.release();
   }
-  await expectSwissRuntimeFailure(() => database.transaction((tx) => finalizeMajorSwissRoundInTransaction(tx, {
-    seasonId: fixture.seasonId, stageRunId, expectedRound: 1, actorId: "local-admin",
-  })));
-  const restoreClient = await pool.connect();
-  try {
-    await restoreClient.query("UPDATE matches SET score_a = 13, score_b = 11 WHERE id = $1", [corruptedMatchId]);
-  } finally {
-    restoreClient.release();
-  }
   const correctionPlan = await database.transaction((tx) => planResultCorrectionInTx(tx, {
-    matchId: corruptedMatchId,
-    proposal: { scoreA: 16, scoreB: 13 },
+    matchId: correctionTargetId,
+    proposal: correctionProposal,
   }));
-  if (correctionPlan.winnerChanges || correctionPlan.blockedReasons.length > 0) {
-    throw new Error("Golden rehearsal 的同胜者结果更正不应被错误阻断。 ");
+  if (!correctionPlan.winnerChanges || correctionPlan.blockedReasons.length > 0) {
+    throw new Error("Golden rehearsal 的合法 BO1 系列赛结果更正不应被错误阻断。 ");
   }
   const appliedCorrection = await database.transaction((tx) => applyResultCorrectionInTx(tx, {
-    matchId: corruptedMatchId,
-    proposal: { scoreA: 16, scoreB: 13 },
+    matchId: correctionTargetId,
+    proposal: correctionProposal,
     actorId: "local-admin",
+    confirmRecovery: true,
   }));
   const repeatedCorrection = await database.transaction((tx) => applyResultCorrectionInTx(tx, {
-    matchId: corruptedMatchId,
-    proposal: { scoreA: 16, scoreB: 13 },
+    matchId: correctionTargetId,
+    proposal: correctionProposal,
     actorId: "local-admin-retry",
+    confirmRecovery: true,
   }));
   if (appliedCorrection.alreadyApplied || repeatedCorrection.alreadyApplied !== true) {
     throw new Error("Golden rehearsal 的结果更正重试没有保持幂等。 ");

--- a/tests/integration/db/match-score-semantics.test.ts
+++ b/tests/integration/db/match-score-semantics.test.ts
@@ -1,0 +1,346 @@
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { describe, expect, it, vi } from "vitest";
+import { localDatabaseUrl } from "./harness/database";
+
+const requireSeasonAdminMock = vi.hoisted(() => vi.fn());
+const auditActorIdMock = vi.hoisted(() => vi.fn((session: { userId: string }) => session.userId));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireSeasonAdmin: requireSeasonAdminMock,
+  auditActorId: auditActorIdMock,
+}));
+
+vi.mock("@/lib/revalidation", () => ({
+  revalidateMatchPaths: vi.fn(),
+}));
+
+vi.mock("@/actions/transitions", () => ({
+  maybeFinishSeason: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  updateTag: vi.fn(),
+}));
+
+import {
+  correctMapScore,
+  forfeitMatch,
+  recordMapResult,
+  updateMatchStatus,
+} from "../../../src/actions/matches/results";
+import { saveVetoSteps } from "../../../src/actions/matches/veto";
+
+type MatchFormat = "bo1" | "bo3" | "bo5";
+
+const MAP_POOL = [
+  "de_ancient",
+  "de_anubis",
+  "de_cache",
+  "de_dust2",
+  "de_inferno",
+  "de_mirage",
+  "de_nuke",
+] as const;
+
+function vetoSteps(format: MatchFormat, entryAId: string, entryBId: string) {
+  const maps = MAP_POOL;
+  const steps =
+    format === "bo1"
+      ? [
+          ["ban", entryAId], ["ban", entryAId], ["ban", entryBId], ["ban", entryBId],
+          ["ban", entryBId], ["ban", entryAId], ["decider", entryBId],
+        ]
+      : format === "bo3"
+        ? [
+            ["ban", entryAId], ["ban", entryBId], ["pick", entryAId], ["pick", entryBId],
+            ["ban", entryBId], ["ban", entryAId], ["decider", entryBId],
+          ]
+        : [
+            ["ban", entryAId], ["ban", entryBId], ["pick", entryAId], ["pick", entryBId],
+            ["pick", entryAId], ["pick", entryBId], ["decider", entryBId],
+          ];
+
+  return steps.map(([actionType, entryId], index) => ({
+    actionType: actionType as "ban" | "pick" | "decider",
+    mapName: maps[index]!,
+    entryId,
+    side: null as null,
+  }));
+}
+
+interface Fixture {
+  seasonId: string;
+  adminId: string;
+  entryAId: string;
+  entryBId: string;
+  memberAId: string;
+  memberBId: string;
+  eventRosterAId: string;
+  eventRosterBId: string;
+}
+
+async function createFixture(client: import("pg").PoolClient): Promise<Fixture> {
+  const fixture: Fixture = {
+    seasonId: randomUUID(),
+    adminId: randomUUID(),
+    entryAId: randomUUID(),
+    entryBId: randomUUID(),
+    memberAId: randomUUID(),
+    memberBId: randomUUID(),
+    eventRosterAId: randomUUID(),
+    eventRosterBId: randomUUID(),
+  };
+  const revisionAId = randomUUID();
+  const revisionBId = randomUUID();
+  const rosterUserAId = randomUUID();
+  const rosterUserBId = randomUUID();
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      "INSERT INTO users (id, email) VALUES ($1, $2), ($3, $4), ($5, $6)",
+      [
+        fixture.adminId,
+        `score-admin-${fixture.seasonId}@local.test`,
+        rosterUserAId,
+        `score-a-${fixture.seasonId}@local.test`,
+        rosterUserBId,
+        `score-b-${fixture.seasonId}@local.test`,
+      ],
+    );
+    await client.query(
+      `INSERT INTO seasons (
+         id, slug, name, kind, status, registration_mode, has_captain_voting, has_draft,
+         stage_plan, registration_config, team_registration_config, min_team_size, max_team_size, starter_count
+       ) VALUES ($1, $2, 'Match score semantics', 'Rivals', 'playing', 'team', false, false,
+         '[]'::json, $3::json, '{}'::json, 1, 1, 1)`,
+      [
+        fixture.seasonId,
+        `match-score-semantics-${fixture.seasonId}`,
+        JSON.stringify({ mapPool: MAP_POOL }),
+      ],
+    );
+    await client.query(
+      `INSERT INTO competition_entries (
+         id, competition_id, source, name, representative_user_id,
+         current_roster_revision_id, approved_roster_revision_id, registration_status
+       ) VALUES ($1, $2, 'event_native', 'Score A', $3, $4, $4, 'approved'),
+                ($5, $2, 'event_native', 'Score B', $6, $7, $7, 'approved')`,
+      [fixture.entryAId, fixture.seasonId, rosterUserAId, revisionAId, fixture.entryBId, rosterUserBId, revisionBId],
+    );
+    await client.query(
+      `INSERT INTO competition_entry_representative_changes (entry_id, from_user_id, to_user_id, changed_by_actor_id)
+       VALUES ($1, NULL, $2, 'score-test'), ($3, NULL, $4, 'score-test')`,
+      [fixture.entryAId, rosterUserAId, fixture.entryBId, rosterUserBId],
+    );
+    await client.query(
+      `INSERT INTO competition_entry_roster_revisions (id, entry_id, revision_number, status, created_by, approved_at)
+       VALUES ($1, $2, 1, 'approved', 'score-test', now()),
+              ($3, $4, 1, 'approved', 'score-test', now())`,
+      [revisionAId, fixture.entryAId, revisionBId, fixture.entryBId],
+    );
+    await client.query(
+      `INSERT INTO event_rosters (
+         id, entry_id, source_roster_revision_id, status, confirmed_at, confirmed_by, frozen_at, frozen_by
+       ) VALUES ($1, $2, $3, 'preparing', NULL, NULL, NULL, NULL),
+                ($4, $5, $6, 'preparing', NULL, NULL, NULL, NULL)`,
+      [fixture.eventRosterAId, fixture.entryAId, revisionAId, fixture.eventRosterBId, fixture.entryBId, revisionBId],
+    );
+    await client.query(
+      `INSERT INTO event_roster_members (id, event_roster_id, user_id, is_primary_starter)
+       VALUES ($1, $2, $3, true), ($4, $5, $6, true)`,
+      [fixture.memberAId, fixture.eventRosterAId, rosterUserAId, fixture.memberBId, fixture.eventRosterBId, rosterUserBId],
+    );
+    await client.query(
+      `UPDATE event_rosters
+       SET status = 'confirmed', confirmed_at = now(), confirmed_by = 'score-test'
+       WHERE id IN ($1, $2)`,
+      [fixture.eventRosterAId, fixture.eventRosterBId],
+    );
+    await client.query(
+      `UPDATE event_rosters
+       SET status = 'frozen', frozen_at = now(), frozen_by = 'score-test'
+       WHERE id IN ($1, $2)`,
+      [fixture.eventRosterAId, fixture.eventRosterBId],
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
+
+  return fixture;
+}
+
+async function createMatch(
+  client: import("pg").PoolClient,
+  fixture: Fixture,
+  format: MatchFormat,
+  options: { withLineups?: boolean } = {},
+): Promise<string> {
+  const matchId = randomUUID();
+  await client.query(
+    `INSERT INTO matches (id, season_id, entry_a_id, entry_b_id, stage, format, status)
+     VALUES ($1, $2, $3, $4, 'qualifier', $5, 'scheduled')`,
+    [matchId, fixture.seasonId, fixture.entryAId, fixture.entryBId, format],
+  );
+
+  if (options.withLineups) {
+    const rosterAId = randomUUID();
+    const rosterBId = randomUUID();
+    await client.query(
+      `INSERT INTO match_rosters (
+         id, match_id, entry_id, submitted_by, source, status, locked_at, confirmed_at, confirmed_by
+       ) VALUES ($1, $2, $3, NULL, 'admin_select', 'confirmed', now(), now(), 'score-test'),
+                ($4, $2, $5, NULL, 'admin_select', 'confirmed', now(), now(), 'score-test')`,
+      [rosterAId, matchId, fixture.entryAId, rosterBId, fixture.entryBId],
+    );
+    await client.query(
+      `INSERT INTO match_roster_players (roster_id, event_roster_member_id, is_starter)
+       VALUES ($1, $2, true), ($3, $4, true)`,
+      [rosterAId, fixture.memberAId, rosterBId, fixture.memberBId],
+    );
+  }
+
+  return matchId;
+}
+
+async function expectSuccess<T>(resultPromise: Promise<{ success: boolean; data?: T; error?: unknown }>): Promise<T> {
+  const result = await resultPromise;
+  if (!result.success) throw new Error(`action failed: ${JSON.stringify(result.error)}`);
+  expect(result.success).toBe(true);
+  return result.data as T;
+}
+
+describe("match score persistence semantics PostgreSQL integration", () => {
+  it("uses map facts for BO1/BO3/BO5 results and never creates forfeit maps", async () => {
+    const pool = new Pool({ connectionString: localDatabaseUrl(), ssl: false, max: 2 });
+    const client = await pool.connect();
+    let fixture: Fixture | undefined;
+    try {
+      fixture = await createFixture(client);
+      requireSeasonAdminMock.mockResolvedValue({ userId: fixture.adminId, email: `score-admin-${fixture.seasonId}@local.test` });
+
+      const bo1MatchId = await createMatch(client, fixture, "bo1", { withLineups: true });
+      const bo3MatchId = await createMatch(client, fixture, "bo3", { withLineups: true });
+      const bo5MatchId = await createMatch(client, fixture, "bo5", { withLineups: true });
+      const forfeitBo1MatchId = await createMatch(client, fixture, "bo1");
+      const forfeitBo3MatchId = await createMatch(client, fixture, "bo3");
+      const scoredForfeitMatchId = await createMatch(client, fixture, "bo3", { withLineups: true });
+
+      for (const [matchId, format] of [[bo1MatchId, "bo1"], [bo3MatchId, "bo3"], [bo5MatchId, "bo5"]] as const) {
+        await expectSuccess(saveVetoSteps(matchId, { steps: vetoSteps(format, fixture.entryAId, fixture.entryBId) }));
+        await expectSuccess(updateMatchStatus(matchId, "in_progress"));
+      }
+      await expectSuccess(saveVetoSteps(forfeitBo3MatchId, { steps: vetoSteps("bo3", fixture.entryAId, fixture.entryBId) }));
+      await expectSuccess(saveVetoSteps(scoredForfeitMatchId, { steps: vetoSteps("bo3", fixture.entryAId, fixture.entryBId) }));
+      await expectSuccess(updateMatchStatus(scoredForfeitMatchId, "in_progress"));
+
+      const bo1MapName = MAP_POOL[6]!;
+      const bo1Result = await expectSuccess(recordMapResult(bo1MatchId, 1, bo1MapName, 13, 8, null, null));
+      expect(bo1Result).toEqual({ seriesFinished: true });
+      const bo1MapId = (await client.query<{ id: string }>(
+        "SELECT id FROM match_maps WHERE match_id = $1 AND map_name = $2",
+        [bo1MatchId, bo1MapName],
+      )).rows[0]!.id;
+      await expectSuccess(correctMapScore(bo1MapId, 13, 10));
+
+      const bo3Scores = [[13, 8], [10, 13], [13, 7]] as const;
+      const bo3MapNames = [MAP_POOL[2], MAP_POOL[3], MAP_POOL[6]] as const;
+      for (const [index, [scoreA, scoreB]] of bo3Scores.entries()) {
+        await expectSuccess(recordMapResult(bo3MatchId, index + 1, bo3MapNames[index]!, scoreA, scoreB, null, null));
+      }
+
+      const bo5Scores = [[13, 8], [10, 13], [13, 7], [8, 13], [13, 10]] as const;
+      const bo5MapNames = [MAP_POOL[2], MAP_POOL[3], MAP_POOL[4], MAP_POOL[5], MAP_POOL[6]] as const;
+      for (const [index, [scoreA, scoreB]] of bo5Scores.entries()) {
+        await expectSuccess(recordMapResult(bo5MatchId, index + 1, bo5MapNames[index]!, scoreA, scoreB, null, null));
+      }
+
+      await expectSuccess(recordMapResult(scoredForfeitMatchId, 1, MAP_POOL[2]!, 13, 8, null, null));
+      await expectSuccess(forfeitMatch(forfeitBo1MatchId, fixture.entryBId, "BO1 fixture adjudication"));
+      await expectSuccess(forfeitMatch(forfeitBo3MatchId, fixture.entryBId, "BO3 fixture adjudication"));
+      await expectSuccess(forfeitMatch(scoredForfeitMatchId, fixture.entryBId, "BO3 after one played map"));
+
+      const facts = await client.query<{
+        id: string;
+        format: MatchFormat;
+        status: string;
+        score_a: number | null;
+        score_b: number | null;
+        is_forfeit: boolean;
+      }>(
+        `SELECT id, format, status, score_a, score_b, is_forfeit
+         FROM matches WHERE id IN ($1, $2, $3, $4, $5, $6) ORDER BY id`,
+        [bo1MatchId, bo3MatchId, bo5MatchId, forfeitBo1MatchId, forfeitBo3MatchId, scoredForfeitMatchId],
+      );
+      expect(facts.rows).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: bo1MatchId, format: "bo1", status: "finished", score_a: 1, score_b: 0, is_forfeit: false }),
+        expect.objectContaining({ id: bo3MatchId, format: "bo3", status: "finished", score_a: 2, score_b: 1, is_forfeit: false }),
+        expect.objectContaining({ id: bo5MatchId, format: "bo5", status: "finished", score_a: 3, score_b: 2, is_forfeit: false }),
+        expect.objectContaining({ id: forfeitBo1MatchId, format: "bo1", status: "finished", score_a: 1, score_b: 0, is_forfeit: true }),
+        expect.objectContaining({ id: forfeitBo3MatchId, format: "bo3", status: "finished", score_a: 2, score_b: 0, is_forfeit: true }),
+        expect.objectContaining({ id: scoredForfeitMatchId, format: "bo3", status: "finished", score_a: 2, score_b: 0, is_forfeit: true }),
+      ]));
+
+      const bo1Maps = await client.query<{ map_name: string; score_a: number; score_b: number }>(
+        "SELECT map_name, score_a, score_b FROM match_maps WHERE match_id = $1",
+        [bo1MatchId],
+      );
+      expect(bo1Maps.rows).toEqual([{ map_name: bo1MapName, score_a: 13, score_b: 10 }]);
+
+      const bo3Maps = await client.query<{ map_name: string; score_a: number; score_b: number }>(
+        "SELECT map_name, score_a, score_b FROM match_maps WHERE match_id = $1 ORDER BY map_order",
+        [bo3MatchId],
+      );
+      expect(bo3Maps.rows).toEqual([
+        { map_name: MAP_POOL[2], score_a: 13, score_b: 8 },
+        { map_name: MAP_POOL[3], score_a: 10, score_b: 13 },
+        { map_name: MAP_POOL[6], score_a: 13, score_b: 7 },
+      ]);
+
+      const forfeitMaps = await client.query<{ match_id: string; score_a: number | null; score_b: number | null }>(
+        `SELECT match_id, score_a, score_b FROM match_maps
+         WHERE match_id IN ($1, $2) ORDER BY match_id, map_order`,
+        [forfeitBo1MatchId, forfeitBo3MatchId],
+      );
+      expect(forfeitMaps.rows).toHaveLength(0);
+
+      const scoredForfeitMaps = await client.query<{ score_a: number; score_b: number }>(
+        "SELECT score_a, score_b FROM match_maps WHERE match_id = $1 ORDER BY map_order",
+        [scoredForfeitMatchId],
+      );
+      expect(scoredForfeitMaps.rows).toEqual([{ score_a: 13, score_b: 8 }]);
+    } finally {
+      client.release();
+      if (fixture) {
+        const cleanupClient = await pool.connect();
+        try {
+          await cleanupClient.query("BEGIN");
+          await cleanupClient.query("SET LOCAL session_replication_role = replica");
+          await cleanupClient.query("DELETE FROM audit_logs WHERE season_id = $1", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM match_roster_players WHERE roster_id IN (SELECT id FROM match_rosters WHERE match_id IN (SELECT id FROM matches WHERE season_id = $1))", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM match_rosters WHERE match_id IN (SELECT id FROM matches WHERE season_id = $1)", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM match_veto_steps WHERE match_id IN (SELECT id FROM matches WHERE season_id = $1)", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM match_maps WHERE match_id IN (SELECT id FROM matches WHERE season_id = $1)", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM matches WHERE season_id = $1", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM event_roster_members WHERE event_roster_id IN (SELECT id FROM event_rosters WHERE entry_id IN (SELECT id FROM competition_entries WHERE competition_id = $1))", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM event_rosters WHERE entry_id IN (SELECT id FROM competition_entries WHERE competition_id = $1)", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM competition_entry_roster_revisions WHERE entry_id IN (SELECT id FROM competition_entries WHERE competition_id = $1)", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM competition_entries WHERE competition_id = $1", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM seasons WHERE id = $1", [fixture.seasonId]);
+          await cleanupClient.query("DELETE FROM users WHERE id = $1 OR email LIKE $2", [fixture.adminId, `score-%-${fixture.seasonId}@local.test`]);
+          await cleanupClient.query("COMMIT");
+        } catch {
+          await cleanupClient.query("ROLLBACK").catch(() => undefined);
+        } finally {
+          cleanupClient.release();
+        }
+      }
+      await pool.end();
+    }
+  });
+});

--- a/tests/integration/db/migrations/match-score-semantics.test.ts
+++ b/tests/integration/db/migrations/match-score-semantics.test.ts
@@ -1,0 +1,372 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { describe, expect, it } from "vitest";
+import { capturePostgresError } from "../harness/database";
+import { migrationFiles, replayMigration, withScratchDatabase } from "../harness/migration-replay";
+
+interface ScoreFixture {
+  seasonId: string;
+  entryAId: string;
+  entryBId: string;
+  legacyNormalMatchId: string;
+  legacyNormalMapId: string;
+  canonicalMatchId: string;
+  canonicalMapId: string;
+  conflictMatchId: string;
+  multipleMapsMatchId: string;
+  legacyForfeitMatchId: string;
+  legacyForfeitMapId: string;
+}
+
+function targetMigration(): string {
+  const target = migrationFiles((name) => name.endsWith("_match_score_semantics.sql"))[0];
+  if (!target) throw new Error("找不到 match score semantics migration。");
+  return target;
+}
+
+async function replayBefore(client: Client, target: string): Promise<void> {
+  for (const migration of migrationFiles((name) => name.endsWith(".sql") && name < target)) {
+    await replayMigration(client, migration);
+  }
+}
+
+async function insertMatch(
+  client: Client,
+  args: {
+    id: string;
+    seasonId: string;
+    entryAId: string;
+    entryBId: string;
+    format?: "bo1" | "bo3" | "bo5";
+    scoreA: number | null;
+    scoreB: number | null;
+    isForfeit?: boolean;
+  },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO matches (
+       id, season_id, entry_a_id, entry_b_id, stage, format, status,
+       score_a, score_b, is_forfeit, completed_at
+     ) VALUES ($1, $2, $3, $4, 'qualifier', $5, 'finished', $6, $7, $8, '2026-08-01T10:00:00Z')`,
+    [
+      args.id,
+      args.seasonId,
+      args.entryAId,
+      args.entryBId,
+      args.format ?? "bo1",
+      args.scoreA,
+      args.scoreB,
+      args.isForfeit ?? false,
+    ],
+  );
+}
+
+async function insertMap(
+  client: Client,
+  args: {
+    id: string;
+    matchId: string;
+    mapOrder: number;
+    scoreA: number | null;
+    scoreB: number | null;
+    completedAt?: string | null;
+  },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO match_maps (id, match_id, map_order, map_name, score_a, score_b, completed_at)
+     VALUES ($1, $2, $3, 'de_mirage', $4, $5, $6)`,
+    [args.id, args.matchId, args.mapOrder, args.scoreA, args.scoreB, args.completedAt ?? null],
+  );
+}
+
+async function insertScoreFixture(client: Client): Promise<ScoreFixture> {
+  const fixture: ScoreFixture = {
+    seasonId: randomUUID(),
+    entryAId: randomUUID(),
+    entryBId: randomUUID(),
+    legacyNormalMatchId: randomUUID(),
+    legacyNormalMapId: randomUUID(),
+    canonicalMatchId: randomUUID(),
+    canonicalMapId: randomUUID(),
+    conflictMatchId: randomUUID(),
+    multipleMapsMatchId: randomUUID(),
+    legacyForfeitMatchId: randomUUID(),
+    legacyForfeitMapId: randomUUID(),
+  };
+  const userAId = randomUUID();
+  const userBId = randomUUID();
+  const revisionAId = randomUUID();
+  const revisionBId = randomUUID();
+
+  await client.query("BEGIN");
+  try {
+    await client.query("INSERT INTO users (id, email) VALUES ($1, $2), ($3, $4)", [
+      userAId,
+      `score-a-${fixture.seasonId}@local.test`,
+      userBId,
+      `score-b-${fixture.seasonId}@local.test`,
+    ]);
+    await client.query(
+      "INSERT INTO seasons (id, slug, name, kind, status) VALUES ($1, $2, 'Match score semantics', 'Rivals', 'finished')",
+      [fixture.seasonId, `match-score-semantics-${fixture.seasonId}`],
+    );
+    await client.query(
+      `INSERT INTO competition_entries (
+         id, competition_id, source, name, representative_user_id,
+         current_roster_revision_id, approved_roster_revision_id, registration_status
+       ) VALUES ($1, $2, 'event_native', 'Score A', $3, $4, $4, 'approved'),
+                ($5, $2, 'event_native', 'Score B', $6, $7, $7, 'approved')`,
+      [fixture.entryAId, fixture.seasonId, userAId, revisionAId, fixture.entryBId, userBId, revisionBId],
+    );
+    await client.query(
+      `INSERT INTO competition_entry_representative_changes (entry_id, from_user_id, to_user_id, changed_by_actor_id)
+       VALUES ($1, NULL, $2, 'migration-test'), ($3, NULL, $4, 'migration-test')`,
+      [fixture.entryAId, userAId, fixture.entryBId, userBId],
+    );
+    await client.query(
+      `INSERT INTO competition_entry_roster_revisions (id, entry_id, revision_number, status, created_by, approved_at)
+       VALUES ($1, $2, 1, 'approved', 'migration-test', now()),
+              ($3, $4, 1, 'approved', 'migration-test', now())`,
+      [revisionAId, fixture.entryAId, revisionBId, fixture.entryBId],
+    );
+
+    await insertMatch(client, {
+      id: fixture.legacyNormalMatchId,
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 13,
+      scoreB: 8,
+    });
+    await insertMap(client, {
+      id: fixture.legacyNormalMapId,
+      matchId: fixture.legacyNormalMatchId,
+      mapOrder: 1,
+      scoreA: null,
+      scoreB: null,
+    });
+
+    await insertMatch(client, {
+      id: fixture.canonicalMatchId,
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 1,
+      scoreB: 0,
+    });
+    await insertMap(client, {
+      id: fixture.canonicalMapId,
+      matchId: fixture.canonicalMatchId,
+      mapOrder: 1,
+      scoreA: 13,
+      scoreB: 8,
+      completedAt: "2026-08-01T10:01:00Z",
+    });
+
+    await insertMatch(client, {
+      id: fixture.conflictMatchId,
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 1,
+      scoreB: 0,
+    });
+    await insertMap(client, {
+      id: randomUUID(),
+      matchId: fixture.conflictMatchId,
+      mapOrder: 1,
+      scoreA: 8,
+      scoreB: 13,
+      completedAt: "2026-08-01T10:01:00Z",
+    });
+
+    await insertMatch(client, {
+      id: fixture.multipleMapsMatchId,
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 13,
+      scoreB: 8,
+    });
+    await insertMap(client, {
+      id: randomUUID(),
+      matchId: fixture.multipleMapsMatchId,
+      mapOrder: 1,
+      scoreA: null,
+      scoreB: null,
+    });
+    await insertMap(client, {
+      id: randomUUID(),
+      matchId: fixture.multipleMapsMatchId,
+      mapOrder: 2,
+      scoreA: null,
+      scoreB: null,
+    });
+
+    await insertMatch(client, {
+      id: fixture.legacyForfeitMatchId,
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 13,
+      scoreB: 0,
+      isForfeit: true,
+    });
+    await insertMap(client, {
+      id: fixture.legacyForfeitMapId,
+      matchId: fixture.legacyForfeitMatchId,
+      mapOrder: 1,
+      scoreA: null,
+      scoreB: null,
+    });
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
+
+  return fixture;
+}
+
+async function assertMigrationFailedClosed(client: Client, fixture: ScoreFixture, target: string): Promise<void> {
+  await expect(replayMigration(client, target)).rejects.toThrow(/preflight failed/);
+
+  const matches = await client.query<{ id: string; score_a: number; score_b: number }>(
+    `SELECT id, score_a, score_b FROM matches
+     WHERE id IN ($1, $2, $3, $4)
+     ORDER BY id`,
+    [fixture.legacyNormalMatchId, fixture.canonicalMatchId, fixture.conflictMatchId, fixture.legacyForfeitMatchId],
+  );
+  expect(matches.rows).toHaveLength(4);
+  expect(matches.rows.find((row) => row.id === fixture.legacyNormalMatchId)).toMatchObject({ score_a: 13, score_b: 8 });
+  expect(matches.rows.find((row) => row.id === fixture.canonicalMatchId)).toMatchObject({ score_a: 1, score_b: 0 });
+  expect(matches.rows.find((row) => row.id === fixture.conflictMatchId)).toMatchObject({ score_a: 1, score_b: 0 });
+  expect(matches.rows.find((row) => row.id === fixture.legacyForfeitMatchId)).toMatchObject({ score_a: 13, score_b: 0 });
+
+  const normalMap = await client.query<{ score_a: number | null; score_b: number | null }>(
+    "SELECT score_a, score_b FROM match_maps WHERE id = $1",
+    [fixture.legacyNormalMapId],
+  );
+  expect(normalMap.rows[0]).toEqual({ score_a: null, score_b: null });
+}
+
+async function assertConstraints(client: Client, fixture: ScoreFixture): Promise<void> {
+  await client.query("BEGIN");
+  try {
+    const halfMatch = await capturePostgresError(client, () => client.query(
+      `INSERT INTO matches (id, season_id, entry_a_id, entry_b_id, stage, format, score_a, score_b)
+       VALUES ($1, $2, $3, $4, 'qualifier', 'bo1', 1, NULL)`,
+      [randomUUID(), fixture.seasonId, fixture.entryAId, fixture.entryBId],
+    ));
+    expect(halfMatch).toMatchObject({ code: "23514" });
+
+    const halfMap = await capturePostgresError(client, () => client.query(
+      `INSERT INTO match_maps (id, match_id, map_order, map_name, score_a, score_b)
+       VALUES ($1, $2, 2, 'de_nuke', 13, NULL)`,
+      [randomUUID(), fixture.canonicalMatchId],
+    ));
+    expect(halfMap).toMatchObject({ code: "23514" });
+
+    const oldBo1 = await capturePostgresError(client, () => insertMatch(client, {
+      id: randomUUID(),
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 13,
+      scoreB: 8,
+    }));
+    expect(oldBo1).toMatchObject({ code: "23514" });
+
+    await insertMatch(client, {
+      id: randomUUID(),
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      scoreA: 1,
+      scoreB: 0,
+    });
+    await insertMatch(client, {
+      id: randomUUID(),
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      format: "bo3",
+      scoreA: 2,
+      scoreB: 1,
+    });
+
+    const oldBo3 = await capturePostgresError(client, () => insertMatch(client, {
+      id: randomUUID(),
+      seasonId: fixture.seasonId,
+      entryAId: fixture.entryAId,
+      entryBId: fixture.entryBId,
+      format: "bo3",
+      scoreA: 13,
+      scoreB: 8,
+    }));
+    expect(oldBo3).toMatchObject({ code: "23514" });
+  } finally {
+    await client.query("ROLLBACK");
+  }
+}
+
+describe("match score semantics migration", () => {
+  it("backfills legacy BO1 facts, rejects malformed data before writing, and replays idempotently", async () => {
+    await withScratchDatabase("rivalhub_match_score_semantics", async (client) => {
+      const target = targetMigration();
+      await replayBefore(client, target);
+      const fixture = await insertScoreFixture(client);
+
+      await assertMigrationFailedClosed(client, fixture, target);
+      await client.query("DELETE FROM match_maps WHERE match_id IN ($1, $2)", [fixture.conflictMatchId, fixture.multipleMapsMatchId]);
+      await client.query("DELETE FROM matches WHERE id IN ($1, $2)", [fixture.conflictMatchId, fixture.multipleMapsMatchId]);
+
+      await replayMigration(client, target);
+      const normal = await client.query<{ score_a: number; score_b: number; is_forfeit: boolean }>(
+        "SELECT score_a, score_b, is_forfeit FROM matches WHERE id = $1",
+        [fixture.legacyNormalMatchId],
+      );
+      expect(normal.rows[0]).toEqual({ score_a: 1, score_b: 0, is_forfeit: false });
+      const normalMap = await client.query<{ id: string; score_a: number; score_b: number; completed_at: Date }>(
+        "SELECT id, score_a, score_b, completed_at FROM match_maps WHERE id = $1",
+        [fixture.legacyNormalMapId],
+      );
+      expect(normalMap.rows[0]?.id).toBe(fixture.legacyNormalMapId);
+      expect(normalMap.rows[0]?.score_a).toBe(13);
+      expect(normalMap.rows[0]?.score_b).toBe(8);
+      expect(normalMap.rows[0]?.completed_at.toISOString()).toBe("2026-08-01T10:00:00.000Z");
+
+      const playerStatId = randomUUID();
+      await client.query(
+        "INSERT INTO match_player_stats (id, match_id, map_id, perfect_name) VALUES ($1, $2, $3, 'Migration Player')",
+        [playerStatId, fixture.legacyNormalMatchId, fixture.legacyNormalMapId],
+      );
+      const preservedStat = await client.query<{ id: string; map_id: string }>(
+        "SELECT id, map_id FROM match_player_stats WHERE id = $1",
+        [playerStatId],
+      );
+      expect(preservedStat.rows[0]).toEqual({ id: playerStatId, map_id: fixture.legacyNormalMapId });
+
+      const canonical = await client.query<{ score_a: number; score_b: number }>(
+        "SELECT score_a, score_b FROM matches WHERE id = $1",
+        [fixture.canonicalMatchId],
+      );
+      expect(canonical.rows[0]).toEqual({ score_a: 1, score_b: 0 });
+      const forfeit = await client.query<{ score_a: number; score_b: number; is_forfeit: boolean }>(
+        "SELECT score_a, score_b, is_forfeit FROM matches WHERE id = $1",
+        [fixture.legacyForfeitMatchId],
+      );
+      expect(forfeit.rows[0]).toEqual({ score_a: 1, score_b: 0, is_forfeit: true });
+      const forfeitMaps = await client.query("SELECT id FROM match_maps WHERE id = $1", [fixture.legacyForfeitMapId]);
+      expect(forfeitMaps.rows).toHaveLength(0);
+
+      await replayMigration(client, target);
+      const replayed = await client.query<{ score_a: number; score_b: number }>(
+        "SELECT score_a, score_b FROM matches WHERE id = $1",
+        [fixture.legacyNormalMatchId],
+      );
+      expect(replayed.rows[0]).toEqual({ score_a: 1, score_b: 0 });
+      await assertConstraints(client, fixture);
+    });
+  });
+});

--- a/tests/unit/actions/match-lineup-actions.test.ts
+++ b/tests/unit/actions/match-lineup-actions.test.ts
@@ -227,12 +227,12 @@ describe("correction workflow actions", () => {
     mockedGetMatch.mockResolvedValue(FINISHED_MATCH as never);
     stubs.planResultCorrectionInTx.mockResolvedValue({ winnerChanges: true, impacts: [] });
 
-    const result = await planMatchResultCorrection("match-1", { scoreA: 13, scoreB: 4 });
+    const result = await planMatchResultCorrection("match-1", { scoreA: 1, scoreB: 0 });
 
     expect(result.success).toBe(true);
     const [txArg, args] = stubs.planResultCorrectionInTx.mock.calls[0]!;
     expect(txArg).toBe(stubs.txStub);
-    expect(args.proposal).toEqual({ scoreA: 13, scoreB: 4 });
+    expect(args.proposal).toEqual({ scoreA: 1, scoreB: 0 });
   });
 
   it("forwards confirmRecovery as an explicit boolean flag", async () => {
@@ -245,14 +245,14 @@ describe("correction workflow actions", () => {
     });
 
     const result = await applyMatchResultCorrection("match-1", {
-      scoreA: 13,
-      scoreB: 4,
+      scoreA: 1,
+      scoreB: 0,
       confirmRecovery: true,
     });
 
     expect(result.success).toBe(true);
     expect(stubs.applyResultCorrectionInTx.mock.calls[0]![1]).toMatchObject({
-      proposal: { scoreA: 13, scoreB: 4 },
+      proposal: { scoreA: 1, scoreB: 0 },
       actorId: "admin@local.test",
       confirmRecovery: true,
     });

--- a/tests/unit/actions/matches-results.test.ts
+++ b/tests/unit/actions/matches-results.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/revalidation", () => ({
 }));
 
 // ── import after mocks ─────────────────────────────────────────────────────────
-import { correctMatchScore, correctMapScore } from "@/actions/matches/results";
+import { correctMapScore } from "@/actions/matches/results";
 import { matches, matchMaps } from "@/db/schema";
 
 // ── helpers ─────────────────────────────────────────────────────────────────────
@@ -140,89 +140,6 @@ function setupTxMaps(maps: { id: string; scoreA: number; scoreB: number }[]) {
     })),
   );
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-describe("correctMatchScore — winner guard", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    matchesUpdateSetCalls.length = 0;
-    matchMapsUpdateSetCalls.length = 0;
-    txInsertValuesCalls.length = 0;
-    setupSeason();
-    setupAdminSession();
-    setupTxWriteMocks();
-  });
-
-  it("BO3 same winner correction (2:0 → 2:1) → success + audit", async () => {
-    setupMatch({ format: "bo3", scoreA: 2, scoreB: 0 });
-
-    const result = await correctMatchScore("match-1", 2, 1);
-
-    expect(result.success).toBe(true);
-    expect(matchesUpdateSetCalls).toContainEqual({
-      scoreA: 2,
-      scoreB: 1,
-      updatedAt: expect.any(Date),
-    });
-    expect(
-      txInsertValuesCalls.some(
-        (v) => (v as { action: string }).action === "match.correct_score",
-      ),
-    ).toBe(true);
-  });
-
-  it("BO3 winner-changing correction (2:1 → 1:2) → reject without writes", async () => {
-    setupMatch({ format: "bo3", scoreA: 2, scoreB: 1 });
-
-    const result = await correctMatchScore("match-1", 1, 2);
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
-      expect(result.error.message).toContain("改变比赛胜者");
-    }
-    expect(matchesUpdateSetCalls).toEqual([]);
-    expect(txInsertValuesCalls).toEqual([]);
-  });
-
-  it("BO1 same winner correction (13:8 → 16:14) → success", async () => {
-    setupMatch({ format: "bo1", scoreA: 13, scoreB: 8 });
-
-    const result = await correctMatchScore("match-1", 16, 14);
-
-    expect(result.success).toBe(true);
-    expect(matchesUpdateSetCalls).toContainEqual({
-      scoreA: 16,
-      scoreB: 14,
-      updatedAt: expect.any(Date),
-    });
-  });
-
-  it("BO1 winner-changing correction (13:8 → 8:13) → reject without writes", async () => {
-    setupMatch({ format: "bo1", scoreA: 13, scoreB: 8 });
-
-    const result = await correctMatchScore("match-1", 8, 13);
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toContain("改变比赛胜者");
-    }
-    expect(matchesUpdateSetCalls).toEqual([]);
-    expect(txInsertValuesCalls).toEqual([]);
-  });
-
-  it("BO1 illegal MR12 score still rejected (14:13)", async () => {
-    setupMatch({ format: "bo1", scoreA: 13, scoreB: 8 });
-
-    const result = await correctMatchScore("match-1", 14, 13);
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.code).toBe(ErrorCode.MATCH_INVALID_SCORE);
-    }
-    expect(matchesUpdateSetCalls).toEqual([]);
-  });
-});
 
 // ─────────────────────────────────────────────────────────────────────────────
 describe("correctMapScore — shared legality + winner guard", () => {

--- a/tests/unit/components/matches/PreMatchOperatorChecklist.test.tsx
+++ b/tests/unit/components/matches/PreMatchOperatorChecklist.test.tsx
@@ -10,14 +10,14 @@ const team = { name: "Alpha", submitted: true, confirmed: true, starters: 5, pre
 
 describe("PreMatchOperatorChecklist", () => {
   it("does not turn a non-Major match's absent preflight into a blocker", () => {
-    render(<PreMatchOperatorChecklist teamA={team} teamB={{ ...team, name: "Beta" }} mapState="not_required" />);
+    render(<PreMatchOperatorChecklist teamA={team} teamB={{ ...team, name: "Beta" }} mapState="not_recorded" />);
 
     expect(screen.getByText("可以开始比赛")).toBeInTheDocument();
     expect(screen.getAllByText(/按常规赛务流程进行/)).toHaveLength(2);
   });
 
   it("shows absent Major preflight as a server-check blocker", () => {
-    render(<PreMatchOperatorChecklist requiresPreflight teamA={team} teamB={{ ...team, name: "Beta" }} mapState="not_required" />);
+    render(<PreMatchOperatorChecklist requiresPreflight teamA={team} teamB={{ ...team, name: "Beta" }} mapState="not_recorded" />);
 
     expect(screen.getByText("当前不可开赛")).toBeInTheDocument();
     expect(screen.getByText(/Alpha 尚未完成首发资格检查/)).toBeInTheDocument();

--- a/tests/unit/components/matches/ResultCorrectionPanel.test.tsx
+++ b/tests/unit/components/matches/ResultCorrectionPanel.test.tsx
@@ -41,8 +41,8 @@ function planFixture(overrides: Partial<{
     matchId: "match-1",
     stageKey: "stage1",
     stageType: "swiss",
-    current: { scoreA: 9, scoreB: 13, isForfeit: false },
-    proposed: { scoreA: 13, scoreB: 4, isForfeit: false },
+    current: { scoreA: 0, scoreB: 1, isForfeit: false },
+    proposed: { scoreA: 1, scoreB: 0, isForfeit: false },
     currentWinnerTeamId: "team-b",
     proposedWinnerTeamId: "team-a",
     winnerChanges: true,
@@ -56,8 +56,8 @@ function planFixture(overrides: Partial<{
 
 async function fillScores(user: ReturnType<typeof userEvent.setup>) {
   const inputs = screen.getAllByPlaceholderText("比分");
-  await user.type(inputs[0]!, "13");
-  await user.type(inputs[1]!, "4");
+  await user.type(inputs[0]!, "1");
+  await user.type(inputs[1]!, "0");
 }
 
 beforeEach(() => {
@@ -128,7 +128,7 @@ describe("ResultCorrectionPanel", () => {
 
     await waitFor(() => expect(mockedApply).toHaveBeenCalled());
     expect(mockedApply.mock.calls[0]![0]).toBe("match-1");
-    expect(mockedApply.mock.calls[0]![1]).toMatchObject({ scoreA: 13, scoreB: 4, confirmRecovery: false });
+    expect(mockedApply.mock.calls[0]![1]).toMatchObject({ scoreA: 1, scoreB: 0, confirmRecovery: false });
   });
 
   it("rejects impossible score input without calling any action", async () => {

--- a/tests/unit/lib/formats/double-elim.test.ts
+++ b/tests/unit/lib/formats/double-elim.test.ts
@@ -21,12 +21,15 @@ vi.mock("@/db/client", () => ({
 
 vi.mock("@/db/schema", () => ({
   matches: { id: {}, seasonId: {}, stage: {}, status: {}, entryAId: {}, entryBId: {}, scoreA: {}, scoreB: {}, createdAt: {}, entryRound: {} },
+  matchMaps: { matchId: {}, scoreA: {}, scoreB: {} },
   seasons: { id: {}, stagePlan: {} },
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  inArray: vi.fn(),
+  isNotNull: vi.fn(),
   count: vi.fn(),
   sql: vi.fn((strings: TemplateStringsArray) => strings.join("")),
   desc: vi.fn(),

--- a/tests/unit/lib/formats/round-robin.test.ts
+++ b/tests/unit/lib/formats/round-robin.test.ts
@@ -23,12 +23,15 @@ vi.mock("@/db/client", () => ({
 
 vi.mock("@/db/schema", () => ({
   matches: { id: {}, seasonId: {}, stage: {}, status: {}, entryAId: {}, entryBId: {}, scoreA: {}, scoreB: {} },
+  matchMaps: { matchId: {}, scoreA: {}, scoreB: {} },
   competitionEntries: { id: {}, name: {}, competitionId: {}, draftOrder: {} },
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  inArray: vi.fn(),
+  isNotNull: vi.fn(),
   count: vi.fn(),
   sql: vi.fn((strings: TemplateStringsArray) => strings.join("")),
 }));
@@ -87,9 +90,9 @@ describe("roundRobinExecutor", () => {
       ]);
 
       mockMatchFindMany.mockResolvedValue([
-        { id: "m1", seasonId: "season-1", entryAId: "t1", entryBId: "t2", status: "finished", scoreA: 13, scoreB: 8, stage: "round-robin" },
-        { id: "m2", seasonId: "season-1", entryAId: "t1", entryBId: "t3", status: "finished", scoreA: 13, scoreB: 5, stage: "round-robin" },
-        { id: "m3", seasonId: "season-1", entryAId: "t2", entryBId: "t3", status: "finished", scoreA: 13, scoreB: 6, stage: "round-robin" },
+        { id: "m1", seasonId: "season-1", entryAId: "t1", entryBId: "t2", status: "finished", scoreA: 1, scoreB: 0, stage: "round-robin" },
+        { id: "m2", seasonId: "season-1", entryAId: "t1", entryBId: "t3", status: "finished", scoreA: 1, scoreB: 0, stage: "round-robin" },
+        { id: "m3", seasonId: "season-1", entryAId: "t2", entryBId: "t3", status: "finished", scoreA: 1, scoreB: 0, stage: "round-robin" },
       ]);
 
       const result = await roundRobinExecutor.getQualifiers("season-1", {

--- a/tests/unit/lib/standings.test.ts
+++ b/tests/unit/lib/standings.test.ts
@@ -16,8 +16,8 @@ function fm(overrides: Record<string, unknown> = {}): Match {
     status: "finished",
     entryAId: "t1",
     entryBId: "t2",
-    scoreA: 13,
-    scoreB: 8,
+    scoreA: 1,
+    scoreB: 0,
     format: "bo1",
     round: null,
     entryRound: null,
@@ -30,99 +30,65 @@ function fm(overrides: Record<string, unknown> = {}): Match {
   } as Match;
 }
 
-describe("calculateStandings", () => {
-  it("无比赛时按 draftOrder 排序，全队 0-0", () => {
-    const teams = [makeTeam("t2", "B队", 2), makeTeam("t1", "A队", 1)];
-    const standings = calculateStandings(teams, []);
-    expect(standings[0].teamId).toBe("t1");
-    expect(standings[0].seed).toBe(1);
-    expect(standings[0].wins).toBe(0);
-    expect(standings[0].losses).toBe(0);
-    expect(standings[1].teamId).toBe("t2");
-    expect(standings[1].seed).toBe(2);
-  });
+function mapScores(...scores: [string, number, number][]) {
+  return new Map(scores.map(([matchId, scoreA, scoreB]) => [matchId, [{ scoreA, scoreB }]]));
+}
 
-  it("单场胜负正确统计 wins/losses/netRounds/totalRoundsWon", () => {
-    const finishedMatches = [
-      fm({ entryAId: "t1", entryBId: "t2", scoreA: 13, scoreB: 8 }),
-    ];
+describe("calculateStandings", () => {
+  it("uses series scores for wins/losses and match_maps for rounds", () => {
+    const finishedMatches = [fm({ id: "m1", entryAId: "t1", entryBId: "t2", scoreA: 1, scoreB: 0 })];
     const teams = [makeTeam("t1", "A队", 1), makeTeam("t2", "B队", 2)];
-    const standings = calculateStandings(teams, finishedMatches);
+    const standings = calculateStandings(teams, finishedMatches, mapScores(["m1", 13, 8]));
     expect(standings[0].teamId).toBe("t1");
     expect(standings[0].wins).toBe(1);
     expect(standings[0].losses).toBe(0);
     expect(standings[0].netRounds).toBe(5);
     expect(standings[0].totalRoundsWon).toBe(13);
-
-    expect(standings[1].teamId).toBe("t2");
     expect(standings[1].wins).toBe(0);
     expect(standings[1].losses).toBe(1);
-    expect(standings[1].netRounds).toBe(-5);
-    expect(standings[1].totalRoundsWon).toBe(8);
   });
 
-  it("胜场优先于净胜回合排序", () => {
-    // t1 2-0, t2 1-1, t3 0-2
+  it("prioritizes wins, then map-level net rounds", () => {
     const finishedMatches = [
-      fm({ entryAId: "t1", entryBId: "t2", scoreA: 13, scoreB: 11 }),
-      fm({ entryAId: "t1", entryBId: "t3", scoreA: 13, scoreB: 11 }),
-      fm({ entryAId: "t2", entryBId: "t3", scoreA: 16, scoreB: 1 }),
+      fm({ id: "m1", entryAId: "t1", entryBId: "t2", scoreA: 1, scoreB: 0 }),
+      fm({ id: "m2", entryAId: "t1", entryBId: "t3", scoreA: 1, scoreB: 0 }),
+      fm({ id: "m3", entryAId: "t2", entryBId: "t3", scoreA: 1, scoreB: 0 }),
     ];
-    const teams = [
-      makeTeam("t1", "A队", 1),
-      makeTeam("t2", "B队", 2),
-      makeTeam("t3", "C队", 3),
-    ];
-    const standings = calculateStandings(teams, finishedMatches);
+    const teams = [makeTeam("t1", "A队", 1), makeTeam("t2", "B队", 2), makeTeam("t3", "C队", 3)];
+    const standings = calculateStandings(
+      teams,
+      finishedMatches,
+      mapScores(["m1", 13, 11], ["m2", 13, 10], ["m3", 13, 1]),
+    );
     expect(standings[0].teamId).toBe("t1");
     expect(standings[0].wins).toBe(2);
     expect(standings[2].teamId).toBe("t3");
     expect(standings[2].losses).toBe(2);
   });
 
-  it("同胜场同净胜时按总胜回合排序", () => {
-    // 两队都只打了一场，都是 1-0 +5 净胜，但 t1 16 回合胜 > t3 13 回合胜
+  it("uses total map rounds and head-to-head only after wins/net rounds", () => {
     const finishedMatches = [
-      fm({ entryAId: "t1", entryBId: "t2", scoreA: 16, scoreB: 3 }),
-      fm({ entryAId: "t3", entryBId: "t4", scoreA: 13, scoreB: 8 }),
+      fm({ id: "m1", entryAId: "t1", entryBId: "t2", scoreA: 1, scoreB: 0 }),
+      fm({ id: "m2", entryAId: "t1", entryBId: "t3", scoreA: 0, scoreB: 1 }),
+      fm({ id: "m3", entryAId: "t2", entryBId: "t3", scoreA: 1, scoreB: 0 }),
     ];
-    const teams = [
-      makeTeam("t1", "A队", 1),
-      makeTeam("t2", "B队", 2),
-      makeTeam("t3", "C队", 3),
-      makeTeam("t4", "D队", 4),
-    ];
-    const standings = calculateStandings(teams, finishedMatches);
-    // t1 和 t3 都是 1-0，但 t1 totalRoundsWon=16 > t3=13
-    expect(standings[0].teamId).toBe("t1");
-    expect(standings[0].totalRoundsWon).toBe(16);
-    expect(standings[1].teamId).toBe("t3");
-    expect(standings[1].totalRoundsWon).toBe(13);
-  });
-
-  it("相互战绩打破平局", () => {
-    // t1 和 t2 都是 1-1，但 t1 赢了 t2
-    const finishedMatches = [
-      fm({ entryAId: "t1", entryBId: "t2", scoreA: 13, scoreB: 11 }), // t1 wins h2h
-      fm({ entryAId: "t1", entryBId: "t3", scoreA: 8, scoreB: 13 }),  // t1 loses
-      fm({ entryAId: "t2", entryBId: "t3", scoreA: 13, scoreB: 8 }),  // t2 wins
-    ];
-    const teams = [
-      makeTeam("t1", "A队", 1),
-      makeTeam("t2", "B队", 2),
-      makeTeam("t3", "C队", 3),
-    ];
-    const standings = calculateStandings(teams, finishedMatches);
-    // t2 +3, t3 0, t1 -3 → t2 #1, t3 #2, t1 #3
+    const teams = [makeTeam("t1", "A队", 1), makeTeam("t2", "B队", 2), makeTeam("t3", "C队", 3)];
+    const standings = calculateStandings(
+      teams,
+      finishedMatches,
+      mapScores(["m1", 13, 11], ["m2", 8, 13], ["m3", 13, 8]),
+    );
     expect(standings[0].teamId).toBe("t2");
     expect(standings[1].teamId).toBe("t3");
     expect(standings[2].teamId).toBe("t1");
   });
 
-  it("无已完成比赛时按 draftOrder 排序", () => {
-    const teams = [makeTeam("t1", "A队", 1), makeTeam("t2", "B队", 2)];
-    const standings = calculateStandings(teams, []);
-    expect(standings[0].wins).toBe(0);
-    expect(standings[1].wins).toBe(0);
+  it("falls back to draftOrder when there are no completed matches", () => {
+    const teams = [makeTeam("t2", "B队", 2), makeTeam("t1", "A队", 1)];
+    const standings = calculateStandings(teams, [], new Map());
+    expect(standings[0].teamId).toBe("t1");
+    expect(standings[0].seed).toBe(1);
+    expect(standings[1].teamId).toBe("t2");
+    expect(standings[1].seed).toBe(2);
   });
 });


### PR DESCRIPTION
## Before / After

Before:
- BO1 `matches.scoreA/scoreB` 表示单图回合比分，`match_maps` 可能没有比分。

After:
- `matches.scoreA/scoreB` 在 BO1、BO3、BO5 中统一表示官方系列赛比分。
- `match_maps.scoreA/scoreB` 在所有 format 中统一表示实际地图回合比分。

## 变更

- BO1、BO3、BO5 的正常结果统一通过 `MapByMapInput → recordMapResult()` 写入实际地图回合事实，并从已完成地图推导系列赛比分；`ScoreInput` 仅保留 scheduled 状态控制。
- `validateMapScore()` 负责 MR12 单图比分，`validateSeriesScore()` 只接受系列赛比分；普通地图修正由 `correctMapScore()` 负责。
- 弃赛使用对应 format 的官方系列赛胜场阈值，保留已经完成的真实地图、清理 pending 地图，并且不创建虚构地图。
- `matches` 与 `match_maps` 固化比分成对完整性检查，`matches` 固化按 format 的系列赛比分形态检查。
- 统计与积分榜的回合事实统一来自 `match_maps.scoreA + match_maps.scoreB`。

## Legacy data migration

- active Drizzle migration `0037_match_score_semantics` 先执行 fail-closed preflight，再规范历史数据：旧 BO1 正常赛果把原 `matches` 回合比分回填至原 map row 并转成 `1:0 / 0:1`；旧 BO1 弃赛转成官方系列赛比分且不创建 map；migration replay 幂等。
- production/staging 数据变更由该 active migration 在 PR 合入后的受保护 release workflow 执行，本 PR 携带完整数据迁移与约束变更。

## Verification

- Real PostgreSQL：`pnpm test:integration`，29 个文件 / 39 个测试通过，包含正常 BO1、BO3、BO5、地图修正、弃赛、migration replay 与 DB constraints。
- `pnpm test`：197 个文件 / 1258 个测试通过。
- `pnpm type-check`
- `pnpm lint`
- `pnpm db:check`
- `pnpm exec drizzle-kit check --config=drizzle.config.ts`
- `pnpm knip` / `pnpm knip --production`：exit 0。
- `env -u DATABASE_URL pnpm build`
- 浏览器 E2E 由 CI 的 system Chrome lane 执行；本机 runner 未预装 bundled Chromium，未将本地 E2E 作为通过证据。

## Downstream

落地后，`#421` 可将 `match_maps.scoreA + match_maps.scoreB` 作为唯一正常 rounds source，并移除 match-level rounds fallback。

## Changeset

- `.changeset/match-score-semantics.md`

Refs #421
