### PR TITLE
docs: 修正 CHANGELOG 版本引用顺序

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1825,6 +1825,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.3.0...v2.4.0
@@ -1929,4 +1930,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.1.0]: https://github.com/Starfie1d1272/RivalHub/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/Starfie1d1272/RivalHub/compare/v1.0.0...v1.0.2
 [1.0.0]: https://github.com/Starfie1d1272/RivalHub/compare/v0.3.0...v1.0.0
-[2.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.5.0...v2.6.0


### PR DESCRIPTION
## 关联

Refs #409

## 变更

- 将 `v2.6.0` 的 compare reference 移到 CHANGELOG trailing reference block 的顶部，保持版本由新到旧排序。

## 验证

- `git diff --check`
- 确认 `v2.6.0` 仍比较 `v2.5.0...v2.6.0`

## Changeset

- 本 PR 无需 changeset：仅修正文档引用链接的排序，不改变 shipped runtime 或用户/管理员行为。