### PR TITLE
[2.x] 收敛为单一 main 主干

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   merge_group:
   release:
     types: [published]

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,7 +6,7 @@ on:
       ref:
         description: "要验证并用于 staging rehearsal 的 branch、tag 或 commit"
         required: true
-        default: dev
+        default: main
         type: string
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,18 @@
 
 ## Branch、Issue 与 PR
 
-- `main` 是 production branch，`dev` 是 integration/staging branch。常规工作从最新 `dev` 创建 `feat/*`、`fix/*` 或 `docs/*` 分支，PR base 为 `dev`；production hotfix 从 `main` 开始并回同步到 `dev`。`main`/`dev` 不 force-push、不删除。
+- `main` 是唯一长期 integration / releasable trunk；常规工作与 hotfix 都从最新 `main` 创建 `feat/*`、`fix/*` 或 `docs/*` 分支，PR base 为 `main`。所有 PR 只允许 squash merge；`main` 不直接 push、不 force-push 或删除。`vX.Y.Z` tag 才是 immutable shipped production identity，普通 `main` merge 不等于 Production deploy。
 - 2.x Issue 标题使用 `[2.x] <问题或目标>`；开放 Issue 必须且只能有一个 `priority:P0`–`priority:P3` label。计划性工作使用现有类型 label；milestone/assignee 只有存在真实 release boundary 或明确 owner 时设置。
 - Issue 最小结构是背景 → 目标 → 验收；只有能限定实现时才增加范围、非目标或关联。通过 API/agent 创建或修改 Issue 时显式设置 title 和 labels，不能假设 UI form 自动补齐。
 - PR 标题、正文、Changeset 摘要和 release note 默认使用中文，必要的代码名、字段名、协议名和库名保留英文。PR 关联 Issue 使用 `Refs #N`，不要用 `Closes` 代替验收判断。
-- `dev` PR 依赖自动化 `ci-gate`；普通 PR 不以第二人 approval 作为仓库质量策略。规则是否实际生效以 GitHub ruleset 为准，而不是只看本文件。
+- `main` PR 依赖 strict up-to-date 的自动化 `ci-gate` 与已解决的 review thread；普通 PR 不以第二人 approval 作为仓库质量策略。规则是否实际生效以 GitHub ruleset 为准，而不是只看本文件。
 
 ## Changeset、合并与 release
 
 - 影响用户/管理员体验、production runtime/data contract 或版本发布的 feat/fix/refactor/migration/security 变更，在同一个 feature PR 提交中文 `.changeset/*.md`。纯文档、纯测试、CI/开发工具和不改变 shipped runtime/用户行为的 development-only 依赖维护可不写，并在 PR 中说明“无需 changeset”及原因。
 - Changeset 面向 release/CHANGELOG 描述用户可观察影响；不要把内部实现细节或 commit message 原样当 release note。不要手改 `package.json` version；版本、CHANGELOG 和 release path 按 Changesets 与 release skill 处理。
-- `dev` 合入且 Issue 验收条件已经满足后，Issue 才可关闭；如果验收仍包含 production、真实运营、外部配置或其它 merge 后动作，应保持 open 并记录剩余条件。创建 PR 本身不关闭 Issue。
-- release tag 只有在对应 release commit 已进入 `main` 后创建；production migration、exact-tag deployment 和 smoke 的顺序以 [`docs/deployment.md`](docs/deployment.md) 与 protected workflow 为准。
+- `main` 合入且 Issue 验收条件已经满足后，Issue 才可关闭；如果验收仍包含 production、真实运营、外部配置或其它 merge 后动作，应保持 open 并记录剩余条件。创建 PR 本身不关闭 Issue。
+- release branch 从最新 `main` 创建，消费 Changesets 并完成 CHANGELOG editorial review 后通过 PR squash 回 `main`。release tag 只有在对应实际 `main` release commit 已进入历史后创建；production migration、exact-tag deployment 和 smoke 的顺序以 [`docs/deployment.md`](docs/deployment.md) 与 protected workflow 为准。stable tag 创建后不可移动或删除，GitHub Release 发布后其 tag 与 assets 同样保持不可变。
 
 ### 本地 Node/pnpm runtime
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,11 +5,11 @@
 | 环境 | 用途 | 数据库规则 |
 |---|---|---|
 | local | 开发、migration/fixture 验证、并发与破坏性测试 | 仅 loopback Local Supabase，由 `db:local:*` 注入 |
-| preview | `dev`、feature branch、PR 和 release branch 的应用预览 | 由 Vercel Git Preview 提供；不授予 staging 数据库写入权限 |
+| preview | feature branch、PR 和 release branch 的应用预览 | 由 Vercel Git Preview 提供；不授予 staging 数据库写入权限 |
 | staging | 受保护的 migration rehearsal 与 schema verification | 独立 Supabase project，由手动 GitHub Environment workflow 访问 |
 | production | 正式赛事与真实用户 | 只做真实赛事所需操作；不运行 destructive rehearsal |
 
-`dev` 或 Vercel Preview 不自动证明数据库隔离。**Preview ≠ staging DB authorization**：必须确认 target Vercel environment 和 Supabase project，才可在 staging 执行 seed、migration rehearsal、写入型 E2E 或赛事模拟。
+Vercel Preview 不自动证明数据库隔离。**Preview ≠ staging DB authorization**：必须确认 target Vercel environment 和 Supabase project，才可在 staging 执行 seed、migration rehearsal、写入型 E2E 或赛事模拟。
 
 ## Vercel deployment contract
 
@@ -17,7 +17,7 @@ Repository-level Vercel Functions region 固定为 `hnd1`，与 production 当�
 
 ### Preview
 
-`dev`、feature branch、PR 和 release branch 继续通过 Vercel Git Integration 创建 Preview deployment。`vercel.json` 只关闭 `main` branch 的 Git auto-deployment，未声明的 branch 继续使用默认开启语义；GitHub Integration、PR Preview 与 CLI deployment 均保留。
+feature branch、PR 和 release branch 继续通过 Vercel Git Integration 创建 Preview deployment。`vercel.json` 只关闭 `main` branch 的 Git auto-deployment，未声明的 branch 继续使用默认开启语义；GitHub Integration、PR Preview 与 CLI deployment 均保留。
 
 ### Production
 
@@ -36,7 +36,7 @@ release commit 合入 main
 
 ### Staging
 
-应用 Preview 不会自动部署或迁移 staging。需要真实 staging rehearsal 时，人工触发 [`.github/workflows/staging.yml`](../.github/workflows/staging.yml) 的 `workflow_dispatch`，并使用 `ref` input 指定 branch、tag 或 commit（默认 `dev`）。workflow 会记录实际 checkout 的 commit SHA，在 GitHub `staging` Environment 保护下执行：
+应用 Preview 不会自动部署或迁移 staging。需要真实 staging rehearsal 时，人工触发 [`.github/workflows/staging.yml`](../.github/workflows/staging.yml) 的 `workflow_dispatch`，并使用 `ref` input 指定 branch、tag 或 commit（默认 `main`）。workflow 会记录实际 checkout 的 commit SHA，在 GitHub `staging` Environment 保护下执行：
 
 ```text
 checkout requested ref
@@ -46,7 +46,7 @@ checkout requested ref
 → always stop Local PostgreSQL
 ```
 
-`db:staging:migrate` 内部已经负责 `drizzle check`、Local migration replay、Local verify、protected staging migrate 和 staging verify；workflow 不复制 migration algorithm、不执行 seed、reset 或 `db:push`。GitHub `staging` Environment 需要提供 `RIVALHUB_STAGING_DB_PASSWORD`；project confirmation 固定使用 `cueazphyskstwdhnzsxx`，写入必须由 `RIVALHUB_ALLOW_REMOTE_DB_WRITE=staging` 显式授权。该 workflow 只准备和验证 staging DB，不创建 staging app deployment，也不形成自动 `dev → staging → production` promotion pipeline。
+`db:staging:migrate` 内部已经负责 `drizzle check`、Local migration replay、Local verify、protected staging migrate 和 staging verify；workflow 不复制 migration algorithm、不执行 seed、reset 或 `db:push`。GitHub `staging` Environment 需要提供 `RIVALHUB_STAGING_DB_PASSWORD`；project confirmation 固定使用 `cueazphyskstwdhnzsxx`，写入必须由 `RIVALHUB_ALLOW_REMOTE_DB_WRITE=staging` 显式授权。该 workflow 只准备和验证 staging DB，不创建 staging app deployment，也不形成自动 `main → staging → production` promotion pipeline。
 
 ## Local Supabase
 
@@ -100,9 +100,9 @@ CREATE INDEX ...;
 
 `contract-cleanup` 只接受 `DROP`、rename、`ALTER TYPE`/`ALTER COLUMN TYPE` 与 `SET NOT NULL`；`locking-reviewed` 只接受 `rewrite-or-exclusive-lock`（例如非 concurrent `CREATE INDEX` 与 `ADD CONSTRAINT`）。annotation category 错配或缺失都会 fail closed。注释只记录风险策略、阶段和原因，不自动证明安全；带风险的 migration 仍须通过 Local/real-PG replay、必要的 staging rehearsal 与 production preflight。active Drizzle ledger 仍是唯一 migration authority，checker 不建立 shadow migration system。明显 blocking risk 的 SQL 可以在经过验证的 SQL/session 中显式设置 bounded `lock_timeout` 或 `statement_timeout`，但本仓库不向 Drizzle URL 猜测性注入全局 timeout。
 
-本地要复现 CI 的 changed-surface 判定，应显式使用当前 `dev` 基线，例如：`RIVALHUB_MIGRATION_BASE_SHA=$(git merge-base HEAD origin/dev) RIVALHUB_MIGRATION_HEAD_SHA=HEAD pnpm db:migration-risk`。CI 在 checkout 完整历史后传入 PR base/head SHA；没有 active migration 变化时，checker 明确输出 no changed active migrations。
+本地要复现 CI 的 changed-surface 判定，应显式使用当前 `main` 基线，例如：`RIVALHUB_MIGRATION_BASE_SHA=$(git merge-base HEAD origin/main) RIVALHUB_MIGRATION_HEAD_SHA=HEAD pnpm db:migration-risk`。CI 在 checkout 完整历史后传入 PR base/head SHA；没有 active migration 变化时，checker 明确输出 no changed active migrations。
 
-`pnpm db:release-compat` 是独立于 `db:migration-risk` 的 N/N+1 兼容性门禁。它解析的是 actual previous production stable，而不是 candidate branch 的最高 ancestor tag：若设置 `RIVALHUB_PREVIOUS_RELEASE_TAG`，该值必须是可解析的 stable `vX.Y.Z` tag；空值、raw revision、无效 tag 与 `-rc` 等 prerelease 都直接 fail closed。未显式指定时，CI/release 将 `RIVALHUB_PRODUCTION_STABLE_REF` 设为 `origin/main`，resolver 在该 production lineage 上按 semver 选择早于 candidate 的最新 stable tag；显式提供的 production ref 为空或不可解析时同样 fail closed。candidate 的 tag commit 不要求是 candidate HEAD 的 ancestor，也没有静默退回 ancestor tag 的路径。CI 与 release workflow 都在 gate 前取得完整的 `origin/main`/tag history。PR CI 通过 `RIVALHUB_MIGRATION_BASE_SHA` / `RIVALHUB_MIGRATION_HEAD_SHA` 仅限定 candidate changed surface；release tag workflow 在没有这两个覆盖值时，以 previous production stable commit 到 candidate HEAD 的 active migration surface 复核一次。需要 source 证明时，checker 只读取 previous stable tag 中的 `src/db/schema/**`、`src/actions/**`、`src/lib/**`、`src/app/**`、`src/components/**` 与 `scripts/**`，并输出 migration `path:line` 及 previous source `path:line` evidence。
+`pnpm db:release-compat` 是独立于 `db:migration-risk` 的 N/N+1 兼容性门禁。它解析的是 single-trunk 上实际的 previous production stable，而不是 candidate branch 上偶然可见的最高 tag：若设置 `RIVALHUB_PREVIOUS_RELEASE_TAG`，该值必须是可解析的 stable `vX.Y.Z` tag；空值、raw revision、无效 tag 与 `-rc` 等 prerelease 都直接 fail closed。未显式指定时，CI/release 将 `RIVALHUB_PRODUCTION_STABLE_REF` 设为 `origin/main`，resolver 在该 main lineage 上按 semver 选择早于 candidate 的最新 stable tag；显式提供的 production ref 为空或不可解析时同样 fail closed。release retry 的 candidate tag 必须是实际 checkout commit，也没有静默退回其它 tag 的路径。CI 与 release workflow 都在 gate 前取得完整的 `origin/main`/tag history。PR CI 通过 `RIVALHUB_MIGRATION_BASE_SHA` / `RIVALHUB_MIGRATION_HEAD_SHA` 仅限定 candidate changed surface；release tag workflow 在没有这两个覆盖值时，以 previous production stable commit 到 candidate HEAD 的 active migration surface 复核一次。需要 source 证明时，checker 只读取 previous stable tag 中的 `src/db/schema/**`、`src/actions/**`、`src/lib/**`、`src/app/**`、`src/components/**` 与 `scripts/**`，并输出 migration `path:line` 及 previous source `path:line` evidence。
 
 DROP/RENAME 的 relation、column、type owner 若仍被 previous stable shipped code 以 Drizzle schema/property 或带 table context 的 SQL 使用则拒绝；migration-risk annotation 只表示 cleanup 意图，不能绕过该证明。`ALTER TYPE` 与 `SET NOT NULL` 第一版始终 fail closed；`rewrite-or-exclusive-lock` 仍由 migration-risk 和 migration review 负责，不被误当作 app contract 证明。无法安全解析 owner 或无法判断 schema context 时同样拒绝猜测。
 
@@ -115,7 +115,7 @@ Release N+2: previous stable 已不再读写 old owner 后才允许 contract
 
 ### Protected staging migration
 
-`pnpm db:staging:migrate` 和 `pnpm db:staging:verify` 只服务受保护的 `rivalhub-dev` staging workflow。命令拒绝继承 `DATABASE_URL` 或 `.env.local`，并对 project ref、Transaction Pooler shape 和写入授权 fail closed。
+`pnpm db:staging:migrate` 和 `pnpm db:staging:verify` 只服务受保护的 staging workflow。命令拒绝继承 `DATABASE_URL` 或 `.env.local`，并对 project ref、Transaction Pooler shape 和写入授权 fail closed。
 
 ```bash
 # Read-only ledger and schema verification

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,7 +91,7 @@ v2.0 stable 的目标不是把整个 2.x backlog 一次完成，而是形成一�
 - active Drizzle migrations 是唯一 migration authority；
 - stable 发布必须验证真实前序版本到当前 schema 的升级路径，而不只验证 fresh database；
 - release commit、production migration、smoke、tag 与 GitHub Release 按仓库 release 规则执行；
-- 已进入 `dev` 但仍保持 Open 的 release-gate Issue，在对应变更进入 `main` / release convergence 后统一关闭。
+- 已进入 `main` 但仍保持 Open 的 release-gate Issue，在对应 stable release 完成后统一关闭。
 
 ## 2.x 产品主线
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,7 +65,7 @@ pnpm verify:local
 
 CI 的 `postgres` job 使用官方 `postgres:17` service container，不启动 Supabase CLI 或任何 Auth、Storage、Kong、PostgREST、Studio、Realtime 等服务；`scripts/db/prepare-pg17.ts` 只在 vanilla PostgreSQL 缺少时建立 `anon` 与 `authenticated` 两个 `NOLOGIN` 角色，并验证 `gen_random_uuid()`，不修改 active migrations。随后 `test:integration:pg17` 回放完整 active chain、seed、fixture、`verify-db`、worker clone 和完整 integration suite；其中 `database-access-boundary.test.ts` 回放 0034，验证 64 张 public base table 的 matrix、trusted server bracket CRUD 以及 anon/authenticated bracket SELECT/INSERT/UPDATE/DELETE 的 `42501` 拒绝。开发者的 `db:local:start-db` 仍保留为 Local Supabase 兼容入口，不是 CI migration authority。
 
-PostgreSQL CI 在现有 service container 中按 `db:check → db:release-compat → test:integration:pg17` 执行；release workflow 在 production migrate 前再次执行 `db:release-compat`，不创建重复的 PostgreSQL/Supabase job。`tests/unit/db/release-compat.test.ts` 使用临时 git repository、stable/prerelease tags、previous source 与 candidate migration 覆盖 DROP/RENAME owner 依赖、production lineage 与 release/dev diverged topology、explicit stable tag 的 fail-closed 解析、annotation 不得绕过、ALTER TYPE/SET NOT NULL fail closed、additive/no-change pass 与可定位 evidence 输出。`tests/unit/db/migration-risk.test.ts` 同时覆盖 contract/locking annotation 的 category 匹配、缺失/错配拒绝和 file/line/category 输出。
+PostgreSQL CI 在现有 service container 中按 `db:check → db:release-compat → test:integration:pg17` 执行；release workflow 在 production migrate 前再次执行 `db:release-compat`，不创建重复的 PostgreSQL/Supabase job。`tests/unit/db/release-compat.test.ts` 使用临时 git repository、stable/prerelease tags、previous source 与 candidate migration 覆盖 DROP/RENAME owner 依赖、single-main/tag topology、explicit stable tag 的 fail-closed 解析、annotation 不得绕过、ALTER TYPE/SET NOT NULL fail closed、additive/no-change pass 与可定位 evidence 输出。`tests/unit/db/migration-risk.test.ts` 同时覆盖 contract/locking annotation 的 category 匹配、缺失/错配拒绝和 file/line/category 输出。
 
 ## PR CI graph
 
@@ -80,7 +80,7 @@ plan → static ─┐
 
 `static` matrix 当前包含 type-check、lint、unit、build 与 `dead-code`；`dead-code` 在同一个 install 后按顺序运行 `pnpm knip` 和 `pnpm knip --production`。它是现有 static capability 的一个 task，不改变 #355 的 selective/full convergence graph。
 
-只有 pull request 使用上述 selective graph；`push` 到 `dev` 或 `main`、`merge_group`、已发布 `release` 以及 `workflow_dispatch` 都将 `FORCE_FULL`，运行 `static + postgres + system + ci-gate` 的完整 convergence gate。
+只有 pull request 使用上述 selective graph；`push` 到 `main`、`merge_group`、已发布 `release` 以及 `workflow_dispatch` 都将 `FORCE_FULL`，运行 `static + postgres + system + ci-gate` 的完整 convergence gate。
 
 当前 planner contract 如下：
 

--- a/tests/unit/db/release-compat.test.ts
+++ b/tests/unit/db/release-compat.test.ts
@@ -181,10 +181,10 @@ describe("release compatibility gate", () => {
     expect(result.previousRelease.ref).toBe("v1.1.0");
   });
 
-  it("resolves the production stable tag across the release/dev topology", () => {
-    const fixture = createDivergedTopologyFixture();
+  it("resolves the latest shipped tag on the single main lineage", () => {
+    const fixture = createSingleMainTopologyFixture();
 
-    expect(() => runGit(fixture.directory, ["merge-base", "--is-ancestor", fixture.productionCommit!, fixture.candidateCommit!])).toThrow();
+    expect(() => runGit(fixture.directory, ["merge-base", "--is-ancestor", fixture.productionCommit, fixture.candidateCommit])).not.toThrow();
     const result = checkReleaseCompatibility(fixture.directory);
 
     expect(result.previousRelease).toEqual({ ref: "v2.2.3", commit: fixture.productionCommit });
@@ -246,7 +246,7 @@ function createFixture(options: FixtureOptions): Fixture {
   return { directory };
 }
 
-function createDivergedTopologyFixture(): Fixture & { candidateCommit: string; productionCommit: string } {
+function createSingleMainTopologyFixture(): Fixture & { candidateCommit: string; productionCommit: string } {
   const directory = mkdtempSync(join(tmpdir(), "rivalhub-release-topology-"));
   fixtureDirectories.push(directory);
   runGit(directory, ["init", "-q"]);
@@ -260,28 +260,19 @@ function createDivergedTopologyFixture(): Fixture & { candidateCommit: string; p
   const baselineCommit = runGit(directory, ["rev-parse", "HEAD"]);
   runGit(directory, ["tag", "v2.2.2"]);
 
-  runGit(directory, ["checkout", "-q", "-b", "release", baselineCommit]);
+  runGit(directory, ["checkout", "-q", "-b", "main", baselineCommit]);
   writeFixtureFile(directory, "release-bookkeeping.txt", "v2.2.3\n");
   runGit(directory, ["add", "."]);
-  runGit(directory, ["commit", "-q", "-m", "release bookkeeping"]);
-  const releaseBookkeepingCommit = runGit(directory, ["rev-parse", "HEAD"]);
-
-  runGit(directory, ["checkout", "-q", "-b", "main", baselineCommit]);
-  runGit(directory, ["merge", "--no-ff", "-q", "release", "-m", "release v2.2.3"]);
+  runGit(directory, ["commit", "-q", "-m", "release v2.2.3"]);
   const productionCommit = runGit(directory, ["rev-parse", "HEAD"]);
   runGit(directory, ["tag", "v2.2.3"]);
 
-  runGit(directory, ["checkout", "-q", "-b", "dev", baselineCommit]);
-  writeFixtureFile(directory, "release-bookkeeping.txt", "v2.2.3\n");
-  runGit(directory, ["add", "."]);
-  runGit(directory, ["commit", "-q", "-m", "sync release bookkeeping"]);
   writeFixtureFile(directory, "drizzle/migrations/0002_next.sql", "ALTER TABLE teams ADD COLUMN new_column text;\n");
   runGit(directory, ["add", "."]);
   runGit(directory, ["commit", "-q", "-m", "candidate"]);
   const candidateCommit = runGit(directory, ["rev-parse", "HEAD"]);
   runGit(directory, ["update-ref", "refs/remotes/origin/main", productionCommit]);
 
-  expect(runGit(directory, ["rev-parse", "release"])).toBe(releaseBookkeepingCommit);
   return { directory, candidateCommit, productionCommit };
 }
 

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -77,6 +77,13 @@ describe("deployment and operations contracts", () => {
     expect(readWorkflowJob(ci, "dependency-review")).not.toContain("pnpm/setup");
   });
 
+  it("uses main as the sole long-lived CI ref", () => {
+    const ci = readProjectFile(".github/workflows/ci.yml");
+
+    expect(ci).toContain("branches: [main]");
+    expect(ci).not.toMatch(/branches:\s*\[[^\]]*\bdev\b/);
+  });
+
   it("declares the single Vercel Function region and disables only main Git deployment", () => {
     const config = JSON.parse(readProjectFile("vercel.json")) as {
       buildCommand?: string;
@@ -95,7 +102,7 @@ describe("deployment and operations contracts", () => {
 
     expect(workflow).toMatch(/^on:\n  workflow_dispatch:\s*$/m);
     expect(workflow).not.toMatch(/^\s+(push|pull_request|schedule|release):/m);
-    expect(workflow).toContain("default: dev");
+    expect(workflow).toContain("default: main");
     expect(workflow).toContain("ref: ${{ inputs.ref }}");
     expect(workflow).toContain("git rev-parse HEAD");
     expect(workflow).toContain("environment: staging");


### PR DESCRIPTION
## 收敛内容

- CI 的 push / pull_request contract 仅覆盖 `main`；staging rehearsal 的默认 ref 同步改为 `main`。
- 协作、部署、测试和 roadmap 文档统一为 `main = integrated/releasable`、`v* = shipped production`；普通 main merge 仍不触发 Production。
- release-compat 保留 existing main/tag N/N+1 gate，删除只服务旧 release/dev 分叉的 fixture，改为 deterministic single-main lineage regression。

## 非目标

- 不改产品、schema、migration 或 production runtime。
- 不改变 exact-tag release workflow、staging 手动保护边界或 Vercel main Git auto-production 禁止。

## 验证

- `type-check`、`lint`
- `vitest run tests/unit/db/release-compat.test.ts tests/unit/release/runtime-contract.test.ts`（25 passed）
- `pnpm db:release-compat`

`v2.3.0` 已先按旧双分支 flow 完成 production migrate/verify、exact deployment、smoke 和 GitHub Release；本 PR 合入后再删除 remote `dev`。

Refs #428