### PR TITLE
ci: 统一 pnpm 与 Node runtime bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 11.25.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24.x
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          require-lockfile: true
 
       - name: Run static task
         run: |
@@ -113,16 +107,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 11.25.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24.x
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          require-lockfile: true
       - name: Fetch production stable lineage
         run: git fetch origin main --tags
       - name: Measure PostgreSQL readiness
@@ -162,16 +150,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 11.25.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24.x
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          require-lockfile: true
       - run: pnpm db:local:start-services
       - run: pnpm db:local:bootstrap-services
       - run: pnpm db:local:verify-supabase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,16 +60,10 @@ jobs:
           fi
           echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 11.25.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          require-lockfile: true
 
       - name: Install pinned Vercel CLI
         run: pnpm add --global vercel@59.10.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -34,16 +34,10 @@ jobs:
           echo "Requested ref: $REQUESTED_REF"
           echo "Checked-out commit: $(git rev-parse HEAD)"
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          version: 11.25.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 24.x
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+          cache: true
+          require-lockfile: true
 
       - name: Start Local PostgreSQL for migration replay
         run: pnpm db:local:start-db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@
 - `dev` 合入且 Issue 验收条件已经满足后，Issue 才可关闭；如果验收仍包含 production、真实运营、外部配置或其它 merge 后动作，应保持 open 并记录剩余条件。创建 PR 本身不关闭 Issue。
 - release tag 只有在对应 release commit 已进入 `main` 后创建；production migration、exact-tag deployment 和 smoke 的顺序以 [`docs/deployment.md`](docs/deployment.md) 与 protected workflow 为准。
 
+### 本地 Node/pnpm runtime
+
+`packageManager`、`devEngines.runtime` 和 `engines.node` 共同声明仓库的 pnpm 11.25.0 / Node 24.x contract。pnpm 11 会在 `pnpm install` 时解析 `devEngines.runtime`，并将所需 Node runtime 记录为 `pnpm-lock.yaml` 中的 `node@runtime` 条目；首次安装或清空 pnpm runtime cache 时需要联网下载，后续安装复用缓存。不要删除该 lockfile 条目，也不要把 Node/pnpm 版本重新写回 workflow 私有常量；GitHub Actions 的 `pnpm/setup` 会从同一 manifest 接管 runtime、cache 和 frozen install。
+
 ## 验证与提交前检查
 
 按变更范围选择 [`docs/testing.md`](docs/testing.md) 中的 evidence。至少检查完整 diff、未跟踪文件、敏感信息、临时产物和 active migration 归属；不要用视觉 demo 或 PR 文案替代运行时证据。

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "type-check:app": "next typegen && tsc -p tsconfig.app.json --noEmit",
     "type-check:tests": "tsc -p tsconfig.tests.json --noEmit",
     "type-check:scripts": "tsc -p tsconfig.scripts.json --noEmit",
-    "type-check": "corepack pnpm type-check:app && corepack pnpm type-check:tests && corepack pnpm type-check:scripts",
-    "check": "corepack pnpm type-check && corepack pnpm lint && corepack pnpm db:check && corepack pnpm test",
-    "verify": "corepack pnpm check && corepack pnpm build",
+    "type-check": "pnpm type-check:app && pnpm type-check:tests && pnpm type-check:scripts",
+    "check": "pnpm type-check && pnpm lint && pnpm db:check && pnpm test",
+    "verify": "pnpm check && pnpm build",
     "verify:local": "tsx scripts/db/local.ts verify-local",
     "db:generate": "drizzle-kit generate",
-    "db:check": "corepack pnpm db:migration-risk && drizzle-kit check",
+    "db:check": "pnpm db:migration-risk && drizzle-kit check",
     "db:migration-risk": "tsx scripts/db/migration-risk.ts",
     "db:release-compat": "tsx scripts/db/release-compat.ts",
     "db:push": "tsx scripts/db/block-drizzle-push.ts",
@@ -109,6 +109,13 @@
     "vitest": "4.1.11"
   },
   "packageManager": "pnpm@11.25.0",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.x",
+      "onFail": "download"
+    }
+  },
   "engines": {
     "node": "24.x"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "corepack pnpm dev:local",
+    command: "pnpm dev:local",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       knip:
         specifier: ^6.34.0
         version: 6.34.0
+      node:
+        specifier: runtime:24.x
+        version: runtime:24.20.0
       pg:
         specifier: ^8.23.0
         version: 8.23.0
@@ -3936,6 +3939,138 @@ packages:
   node-releases@2.0.54:
     resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
+
+  node@runtime:24.20.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-FLW9etQKtfRxX7Ti+WSFjYINlCX+KR09ZfmJJua4nB4=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-QOVgfl7LPbkZJyN3baLXXZZiYPx0p6nnMcG9Z92pa8g=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-nlsmRM8Qe++2rvymdrltMpa8EBOAlvAi7TeNYjPtgfQ=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-NRVgPiSHh5o5vHVxbxoq/9AnUAxkulDoRc9yyzMhkBM=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-pzSzbI0dFs5FXA65wymwfdEhwshVQ1UGSphhvJbDrcw=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-2MIktG7wHweKUj2bfbeSgjBvrigemGoVotv/6UfFMB4=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-1ubRu7mtSssW1YC4m+ipyafkkJJuk708MKINRuFSv4o=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-hV1YH4pOsagRfjQm3iX+AncFkv68+zE2mu4f+/7p6Ow=
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-McZ5l0TeilRgFkMJgEDGjDaX5WyU5AfWHQ5fpfNBkdc=
+            prefix: node-v24.20.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-bKyf+8qPakcJHktcdy4GBgScOHHLZ9kAwM7d5jDlRbo=
+            prefix: node-v24.20.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.20.0/node-v24.20.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-LIxQfMsPIIEtlSa6jKRUsWUqre9o/IutBvB/sRIt0e8=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-muE5n+9L2JkOFXc84TJ7M2oguel9jHVJ9PQspzxD9WI=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.20.0/node-v24.20.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.20.0
+    hasBin: true
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -8602,6 +8737,8 @@ snapshots:
       semver: 6.3.1
 
   node-releases@2.0.54: {}
+
+  node@runtime:24.20.0: {}
 
   nwsapi@2.2.23: {}
 

--- a/scripts/db/local.ts
+++ b/scripts/db/local.ts
@@ -19,7 +19,7 @@ const drizzleBin = resolve(projectRoot, `node_modules/.bin/drizzle-kit${binSuffi
 const tsxBin = resolve(projectRoot, `node_modules/.bin/tsx${binSuffix}`);
 const nextBin = resolve(projectRoot, `node_modules/.bin/next${binSuffix}`);
 const playwrightBin = resolve(projectRoot, `node_modules/.bin/playwright${binSuffix}`);
-const corepackBin = process.platform === "win32" ? "corepack.cmd" : "corepack";
+const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 // Keep only the services exercised by Auth, Storage, PostgREST and browser E2E.
 // These names are the Supabase CLI's current --exclude values.
 const MINIMAL_SUPABASE_EXCLUDES =
@@ -266,7 +266,7 @@ function verifyLocalWorkflow(): void {
   migrateLocalDatabase();
   seedLocalDatabase();
   verifyLocalStack();
-  run(corepackBin, ["pnpm", "run", "verify"], { env: sanitizedEnvironment() });
+  run(pnpmBin, ["run", "verify"], { env: sanitizedEnvironment() });
   runLocalIntegrationSuite([]);
   runLocalE2E([]);
 }

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -3,12 +3,80 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const projectRoot = resolve(process.cwd());
+const PNPM_SETUP_SHA = "703c52620218391530e48b9e8870d5c0082e1b9b";
 
 function readProjectFile(path: string): string {
   return readFileSync(resolve(projectRoot, path), "utf8");
 }
 
+function readPackageManifest(): {
+  packageManager?: string;
+  engines?: { node?: string };
+  devEngines?: { runtime?: { name?: string; version?: string; onFail?: string } };
+  scripts?: Record<string, string>;
+} {
+  return JSON.parse(readProjectFile("package.json")) as {
+    packageManager?: string;
+    engines?: { node?: string };
+    devEngines?: { runtime?: { name?: string; version?: string; onFail?: string } };
+    scripts?: Record<string, string>;
+  };
+}
+
+function readWorkflowJob(workflow: string, jobName: string): string {
+  const match = workflow.match(new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  [a-z][\\w-]*:\\n|$)`));
+  if (!match) throw new Error(`workflow job not found: ${jobName}`);
+  return match[1];
+}
+
+function expectPnpmSetup(workflow: string, jobNames: string[]): void {
+  expect(workflow).not.toContain("pnpm/action-setup");
+  expect(workflow).not.toContain("actions/setup-node");
+  expect(workflow).not.toContain("pnpm install --frozen-lockfile");
+  expect(workflow.match(/uses: pnpm\/setup@[0-9a-f]{40}/g) ?? []).toHaveLength(jobNames.length);
+
+  for (const jobName of jobNames) {
+    const job = readWorkflowJob(workflow, jobName);
+    expect(job).toContain(`uses: pnpm/setup@${PNPM_SETUP_SHA} # v2.1.0`);
+    expect(job).toContain("cache: true");
+    expect(job).toContain("require-lockfile: true");
+    expect(job).not.toContain("version: 11.25.0");
+    expect(job).not.toContain("node-version:");
+  }
+}
+
 describe("deployment and operations contracts", () => {
+  it("keeps pnpm and Node runtime ownership in the package manifest", () => {
+    const manifest = readPackageManifest();
+
+    expect(manifest.packageManager).toBe("pnpm@11.25.0");
+    expect(manifest.engines?.node).toBe("24.x");
+    expect(manifest.devEngines?.runtime).toEqual({
+      name: "node",
+      version: "24.x",
+      onFail: "download",
+    });
+    expect(Object.values(manifest.scripts ?? {}).some((script) => script.includes("corepack pnpm"))).toBe(false);
+    expect(readProjectFile("scripts/db/local.ts")).not.toContain("corepack");
+    expect(readProjectFile("playwright.config.ts")).not.toContain("corepack");
+    expect(readProjectFile("pnpm-lock.yaml")).toMatch(
+      /node:\n\s+specifier: runtime:24\.x\n\s+version: runtime:24\.\d+\.\d+/,
+    );
+  });
+
+  it("uses the pinned pnpm/setup owner only in dependency-bearing CI jobs", () => {
+    const ci = readProjectFile(".github/workflows/ci.yml");
+    const staging = readProjectFile(".github/workflows/staging.yml");
+    const release = readProjectFile(".github/workflows/release.yml");
+
+    expectPnpmSetup(ci, ["static", "postgres", "system"]);
+    expectPnpmSetup(staging, ["staging"]);
+    expectPnpmSetup(release, ["release"]);
+    expect(readWorkflowJob(ci, "plan")).not.toContain("pnpm/setup");
+    expect(readWorkflowJob(ci, "ci-gate")).not.toContain("pnpm/setup");
+    expect(readWorkflowJob(ci, "dependency-review")).not.toContain("pnpm/setup");
+  });
+
   it("declares the single Vercel Function region and disables only main Git deployment", () => {
     const config = JSON.parse(readProjectFile("vercel.json")) as {
       buildCommand?: string;


### PR DESCRIPTION
## 摘要

Refs #429

- 在 `package.json` 中集中声明 pnpm 11.25.0、Node 24.x 与 `devEngines.runtime`，并生成对应 runtime lockfile entry。
- 将 `ci.yml`、`staging.yml`、`release.yml` 的依赖型 job 统一迁移到 SHA pinned `pnpm/setup` v2.1.0，由 action 接管 runtime、cache 与 frozen install。
- 保留 `plan`、`ci-gate`、dependency-review 的轻量语义，移除 package/local/Playwright 路径中无必要的 `corepack pnpm` 二次 launcher。
- 增加 workflow/runtime structural regression tests，并记录本地 pnpm 11 的 runtime cache/install 语义。

## 验证

- `tests/unit/release/runtime-contract.test.ts`、`tests/unit/ci/plan.test.mjs`、`tests/unit/ci/gate.test.mjs`：34 passed
- `tsc -p tsconfig.scripts.json --noEmit`：passed
- `tsc -p tsconfig.tests.json --noEmit`：passed
- targeted ESLint：passed；完整 ESLint：passed
- `scripts/db/migration-risk.ts`：无 active migration 变化
- `drizzle-kit check`：passed
- 本地全量 Vitest 受现有超时/组件基线失败影响，未改动相关源码；最终以 GitHub FULL CI 为 required evidence
- 无需 changeset：仅 CI/dev infrastructure，不改变 shipped runtime 或用户行为

## 性能证据

最终 PR head：`e2996f8d1bdf9be46bb7487ac4117d4ab7040c22`；GitHub Actions `CI` run `33883897443` 的 3 次 fresh FULL attempt 均成功。setup/install 为所有依赖型 job 的 `pnpm/setup` step fan-out，static 为所有 static job 的 `Run static task` fan-out；PostgreSQL、system/E2E 为对应 job wall，FULL 为该 attempt 的 workflow wall：

| attempt | setup/install | static | PostgreSQL | system / E2E step | FULL workflow |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 26s | 61s | 67s | 168s / 38s | 195s (3m15s) |
| 2 | 24s | 61s | 63s | 158s / 37s | 183s (3m03s) |
| 3 | 38s | 40s | 75s | 152s / 35s | 175s (2m55s) |

第三次 attempt 的 raw log 确认 `pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b` 实际收到 `cache: true`、`require-lockfile: true`，并自动完成 Node 24.20.0、pnpm 11.25.0 与 `pnpm install --frozen-lockfile --no-runtime`；三次 FULL 墙钟均低于 4 分钟。

required CI checks 已在该 final head 全绿；PR 保持 Ready for review，等待评审，不执行合并。
