### PR TITLE
chore(tooling): 升级 pnpm 到 12.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/Drizzle-ORM-C5F74F?logo=drizzle&logoColor=black" alt="Drizzle ORM" />
   <img src="https://img.shields.io/badge/Supabase-Postgres%20%2F%20Auth-3FCF8E?logo=supabase&logoColor=white" alt="Supabase" />
-  <img src="https://img.shields.io/badge/pnpm-11-F69220?logo=pnpm&logoColor=white" alt="pnpm" />
+  <img src="https://img.shields.io/badge/pnpm-12-F69220?logo=pnpm&logoColor=white" alt="pnpm" />
   <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
 </p>
 
@@ -79,7 +79,7 @@ RivalHub 2.x 先把官方实例和真实赛事运营做好。代码以 AGPL-3.0 
 | 依赖 | 版本 |
 | --- | --- |
 | Node.js | `24.x` |
-| pnpm | `11.x` |
+| pnpm | `12.x` |
 | Docker | Local Supabase 需要 |
 
 ### 快速开始

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -7,7 +7,7 @@
 仓库当前 runtime contract 由 `package.json` / lockfile 统一声明：
 
 - Node.js 24.x
-- pnpm 11.x
+- pnpm 12.x
 
 `packageManager`、`devEngines.runtime` 与 `engines.node` 共同声明仓库 runtime。pnpm 安装时会按 manifest 解析所需 Node，并把对应 runtime 记录到 lockfile；首次获取可能需要联网，后续可复用本机缓存。不要删除相关 lockfile runtime 条目，也不要在 workflow、脚本或个人环境里再维护另一份 Node/pnpm 版本常量；CI 同样从仓库 manifest/lockfile 取得 runtime。
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "typescript": "^6.0.3",
     "vitest": "5.0.0"
   },
-  "packageManager": "pnpm@11.25.0",
+  "packageManager": "pnpm@12.3.4",
   "devEngines": {
     "runtime": {
       "name": "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -49,7 +49,7 @@ describe("deployment and operations contracts", () => {
   it("keeps pnpm and Node runtime ownership in the package manifest", () => {
     const manifest = readPackageManifest();
 
-    expect(manifest.packageManager).toBe("pnpm@11.25.0");
+    expect(manifest.packageManager).toBe("pnpm@12.3.4");
     expect(manifest.engines?.node).toBe("24.x");
     expect(manifest.devEngines?.runtime).toEqual({
       name: "node",


### PR DESCRIPTION
## 变更

- 将 `packageManager` 从 `pnpm@11.25.0` 升级到 `pnpm@12.3.4`。
- `12.3.4` 是实施时 npm `latest` stable，未采用 RC、beta 或 canary。
- 使用 pnpm 12 重新生成锁文件的 environment document 与 `packageManagerDependencies`，保留 Node 24.x 的 `devEngines.runtime` / `engines.node` contract；不新增重复的 package-manager runtime 声明。
- 保持现有 `pnpm/setup@v2.1.0` owner 与 `require-lockfile` 流程不变；该 action 从 manifest 读取 pnpm 与 Node pin。
- 将根 README 与 `docs/operations/local-development.md` 的稳定 runtime 终态更新为 pnpm 12.x，并更新 runtime contract test。

## 官方迁移面

- [pnpm 12.3.4 release notes](https://github.com/pnpm/pnpm/releases/tag/v12.3.4)：修复 pnpm 12 对 Vercel `pnpm install --unsafe-perm` 等布尔 flag 的兼容问题。
- [pnpm package.json contract](https://pnpm.io/package_json)：`packageManager` / `devEngines.runtime` 的声明与 pnpm 12 environment lockfile 行为。
- [pnpm/setup v2.1.0](https://github.com/pnpm/setup/releases/tag/v2.1.0)：pnpm 11+、manifest pin、runtime install 与 frozen install contract。

本 PR 不改应用代码、schema/migration、CI workflow 版本常量、release production action 或产品行为。

## 验证

- `pnpm install --frozen-lockfile`
- runtime contract test：8 tests passed
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`：251 files / 1534 tests passed
- `pnpm knip && pnpm knip --production`
- `pnpm db:check`
- `pnpm build`
- `pnpm exec tsx scripts/vercel-build.ts`
- `git diff --check`
- no-negative-echo：PASS
- `pnpm peers check` 仍只报告既有 ESLint 10 与三个 ESLint plugin 的 peer range 警告，无 pnpm 相关警告。

PostgreSQL integration、Local Supabase/E2E 与 Vercel Preview 由 PR required CI 提供；本地未启动数据库、Supabase、Docker 或 production 服务。

## Changeset / 文档

不添加 Changeset：这是不改变 shipped behavior 的 package-manager/tooling maintenance。runtime contract 发生稳定变化，因此已在本 PR 同步更新 README 与 local-development canonical doc。

## 回滚

回滚本 PR 的 squash commit 可恢复 `pnpm@11.25.0`、原锁文件格式与 pnpm 11 文档/runtime contract；不需要 production 写入或 release 操作。

Refs #462
