### PR TITLE
ci: 强制统一 PR 标题格式

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+> PR 标题必须符合 `type(scope): 摘要`；`[2.x]` 仅用于 Issue
+
 ## 关联
 
 Refs #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
   merge_group:
   release:
     types: [published]
@@ -43,6 +44,19 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
           FORCE_FULL: ${{ github.event_name != 'pull_request' }}
+
+  pr_title:
+    name: pr-title
+    if: ${{ github.event_name == 'pull_request' && needs.plan.result == 'success' }}
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate pull request title
+        run: node scripts/ci/validate-pr-title.mjs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
 
   static:
     name: static / ${{ matrix.task }}
@@ -166,7 +180,7 @@ jobs:
   ci-gate:
     name: ci-gate
     if: ${{ always() }}
-    needs: [plan, static, postgres, system, dependency-review]
+    needs: [plan, pr_title, static, postgres, system, dependency-review]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -179,5 +193,6 @@ jobs:
           POSTGRES_RESULT: ${{ needs.postgres.result }}
           SYSTEM_RESULT: ${{ needs.system.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
+          TITLE_RESULT: ${{ needs.pr_title.result }}
           EVENT_NAME: ${{ github.event_name }}
           REQUIRED_JOBS: ${{ needs.plan.outputs.required_jobs }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ RivalHub 是基于 Next.js App Router、TypeScript、Drizzle/PostgreSQL、Supaba
 按变更风险选择最小证据；完整矩阵见 [`docs/testing.md`](docs/testing.md)。常用入口为 `pnpm type-check`、`pnpm lint`、`pnpm test`、`pnpm db:check`、`pnpm knip`、`pnpm knip --production` 与 `pnpm verify`。提交前检查完整 diff、未跟踪文件、敏感信息和临时产物。
 
 协作流程、changeset 判断、PR closure 语义与 release 操作不在本文件重复维护；以 `CONTRIBUTING.md` 为准。`CLAUDE.md` 只引用本文件，不建立平行规则集。
+- Agent 创建或修改 PR 时必须遵守 `CONTRIBUTING.md` 中的 PR title contract。
 
 <!-- BEGIN:nextjs-agent-rules -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 - 2.x Issue 标题使用 `[2.x] <问题或目标>`；开放 Issue 必须且只能有一个 `priority:P0`–`priority:P3` label。计划性工作使用现有类型 label；milestone/assignee 只有存在真实 release boundary 或明确 owner 时设置。
 - Issue 最小结构是背景 → 目标 → 验收；只有能限定实现时才增加范围、非目标或关联。通过 API/agent 创建或修改 Issue 时显式设置 title 和 labels，不能假设 UI form 自动补齐。
 - PR 标题、正文、Changeset 摘要和 release note 默认使用中文，必要的代码名、字段名、协议名和库名保留英文。PR 关联 Issue 使用 `Refs #N`，不要用 `Closes` 代替验收判断。
+- PR 标题必须符合 `type(scope): 摘要`；`scope` 可选，允许的 `type` 为 `feat`、`fix`、`refactor`、`perf`、`docs`、`test`、`build`、`ci`、`chore`、`release`、`revert`。摘要必须非空；人工 PR 摘要默认使用中文，但不机器强制语言，Dependabot 等自动化标题也必须保持合法。`[2.x]` 只用于 Issue 标题，不用于 PR 标题。示例：`feat(major): 补齐赛前冻结`、`fix: 修复移动端溢出`、`ci: 强制统一 PR 标题格式`、`release: v2.5.0`。
 - `main` PR 依赖 strict up-to-date 的自动化 `ci-gate` 与已解决的 review thread；普通 PR 不以第二人 approval 作为仓库质量策略。规则是否实际生效以 GitHub ruleset 为准，而不是只看本文件。
 
 ## Changeset、合并与 release

--- a/knip.json
+++ b/knip.json
@@ -30,6 +30,7 @@
     "eslint.config.mjs!",
     "scripts/ci/plan.mjs!",
     "scripts/ci/gate.mjs!",
+    "scripts/ci/validate-pr-title.mjs!",
     "scripts/db/block-drizzle-push.ts!",
     "scripts/db/local.ts!",
     "scripts/db/integration-runner.ts!",

--- a/scripts/ci/gate.mjs
+++ b/scripts/ci/gate.mjs
@@ -6,6 +6,7 @@ const statuses = {
   system: process.env.SYSTEM_RESULT,
 };
 const dependencyReviewStatus = process.env.DEPENDENCY_REVIEW_RESULT;
+const titleStatus = process.env.TITLE_RESULT;
 const eventName = process.env.EVENT_NAME || process.env.GITHUB_EVENT_NAME;
 
 if (statuses.plan !== "success") {
@@ -13,14 +14,21 @@ if (statuses.plan !== "success") {
 }
 
 if (eventName === "pull_request") {
+  if (titleStatus !== "success") {
+    fail(`pull_request 的 pr-title 未成功：${titleStatus ?? "missing"}`);
+  }
+  console.log("required pr-title: success");
   if (dependencyReviewStatus !== "success") {
     fail(`pull_request 的 dependency-review 未成功：${dependencyReviewStatus ?? "missing"}`);
   }
   console.log("required dependency-review: success");
 } else if (dependencyReviewStatus !== "skipped" && dependencyReviewStatus !== "success") {
   fail(`非 pull_request 的 dependency-review 出现异常状态：${dependencyReviewStatus ?? "missing"}`);
+} else if (titleStatus !== undefined && titleStatus !== "skipped" && titleStatus !== "success") {
+  fail(`非 pull_request 的 pr-title 出现异常状态：${titleStatus}`);
 } else {
   console.log(`optional dependency-review: ${dependencyReviewStatus}`);
+  console.log(`optional pr-title: ${titleStatus ?? "not applicable"}`);
 }
 
 for (const job of ["static", "postgres", "system"]) {

--- a/scripts/ci/validate-pr-title.mjs
+++ b/scripts/ci/validate-pr-title.mjs
@@ -1,0 +1,32 @@
+import { pathToFileURL } from "node:url";
+
+const ALLOWED_TYPES = [
+  "feat",
+  "fix",
+  "refactor",
+  "perf",
+  "docs",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "release",
+  "revert",
+];
+
+const PR_TITLE_PATTERN = new RegExp(
+  `^(${ALLOWED_TYPES.join("|")})(?:\\([^()\\s]+\\))?:\\s+\\S.*$`,
+);
+
+export function isValidPrTitle(title) {
+  return typeof title === "string" && PR_TITLE_PATTERN.test(title);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const title = process.env.PR_TITLE ?? "";
+  if (!isValidPrTitle(title)) {
+    console.error("PR title must match type(scope): summary with an allowed type and non-empty summary.");
+    process.exit(1);
+  }
+  console.log(`Valid PR title: ${title}`);
+}

--- a/tests/unit/ci/gate.test.mjs
+++ b/tests/unit/ci/gate.test.mjs
@@ -14,6 +14,7 @@ function runGate(overrides) {
       POSTGRES_RESULT: "skipped",
       SYSTEM_RESULT: "skipped",
       DEPENDENCY_REVIEW_RESULT: "skipped",
+      TITLE_RESULT: "skipped",
       EVENT_NAME: "push",
       REQUIRED_JOBS: "[]",
       ...overrides,
@@ -28,13 +29,21 @@ describe("ci-gate", () => {
   });
 
   it("requires dependency review on pull requests", () => {
-    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success" });
+    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "success" });
     expect(passed.status).toBe(0);
 
     for (const status of ["skipped", "failure", "cancelled", undefined]) {
-      const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: status });
+      const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: status, TITLE_RESULT: "success" });
       expect(result.status, status).not.toBe(0);
     }
+  });
+
+  it("requires PR title validation on pull requests", () => {
+    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "success" });
+    expect(passed.status).toBe(0);
+
+    const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "failure" });
+    expect(result.status).not.toBe(0);
   });
 
   it("accepts the expected skipped dependency review outside pull requests", () => {

--- a/tests/unit/ci/validate-pr-title.test.mjs
+++ b/tests/unit/ci/validate-pr-title.test.mjs
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isValidPrTitle } from "../../../scripts/ci/validate-pr-title.mjs";
+
+describe("pull request title validator", () => {
+  it.each([
+    "feat(major): 补齐赛前冻结",
+    "fix: 修复移动端溢出",
+    "chore(deps): bump next from 16.3.3 to 16.3.4",
+    "chore(deps-dev): bump vitest from 4.1.10 to 4.1.11",
+    "release: v2.5.0",
+  ])("accepts %s", (title) => {
+    expect(isValidPrTitle(title)).toBe(true);
+  });
+
+  it.each(["[2.x] 修复移动端溢出", "修复移动端溢出", "feature: 新功能", "fix:", "feat(major): "]) (
+    "rejects %s",
+    (title) => {
+      expect(isValidPrTitle(title)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## 变更

- 将 PR title contract 收口到 CONTRIBUTING.md，并由 AGENTS.md 与 PR template 指向。
- 在现有 plan/ci-gate 链增加无依赖的 PR title validator，覆盖 opened、synchronize、reopened、edited 与 ready_for_review。
- 补充 validator 与 ci-gate 最小测试。

## Changeset

无需 changeset：本 PR 只改变 CI 与协作治理，不改变 shipped runtime 或用户行为。