### PR TITLE
refactor(maintenance): 收口升级后的兼容残留

### DIFF
--- a/src/actions/community-awards.ts
+++ b/src/actions/community-awards.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { communityAwards, seasons } from "@/db/schema";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
 import {
   addCommunityAwardEvidenceInTx,
@@ -18,7 +18,7 @@ import {
 } from "@/lib/community-awards/service";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { isHttpUrl } from "@/lib/external-url";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 
 const uuid = z.guid();
 const optionalText = (max: number) => z.string().trim().max(max).nullable().optional();
@@ -30,9 +30,6 @@ const awardInput = z.object({
   supplementaryNote: optionalText(3000),
 });
 
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 function revalidateAwards(slug: string): void {
   revalidatePath(`/${slug}/community-awards`);
@@ -49,7 +46,7 @@ async function awardAndAdminOrThrow(awardId: string) {
 
 export async function submitCommunityAward(input: unknown): Promise<ActionResult<{ awardId: string }>> {
   const parsed = awardInput.safeParse(input);
-  if (!parsed.success) return invalid("社区奖信息不完整或格式无效。 ");
+  if (!parsed.success) return failValidation("社区奖信息不完整或格式无效。 ");
   try {
     const user = await requireAuth();
     const season = await db.query.seasons.findFirst({ where: eq(seasons.id, parsed.data.seasonId), columns: { slug: true } });
@@ -62,7 +59,7 @@ export async function submitCommunityAward(input: unknown): Promise<ActionResult
 
 export async function reviseCommunityAward(input: unknown): Promise<ActionResult<void>> {
   const parsed = awardInput.extend({ awardId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("社区奖补充信息无效。 ");
+  if (!parsed.success) return failValidation("社区奖补充信息无效。 ");
   try {
     const user = await requireAuth();
     const award = await db.query.communityAwards.findFirst({ where: eq(communityAwards.id, parsed.data.awardId), columns: { seasonId: true } });
@@ -77,7 +74,7 @@ export async function reviseCommunityAward(input: unknown): Promise<ActionResult
 
 export async function reviewCommunityAward(input: unknown): Promise<ActionResult<void>> {
   const parsed = z.object({ awardId: uuid, status: z.enum(["approved", "rejected"]), publicNote: optionalText(2000), reviewNote: optionalText(2000) }).safeParse(input);
-  if (!parsed.success) return invalid("审核参数无效。 ");
+  if (!parsed.success) return failValidation("审核参数无效。 ");
   try {
     const { award, season, admin } = await awardAndAdminOrThrow(parsed.data.awardId);
     await db.transaction((tx) => reviewCommunityAwardInTx(tx, { ...parsed.data, awardId: award.id, actorId: auditActorId(admin) }));
@@ -88,7 +85,7 @@ export async function reviewCommunityAward(input: unknown): Promise<ActionResult
 
 export async function requestCommunityAwardSupplement(input: unknown): Promise<ActionResult<void>> {
   const parsed = z.object({ awardId: uuid, note: z.string().trim().min(1).max(2000) }).safeParse(input);
-  if (!parsed.success) return invalid("补充说明无效。 ");
+  if (!parsed.success) return failValidation("补充说明无效。 ");
   try {
     const { award, season, admin } = await awardAndAdminOrThrow(parsed.data.awardId);
     await db.transaction((tx) => requestCommunityAwardSupplementInTx(tx, { ...parsed.data, awardId: award.id, actorId: auditActorId(admin) }));
@@ -99,7 +96,7 @@ export async function requestCommunityAwardSupplement(input: unknown): Promise<A
 
 export async function withdrawCommunityAward(input: unknown): Promise<ActionResult<void>> {
   const parsed = z.object({ awardId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("撤回参数无效。 ");
+  if (!parsed.success) return failValidation("撤回参数无效。 ");
   try {
     const user = await requireAuth();
     const award = await db.query.communityAwards.findFirst({ where: eq(communityAwards.id, parsed.data.awardId), columns: { seasonId: true } });
@@ -114,7 +111,7 @@ export async function withdrawCommunityAward(input: unknown): Promise<ActionResu
 
 export async function addCommunityAwardEvidence(input: unknown): Promise<ActionResult<{ evidenceId: string }>> {
   const parsed = z.object({ awardId: uuid, candidateUserId: uuid.nullable().optional(), matchId: uuid.nullable().optional(), explanation: z.string().trim().min(1).max(3000), videoUrl: z.string().trim().max(2000).refine(isHttpUrl, "证据视频链接必须是 http 或 https URL").nullable().optional() }).safeParse(input);
-  if (!parsed.success) return invalid("证据资料无效。 ");
+  if (!parsed.success) return failValidation("证据资料无效。 ");
   try {
     const user = await requireAuth();
     const award = await db.query.communityAwards.findFirst({ where: eq(communityAwards.id, parsed.data.awardId), columns: { seasonId: true } });
@@ -129,7 +126,7 @@ export async function addCommunityAwardEvidence(input: unknown): Promise<ActionR
 
 export async function resolveCommunityAward(input: unknown): Promise<ActionResult<void>> {
   const parsed = z.object({ awardId: uuid, status: z.enum(["awarded", "not_awarded", "cancelled"]), recipientUserId: uuid.nullable().optional(), outcomeNote: z.string().trim().min(1).max(2000) }).safeParse(input);
-  if (!parsed.success) return invalid("结奖参数无效。 ");
+  if (!parsed.success) return failValidation("结奖参数无效。 ");
   try {
     const { award, season, admin } = await awardAndAdminOrThrow(parsed.data.awardId);
     await db.transaction((tx) => resolveCommunityAwardInTx(tx, { ...parsed.data, awardId: award.id, actorId: auditActorId(admin) }));

--- a/src/actions/competition-entries.ts
+++ b/src/actions/competition-entries.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { competitionEntries } from "@/db/schema";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireAuth, requireSeasonAdmin } from "@/lib/auth/session";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { requestCompetitionEntryRosterChangeInTx } from "@/lib/competition-entries/roster-change";
@@ -22,13 +22,10 @@ import {
   withdrawCompetitionEntryInTx,
   withdrawCompetitionEntryParticipationInTx,
 } from "@/lib/competition-entries/commands";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 import { traceOperation } from "@/lib/observability/server";
 
 const uuid = z.guid();
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 function revalidateEntry(seasonSlug: string, entryId?: string): void {
   revalidatePath(`/${seasonSlug}/register`);
@@ -39,7 +36,7 @@ function revalidateEntry(seasonSlug: string, entryId?: string): void {
 
 export async function createCompetitionEntry(input: { competitionId: string; teamId: string }): Promise<ActionResult<{ entryId: string }>> {
   const parsed = z.object({ competitionId: uuid, teamId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛事或队伍标识无效。");
+  if (!parsed.success) return failValidation("赛事或队伍标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => createCompetitionEntryInTx(tx, { ...parsed.data, userId: session.userId, actorId: auditActorId(session) }));
@@ -50,7 +47,7 @@ export async function createCompetitionEntry(input: { competitionId: string; tea
 
 export async function saveCompetitionEntryRoster(input: { entryId: string; userIds: string[]; primaryStarterUserIds: string[]; perfectTeamId?: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid, userIds: z.array(uuid).min(1).max(9), primaryStarterUserIds: z.array(uuid).max(5), perfectTeamId: z.string().trim().max(128).optional() }).safeParse(input);
-  if (!parsed.success || new Set(parsed.data.userIds).size !== parsed.data.userIds.length || new Set(parsed.data.primaryStarterUserIds).size !== parsed.data.primaryStarterUserIds.length || parsed.data.primaryStarterUserIds.some((id) => !parsed.data.userIds.includes(id))) return invalid("赛事名单或预定主力无效。");
+  if (!parsed.success || new Set(parsed.data.userIds).size !== parsed.data.userIds.length || new Set(parsed.data.primaryStarterUserIds).size !== parsed.data.primaryStarterUserIds.length || parsed.data.primaryStarterUserIds.some((id) => !parsed.data.userIds.includes(id))) return failValidation("赛事名单或预定主力无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => saveCompetitionEntryRosterInTx(tx, { ...parsed.data, userId: session.userId, actorId: auditActorId(session) }));
@@ -61,7 +58,7 @@ export async function saveCompetitionEntryRoster(input: { entryId: string; userI
 
 export async function confirmCompetitionEntryParticipation(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => confirmCompetitionEntryParticipationInTx(tx, { entryId: parsed.data.entryId, userId: session.userId, actorId: auditActorId(session) }));
@@ -72,7 +69,7 @@ export async function confirmCompetitionEntryParticipation(input: { entryId: str
 
 export async function withdrawCompetitionEntryParticipation(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => withdrawCompetitionEntryParticipationInTx(tx, { entryId: parsed.data.entryId, userId: session.userId, actorId: auditActorId(session) }));
@@ -83,7 +80,7 @@ export async function withdrawCompetitionEntryParticipation(input: { entryId: st
 
 export async function declineCompetitionEntryParticipation(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => declineCompetitionEntryParticipationInTx(tx, { entryId: parsed.data.entryId, userId: session.userId, actorId: auditActorId(session) }));
@@ -94,7 +91,7 @@ export async function declineCompetitionEntryParticipation(input: { entryId: str
 
 export async function withdrawCompetitionEntry(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => withdrawCompetitionEntryInTx(tx, {
@@ -109,7 +106,7 @@ export async function withdrawCompetitionEntry(input: { entryId: string }): Prom
 
 export async function requestCompetitionEntryRosterChange(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => requestCompetitionEntryRosterChangeInTx(tx, {
@@ -124,7 +121,7 @@ export async function requestCompetitionEntryRosterChange(input: { entryId: stri
 
 export async function submitCompetitionEntry(input: { entryId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("参赛条目标识无效。");
+  if (!parsed.success) return failValidation("参赛条目标识无效。");
   try {
     const session = await requireAuth();
     const result = await traceOperation("competition_entry.submit", {
@@ -143,7 +140,7 @@ export async function submitCompetitionEntry(input: { entryId: string }): Promis
 
 export async function reviewCompetitionEntry(input: { entryId: string; decision: "changes_requested" | "waitlisted" | "approved" | "rejected"; reason?: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid, decision: z.enum(["changes_requested", "waitlisted", "approved", "rejected"]), reason: z.string().trim().max(1000).optional() }).safeParse(input);
-  if (!parsed.success || ((parsed.data.decision === "changes_requested" || parsed.data.decision === "rejected") && !parsed.data.reason)) return invalid("审核决定或原因无效。");
+  if (!parsed.success || ((parsed.data.decision === "changes_requested" || parsed.data.decision === "rejected") && !parsed.data.reason)) return failValidation("审核决定或原因无效。");
   try {
     const existing = await db.query.competitionEntries.findFirst({ where: eq(competitionEntries.id, parsed.data.entryId), columns: { competitionId: true } });
     if (!existing) throw new AppError(ErrorCode.NOT_FOUND, "赛事参赛条目不存在。");
@@ -165,7 +162,7 @@ export async function reviewCompetitionEntry(input: { entryId: string; decision:
 
 export async function grantCompetitionEntryRestrictionOverride(input: { entryId: string; restrictionCode: string; reason: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid, restrictionCode: z.string().trim().min(1).max(128), reason: z.string().trim().min(1).max(1000) }).safeParse(input);
-  if (!parsed.success) return invalid("解除限制必须指定具体限制并填写非空理由。 ");
+  if (!parsed.success) return failValidation("解除限制必须指定具体限制并填写非空理由。 ");
   try {
     const existing = await db.query.competitionEntries.findFirst({ where: eq(competitionEntries.id, parsed.data.entryId), columns: { competitionId: true } });
     if (!existing) throw new AppError(ErrorCode.NOT_FOUND, "赛事参赛条目不存在。 ");
@@ -181,7 +178,7 @@ export async function grantCompetitionEntryRestrictionOverride(input: { entryId:
 
 export async function revokeCompetitionEntryRestrictionOverride(input: { entryId: string; restrictionCode: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid, restrictionCode: z.string().trim().min(1).max(128) }).safeParse(input);
-  if (!parsed.success) return invalid("解除限制标识无效。 ");
+  if (!parsed.success) return failValidation("解除限制标识无效。 ");
   try {
     const existing = await db.query.competitionEntries.findFirst({ where: eq(competitionEntries.id, parsed.data.entryId), columns: { competitionId: true } });
     if (!existing) throw new AppError(ErrorCode.NOT_FOUND, "赛事参赛条目不存在。 ");
@@ -197,7 +194,7 @@ export async function revokeCompetitionEntryRestrictionOverride(input: { entryId
 
 export async function transferCompetitionEntryRepresentative(input: { entryId: string; toUserId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ entryId: uuid, toUserId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛事负责人交接信息无效。");
+  if (!parsed.success) return failValidation("赛事负责人交接信息无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => transferCompetitionEntryRepresentativeInTx(tx, {

--- a/src/actions/major-prestart.ts
+++ b/src/actions/major-prestart.ts
@@ -12,11 +12,11 @@ import {
   majorPrestartIssues,
   seasons,
 } from "@/db/schema";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { getStandardMajorDefinition } from "@/lib/major/standard";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 import { startMajorInTransaction, type MajorStartResult } from "@/lib/major/start";
 import { finalizeMajorSwissRoundInTransaction, type MajorSwissRoundFinalizationResult } from "@/lib/major/swiss-runtime";
 import { transitionMajorSwissStageInTransaction, type MajorStageTransitionResult } from "@/lib/major/stage-transition";
@@ -36,9 +36,6 @@ const rosterExceptionInput = z.object({ seasonId: uuid, entrantId: uuid, reason:
 const entrantSelectionInput = z.object({ seasonId: uuid, competitionEntryIds: z.array(uuid) });
 const tournamentSeedsInput = z.object({ seasonId: uuid, entryIds: z.array(uuid), overrideReason: z.string().trim().max(500).optional() });
 
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 function standardMajorOrThrow(season: typeof seasons.$inferSelect): void {
   getStandardMajorDefinition(season, {
@@ -65,7 +62,7 @@ function revalidateMajorPrestart(seasonSlug: string): void {
 export async function selectMajorEntrants(input: { seasonId: string; competitionEntryIds: string[] }): Promise<ActionResult<void>> {
   const parsed = entrantSelectionInput.safeParse(input);
   if (!parsed.success || new Set(parsed.data.competitionEntryIds).size !== parsed.data.competitionEntryIds.length) {
-    return invalid("正式参赛队选择无效，不能包含重复 Entry。 ");
+    return failValidation("正式参赛队选择无效，不能包含重复 Entry。 ");
   }
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
@@ -86,13 +83,13 @@ export async function selectMajorEntrants(input: { seasonId: string; competition
 /** Explicit exception path only; normal flow uses selectMajorEntrants. */
 export async function repairMajorPrestartRoster(input: z.infer<typeof rosterRepairInput>): Promise<ActionResult<void>> {
   const parsed = rosterRepairInput.safeParse(input);
-  if (!parsed.success) return invalid("最终名单输入无效。");
+  if (!parsed.success) return failValidation("最终名单输入无效。");
   const userIds = [...new Set(parsed.data.userIds)];
-  if (userIds.length !== parsed.data.userIds.length) return invalid("最终名单中不能重复同一位选手。");
+  if (userIds.length !== parsed.data.userIds.length) return failValidation("最终名单中不能重复同一位选手。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     if (userIds.length < season.minTeamSize || userIds.length > season.maxTeamSize) {
-      return invalid(`最终名单必须为 ${season.minTeamSize}-${season.maxTeamSize} 人。`);
+      return failValidation(`最终名单必须为 ${season.minTeamSize}-${season.maxTeamSize} 人。`);
     }
     await db.transaction((tx) => saveMajorPrestartRosterInTx(tx, {
       seasonId: season.id,
@@ -108,7 +105,7 @@ export async function repairMajorPrestartRoster(input: z.infer<typeof rosterRepa
 
 export async function confirmMajorPrestartRoster(input: z.input<typeof rosterExceptionInput>): Promise<ActionResult<void>> {
   const parsed = rosterExceptionInput.safeParse(input);
-  if (!parsed.success) return invalid("赛季或正式参赛队标识无效。");
+  if (!parsed.success) return failValidation("赛季或正式参赛队标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -145,7 +142,7 @@ export async function confirmMajorPrestartRoster(input: z.input<typeof rosterExc
 /** 已确认的单队名单在全局锁定前可由管理员显式重新开放；该动作不会解冻赛事。 */
 export async function reopenMajorPrestartRoster(input: z.input<typeof rosterExceptionInput>): Promise<ActionResult<void>> {
   const parsed = rosterExceptionInput.safeParse(input);
-  if (!parsed.success) return invalid("赛季或正式参赛队标识无效。");
+  if (!parsed.success) return failValidation("赛季或正式参赛队标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -168,7 +165,7 @@ export async function reopenMajorPrestartRoster(input: z.input<typeof rosterExce
 
 export async function addMajorPrestartIssue(input: { seasonId: string; category: "qualification" | "administration"; label: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ seasonId: uuid, category: issueCategory, label: z.string().trim().min(1).max(240) }).safeParse(input);
-  if (!parsed.success) return invalid("待处理事项输入无效。");
+  if (!parsed.success) return failValidation("待处理事项输入无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -187,7 +184,7 @@ export async function addMajorPrestartIssue(input: { seasonId: string; category:
 
 export async function resolveMajorPrestartIssue(input: { seasonId: string; issueId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ seasonId: uuid, issueId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛季或事项标识无效。");
+  if (!parsed.success) return failValidation("赛季或事项标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -208,7 +205,7 @@ export async function resolveMajorPrestartIssue(input: { seasonId: string; issue
 
 export async function lockMajorPrestartEntrants(input: { seasonId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ seasonId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛季标识无效。");
+  if (!parsed.success) return failValidation("赛季标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await traceOperation("major.prestart.lock_entrants", {
@@ -226,8 +223,8 @@ export async function lockMajorPrestartEntrants(input: { seasonId: string }): Pr
 
 export async function saveMajorTournamentSeeds(input: { seasonId: string; entryIds: string[]; overrideReason?: string }): Promise<ActionResult<void>> {
   const parsed = tournamentSeedsInput.safeParse(input);
-  if (!parsed.success) return invalid("赛事种子或人工调整说明无效。 ");
-  if (new Set(parsed.data.entryIds).size !== parsed.data.entryIds.length) return invalid("赛事种子不能包含重复 Entry。 ");
+  if (!parsed.success) return failValidation("赛事种子或人工调整说明无效。 ");
+  if (new Set(parsed.data.entryIds).size !== parsed.data.entryIds.length) return failValidation("赛事种子不能包含重复 Entry。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -246,7 +243,7 @@ export async function saveMajorTournamentSeeds(input: { seasonId: string; entryI
 
 export async function confirmMajorTournamentSeeds(input: { seasonId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ seasonId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛季标识无效。");
+  if (!parsed.success) return failValidation("赛季标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     await db.transaction(async (tx) => {
@@ -263,7 +260,7 @@ export async function confirmMajorTournamentSeeds(input: { seasonId: string }): 
 /** 管理员显式确认后原子启动 Stage 1；重试返回同一已创建运行记录。 */
 export async function startMajor(input: { seasonId: string }): Promise<ActionResult<MajorStartResult>> {
   const parsed = z.object({ seasonId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛季标识无效。");
+  if (!parsed.success) return failValidation("赛季标识无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await traceOperation("major.start", {
@@ -283,7 +280,7 @@ export async function startMajor(input: { seasonId: string }): Promise<ActionRes
 /** 明确确认指定 StageRun 的一轮 Swiss 比赛，并在同一事务中生成下一轮。 */
 export async function finalizeMajorSwissRound(input: { seasonId: string; stageRunId: string; expectedRound: 1 | 2 | 3 | 4 | 5 }): Promise<ActionResult<MajorSwissRoundFinalizationResult>> {
   const parsed = z.object({ seasonId: uuid, stageRunId: uuid, expectedRound: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)]) }).safeParse(input);
-  if (!parsed.success) return invalid("赛季或待确认轮次无效。 ");
+  if (!parsed.success) return failValidation("赛季或待确认轮次无效。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await traceOperation("major.swiss_round.finalize", {
@@ -304,7 +301,7 @@ export async function finalizeMajorSwissRound(input: { seasonId: string; stageRu
 
 export async function transitionMajorSwissStage(input: { seasonId: string; sourceStageRunId: string }): Promise<ActionResult<MajorStageTransitionResult>> {
   const parsed = z.object({ seasonId: uuid, sourceStageRunId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("阶段切换请求无效。 ");
+  if (!parsed.success) return failValidation("阶段切换请求无效。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await traceOperation("major.swiss_stage.transition", {
@@ -324,7 +321,7 @@ export async function transitionMajorSwissStage(input: { seasonId: string; sourc
 
 export async function startMajorPlayoff(input: { seasonId: string; sourceStageRunId: string; hasThirdPlaceMatch: boolean }): Promise<ActionResult<MajorPlayoffStartResult>> {
   const parsed = z.object({ seasonId: uuid, sourceStageRunId: uuid, hasThirdPlaceMatch: z.boolean() }).safeParse(input);
-  if (!parsed.success) return invalid("淘汰赛启动请求无效。 ");
+  if (!parsed.success) return failValidation("淘汰赛启动请求无效。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await traceOperation("major.playoff.start", {
@@ -342,7 +339,7 @@ export async function startMajorPlayoff(input: { seasonId: string; sourceStageRu
 
 export async function finalizeMajorPlayoffRound(input: { seasonId: string; stageRunId: string; expectedRound: "quarterfinal" | "semifinal" | "final" }): Promise<ActionResult<MajorPlayoffFinalizationResult>> {
   const parsed = z.object({ seasonId: uuid, stageRunId: uuid, expectedRound: z.enum(["quarterfinal", "semifinal", "final"]) }).safeParse(input);
-  if (!parsed.success) return invalid("淘汰赛确认请求无效。 ");
+  if (!parsed.success) return failValidation("淘汰赛确认请求无效。 ");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => finalizeMajorPlayoffRoundInTransaction(tx, {

--- a/src/actions/postevent.ts
+++ b/src/actions/postevent.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { postEventAdjudications, seasons, tournamentHonors } from "@/db/schema";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
 import { AppError, ErrorCode } from "@/lib/errors";
 import {
@@ -17,15 +17,12 @@ import {
   revokePostEventAdjudicationInTx,
   revokeTournamentHonorInTx,
 } from "@/lib/postevent/service";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 
 const uuid = z.guid();
 const clientRequestId = z.guid();
 const impactSchema = z.enum(ADJUDICATION_IMPACTS);
 
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 async function seasonAndAdminOrThrow(seasonId: string) {
   const season = await db.query.seasons.findFirst({ where: eq(seasons.id, seasonId), columns: { id: true, slug: true } });
@@ -42,7 +39,7 @@ function revalidatePostEvent(slug: string): void {
 
 export async function confirmMajorFinalResult(input: unknown): Promise<ActionResult<{ resultId: string; alreadyConfirmed: boolean }>> {
   const parsed = z.object({ seasonId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛事结果确认参数无效。");
+  if (!parsed.success) return failValidation("赛事结果确认参数无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => confirmMajorFinalResultInTx(tx, { seasonId: season.id, actorId: auditActorId(admin) }));
@@ -67,7 +64,7 @@ const createAdjudicationSchema = z.object({
 
 export async function createPostEventAdjudication(input: unknown): Promise<ActionResult<{ adjudicationId: string; created: boolean }>> {
   const parsed = createAdjudicationSchema.safeParse(input);
-  if (!parsed.success) return invalid("赛后裁决参数无效。");
+  if (!parsed.success) return failValidation("赛后裁决参数无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => createPostEventAdjudicationInTx(tx, {
@@ -82,7 +79,7 @@ export async function createPostEventAdjudication(input: unknown): Promise<Actio
 
 export async function revokePostEventAdjudication(input: unknown): Promise<ActionResult<{ adjudicationId: string; alreadyRevoked: boolean }>> {
   const parsed = z.object({ adjudicationId: uuid, reason: z.string().trim().min(1).max(2000) }).safeParse(input);
-  if (!parsed.success) return invalid("撤销裁决参数无效。");
+  if (!parsed.success) return failValidation("撤销裁决参数无效。");
   try {
     const [adjudication] = await db.select({ seasonId: postEventAdjudications.seasonId }).from(postEventAdjudications)
       .where(eq(postEventAdjudications.id, parsed.data.adjudicationId));
@@ -114,7 +111,7 @@ const grantHonorSchema = z.object({
 
 export async function grantTournamentHonor(input: unknown): Promise<ActionResult<{ honorId: string; created: boolean }>> {
   const parsed = grantHonorSchema.safeParse(input);
-  if (!parsed.success) return invalid("荣誉授予参数无效。");
+  if (!parsed.success) return failValidation("荣誉授予参数无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => grantTournamentHonorInTx(tx, {
@@ -129,7 +126,7 @@ export async function grantTournamentHonor(input: unknown): Promise<ActionResult
 
 export async function revokeTournamentHonor(input: unknown): Promise<ActionResult<{ honorId: string; alreadyRevoked: boolean }>> {
   const parsed = z.object({ honorId: uuid, reason: z.string().trim().min(1).max(2000) }).safeParse(input);
-  if (!parsed.success) return invalid("撤销荣誉参数无效。");
+  if (!parsed.success) return failValidation("撤销荣誉参数无效。");
   try {
     const [honor] = await db.select({ seasonId: tournamentHonors.seasonId }).from(tournamentHonors)
       .where(eq(tournamentHonors.id, parsed.data.honorId));
@@ -147,7 +144,7 @@ export async function revokeTournamentHonor(input: unknown): Promise<ActionResul
 
 export async function archiveMajorTournament(input: unknown): Promise<ActionResult<{ archived: boolean; alreadyArchived: boolean }>> {
   const parsed = z.object({ seasonId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("赛事归档参数无效。");
+  if (!parsed.success) return failValidation("赛事归档参数无效。");
   try {
     const { season, admin } = await seasonAndAdminOrThrow(parsed.data.seasonId);
     const result = await db.transaction((tx) => archiveTournamentInTx(tx, { seasonId: season.id, actorId: auditActorId(admin) }));

--- a/src/actions/postmatch.ts
+++ b/src/actions/postmatch.ts
@@ -3,20 +3,19 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { matches, seasons } from "@/db/schema";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireSeasonAdmin } from "@/lib/auth/session";
 import { addMatchCommentatorInTx, removeMatchCommentatorInTx, revokePostMatchSubmissionInTx, setMatchVideoUrlInTx, submitPostMatchReportInTx } from "@/lib/postmatch/service";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { isHttpUrl } from "@/lib/external-url";
 import { revalidateMatchPaths } from "@/lib/revalidation";
 const uuid = z.guid();
 const url = z.string().trim().max(2000).refine(isHttpUrl, "录像链接必须是 http 或 https URL");
-function invalid(message: string): ActionResult<never> { return fail({ code: ErrorCode.VALIDATION_FAILED, message }); }
 async function matchAndAdminOrThrow(matchId: string) { const match = await db.query.matches.findFirst({ where: eq(matches.id, matchId), columns: { id: true, seasonId: true } }); if (!match) throw new AppError(ErrorCode.MATCH_NOT_FOUND, "比赛不存在。"); const season = await db.query.seasons.findFirst({ where: eq(seasons.id, match.seasonId), columns: { slug: true } }); if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛季不存在。"); return { match, season, admin: await requireSeasonAdmin(match.seasonId) }; }
 async function run(matchId: string, work: (actorId: string) => Promise<void>): Promise<ActionResult<void>> { try { const { match, season, admin } = await matchAndAdminOrThrow(matchId); await work(auditActorId(admin)); revalidateMatchPaths(season.slug, match.id); return ok(undefined); } catch (error) { return actionError("postmatch", error); } }
-export async function addMatchCommentator(input: unknown) { const p = z.object({ matchId: uuid, userId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => addMatchCommentatorInTx(tx, { ...p.data, actorId })); }) : invalid("解说参数无效。"); }
-export async function removeMatchCommentator(input: unknown) { const p = z.object({ matchId: uuid, userId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => removeMatchCommentatorInTx(tx, { ...p.data, actorId })); }) : invalid("解说参数无效。"); }
-export async function updateMatchVideoUrl(input: unknown) { const p = z.object({ matchId: uuid, videoUrl: z.union([url, z.literal(""), z.null()]).optional() }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => setMatchVideoUrlInTx(tx, { matchId: p.data.matchId, videoUrl: p.data.videoUrl || null, actorId })); }) : invalid("录像链接无效。"); }
-export async function submitPostMatchReport(input: unknown) { const p = z.object({ matchId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => submitPostMatchReportInTx(tx, { matchId: p.data.matchId, actorId })); }) : invalid("赛后提交参数无效。"); }
-export async function revokePostMatchSubmission(input: unknown) { const p = z.object({ matchId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => revokePostMatchSubmissionInTx(tx, { matchId: p.data.matchId, actorId })); }) : invalid("撤销提交参数无效。"); }
+export async function addMatchCommentator(input: unknown) { const p = z.object({ matchId: uuid, userId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => addMatchCommentatorInTx(tx, { ...p.data, actorId })); }) : failValidation("解说参数无效。"); }
+export async function removeMatchCommentator(input: unknown) { const p = z.object({ matchId: uuid, userId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => removeMatchCommentatorInTx(tx, { ...p.data, actorId })); }) : failValidation("解说参数无效。"); }
+export async function updateMatchVideoUrl(input: unknown) { const p = z.object({ matchId: uuid, videoUrl: z.union([url, z.literal(""), z.null()]).optional() }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => setMatchVideoUrlInTx(tx, { matchId: p.data.matchId, videoUrl: p.data.videoUrl || null, actorId })); }) : failValidation("录像链接无效。"); }
+export async function submitPostMatchReport(input: unknown) { const p = z.object({ matchId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => submitPostMatchReportInTx(tx, { matchId: p.data.matchId, actorId })); }) : failValidation("赛后提交参数无效。"); }
+export async function revokePostMatchSubmission(input: unknown) { const p = z.object({ matchId: uuid }).safeParse(input); return p.success ? run(p.data.matchId, async (actorId) => { await db.transaction((tx) => revokePostMatchSubmissionInTx(tx, { matchId: p.data.matchId, actorId })); }) : failValidation("撤销提交参数无效。"); }

--- a/src/actions/recruitment.ts
+++ b/src/actions/recruitment.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db } from "@/db/client";
-import { actionError } from "@/lib/action-utils";
+import { actionError, failValidation } from "@/lib/action-utils";
 import { auditActorId, requireAuth } from "@/lib/auth/session";
 import { CS2_POSITION_VALUES } from "@/lib/config/cs2-positions";
 import {
@@ -15,8 +15,7 @@ import {
   upsertTeamRecruitmentInTx,
   withdrawRecruitmentInterestInTx,
 } from "@/lib/recruitment/commands";
-import { ErrorCode } from "@/lib/errors";
-import { fail, ok, type ActionResult } from "@/types/action";
+import { ok, type ActionResult } from "@/types/action";
 
 const uuid = z.guid();
 const position = z.enum(CS2_POSITION_VALUES);
@@ -25,9 +24,6 @@ const optionalSeason = uuid.nullable().optional();
 const teamPositions = z.array(position).max(CS2_POSITION_VALUES.length).refine((positions) => new Set(positions).size === positions.length, "位置不能重复");
 const playerPositions = z.array(position).min(1).max(3).refine((positions) => new Set(positions).size === positions.length, "位置不能重复");
 
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 function revalidateRecruitment(userId?: string, teamSlug?: string): void {
   revalidatePath("/teams");
@@ -40,7 +36,7 @@ function revalidateRecruitment(userId?: string, teamSlug?: string): void {
 
 export async function saveTeamRecruitment(input: { teamId: string; positions: string[]; targetSeasonId?: string | null; note?: string }): Promise<ActionResult<{ expiresAt: string }>> {
   const parsed = z.object({ teamId: uuid, positions: teamPositions, targetSeasonId: optionalSeason, note: optionalNote }).safeParse(input);
-  if (!parsed.success) return invalid("招募信息无效：最多可选择五个位置，说明不超过 280 字。");
+  if (!parsed.success) return failValidation("招募信息无效：最多可选择五个位置，说明不超过 280 字。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => upsertTeamRecruitmentInTx(tx, {
@@ -58,7 +54,7 @@ export async function saveTeamRecruitment(input: { teamId: string; positions: st
 
 export async function closeTeamRecruitment(input: { teamId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("队伍标识无效。");
+  if (!parsed.success) return failValidation("队伍标识无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => closeTeamRecruitmentInTx(tx, { teamId: parsed.data.teamId, userId: session.userId, actorId: auditActorId(session) }));
@@ -69,7 +65,7 @@ export async function closeTeamRecruitment(input: { teamId: string }): Promise<A
 
 export async function savePlayerLft(input: { positions: string[]; targetSeasonId?: string | null; note?: string }): Promise<ActionResult<{ expiresAt: string }>> {
   const parsed = z.object({ positions: playerPositions, targetSeasonId: optionalSeason, note: optionalNote }).safeParse(input);
-  if (!parsed.success) return invalid("找队信息无效：请选择 1-3 个位置，说明不超过 280 字。");
+  if (!parsed.success) return failValidation("找队信息无效：请选择 1-3 个位置，说明不超过 280 字。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => upsertPlayerLftInTx(tx, {
@@ -95,7 +91,7 @@ export async function closePlayerLft(): Promise<ActionResult<void>> {
 
 export async function expressRecruitmentInterest(input: { recruitmentIntentId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ recruitmentIntentId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("招募信息无效。");
+  if (!parsed.success) return failValidation("招募信息无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => expressRecruitmentInterestInTx(tx, { recruitmentIntentId: parsed.data.recruitmentIntentId, userId: session.userId, actorId: auditActorId(session) }));
@@ -106,7 +102,7 @@ export async function expressRecruitmentInterest(input: { recruitmentIntentId: s
 
 export async function withdrawRecruitmentInterest(input: { recruitmentIntentId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ recruitmentIntentId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("招募信息无效。");
+  if (!parsed.success) return failValidation("招募信息无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => withdrawRecruitmentInterestInTx(tx, { recruitmentIntentId: parsed.data.recruitmentIntentId, userId: session.userId, actorId: auditActorId(session) }));
@@ -117,7 +113,7 @@ export async function withdrawRecruitmentInterest(input: { recruitmentIntentId: 
 
 export async function dismissRecruitmentInterest(input: { recruitmentIntentId: string; userId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ recruitmentIntentId: uuid, userId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("加入意向无效。");
+  if (!parsed.success) return failValidation("加入意向无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => dismissRecruitmentInterestInTx(tx, { recruitmentIntentId: parsed.data.recruitmentIntentId, interestUserId: parsed.data.userId, userId: session.userId, actorId: auditActorId(session) }));

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -37,9 +37,6 @@ const PENDING_DIRECT_INVITATION_CONSTRAINT = "team_invitations_one_pending_direc
 const uuid = z.guid();
 const teamName = z.string().trim().min(MIN_TEAM_NAME_LENGTH).max(MAX_TEAM_NAME_LENGTH);
 const description = z.string().trim().max(500);
-function invalid(message: string): ActionResult<never> {
-  return fail({ code: ErrorCode.VALIDATION_FAILED, message });
-}
 
 function revalidateTeam(slug?: string): void {
   revalidatePath("/teams");
@@ -50,7 +47,7 @@ function revalidateTeam(slug?: string): void {
 
 export async function createTeam(input: { name: string; description?: string }): Promise<ActionResult<{ teamId: string; slug: string }>> {
   const parsed = z.object({ name: teamName, description: description.optional() }).safeParse(input);
-  if (!parsed.success) return invalid(`队伍名称需为 ${MIN_TEAM_NAME_LENGTH}-${MAX_TEAM_NAME_LENGTH} 个字符，简介不超过 500 字。`);
+  if (!parsed.success) return failValidation(`队伍名称需为 ${MIN_TEAM_NAME_LENGTH}-${MAX_TEAM_NAME_LENGTH} 个字符，简介不超过 500 字。`);
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => createTeamInTx(tx, { name: parsed.data.name, description: parsed.data.description, userId: session.userId, actorId: auditActorId(session) }));
@@ -61,7 +58,7 @@ export async function createTeam(input: { name: string; description?: string }):
 
 export async function updateTeamProfile(input: { teamId: string; name: string; description?: string }): Promise<ActionResult<{ slug: string }>> {
   const parsed = z.object({ teamId: uuid, name: teamName, description: description.optional() }).safeParse(input);
-  if (!parsed.success) return invalid("队伍资料无效。");
+  if (!parsed.success) return failValidation("队伍资料无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => updateTeamProfileInTx(tx, { ...parsed.data, description: parsed.data.description, userId: session.userId, actorId: auditActorId(session) }));
@@ -95,7 +92,7 @@ export async function uploadTeamLogo(teamId: string, formData: FormData): Promis
 
 export async function inviteTeamMember(input: { teamId: string; email: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, email: z.string().email() }).safeParse(input);
-  if (!parsed.success) return invalid("请输入已注册用户的有效邮箱。");
+  if (!parsed.success) return failValidation("请输入已注册用户的有效邮箱。");
   try {
     const session = await requireAuth();
     const user = await db.query.users.findFirst({ where: eq(users.email, normalizeEmail(parsed.data.email)) });
@@ -104,7 +101,7 @@ export async function inviteTeamMember(input: { teamId: string; email: string })
     revalidateTeam();
     return ok(undefined);
   } catch (error) {
-    if (isPgUniqueViolation(error, PENDING_DIRECT_INVITATION_CONSTRAINT)) return invalid("该邀请已存在。");
+    if (isPgUniqueViolation(error, PENDING_DIRECT_INVITATION_CONSTRAINT)) return failValidation("该邀请已存在。");
     return actionError("inviteTeamMember", error);
   }
 }
@@ -112,7 +109,7 @@ export async function inviteTeamMember(input: { teamId: string; email: string })
 /** A Lobby handoff; the canonical invitation command remains the only Team invite owner. */
 export async function inviteTeamMemberByUserId(input: { teamId: string; userId: string; recruitmentIntentId?: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, userId: uuid, recruitmentIntentId: uuid.optional() }).safeParse(input);
-  if (!parsed.success) return invalid("邀请对象无效。");
+  if (!parsed.success) return failValidation("邀请对象无效。");
   try {
     const session = await requireAuth();
     await db.transaction(async (tx) => {
@@ -125,14 +122,14 @@ export async function inviteTeamMemberByUserId(input: { teamId: string; userId: 
     revalidateTeam();
     return ok(undefined);
   } catch (error) {
-    if (isPgUniqueViolation(error, PENDING_DIRECT_INVITATION_CONSTRAINT)) return invalid("该邀请已存在。");
+    if (isPgUniqueViolation(error, PENDING_DIRECT_INVITATION_CONSTRAINT)) return failValidation("该邀请已存在。");
     return actionError("inviteTeamMemberByUserId", error);
   }
 }
 
 export async function createTeamShareInvitation(input: { teamId: string }): Promise<ActionResult<{ token: string; expiresAt: string }>> {
   const parsed = z.object({ teamId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("队伍标识无效。");
+  if (!parsed.success) return failValidation("队伍标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => createTeamShareInvitationInTx(tx, { teamId: parsed.data.teamId, userId: session.userId, actorId: auditActorId(session) }));
@@ -142,7 +139,7 @@ export async function createTeamShareInvitation(input: { teamId: string }): Prom
 
 export async function acceptTeamInvitation(input: { invitationId?: string; token?: string }): Promise<ActionResult<{ teamId: string; slug: string }>> {
   const parsed = z.object({ invitationId: uuid.optional(), token: z.string().min(32).optional() }).refine((value) => Boolean(value.invitationId) !== Boolean(value.token)).safeParse(input);
-  if (!parsed.success) return invalid("邀请标识无效。");
+  if (!parsed.success) return failValidation("邀请标识无效。");
   try {
     const session = await requireAuth();
     const result = await db.transaction((tx) => acceptTeamInvitationInTx(tx, {
@@ -162,7 +159,7 @@ export async function acceptTeamInvitation(input: { invitationId?: string; token
 
 export async function declineTeamInvitation(input: { invitationId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ invitationId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("邀请标识无效。");
+  if (!parsed.success) return failValidation("邀请标识无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => declineTeamInvitationInTx(tx, { invitationId: parsed.data.invitationId, userId: session.userId, actorId: auditActorId(session) }));
@@ -173,7 +170,7 @@ export async function declineTeamInvitation(input: { invitationId: string }): Pr
 
 export async function revokeTeamInvitation(input: { teamId: string; invitationId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, invitationId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("邀请标识无效。");
+  if (!parsed.success) return failValidation("邀请标识无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => revokeTeamInvitationInTx(tx, { ...parsed.data, userId: session.userId, actorId: auditActorId(session) }));
@@ -184,7 +181,7 @@ export async function revokeTeamInvitation(input: { teamId: string; invitationId
 
 export async function setTeamMembershipStatus(input: { teamId: string; userId: string; status: "active" | "benched" }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, userId: uuid, status: z.enum(["active", "benched"]) }).safeParse(input);
-  if (!parsed.success) return invalid("成员状态无效。");
+  if (!parsed.success) return failValidation("成员状态无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => setTeamMembershipStatusInTx(tx, { teamId: parsed.data.teamId, userId: session.userId, targetUserId: parsed.data.userId, status: parsed.data.status, actorId: auditActorId(session) }));
@@ -195,7 +192,7 @@ export async function setTeamMembershipStatus(input: { teamId: string; userId: s
 
 export async function leaveTeam(input: { teamId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("队伍标识无效。");
+  if (!parsed.success) return failValidation("队伍标识无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => leaveTeamInTx(tx, { teamId: parsed.data.teamId, userId: session.userId, actorId: auditActorId(session) }));
@@ -206,7 +203,7 @@ export async function leaveTeam(input: { teamId: string }): Promise<ActionResult
 
 export async function kickTeamMember(input: { teamId: string; userId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, userId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("成员标识无效。");
+  if (!parsed.success) return failValidation("成员标识无效。");
   try {
     const session = await requireAuth();
     await db.transaction((tx) => kickTeamMemberInTx(tx, { teamId: parsed.data.teamId, userId: session.userId, targetUserId: parsed.data.userId, actorId: auditActorId(session) }));
@@ -217,7 +214,7 @@ export async function kickTeamMember(input: { teamId: string; userId: string }):
 
 export async function transferTeamCaptain(input: { teamId: string; toUserId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid, toUserId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("队长交接信息无效。");
+  if (!parsed.success) return failValidation("队长交接信息无效。");
   try {
     const actor = await requireAuth();
     const currentTeam = await db.query.teams.findFirst({ where: eq(teams.id, parsed.data.teamId), columns: { captainUserId: true } });
@@ -231,7 +228,7 @@ export async function transferTeamCaptain(input: { teamId: string; toUserId: str
 
 export async function disbandTeam(input: { teamId: string }): Promise<ActionResult<void>> {
   const parsed = z.object({ teamId: uuid }).safeParse(input);
-  if (!parsed.success) return invalid("队伍标识无效。");
+  if (!parsed.success) return failValidation("队伍标识无效。");
   try {
     const actor = await requireAuth();
     const currentTeam = await db.query.teams.findFirst({ where: eq(teams.id, parsed.data.teamId), columns: { captainUserId: true } });

--- a/src/lib/revalidation.ts
+++ b/src/lib/revalidation.ts
@@ -1,4 +1,4 @@
-import * as nextCache from "next/cache";
+import { revalidatePath, revalidateTag, updateTag } from "next/cache";
 
 import {
   PUBLIC_SEASON_CATALOG_TAG,
@@ -28,28 +28,28 @@ type RevalidationMode = "action" | "route";
 
 /** Server Action semantics: invalidate immediately for read-your-own-writes. */
 export function updatePublicSeasonTags(slug: string, seasonId?: string): void {
-  nextCache.updateTag?.(PUBLIC_SEASON_CATALOG_TAG);
-  nextCache.updateTag?.(publicSeasonTag(slug));
+  updateTag(PUBLIC_SEASON_CATALOG_TAG);
+  updateTag(publicSeasonTag(slug));
   if (seasonId) {
-    nextCache.updateTag?.(seasonParticipantsTag(seasonId));
-    nextCache.updateTag?.(seasonMatchesTag(seasonId));
-    nextCache.updateTag?.(seasonStandingsTag(seasonId));
+    updateTag(seasonParticipantsTag(seasonId));
+    updateTag(seasonMatchesTag(seasonId));
+    updateTag(seasonStandingsTag(seasonId));
   }
 }
 
 /** Route Handler/webhook semantics: stale-while-revalidate the public tags. */
 export function revalidatePublicSeasonTags(slug: string, seasonId?: string): void {
-  nextCache.revalidateTag?.(PUBLIC_SEASON_CATALOG_TAG, "max");
-  nextCache.revalidateTag?.(publicSeasonTag(slug), "max");
+  revalidateTag(PUBLIC_SEASON_CATALOG_TAG, "max");
+  revalidateTag(publicSeasonTag(slug), "max");
   if (seasonId) {
-    nextCache.revalidateTag?.(seasonParticipantsTag(seasonId), "max");
-    nextCache.revalidateTag?.(seasonMatchesTag(seasonId), "max");
-    nextCache.revalidateTag?.(seasonStandingsTag(seasonId), "max");
+    revalidateTag(seasonParticipantsTag(seasonId), "max");
+    revalidateTag(seasonMatchesTag(seasonId), "max");
+    revalidateTag(seasonStandingsTag(seasonId), "max");
   }
 }
 
 export function updatePublicPlayerTag(userId: string): void {
-  nextCache.updateTag?.(publicPlayerTag(userId));
+  updateTag(publicPlayerTag(userId));
 }
 
 export function revalidateSeasonPaths(
@@ -63,7 +63,7 @@ export function revalidateSeasonPaths(
     updatePublicSeasonTags(slug);
   }
   for (const page of pages) {
-    nextCache.revalidatePath(seasonPages[page](slug));
+    revalidatePath(seasonPages[page](slug));
   }
 }
 
@@ -73,6 +73,6 @@ export function revalidateMatchPaths(
   options: { mode?: RevalidationMode } = {},
 ) {
   revalidateSeasonPaths(slug, ["matches", "adminMatches"], options);
-  nextCache.revalidatePath(`/admin/${slug}/matches/${matchId}`);
-  nextCache.revalidatePath(`/${slug}/matches/${matchId}`);
+  revalidatePath(`/admin/${slug}/matches/${matchId}`);
+  revalidatePath(`/${slug}/matches/${matchId}`);
 }

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -452,8 +452,6 @@ export const CAPABILITY_PRESETS = {
   },
 } as const;
 
-/** @alias Compatibility name retained for existing admin/test consumers. */
-export const RIVALS_DEFAULT_CAPABILITIES = DRAFT_LEAGUE_PRESET;
 export const MAJOR_DEFAULT_CAPABILITIES = CAPABILITY_PRESETS.major;
 
 /**

--- a/tests/unit/components/admin/SeasonForm.test.tsx
+++ b/tests/unit/components/admin/SeasonForm.test.tsx
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSeason, deleteSeason, updateSeason } from "@/actions/seasons";
 import { SeasonForm } from "@/components/admin/SeasonForm";
 import {
-  RIVALS_DEFAULT_CAPABILITIES,
+  CAPABILITY_PRESETS,
   MAJOR_DEFAULT_CAPABILITIES,
   type SeasonCapabilities,
 } from "@/types/season";
@@ -91,7 +91,7 @@ describe("SeasonForm presets", () => {
   });
 
   it("does not show Major status in a Rivals display context", () => {
-    render(<SeasonForm mode="create" competitivePlatforms={[{ key: "perfect_world", displayName: "完美世界竞技平台" }]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "选秀联赛")} />);
+    render(<SeasonForm mode="create" competitivePlatforms={[{ key: "perfect_world", displayName: "完美世界竞技平台" }]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "选秀联赛")} />);
 
     expect(screen.queryByText(/标准 Major 摘要|当前配置已偏离标准 Major/)).not.toBeInTheDocument();
   });
@@ -118,7 +118,7 @@ describe("SeasonForm presets", () => {
 
   it("resets the registration total after applying Major then Rivals; built-in team size controls are fixed", async () => {
     const user = userEvent.setup();
-    render(<SeasonForm mode="create" competitivePlatforms={[{ key: "perfect_world", displayName: "完美世界竞技平台" }]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "选秀联赛")} />);
+    render(<SeasonForm mode="create" competitivePlatforms={[{ key: "perfect_world", displayName: "完美世界竞技平台" }]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "选秀联赛")} />);
 
     // Built-in templates fix team size on the server, so the inputs are disabled.
     expect(screen.getByLabelText("每队人数上限")).toBeDisabled();
@@ -131,7 +131,7 @@ describe("SeasonForm presets", () => {
         registrationConfig: expect.objectContaining({
           maxPerPosition: 15,
           maxTotal: 56,
-          mapPool: RIVALS_DEFAULT_CAPABILITIES.registrationConfig.mapPool,
+          mapPool: CAPABILITY_PRESETS["draft-league"].registrationConfig.mapPool,
           screenshotCount: 1,
         }),
       }));
@@ -152,7 +152,7 @@ describe("SeasonForm presets", () => {
 
   it("requires an in-app confirmation before deleting a draft season", async () => {
     const user = userEvent.setup();
-    render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "选秀联赛")} />);
+    render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "选秀联赛")} />);
 
     await user.click(screen.getByRole("button", { name: "删除赛季" }));
     expect(screen.getByRole("alertdialog")).toHaveTextContent("确认删除这个草稿赛季？");
@@ -164,7 +164,7 @@ describe("SeasonForm presets", () => {
 
   it("keeps a create slug in sync with the full name until it is manually edited", async () => {
     const user = userEvent.setup();
-    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "draft", { name: "", slug: "" })} />);
+    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "draft", { name: "", slug: "" })} />);
 
     const name = screen.getByLabelText("名称");
     const slug = screen.getByLabelText("Slug");
@@ -176,7 +176,7 @@ describe("SeasonForm presets", () => {
 
   it("stops following the name after the operator edits the create slug", async () => {
     const user = userEvent.setup();
-    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "draft", { name: "", slug: "" })} />);
+    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "draft", { name: "", slug: "" })} />);
 
     const name = screen.getByLabelText("名称");
     const slug = screen.getByLabelText("Slug");
@@ -190,7 +190,7 @@ describe("SeasonForm presets", () => {
   });
 
   it("requires a manual slug for a name that has no ASCII slug", async () => {
-    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "draft", { name: "", slug: "" })} />);
+    render(<SeasonForm mode="create" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "draft", { name: "", slug: "" })} />);
 
     fireEvent.change(screen.getByLabelText("名称"), { target: { value: "南京大学秋季赛" } });
     await waitFor(() => {
@@ -202,16 +202,16 @@ describe("SeasonForm presets", () => {
   });
 
   it("allows draft slug edits but locks a published slug", () => {
-    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛")} />);
+    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛")} />);
     expect(screen.getByLabelText("Slug")).toBeEnabled();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration")} />);
     expect(screen.getByLabelText("Slug")).toBeDisabled();
   });
 
   it("allows a draft template switch and keeps a published template read-only", async () => {
     const user = userEvent.setup();
-    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛")} />);
+    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛")} />);
     await user.click(screen.getByRole("button", { name: "Major" }));
     await user.click(screen.getByRole("button", { name: "确认" }));
     expect(screen.getByRole("heading", { name: "竞技参考" })).toBeInTheDocument();
@@ -278,29 +278,29 @@ describe("SeasonForm presets", () => {
   });
 
   it("keeps status-specific lifecycle actions in the settings sections", () => {
-    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "draft")} />);
+    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "draft")} />);
     expect(screen.getByRole("button", { name: "发布赛季" })).toBeInTheDocument();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration")} />);
     expect(screen.getByRole("button", { name: "立即开放报名" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "撤回至草稿" })).toBeInTheDocument();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "voting")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "voting")} />);
     expect(screen.getByRole("button", { name: "撤回至报名阶段" })).toBeInTheDocument();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "playing")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "playing")} />);
     expect(screen.getByRole("button", { name: "手动结束赛季" })).toBeInTheDocument();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "finished")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "finished")} />);
     expect(screen.getByRole("button", { name: "归档赛季" })).toBeInTheDocument();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "archived")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "archived")} />);
     expect(screen.getByText("当前状态没有可用的危险操作。")).toBeInTheDocument();
     expect(screen.getByTestId("season-lifecycle-explanation")).toHaveTextContent("赛事已结束");
   });
 
   it("locks custom public registration controls after publish", () => {
-    render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration", { template: "custom" })} />);
+    render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration", { template: "custom" })} />);
 
     expect(screen.getByLabelText("每位置上限")).toBeDisabled();
     expect(screen.getByLabelText("截图链接数量")).toBeDisabled();
@@ -315,27 +315,27 @@ describe("SeasonForm presets", () => {
   });
 
   it("keeps registration deadlines operational before and after opening, then locks them at playing", () => {
-    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
+    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
     expect(screen.getByLabelText("报名开放时间")).toBeDisabled();
     expect(screen.getByLabelText("报名截止时间")).toBeEnabled();
     expect(screen.getByLabelText("名单调整截止时间")).toBeEnabled();
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "playing", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "playing", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
     expect(screen.getByLabelText("报名截止时间")).toBeDisabled();
     expect(screen.getByLabelText("名单调整截止时间")).toBeDisabled();
   });
 
   it("explains each lifecycle edit boundary", () => {
-    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛")} />);
+    const { rerender } = render(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛")} />);
     expect(screen.getByTestId("season-lifecycle-explanation")).toHaveTextContent("所有赛事定义仍可调整");
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration")} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration")} />);
     expect(screen.getByTestId("season-lifecycle-explanation")).toHaveTextContent("公开赛事规则已锁定");
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "registration", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "registration", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
     expect(screen.getByTestId("season-lifecycle-explanation")).toHaveTextContent("竞技上下文、ConversionPolicy 策略身份与冻结快照、实际开放时间已冻结");
 
-    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(RIVALS_DEFAULT_CAPABILITIES), "公开赛", "playing", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
+    rerender(<SeasonForm mode="edit" competitivePlatforms={[]} initial={createInitial(structuredClone(CAPABILITY_PRESETS["draft-league"]), "公开赛", "playing", { registrationOpenedAt: new Date("2026-05-01T00:00:00.000Z") })} />);
     expect(screen.getByTestId("season-lifecycle-explanation")).toHaveTextContent("比赛已开始");
   });
 

--- a/tests/unit/types/standard-major.test.ts
+++ b/tests/unit/types/standard-major.test.ts
@@ -3,7 +3,7 @@ import {
   CURRENT_CS2_ACTIVE_DUTY_MAP_POOL,
   MAJOR_REGISTRATION_CONFIG,
   OPEN_TOURNAMENT_PRESET,
-  RIVALS_DEFAULT_CAPABILITIES,
+  CAPABILITY_PRESETS,
   createMajorDefaultCapabilities,
   normalizeTeamRegistrationConfig,
 } from "@/types/season";
@@ -39,9 +39,9 @@ describe("checkStandardMajorCapabilities()", () => {
     expect(MAJOR_REGISTRATION_CONFIG.mapPool).toEqual([
       "de_ancient", "de_anubis", "de_cache", "de_dust2", "de_inferno", "de_mirage", "de_nuke",
     ]);
-    expect(RIVALS_DEFAULT_CAPABILITIES.registrationConfig.mapPool).toEqual([...CURRENT_CS2_ACTIVE_DUTY_MAP_POOL]);
+    expect(CAPABILITY_PRESETS["draft-league"].registrationConfig.mapPool).toEqual([...CURRENT_CS2_ACTIVE_DUTY_MAP_POOL]);
     expect(MAJOR_REGISTRATION_CONFIG.mapPool).not.toContain("de_overpass");
-    expect(RIVALS_DEFAULT_CAPABILITIES.registrationConfig.mapPool).toContain("de_cache");
+    expect(CAPABILITY_PRESETS["draft-league"].registrationConfig.mapPool).toContain("de_cache");
   });
 
   it("accepts a deep clone of the standard Major defaults", () => {
@@ -197,7 +197,7 @@ describe("checkStandardMajorCapabilities()", () => {
 
 describe("createMajorDefaultCapabilities()", () => {
   it("returns a complete Major replacement without Rivals registration leftovers", () => {
-    const rivals = structuredClone(RIVALS_DEFAULT_CAPABILITIES);
+    const rivals = structuredClone(CAPABILITY_PRESETS["draft-league"]);
     const major = createMajorDefaultCapabilities();
 
     expect(rivals.registrationConfig.maxTotal).toBe(56);


### PR DESCRIPTION
## 概要

- 统一七个 Action 的验证失败出口为 `failValidation()`。
- 使用 Next 16 的具名 cache invalidation API。
- 退休无生产 consumer 的 Rivals preset alias，测试改用 canonical preset index。

## 验证

- `pnpm exec vitest run tests/unit/actions/community-awards.test.ts tests/unit/actions/competition-entries.test.ts tests/unit/actions/major-prestart.test.ts tests/unit/actions/postmatch.test.ts tests/unit/actions/recruitment-errors.test.ts tests/unit/actions/team-invitation-errors.test.ts tests/unit/actions/teams.test.ts tests/unit/types/standard-major.test.ts tests/unit/components/admin/SeasonForm.test.tsx`
- `pnpm exec vitest run tests/unit/lib/revalidation.test.ts`
- `pnpm type-check`
- `pnpm lint`
- `pnpm build`

## Changeset

无：维护性收敛，未改变发布行为。