### PR TITLE
release: 准备 v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.6.1]
+
+v2.6.1 是 v2.6 后的维护版本，刷新认证、数据验证和部署相关依赖，完成运行时与开发工具链升级，并收口 pnpm 12 下的依赖更新自动化兼容策略。没有赛事规则或数据库 schema 变化。
+
 ## [2.6.0]
 
 RivalHub 2.6 统一了高价值列表的查询与分页体验。公共队伍发现与管理员运营队列现在都使用可分享、可恢复的 URL 状态，让筛选后的结果总数和页面位置始终对应同一组真实数据。
@@ -1825,6 +1829,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.6.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.4.0...v2.4.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
## 摘要

准备 RivalHub v2.6.1 maintenance patch release。

- 更新版本号至 2.6.1
- 补充最简用户/operator-facing CHANGELOG 与 v2.6.0...v2.6.1 compare link
- 无赛事规则或数据库 schema 变化

## 验证

- `CI=1 pnpm exec changeset version`
- release metadata 校验通过
- `git diff --check`
- required CI 全部通过

## 发布边界

合入并通过 required CI 后，按 release runbook 在准确的 main commit 上创建 immutable `v2.6.1` tag；本 PR 不包含业务代码或 migration。