### PR TITLE
chore(deps): 升级 Zod 到 4.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "server-only": "^0.0.1",
     "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",
-    "zod": "^3.24.4"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: ^5.9.1
-        version: 5.9.1(@standard-schema/spec@1.1.0)(react-hook-form@7.87.0(react@19.2.8))(zod@3.25.76)
+        version: 5.9.1(@standard-schema/spec@1.1.0)(react-hook-form@7.87.0(react@19.2.8))(zod@4.5.4)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -131,8 +131,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       zod:
-        specifier: ^3.24.4
-        version: 3.25.76
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@changesets/cli':
         specifier: ^3.0.2
@@ -4991,9 +4991,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
@@ -5550,13 +5547,13 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(react-hook-form@7.87.0(react@19.2.8))(zod@3.25.76)':
+  '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(react-hook-form@7.87.0(react@19.2.8))(zod@4.5.4)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.87.0(react@19.2.8)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
-      zod: 3.25.76
+      zod: 4.5.4
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7531,8 +7528,8 @@ snapshots:
       '@babel/parser': 7.29.3
       eslint: 10.10.0(jiti@2.7.0)(supports-color@7.2.0)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.5.4
+      zod-validation-error: 4.0.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -9699,11 +9696,9 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.5.4):
     dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
+      zod: 4.5.4
 
   zod@4.5.4: {}
 

--- a/src/actions/community-awards.ts
+++ b/src/actions/community-awards.ts
@@ -20,7 +20,7 @@ import { AppError, ErrorCode } from "@/lib/errors";
 import { isHttpUrl } from "@/lib/external-url";
 import { fail, ok, type ActionResult } from "@/types/action";
 
-const uuid = z.string().uuid();
+const uuid = z.guid();
 const optionalText = (max: number) => z.string().trim().max(max).nullable().optional();
 const awardInput = z.object({
   seasonId: uuid,

--- a/src/actions/competition-entries.ts
+++ b/src/actions/competition-entries.ts
@@ -25,7 +25,7 @@ import {
 import { fail, ok, type ActionResult } from "@/types/action";
 import { traceOperation } from "@/lib/observability/server";
 
-const uuid = z.string().uuid();
+const uuid = z.guid();
 function invalid(message: string): ActionResult<never> {
   return fail({ code: ErrorCode.VALIDATION_FAILED, message });
 }

--- a/src/actions/competitive-platform.ts
+++ b/src/actions/competitive-platform.ts
@@ -61,7 +61,7 @@ export async function createCompetitivePlatformSeason(input: unknown): Promise<A
     platform: z.string().trim().min(1).max(64),
     seasonKey: seasonKeySchema,
     label: labelSchema,
-    insertAt: z.object({ seasonId: z.string().uuid(), position: z.enum(["before", "after"]) }).optional(),
+    insertAt: z.object({ seasonId: z.guid(), position: z.enum(["before", "after"]) }).optional(),
   }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请填写所属平台、赛季标识和显示名称。" });
   try {
@@ -113,7 +113,7 @@ export async function createCompetitivePlatformSeason(input: unknown): Promise<A
 }
 
 export async function updateCompetitivePlatformSeason(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid(), label: labelSchema }).safeParse(input);
+  const parsed = z.object({ id: z.guid(), label: labelSchema }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请填写赛季显示名称。" });
   try {
     const session = await requireSuperAdmin();
@@ -130,7 +130,7 @@ export async function updateCompetitivePlatformSeason(input: unknown): Promise<A
 }
 
 export async function setCompetitivePlatformSeasonActive(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid(), active: z.boolean() }).safeParse(input);
+  const parsed = z.object({ id: z.guid(), active: z.boolean() }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "赛季目录项无效。" });
   try {
     const session = await requireSuperAdmin();
@@ -148,7 +148,7 @@ export async function setCompetitivePlatformSeasonActive(input: unknown): Promis
 }
 
 export async function setCurrentCompetitivePlatformSeason(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid() }).safeParse(input);
+  const parsed = z.object({ id: z.guid() }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "赛季目录项无效。" });
   try {
     const session = await requireSuperAdmin();
@@ -176,7 +176,7 @@ export async function setCurrentCompetitivePlatformSeason(input: unknown): Promi
  * never violated mid-transaction.
  */
 export async function moveCompetitivePlatformSeason(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid(), direction: z.enum(["earlier", "later"]) }).safeParse(input);
+  const parsed = z.object({ id: z.guid(), direction: z.enum(["earlier", "later"]) }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "排序指令无效。" });
   try {
     const session = await requireSuperAdmin();
@@ -203,7 +203,7 @@ export async function moveCompetitivePlatformSeason(input: unknown): Promise<Act
 }
 
 export async function deleteCompetitivePlatformSeason(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid() }).safeParse(input);
+  const parsed = z.object({ id: z.guid() }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "赛季目录项无效。" });
   try {
     const session = await requireSuperAdmin();
@@ -275,7 +275,7 @@ export async function createCompetitivePlatformRank(input: unknown): Promise<Act
 }
 
 export async function updateCompetitivePlatformRankLabel(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid(), label: labelSchema }).safeParse(input);
+  const parsed = z.object({ id: z.guid(), label: labelSchema }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "请填写段位显示名称。" });
   try {
     const session = await requireSuperAdmin();
@@ -294,7 +294,7 @@ export async function updateCompetitivePlatformRankLabel(input: unknown): Promis
 }
 
 export async function moveCompetitivePlatformRank(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid(), direction: z.enum(["up", "down"]) }).safeParse(input);
+  const parsed = z.object({ id: z.guid(), direction: z.enum(["up", "down"]) }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "排序指令无效。" });
   try {
     const session = await requireSuperAdmin();
@@ -325,7 +325,7 @@ export async function moveCompetitivePlatformRank(input: unknown): Promise<Actio
 }
 
 export async function deleteCompetitivePlatformRank(input: unknown): Promise<ActionResult<void>> {
-  const parsed = z.object({ id: z.string().uuid() }).safeParse(input);
+  const parsed = z.object({ id: z.guid() }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "段位无效。" });
   try {
     const session = await requireSuperAdmin();

--- a/src/actions/discipline.ts
+++ b/src/actions/discipline.ts
@@ -33,8 +33,8 @@ import {
 const effectSchema = z.enum(SANCTION_EFFECTS as unknown as [SanctionEffect, ...SanctionEffect[]]);
 
 const issueSchema = z.object({
-  seasonId: z.string().uuid(),
-  subjectUserId: z.string().uuid(),
+  seasonId: z.guid(),
+  subjectUserId: z.guid(),
   effects: z.array(effectSchema).min(1),
   internalEvidence: z.string().trim().max(4000).optional().nullable(),
   publicExplanation: z.string().trim().max(1000).optional().nullable(),
@@ -80,7 +80,7 @@ export async function revokeSanction(
   input: { caseId: string; reason: string },
 ): Promise<ActionResult<{ alreadyRevoked: boolean; caseId: string }>> {
   const parsed = z
-    .object({ caseId: z.string().uuid(), reason: z.string().trim().min(1).max(1000) })
+    .object({ caseId: z.guid(), reason: z.string().trim().min(1).max(1000) })
     .safeParse(input);
   if (!parsed.success) return actionError("revokeSanction", new AppError(ErrorCode.VALIDATION_FAILED, "撤销参数不合法：必须填写撤销原因。"));
   try {
@@ -102,7 +102,7 @@ export async function revokeSanction(
 export async function expireSanction(
   input: { caseId: string },
 ): Promise<ActionResult<{ alreadyExpired: boolean; caseId: string }>> {
-  const parsed = z.object({ caseId: z.string().uuid() }).safeParse(input);
+  const parsed = z.object({ caseId: z.guid() }).safeParse(input);
   if (!parsed.success) return actionError("expireSanction", new AppError(ErrorCode.VALIDATION_FAILED, "参数不合法。"));
   try {
     const existing = await loadCase(parsed.data.caseId);
@@ -121,7 +121,7 @@ export async function searchSanctionSubjects(
   input: unknown,
 ): Promise<ActionResult<Array<{ id: string; label: string; detail: string | null }>>> {
   const parsed = z
-    .object({ seasonId: z.string().uuid(), query: z.string().trim().min(2).max(64) })
+    .object({ seasonId: z.guid(), query: z.string().trim().min(2).max(64) })
     .safeParse(input);
   if (!parsed.success) {
     return actionError("searchSanctionSubjects", new AppError(ErrorCode.VALIDATION_FAILED, "搜索词不合法：至少 2 个字符。"));

--- a/src/actions/education-verifications.ts
+++ b/src/actions/education-verifications.ts
@@ -100,9 +100,9 @@ export async function declareInstitutionalEmailEducation(input: { academicStatus
 }
 
 export async function reviewEducationVerification(input: { id: string; decision: "approved" | "rejected"; reviewNote?: string }): Promise<ActionResult<void>> {
-  const reviewSchema = z.object({ id: z.string().uuid(), decision: z.enum(["approved", "rejected"]), reviewNote: z.string().trim().max(1000).optional() }).superRefine((value, ctx) => {
+  const reviewSchema = z.object({ id: z.guid(), decision: z.enum(["approved", "rejected"]), reviewNote: z.string().trim().max(1000).optional() }).superRefine((value, ctx) => {
     if (value.decision === "rejected" && !value.reviewNote) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["reviewNote"], message: "驳回原因不能为空。" });
+      ctx.addIssue({ code: "custom", path: ["reviewNote"], message: "驳回原因不能为空。" });
     }
   });
   const parsed = reviewSchema.safeParse(input);

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -29,7 +29,7 @@ import { saveMajorPrestartRosterInTx } from "@/lib/major/prestart-roster";
 import { assertMajorPrestartEntrantsMutable, ensureMajorPrestartStateInTx } from "@/lib/major/prestart-state";
 import { confirmMajorTournamentSeedsInTx, saveMajorTournamentSeedsInTx } from "@/lib/major/prestart-seeds";
 
-const uuid = z.string().uuid();
+const uuid = z.guid();
 const issueCategory = z.enum(["qualification", "administration"]);
 const rosterRepairInput = z.object({ seasonId: uuid, entrantId: uuid, userIds: z.array(uuid).min(1).max(16), reason: z.string().trim().min(1).max(1000) });
 const rosterExceptionInput = z.object({ seasonId: uuid, entrantId: uuid, reason: z.string().trim().min(1).max(1000) });

--- a/src/actions/postevent.ts
+++ b/src/actions/postevent.ts
@@ -19,8 +19,8 @@ import {
 } from "@/lib/postevent/service";
 import { fail, ok, type ActionResult } from "@/types/action";
 
-const uuid = z.string().uuid();
-const clientRequestId = z.string().uuid();
+const uuid = z.guid();
+const clientRequestId = z.guid();
 const impactSchema = z.enum(ADJUDICATION_IMPACTS);
 
 function invalid(message: string): ActionResult<never> {

--- a/src/actions/postmatch.ts
+++ b/src/actions/postmatch.ts
@@ -10,7 +10,7 @@ import { fail, ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { isHttpUrl } from "@/lib/external-url";
 import { revalidateMatchPaths } from "@/lib/revalidation";
-const uuid = z.string().uuid();
+const uuid = z.guid();
 const url = z.string().trim().max(2000).refine(isHttpUrl, "录像链接必须是 http 或 https URL");
 function invalid(message: string): ActionResult<never> { return fail({ code: ErrorCode.VALIDATION_FAILED, message }); }
 async function matchAndAdminOrThrow(matchId: string) { const match = await db.query.matches.findFirst({ where: eq(matches.id, matchId), columns: { id: true, seasonId: true } }); if (!match) throw new AppError(ErrorCode.MATCH_NOT_FOUND, "比赛不存在。"); const season = await db.query.seasons.findFirst({ where: eq(seasons.id, match.seasonId), columns: { slug: true } }); if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在。"); return { match, season, admin: await requireSeasonAdmin(match.seasonId) }; }

--- a/src/actions/recruitment.ts
+++ b/src/actions/recruitment.ts
@@ -18,7 +18,7 @@ import {
 import { ErrorCode } from "@/lib/errors";
 import { fail, ok, type ActionResult } from "@/types/action";
 
-const uuid = z.string().uuid();
+const uuid = z.guid();
 const position = z.enum(CS2_POSITION_VALUES);
 const optionalNote = z.string().trim().max(280).optional();
 const optionalSeason = uuid.nullable().optional();

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -20,9 +20,9 @@ import { updatePublicPlayerTag } from "@/lib/revalidation";
 import { traceOperation } from "@/lib/observability/server";
 
 const draftSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
   email: z.string().email("请先填写有效邮箱"),
-  payload: z.record(z.unknown()).default({}),
+  payload: z.record(z.string(), z.unknown()).default({}),
 });
 
 export async function saveRegistrationDraft(input: unknown) {

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -34,7 +34,7 @@ import { fail, ok, type ActionResult } from "@/types/action";
 
 const PENDING_DIRECT_INVITATION_CONSTRAINT = "team_invitations_one_pending_direct_per_user";
 
-const uuid = z.string().uuid();
+const uuid = z.guid();
 const teamName = z.string().trim().min(MIN_TEAM_NAME_LENGTH).max(MAX_TEAM_NAME_LENGTH);
 const description = z.string().trim().max(500);
 function invalid(message: string): ActionResult<never> {

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -135,7 +135,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
     initial?.stagePlan ?? defaultTemplate.stagePlan,
   );
   const [allowedPlayerTypes, setAllowedPlayerTypes] = useState<PlayerType[]>(
-    defaultConfig.allowedPlayerTypes,
+    [...defaultConfig.allowedPlayerTypes],
   );
   const [currentMin, setCurrentMin] = useState(defaultConfig.rankThreshold.currentMin ?? NO_RANK);
   const [peakMin, setPeakMin] = useState(defaultConfig.rankThreshold.peakMin ?? NO_RANK);
@@ -145,7 +145,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
   const [mapPool, setMapPool] = useState(defaultConfig.mapPool);
   const [teamConfig, setTeamConfig] = useState<TeamRegistrationConfig>(defaultTeamConfig);
   const [affiliationRules, setAffiliationRules] = useState<InstitutionAffiliationRule[]>(
-    initial?.affiliationRules ?? defaultTemplate.affiliationRules,
+    [...(initial?.affiliationRules ?? defaultTemplate.affiliationRules)],
   );
 
   const editCapabilities = getSeasonEditCapabilities({
@@ -256,7 +256,16 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
     };
   }
 
-  const standardMajorCheck = checkStandardMajorCapabilities(buildPayload() as SeasonCapabilities);
+  const payloadForCapabilities = buildPayload();
+  const standardMajorCheck = checkStandardMajorCapabilities({
+    ...payloadForCapabilities,
+    registrationConfig: {
+      ...payloadForCapabilities.registrationConfig,
+      allowedPlayerTypes: [...payloadForCapabilities.registrationConfig.allowedPlayerTypes],
+    },
+    teamRegistrationConfig: teamConfig,
+    affiliationRules,
+  });
   const isMajorDisplayContext = template === "major";
 
   function handleSubmit() {
@@ -295,8 +304,9 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
 
   function handleOpenRegistration() {
     if (!initial?.id) return;
+    const seasonId = initial.id;
     startTransition(async () => {
-      const result = await openSeasonRegistration(initial.id);
+      const result = await openSeasonRegistration(seasonId);
       if (result.success) {
         toast.success("报名已开放，竞技参考策略已冻结");
         router.refresh();

--- a/src/lib/education/validation.ts
+++ b/src/lib/education/validation.ts
@@ -13,7 +13,7 @@ export function normalizeChsiEvidenceCode(value: string): string | null {
 }
 
 export const educationSubmissionSchema = z.object({
-  institutionId: z.string().uuid(),
+  institutionId: z.guid(),
   academicStatus: z.enum(["enrolled", "graduated"]),
   evidenceCode: z.string().trim().min(1).max(64),
 });

--- a/src/lib/major/placement.ts
+++ b/src/lib/major/placement.ts
@@ -28,7 +28,7 @@ export interface MajorFinalPlacementGroup {
 const finalPlacementGroupSchema = z.object({
   from: z.number().int().positive(),
   to: z.number().int().positive(),
-  entryIds: z.array(z.string().uuid()).min(1),
+  entryIds: z.array(z.guid()).min(1),
 });
 
 /** The only parser for persisted official Major placement groups and champion pointer. */

--- a/src/lib/major/run-snapshot.ts
+++ b/src/lib/major/run-snapshot.ts
@@ -14,8 +14,8 @@ const stageSchema = z.object({
 });
 
 const frozenEntrantSchema = z.object({
-  entrantId: z.string().uuid(),
-  competitionEntryId: z.string().uuid(),
+  entrantId: z.guid(),
+  competitionEntryId: z.guid(),
   tournamentSeed: z.number().int().min(1).max(32),
 });
 
@@ -34,8 +34,8 @@ const qualificationFindingSnapshotSchema = z.object({
 });
 
 const frozenRestrictionOverrideSchema = z.object({
-  entryId: z.string().uuid(),
-  rosterRevisionId: z.string().uuid(),
+  entryId: z.guid(),
+  rosterRevisionId: z.guid(),
   restrictionCode: z.string().min(1),
   findingSnapshot: qualificationFindingSnapshotSchema,
   reason: z.string().min(1),
@@ -43,13 +43,13 @@ const frozenRestrictionOverrideSchema = z.object({
   grantedAt: z.string().min(1),
 }).superRefine((value, ctx) => {
   if (value.restrictionCode !== value.findingSnapshot.code) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "解除记录的 restrictionCode 必须与 finding snapshot code 一致" });
+    ctx.addIssue({ code: "custom", message: "解除记录的 restrictionCode 必须与 finding snapshot code 一致" });
   }
   if (!value.findingSnapshot.waivable) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "StageRun 只能冻结可解除的 qualification finding" });
+    ctx.addIssue({ code: "custom", message: "StageRun 只能冻结可解除的 qualification finding" });
   }
   if (!value.reason.trim()) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "解除记录必须包含具体理由" });
+    ctx.addIssue({ code: "custom", message: "解除记录必须包含具体理由" });
   }
 });
 
@@ -68,19 +68,21 @@ const frozenInputObject = z.object({
 const frozenInputSchema = frozenInputObject.superRefine((value, ctx) => {
   const keys = new Set<string>();
   for (const stage of value.stagePlan) {
-    if (keys.has(stage.key)) ctx.addIssue({ code: z.ZodIssueCode.custom, message: "重复的 StagePlan key" });
+    if (keys.has(stage.key)) ctx.addIssue({ code: "custom", message: "重复的 StagePlan key" });
     keys.add(stage.key);
   }
   if (value.rosterRules.starterCount > value.rosterRules.maxTeamSize || value.rosterRules.minTeamSize > value.rosterRules.maxTeamSize) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "无效的 roster policy" });
+    ctx.addIssue({ code: "custom", message: "无效的 roster policy" });
   }
 });
 
-function withFrozenInputInvariants<T extends z.ZodTypeAny>(schema: T): T {
+function withFrozenInputInvariants<T extends z.ZodType>(schema: T): T {
   return schema.superRefine((value, ctx) => {
     const result = frozenInputSchema.safeParse(value);
     if (!result.success) {
-      for (const issue of result.error.issues) ctx.addIssue(issue);
+      for (const issue of result.error.issues) {
+        ctx.addIssue(issue as z.core.$ZodSuperRefineIssue);
+      }
     }
   }) as unknown as T;
 }

--- a/src/lib/seasons/edit.ts
+++ b/src/lib/seasons/edit.ts
@@ -10,6 +10,7 @@ import {
   type CompetitiveFallbackConversion,
   type RegistrationConfig,
   type StagePlan,
+  type PlayerType,
   type TeamRegistrationConfig,
   type SeasonStatus,
 } from "@/types/season";
@@ -48,7 +49,7 @@ const registrationConfigSchema = z.object({
 });
 
 const seasonFormBaseSchema = z.object({
-  id: z.string().uuid().optional(),
+  id: z.guid().optional(),
   name: z.string().min(1, "请填写赛季名称"),
   slug: z.string().min(1, "请填写 slug").regex(/^[a-z0-9][a-z0-9-]*$/, "slug 只能使用小写字母、数字和连字符"),
   kind: z.string().min(1, "请填写赛事类型"),
@@ -104,41 +105,67 @@ const seasonFormBaseSchema = z.object({
         // evidence slot; empty placeholders are never persisted.
         version: z.string().max(128),
         seasonKeyMap: z.record(z.string().min(1).max(128), z.string().min(1).max(128)),
-        mapping: z.unknown(),
+        // Mapping validation belongs to the conversion-policy owner and is
+        // intentionally deferred until registration freeze.
+        mapping: z.any().optional(),
       }).optional(),
     }).optional(),
   }).optional(),
   affiliationRules: z.array(z.object({
     institutionCode: z.string().min(1),
-    eligibleAcademicStatuses: z.array(z.enum(["enrolled", "graduated"])).min(1),
+    eligibleAcademicStatuses: z.array(z.enum(["enrolled", "graduated"])).min(1).readonly(),
     minRosterMembers: z.number().int().min(0),
     minStartingMembers: z.number().int().min(0),
   })).optional(),
 });
 
 export const seasonFormSchema = withSeasonRefinements(seasonFormBaseSchema);
-export const seasonUpdateFormSchema = withSeasonRefinements(seasonFormBaseSchema.extend({ id: z.string().uuid() }));
+export const seasonUpdateFormSchema = withSeasonRefinements(seasonFormBaseSchema.extend({ id: z.guid() }));
 
-export type SeasonFormInput = z.input<typeof seasonFormSchema>;
+type SeasonFormSchemaInput = z.input<typeof seasonFormSchema>;
+type SeasonFormData = Omit<SeasonFormSchemaInput, "registrationConfig" | "teamRegistrationConfig" | "affiliationRules"> & {
+  registrationConfig: Omit<SeasonFormSchemaInput["registrationConfig"], "allowedPlayerTypes"> & {
+    allowedPlayerTypes: readonly PlayerType[];
+  };
+  teamRegistrationConfig?: TeamRegistrationConfig;
+  affiliationRules?: readonly InstitutionAffiliationRule[];
+};
+export type SeasonFormInput = SeasonFormData;
 // Keep planner input tied to the concrete object schema. The refinement helper
 // intentionally accepts a generic Zod schema, so inferring from the refined
 // value would otherwise erase the fields to `any`.
-type ParsedSeasonForm = z.infer<typeof seasonFormBaseSchema>;
+type ParsedSeasonForm = SeasonFormData;
 
-function withSeasonRefinements<T extends z.ZodTypeAny>(schema: T) {
+type SeasonRefinementFields = {
+  starterCount: number;
+  maxTeamSize: number;
+  minTeamSize: number;
+  registrationOpensAt: string | null;
+  registrationClosesAt: string | null;
+  rosterChangeClosesAt: string | null;
+};
+
+function withSeasonRefinements<T extends z.ZodType>(schema: T): T {
   return schema
-    .refine((data) => data.starterCount <= data.maxTeamSize, {
+    .refine((data) => {
+      const value = data as SeasonRefinementFields;
+      return value.starterCount <= value.maxTeamSize;
+    }, {
       path: ["starterCount"],
       message: "首发人数不能超过队伍上限",
     })
-    .refine((data) => data.minTeamSize <= data.maxTeamSize, {
+    .refine((data) => {
+      const value = data as SeasonRefinementFields;
+      return value.minTeamSize <= value.maxTeamSize;
+    }, {
       path: ["minTeamSize"],
       message: "最小人数不能超过最大人数",
     })
     .refine(
       (data) => {
-        if (!data.registrationOpensAt || !data.registrationClosesAt) return true;
-        return new Date(data.registrationClosesAt) > new Date(data.registrationOpensAt);
+        const value = data as SeasonRefinementFields;
+        if (!value.registrationOpensAt || !value.registrationClosesAt) return true;
+        return new Date(value.registrationClosesAt) > new Date(value.registrationOpensAt);
       },
       {
         path: ["registrationClosesAt"],
@@ -147,14 +174,15 @@ function withSeasonRefinements<T extends z.ZodTypeAny>(schema: T) {
     )
     .refine(
       (data) => {
-        if (!data.registrationClosesAt || !data.rosterChangeClosesAt) return true;
-        return new Date(data.rosterChangeClosesAt) >= new Date(data.registrationClosesAt);
+        const value = data as SeasonRefinementFields;
+        if (!value.registrationClosesAt || !value.rosterChangeClosesAt) return true;
+        return new Date(value.rosterChangeClosesAt) >= new Date(value.registrationClosesAt);
       },
       {
         path: ["rosterChangeClosesAt"],
         message: "名单调整截止时间不能早于报名截止时间",
       },
-    );
+    ) as unknown as T;
 }
 
 function assertUniqueStageKeys(stagePlan: StagePlan): void {

--- a/src/lib/validators/draft.ts
+++ b/src/lib/validators/draft.ts
@@ -1,26 +1,26 @@
 import { z } from "zod";
 
 export const startDraftSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
 });
 
 export const pauseDraftSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
 });
 
 export const resumeDraftSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
 });
 
 export const pickPlayerSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
-  entryId: z.string().uuid("队伍 ID 格式不正确"),
-  registrationId: z.string().uuid("报名 ID 格式不正确"),
-  clientRequestId: z.string().uuid("请求 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
+  entryId: z.guid("队伍 ID 格式不正确"),
+  registrationId: z.guid("报名 ID 格式不正确"),
+  clientRequestId: z.guid("请求 ID 格式不正确"),
 });
 
 export const skipDraftTurnSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
 });
 
 export type StartDraftInput = z.infer<typeof startDraftSchema>;

--- a/src/lib/validators/map-preferences.ts
+++ b/src/lib/validators/map-preferences.ts
@@ -30,7 +30,7 @@ function rejectDuplicateMaps(
   const seen = new Set<string>();
   for (const preference of preferences) {
     if (seen.has(preference.map)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "地图偏好不能重复" });
+      ctx.addIssue({ code: "custom", message: "地图偏好不能重复" });
     }
     seen.add(preference.map);
   }
@@ -45,7 +45,7 @@ export function longTermMapPreferencesSchema() {
       rejectDuplicateMaps(preferences, ctx);
       for (const preference of preferences) {
         if (!knownMaps.has(preference.map)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "长期地图资料只能使用稳定地图目录中的地图" });
+          ctx.addIssue({ code: "custom", message: "长期地图资料只能使用稳定地图目录中的地图" });
         }
       }
     });
@@ -61,20 +61,20 @@ export function eventMapPreferencesSchema(mapPool: readonly string[]) {
       let strongCount = 0;
       for (const preference of preferences) {
         if (!mapPool.includes(preference.map)) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "地图不在图池中" });
+          ctx.addIssue({ code: "custom", message: "地图不在图池中" });
         }
         if (preference.level === null) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "请为每张地图选择熟练度" });
+          ctx.addIssue({ code: "custom", message: "请为每张地图选择熟练度" });
           continue;
         }
         if (PLAYABLE_MAP_LEVELS.has(preference.level)) playableCount++;
         if (preference.level === "strong") strongCount++;
       }
       if (playableCount < 3) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "请至少选择 3 张达到「能打」及以上的地图" });
+        ctx.addIssue({ code: "custom", message: "请至少选择 3 张达到「能打」及以上的地图" });
       }
       if (strongCount > 3) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "「强图」最多选择 3 张" });
+        ctx.addIssue({ code: "custom", message: "「强图」最多选择 3 张" });
       }
     })
     .transform((preferences) => preferences as MapPreference[]);

--- a/src/lib/validators/registration.test.ts
+++ b/src/lib/validators/registration.test.ts
@@ -72,7 +72,7 @@ describe("buildRegistrationSchema", () => {
     );
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.errors[0].path).toContain("secondaryPosition");
+      expect(result.error.issues[0].path).toContain("secondaryPosition");
     }
   });
 

--- a/src/lib/validators/registration.ts
+++ b/src/lib/validators/registration.ts
@@ -31,7 +31,7 @@ export { PLAYER_TYPE_LABELS };
 export const RANK_ORDER = REGISTRATION_DEFAULTS.ranks.values;
 
 export const registrationSeedSchema = z.object({
-  seasonId: z.string().uuid("赛季 ID 格式不正确"),
+  seasonId: z.guid("赛季 ID 格式不正确"),
 });
 
 function isAllowedRank(value: string): value is RankValue {
@@ -75,7 +75,7 @@ export function buildRegistrationSchema(
 
   return z
     .object({
-      seasonId: z.string().uuid("赛季 ID 格式不正确"),
+      seasonId: z.guid("赛季 ID 格式不正确"),
 
       // ── 基础信息 ──
       email: z
@@ -118,7 +118,7 @@ export function buildRegistrationSchema(
           const normalized = normalizeSteamProfileUrl(v);
           if (!normalized) {
             ctx.addIssue({
-              code: z.ZodIssueCode.custom,
+              code: "custom",
               message: "Steam 个人资料链接格式不正确",
             });
             return z.NEVER;
@@ -146,7 +146,7 @@ export function buildRegistrationSchema(
 
       // Rating：完美平台 Rating，0.01–3.00，两位小数
       peakRating: z
-        .number({ invalid_type_error: "请输入数字" })
+        .number({ error: "请输入数字" })
         .min(0.01, "Rating 最小 0.01")
         .max(3.00, "Rating 最大 3.00")
         .refine(
@@ -156,7 +156,7 @@ export function buildRegistrationSchema(
 
       // WE：Win Effect，0.0–16.0，一位小数
       peakWe: z
-        .number({ invalid_type_error: "请输入数字" })
+        .number({ error: "请输入数字" })
         .min(0, "WE 不能为负")
         .max(16.0, "WE 最大 16.0")
         .refine(
@@ -171,7 +171,7 @@ export function buildRegistrationSchema(
       }),
 
       currentRating: z
-        .number({ invalid_type_error: "请输入数字" })
+        .number({ error: "请输入数字" })
         .min(0.01, "Rating 最小 0.01")
         .max(3.00, "Rating 最大 3.00")
         .refine(
@@ -180,7 +180,7 @@ export function buildRegistrationSchema(
         ),
 
       currentWe: z
-        .number({ invalid_type_error: "请输入数字" })
+        .number({ error: "请输入数字" })
         .min(0, "WE 不能为负")
         .max(16.0, "WE 最大 16.0")
         .refine(
@@ -228,7 +228,7 @@ export function buildRegistrationSchema(
       notes: z.string().max(500, "备注不超过 500 字").optional(),
 
       antiCheatPledge: z.literal(true, {
-        errorMap: () => ({ message: "请勾选反作弊承诺方可提交" }),
+        error: "请勾选反作弊承诺方可提交",
       }),
     })
     .refine((data) => data.secondaryPosition !== data.primaryPosition, {

--- a/src/lib/validators/vote.ts
+++ b/src/lib/validators/vote.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 
 export const castVoteSchema = z.object({
-  voterRegistrationId: z.string().uuid(),
-  candidateRegistrationId: z.string().uuid(),
+  voterRegistrationId: z.guid(),
+  candidateRegistrationId: z.guid(),
 });
 
 export const retractVoteSchema = z.object({
-  voterRegistrationId: z.string().uuid(),
-  candidateRegistrationId: z.string().uuid(),
+  voterRegistrationId: z.guid(),
+  candidateRegistrationId: z.guid(),
 });
 
 export const confirmCaptainsSchema = z.object({
-  seasonId: z.string().uuid(),
+  seasonId: z.guid(),
 });
 
 export type CastVoteInput = z.infer<typeof castVoteSchema>;

--- a/tests/unit/actions/register.test.ts
+++ b/tests/unit/actions/register.test.ts
@@ -118,7 +118,7 @@ const SESSION = mockUserSession({ userId: USER_ID, email: "player@example.com" }
 
 const USER = createFakeUser({ id: USER_ID, email: "player@example.com" });
 
-// VALID_INPUT 的 seasonId 必须是合法 UUID（registrationSeedSchema 用 z.string().uuid()）
+// VALID_INPUT 的 seasonId 必须是合法 UUID（registrationSeedSchema 用 z.guid()）
 const VALID_INPUT = {
   seasonId: SEASON_ID,
   email: "player@example.com",


### PR DESCRIPTION
## 变更

- 将应用依赖 `zod` 从 `^3.24.4` 升级到当前稳定 `4.5.4`，同步更新 `pnpm-lock.yaml`。
- 按官方迁移指南适配 Zod 4 的 `z.record`、错误参数、`ZodError.issues`、`ZodType` 和 super-refine issue 转发。
- 将原本只要求 UUID 字符串形状的校验迁移到 `z.guid()`，保留 Zod 3 时代对合法 UUID 形状的接受范围；没有新增产品校验规则。
- 保留 season form 的 mapping 延迟校验边界与既有字段错误映射；没有 schema、数据库迁移、生产数据或 UI 产品决策变更。

官方依据：

- [Zod 4 migration guide](https://zod.dev/v4/changelog)
- [Zod v4.5.4 release](https://github.com/colinhacks/zod/releases/tag/v4.5.4)

## 验证

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`：251 files / 1534 tests passed
- Zod canonical validator、Major snapshot、season planner 与 registration Server Action 定向测试：127 tests passed
- `pnpm test:coverage`：251 files / 1534 tests passed，V8 statements 44.84%
- `pnpm db:check`
- `pnpm build`
- `git diff --check`
- no-negative-echo：24 个变更文件 PASS

`pnpm peers check` 仍报告仓库既有的 ESLint 10 与 `eslint-plugin-import`、`eslint-plugin-jsx-a11y`、`eslint-plugin-react` 旧 peer range 警告；没有新增 Zod peer 警告，实际 lint 与完整测试均通过。

本 PR 不含 Changeset：仓库规则允许不改变 shipped behavior 的依赖维护升级不写 Changeset。

## 回滚

回滚本 PR 的 squash commit 即可恢复 Zod 3 锁定版本及对应兼容代码；不涉及数据库或外部系统状态。

Refs #462
