### PR TITLE
chore(deps): 升级 iron-session 到 9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
-    "iron-session": "^8.0.4",
+    "iron-session": "^9.0.1",
     "lucide-react": "^1.41.0",
     "next": "16.3.4",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(pg@8.23.0)
       iron-session:
-        specifier: ^8.0.4
-        version: 8.0.4
+        specifier: ^9.0.1
+        version: 9.0.1
       lucide-react:
         specifier: ^1.41.0
         version: 1.41.0(react@19.2.8)
@@ -2794,9 +2794,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3478,11 +3478,12 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  iron-session@8.0.4:
-    resolution: {integrity: sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA==}
+  iron-session@9.0.1:
+    resolution: {integrity: sha512-ELSZdcLvA0AMhxUCY+rwKCh42UV88SqEb1ia/bHLF9G+6kScikO6mShtlIq+OtF2UlkZP0dmI2dMdG9vh4rebA==}
+    engines: {node: '>=22.13.0'}
 
-  iron-webcrypto@1.2.1:
-    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+  iron-webcrypto@2.0.0:
+    resolution: {integrity: sha512-rtffZKDUHciZElM8mjFCufBC7nVhCxHYyWHESqs89OioEDz4parOofd8/uhrejh/INhQFfYQfByS22LlezR9sQ==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -4917,6 +4918,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   unbash@4.0.11:
     resolution: {integrity: sha512-FoSOKV7NEofQSkAefMVHam4ZPKYMxjAydxiV72UFEDNV/YofxjGfiZ2A9pZjdL/lRJzTjcu4PABo1JYJX8N5iQ==}
     engines: {node: '>=14'}
@@ -4924,9 +4929,6 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
-
-  uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -7349,7 +7351,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.7.2: {}
+  cookie@2.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8174,13 +8176,14 @@ snapshots:
       hasown: 2.0.4
       side-channel: 1.1.1
 
-  iron-session@8.0.4:
+  iron-session@9.0.1:
     dependencies:
-      cookie: 0.7.2
-      iron-webcrypto: 1.2.1
-      uncrypto: 0.1.3
+      cookie: 2.0.1
+      iron-webcrypto: 2.0.0
 
-  iron-webcrypto@1.2.1: {}
+  iron-webcrypto@2.0.0:
+    dependencies:
+      uint8array-extras: 1.5.0
 
   is-alphabetical@2.0.1: {}
 
@@ -9850,6 +9853,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   unbash@4.0.11: {}
 
   unbox-primitive@1.1.0:
@@ -9858,8 +9863,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
 

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -57,7 +57,7 @@ export async function createUserSession(user: UserSession): Promise<void> {
 
   // Clear any pre-existing payload so an old cookie cannot retain authorization data.
   // Keep iron-session's methods; every other enumerable key is session payload.
-  const sessionMethods = new Set(["save", "destroy", "update"]);
+  const sessionMethods = new Set(["save", "destroy", "updateConfig"]);
   for (const key of Object.keys(session)) {
     if (!sessionMethods.has(key)) delete session[key];
   }

--- a/tests/unit/lib/auth-session-compatibility.test.ts
+++ b/tests/unit/lib/auth-session-compatibility.test.ts
@@ -1,0 +1,18 @@
+import { unsealData } from "iron-session";
+import { describe, expect, it } from "vitest";
+
+const V8_TEST_PASSWORD = "iron-session-v8-compatibility-test-password-0123456789";
+// Captured from iron-session@8.0.4 with the test-only password and ttl: 0.
+const V8_SESSION_SEAL =
+  "Fe26.2*1*b24ab8e386ed7ca74c258b8b3e180d30bfaaed4c8da447d60370b0ddf66a5a4b*0_ftrMhYCszhVelJw4Z9ew*49BbtGSYz4veqMax5gAro9Ub9ZhIxa9XFPtEr2pvXZDhgW3F7oy9Jph5fCGwrsR-vs9R9DyefRvzY6XU150dIw**ff3fe83483804187b0804cf742dffb216110535fbb33e4a54d68d1b532ef0e49*YU0OMkd5IjUB2qXVcMcpKj7T7c7QXlEgDH5UTrkJUfU~2";
+
+describe("iron-session cookie compatibility", () => {
+  it("reads a v8 seal after upgrading to v9", async () => {
+    await expect(
+      unsealData<{ userId: string; email: string }>(V8_SESSION_SEAL, {
+        password: V8_TEST_PASSWORD,
+        ttl: 0,
+      }),
+    ).resolves.toEqual({ userId: "user-1", email: "player@example.test" });
+  });
+});

--- a/tests/unit/lib/auth-session.test.ts
+++ b/tests/unit/lib/auth-session.test.ts
@@ -27,7 +27,7 @@ import {
 const identity = { userId: "user-1", email: "player@example.test" };
 
 function session(data: Record<string, unknown> = {}) {
-  return { ...data, save: vi.fn(), destroy: vi.fn(), update: vi.fn() };
+  return { ...data, save: vi.fn(), destroy: vi.fn(), updateConfig: vi.fn() };
 }
 
 function mockCurrentAuthorization(role: "user" | "super_admin", seasonIds: string[]) {
@@ -65,6 +65,7 @@ describe("auth session guards", () => {
     expect(writable).not.toHaveProperty("role");
     expect(writable).not.toHaveProperty("seasonIds");
     expect(writable).not.toHaveProperty("extra");
+    expect(writable.updateConfig).toEqual(expect.any(Function));
     expect(writable.save).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## 摘要
- 将 `iron-session` 从 8.0.4 升级到 9.0.1，锁文件同步到 `iron-webcrypto@2`。
- 保持 `rivalhub-session` 只保存 `userId/email`；role 与 season grants 仍按请求从 DB 读取。
- 将会话清理白名单与实际 API 对齐为 `updateConfig`，并增加 v8 seal 由 v9 回读的兼容性回归测试。

## 验证
- `pnpm install --frozen-lockfile --ignore-scripts`
- 定向 auth/compatibility：2 files / 12 tests passed
- 全量 unit：251 files / 1534 tests passed
- `pnpm type-check`
- `pnpm lint`
- `pnpm db:check`
- `pnpm build`
- `git diff --check`
- 实际运行时验证 v9 读取 v8 seal；保留的 v8.0.4 runtime 反向读取 v9 seal 也通过。

## 范围与回滚
本 PR 只处理 #462 PR5 的依赖、会话 API 对齐和兼容性测试，不改 schema、产品行为、生产配置或部署。v8/v9 cookie 格式保持兼容，若 CI 或 review 暴露问题可直接回退本次提交。

## 上游依据
- https://github.com/vvo/iron-session/releases/tag/v9.0.1
- https://github.com/vvo/iron-session/blob/v9.0.1/MIGRATION.md
- https://github.com/vvo/iron-session/blob/v9.0.1/README.md

鉴权 canonical doc 未改：本次未改变 session security contract。

Refs #462