### PR TITLE
chore(deps): 升级 Vercel CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           require-lockfile: true
 
       - name: Install pinned Vercel CLI
-        run: pnpm add --global vercel@59.10.0
+        run: pnpm add --global vercel@59.11.7
 
       - name: Require Vercel release credential
         env:


### PR DESCRIPTION
## 摘要

- Refs #462
- 按 #462 Phase 1 PR4，将生产 release workflow 的 Vercel CLI 从 `59.10.0` 升级到 stable `59.11.7`。
- 仅更新 `.github/workflows/release.yml` 的 CLI pin，不包含产品代码、schema、migration 或部署行为重设计。

## 官方 release / migration surface

- [Vercel CLI release notes](https://vercel.com/docs/cli/release-notes)：`vercel@59.11.7` 于 2026-09-04 发布，59.11.7 为 patch；从 59.10.0 到 59.11.7 的累积 surface 包括 59.11.0 的 schedules 配置传播与 `--scope` 解析修复、59.11.1 的 multi-service build log tagging、59.11.2 的 Windows nested App Router build 修复，以及 59.11.7 的 CLI command behavior 更新。
- [Vercel CLI npm package](https://www.npmjs.com/package/vercel)：stable `59.11.7` 为 latest，Node engine 为 `>=18`；RivalHub release job 使用 Node `24.x`，满足要求。
- 本仓库只调用 `vercel deploy --prod --yes --token=... --build-env ...`；不使用 schedules、multi-service、Windows build、`--scope` 或本次新增/变更的其他命令面。

## RivalHub affected surface

- `.github/workflows/release.yml` 的 `Install pinned Vercel CLI` 步骤。
- 后续同一 workflow 的 production deploy 使用保持不变：精确 release tag checkout、release credential check、`vercel deploy --prod --yes`、release tag/commit build env 与 smoke test。
- `tests/unit/release/runtime-contract.test.ts` 继续覆盖 release workflow 的 pnpm/setup、migration compatibility gate、production deployment boundary 与 retry contract。

## Compatibility

- 无代码兼容修改；deploy flags、environment variables、production project target、release tag/commit provenance 与 smoke test 保持不变。
- 无数据库、migration、production write、手工 Vercel deploy 或外部账号操作。

## Evidence

- `pnpm exec vitest run tests/unit/release/runtime-contract.test.ts`：1 file / 8 tests passed
- `pnpm dlx --yes vercel@59.11.7 --version`：Vercel CLI 59.11.7
- `git diff --check`
- Required CI 将覆盖完整 static/type/build、PostgreSQL、Local Supabase/Auth/Storage、Playwright E2E、CodeQL、dependency review 与 `ci-gate`；本机未启动 Local Supabase 或执行 production deploy。

## Rollback

回退本 PR 的 squash commit 并恢复 `.github/workflows/release.yml` 中的 CLI pin 即可；本 PR 没有 schema 或数据写入。

## Changeset / docs

- Changeset：不需要；这是 release tooling pin maintenance，无用户可见产品 contract 变化。
- Canonical docs：不需要；生产 release workflow 的 ownership、数据库 gate、deployment boundary 与 retry contract 未变化。

## Merge gate

Ready for review；仅当 required CI 全部通过、PR mergeable 且无 unresolved review thread / request changes 时，按 #462 standing authorization squash merge。
