### PR TITLE
ci(dependabot): 暂停 npm 版本更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       production-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## 变更

- 在 `.github/dependabot.yml` 的 `npm` update block 增加 `open-pull-requests-limit: 0`。
- 仅暂停 npm 常规 version-update PR；`github-actions` weekly lane 保持原配置。
- 不修改 pnpm、Dependabot alerts/security settings、CI workflow 或应用代码。

## 背景与证据

#493 记录的 Dependabot × pnpm 12.3.4 provisioning failure 已连续复现：

- [run 34073028693](https://github.com/Starfie1d1272/RivalHub/actions/runs/34073028693)
- [rerun 34076500062](https://github.com/Starfie1d1272/RivalHub/actions/runs/34076500062)
- 两次均在 updater 执行 `pnpm -v` / lockfile update path 时无法取得 `@pnpm/exe.linux-x64@12.3.4`，未完成依赖更新。
- #492 的应用 install、type-check、lint、unit、build、PostgreSQL、system E2E、Vercel 与 required CI 均已通过。

GitHub 文档说明，`open-pull-requests-limit: 0` 可暂停对应 package ecosystem 的 version updates；本 PR 不改变其它 Dependabot 能力或安全设置：[官方文档](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates#disabling-dependabot-version-updates)。

## 验证

- Ruby YAML parse：通过，并确认只有 npm lane 的 limit 为 `0`。
- `github-actions` lane contract：保持不变。
- `git diff --check`：通过。
- no-negative-echo surface scan：通过。

这是 CI/开发工具维护，不改变 shipped behavior，因此不添加 Changeset。上游兼容性恢复后，删除该配置行即可恢复 npm version updates。

Refs #493
