### PR TITLE
chore(deps): 删除过期 PostCSS override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss@8.4.31: 8.5.23
   uuid@9.0.1: 11.1.1
   esbuild@0.18.20: 0.28.2
   esbuild@0.27.7: 0.28.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,13 +3,6 @@ allowBuilds:
   sharp: true
   unrs-resolver: false
 overrides:
-  # GHSA-6g55-p6wh-862q / GHSA-r28c-9q8g-f849 / GHSA-qx2v-qp2m-jg93 / GHSA-fxqj-rqcc-2cmp:
-  # next 15.5.24 精确 pin postcss@8.4.31（< 8.5.23 patched floor，覆盖全部 4 条 advisory），
-  # path: .>next>postcss（含经由该实例的 nanoid GHSA-28wg-ghj8-5hjv / GHSA-2v37-7h3g-55p8）。
-  # 8.4.31 -> 8.5.23 为同 major 兼容升级；pnpm v10 对已存在 lockfile resolution 不做范围内重解析，
-  # 故对该精确 pin 实例使用 override。
-  # 退出条件：升级 Next（16.x 起 pin postcss 8.5.23+）后此 selector 不再命中，应移除。
-  'postcss@8.4.31': 8.5.23
   # GHSA-w5hq-g745-h8pq: brackets-manager@1.9.1 -> uuid@9.0.1（< 11.1.1 patched floor）。
   # path: .>brackets-manager>uuid；brackets-manager 最新 1.11.0 仍声明 uuid ^9.0.0，
   # 上游生态尚未迁移，无法通过升级 owner 自然解决。uuid 11.1.1 保留 CJS 出口


### PR DESCRIPTION
## 关联

无关联 Issue。

## 变更

- 删除 Next 16 已不再需要的 `postcss@8.4.31` override 及其历史注释。
- 刷新 lockfile override 元数据，保留 uuid 与 esbuild 的现役安全 override。

## 验证

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm why postcss`
- [x] `pnpm why uuid`
- [x] `pnpm why esbuild`
- [x] `pnpm audit`
- [x] `pnpm verify`

## Changeset

- [x] 本 PR 无需 changeset（development-only 依赖维护，不改变 shipped runtime 或用户行为）。
