### PR TITLE
fix(lint): 恢复 React Hooks 诊断

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,12 +86,6 @@ const eslintConfig = [
   },
   {
     rules: {
-      // React 19.2's compiler diagnostics are advisory for this existing
-      // client-component code; runtime behavior remains covered by unit/E2E.
-      "react-hooks/incompatible-library": "off",
-      "react-hooks/purity": "off",
-      "react-hooks/set-state-in-effect": "off",
-      "react-hooks/static-components": "off",
       "@next/next/no-css-tags": "off",
     },
   },

--- a/src/components/admin/DisciplineManagement.tsx
+++ b/src/components/admin/DisciplineManagement.tsx
@@ -115,8 +115,6 @@ export function DisciplineManagement({
     if (debounceRef.current) clearTimeout(debounceRef.current);
     const query = subjectQuery.trim();
     if (query.length < MIN_QUERY_LENGTH) {
-      setSubjectResults([]);
-      setSubjectSearchError(null);
       return;
     }
     debounceRef.current = setTimeout(() => {
@@ -155,6 +153,14 @@ export function DisciplineManagement({
     );
   }
 
+  function handleSubjectQueryChange(value: string) {
+    setSubjectQuery(value);
+    if (value.trim().length < MIN_QUERY_LENGTH) {
+      setSubjectResults([]);
+      setSubjectSearchError(null);
+    }
+  }
+
   function refresh() {
     startTransition(() => router.refresh());
   }
@@ -184,6 +190,7 @@ export function DisciplineManagement({
         setSelectedSubject(null);
         setSubjectQuery("");
         setSubjectResults([]);
+        setSubjectSearchError(null);
         setEffects([]);
         setInternalEvidence("");
         setPublicExplanation("");
@@ -243,7 +250,7 @@ export function DisciplineManagement({
               id="discipline-subject-search"
               type="search"
               value={subjectQuery}
-              onChange={(e) => setSubjectQuery(e.target.value)}
+              onChange={(e) => handleSubjectQueryChange(e.target.value)}
               placeholder="输入关键字按需搜索…"
               className="w-full max-w-sm rounded-sm border border-[var(--color-border)] bg-[var(--color-panel)] px-3 py-1.5 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-fg-dim)] outline-none focus:border-[var(--color-accent)] transition-colors"
             />

--- a/src/components/admin/MajorPrestartManagement.tsx
+++ b/src/components/admin/MajorPrestartManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
   addMajorPrestartIssue,
@@ -124,6 +124,8 @@ function SyncedEntrant({ entrant }: { entrant: MajorPrestartManagementData["entr
 
 export function MajorPrestartManagement({ data }: { data: MajorPrestartManagementData }) {
   const [isPending, startTransition] = useTransition();
+  const selectedEntrantIdsKey = data.entrants.map((entrant) => entrant.teamId).join(",");
+  const [selectionKey, setSelectionKey] = useState(selectedEntrantIdsKey);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set(data.entrants.map((entrant) => entrant.teamId)));
   const [issueLabel, setIssueLabel] = useState("");
   const [issueCategory, setIssueCategory] = useState<"qualification" | "administration">("qualification");
@@ -133,9 +135,10 @@ export function MajorPrestartManagement({ data }: { data: MajorPrestartManagemen
   const approvedCount = data.approvedCandidates.length;
   const requiresExactCapacity = approvedCount > entrantCapacity;
 
-  useEffect(() => {
+  if (selectionKey !== selectedEntrantIdsKey) {
+    setSelectionKey(selectedEntrantIdsKey);
     setSelectedIds(new Set(data.entrants.map((entrant) => entrant.teamId)));
-  }, [data.entrants]);
+  }
 
   const toggleSelection = (entryId: string) => {
     setSelectedIds((current) => {

--- a/src/components/admin/MajorTournamentSeedsManagement.tsx
+++ b/src/components/admin/MajorTournamentSeedsManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { confirmMajorTournamentSeeds, saveMajorTournamentSeeds } from "@/actions/major-prestart";
 import { Button } from "@/components/ui/button";
@@ -95,11 +95,16 @@ export function MajorTournamentSeedsManagement({ data }: { data: MajorTournament
       ? recommendationOrder
       : data.entrants.map((entrant) => entrant.teamId);
   const initialOrderKey = initialOrder.join(",");
+  const initialStateKey = `${initialOrderKey}\u0000${data.overrideReason ?? ""}`;
+  const [seedStateKey, setSeedStateKey] = useState(initialStateKey);
   const [order, setOrder] = useState<string[]>(initialOrder);
   const [overrideReason, setOverrideReason] = useState(data.overrideReason ?? "");
 
-  useEffect(() => setOrder(initialOrderKey ? initialOrderKey.split(",") : []), [initialOrderKey]);
-  useEffect(() => setOverrideReason(data.overrideReason ?? ""), [data.overrideReason]);
+  if (seedStateKey !== initialStateKey) {
+    setSeedStateKey(initialStateKey);
+    setOrder(initialOrderKey ? initialOrderKey.split(",") : []);
+    setOverrideReason(data.overrideReason ?? "");
+  }
 
   const teamById = useMemo(() => new Map(data.entrants.map((entrant) => [entrant.teamId, entrant])), [data.entrants]);
   const recommendation = data.recommendation;

--- a/src/components/admin/SeasonForm.tsx
+++ b/src/components/admin/SeasonForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useEffect } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { createSeason, deleteSeason, openSeasonRegistration, publishSeason, updateSeason, revertSeasonToDraft, revertSeasonToRegistration, forceFinishSeason, archiveSeason, type SeasonFormInput } from "@/actions/seasons";
@@ -198,13 +198,12 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
     setAffiliationRules([...capabilities.affiliationRules]);
   }
 
-  // A create slug follows the name until the operator explicitly takes it over.
-  useEffect(() => {
+  function handleNameChange(nextName: string) {
+    setName(nextName);
     if (mode === "create" && !slugManuallyEdited) {
-      const nextSlug = slugFromName(name);
-      if (slug !== nextSlug) setSlug(nextSlug);
+      setSlug(slugFromName(nextName));
     }
-  }, [mode, name, slug, slugManuallyEdited]);
+  }
 
   function handleRegistrationModeChange(value: "solo" | "team") {
     setRegistrationMode(value);
@@ -382,15 +381,13 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
     });
   }
 
-  const SaveBtn = () => (
-    mode === "edit" ? (
-      <div className="flex justify-end pt-2">
-        <Button type="button" size="sm" disabled={isPending} onClick={handleSubmit}>
-          {isPending ? "保存中…" : "保存"}
-        </Button>
-      </div>
-    ) : null
-  );
+  const saveButton = mode === "edit" ? (
+    <div className="flex justify-end pt-2">
+      <Button type="button" size="sm" disabled={isPending} onClick={handleSubmit}>
+        {isPending ? "保存中…" : "保存"}
+      </Button>
+    </div>
+  ) : null;
 
   if (mode === "create") {
     return (
@@ -445,7 +442,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
         <section className="space-y-4">
           <h2 className="font-semibold">基础信息</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div><Label htmlFor="season-name">名称</Label><Input id="season-name" value={name} onChange={(e) => setName(e.target.value)} /></div>
+            <div><Label htmlFor="season-name">名称</Label><Input id="season-name" value={name} onChange={(e) => handleNameChange(e.target.value)} /></div>
             <div>
               <Label htmlFor="season-slug">Slug</Label>
               <Input id="season-slug" value={slug} aria-invalid={slugNeedsManualInput} onChange={(e) => { setSlugManuallyEdited(true); setSlug(e.target.value); }} />
@@ -587,7 +584,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>
             <Label htmlFor="season-name">名称</Label>
-            <Input id="season-name" value={name} onChange={(e) => setName(e.target.value)} />
+            <Input id="season-name" value={name} onChange={(e) => handleNameChange(e.target.value)} />
           </div>
           <div>
             <Label htmlFor="season-slug">Slug</Label>
@@ -622,7 +619,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
             <ThemeColorPicker value={themeColor} onChange={setThemeColor} />
           </div>
         </div>
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="lifecycle" label="时间与生命周期">
@@ -653,7 +650,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
           {initial?.status === "draft" && <Button type="button" variant="outline" disabled={isPending} onClick={() => setPublishConfirmationOpen(true)}>发布赛季</Button>}
           {initial?.status === "registration" && !initial.registrationOpenedAt && <Button type="button" disabled={isPending} onClick={handleOpenRegistration}>立即开放报名</Button>}
         </div>
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="registration" label="报名与名单">
@@ -692,7 +689,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
             <TeamConfigForm view="team" value={teamConfig} maxTeamSize={maxTeamSize} competitivePlatforms={competitivePlatforms} disabled={!editCapabilities.canEditPublicRules} onChange={setTeamConfig} />
           </div>
         )}
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="qualification" label="资格规则">
@@ -744,7 +741,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
             <AffiliationRulesSummary rules={affiliationRules} />
           </div>
         )}
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="format" label="赛制与地图">
@@ -761,7 +758,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
             </div>
           )}
         </div>
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="competitive" label="竞技参考">
@@ -777,7 +774,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
         ) : (
           <CompetitiveReferenceSummary config={teamConfig} platforms={competitivePlatforms} frozen={Boolean(initial?.registrationOpenedAt)} />
         )}
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="features" label="功能">
@@ -789,7 +786,7 @@ export function SeasonForm({ mode, initial, competitivePlatforms }: SeasonFormPr
           </span>
         </label>
         {!editCapabilities.canEditPublicRules && <div className="mt-4"><FrozenFact title={`社区奖：${hasCommunityAwards ? "已启用" : "已关闭"}`}>社区奖是赛事公开 capability；发布后不能再改变，入口和服务端操作会继续消费这个事实。</FrozenFact></div>}
-        <SaveBtn />
+        {saveButton}
       </SettingsPanel>
 
       <SettingsPanel id="danger" label="危险操作">

--- a/src/components/draft/DraftCountdown.tsx
+++ b/src/components/draft/DraftCountdown.tsx
@@ -9,7 +9,7 @@ interface DraftCountdownProps {
 }
 
 export function DraftCountdown({ deadline, isActive }: DraftCountdownProps) {
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     if (!deadline || !isActive) return;

--- a/src/components/draft/DraftLiveRoom.tsx
+++ b/src/components/draft/DraftLiveRoom.tsx
@@ -75,18 +75,24 @@ export function DraftLiveRoom({
   // Watch for new picks via completedPicks changes
   const prevPickCountRef = useRef(completedPicks.length);
   useEffect(() => {
+    let notificationTimer: ReturnType<typeof setTimeout> | undefined;
     if (completedPicks.length > prevPickCountRef.current) {
       const latestPick = completedPicks[completedPicks.length - 1];
       if (latestPick) {
-        showPickNotification({
-          steamName: latestPick.steamName,
-          displayName: latestPick.displayName,
-          perfectName: latestPick.perfectName,
-          team_id: latestPick.entryId,
+        notificationTimer = setTimeout(() => {
+          showPickNotification({
+            steamName: latestPick.steamName,
+            displayName: latestPick.displayName,
+            perfectName: latestPick.perfectName,
+            team_id: latestPick.entryId,
+          });
         });
       }
     }
     prevPickCountRef.current = completedPicks.length;
+    return () => {
+      if (notificationTimer) clearTimeout(notificationTimer);
+    };
   }, [completedPicks, showPickNotification]);
 
   // 确定当前选秀队

--- a/src/components/matches/BracketView.tsx
+++ b/src/components/matches/BracketView.tsx
@@ -223,8 +223,6 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
   useEffect(() => {
     if (!scriptReady || !window.bracketsViewer || data.stage.length === 0) return;
     if (data.match.length === 0) return;
-    setRenderError(false);
-
     // 注入中文 locale：把 BYE 翻译为 TBD，并将 origin hint 翻译为中文
     if (window.bracketsViewer.addLocale) {
       window.bracketsViewer
@@ -258,6 +256,7 @@ export function BracketView({ data, themeColor, matchNodeMap, seasonSlug }: Brac
       )
       .then(() => {
         if (disposed || !containerRef.current) return;
+        setRenderError(false);
         const container = containerRef.current;
 
         // 兜底：如果上面 addLocale 在 render 之前未生效，把残留的 BYE 字面量替换为 TBD

--- a/src/components/matches/MatchMvpVote.tsx
+++ b/src/components/matches/MatchMvpVote.tsx
@@ -40,7 +40,7 @@ export function MatchMvpVote({
 }: MatchMvpVoteProps) {
   const [optimisticVotes, setOptimisticVotes] = useState(currentVotes);
   const [votedName, setVotedName] = useState(userVotedPlayerName);
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(() => Date.now());
   const [isPending, startTransition] = useTransition();
 
   const deadline = useMemo(

--- a/src/components/matches/MatchTimeNegotiation.tsx
+++ b/src/components/matches/MatchTimeNegotiation.tsx
@@ -54,6 +54,7 @@ export function MatchTimeNegotiation({
   // 0 缓冲（=与最晚完成时间一致）目前仅正赛使用，沿用作为是否显示解说时段提示的判据。
   const isPlayoff = bufferHours === 0;
   const [isPending, startTransition] = useTransition();
+  const [now, setNow] = useState(() => Date.now());
   const [proposedTime, setProposedTime] = useState("");
   const [rejectReasons, setRejectReasons] = useState<Record<string, string>>({});
   const [rejectingId, setRejectingId] = useState<string | null>(null);
@@ -63,18 +64,24 @@ export function MatchTimeNegotiation({
   const completionDeadline = currentCompletionDeadline
     ? new Date(currentCompletionDeadline)
     : null;
-  const confirmationCutoff = completionDeadline
-    ? new Date(completionDeadline.getTime() - bufferHours * 60 * 60 * 1000)
+  const confirmationCutoffTime = completionDeadline
+    ? completionDeadline.getTime() - bufferHours * 60 * 60 * 1000
     : null;
+  const confirmationCutoff = confirmationCutoffTime === null
+    ? null
+    : new Date(confirmationCutoffTime);
   const isNegotiationClosed =
-    confirmationCutoff !== null && Date.now() >= confirmationCutoff.getTime();
+    confirmationCutoffTime !== null && now >= confirmationCutoffTime;
 
   // 有 pending 提议时自动轮询，确保自动采纳后页面及时更新
   useEffect(() => {
-    if (pendingProposals.length === 0) return;
-    const timer = window.setInterval(() => router.refresh(), 30_000);
+    if (pendingProposals.length === 0 && confirmationCutoffTime === null) return;
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+      if (pendingProposals.length > 0) router.refresh();
+    }, 30_000);
     return () => window.clearInterval(timer);
-  }, [pendingProposals.length, router]);
+  }, [confirmationCutoffTime, pendingProposals.length, router]);
 
   // 检测被系统自动采纳的提议
   const autoAcceptedProposal = initialProposals.find((p) => {
@@ -169,7 +176,7 @@ export function MatchTimeNegotiation({
             );
             const hoursLeft = Math.max(
               0,
-              Math.round((autoAcceptAt.getTime() - Date.now()) / (60 * 60 * 1000) * 10) / 10,
+              Math.round((autoAcceptAt.getTime() - now) / (60 * 60 * 1000) * 10) / 10,
             );
 
             return (

--- a/src/components/register/RegistrationForm.tsx
+++ b/src/components/register/RegistrationForm.tsx
@@ -245,6 +245,8 @@ export function RegistrationForm({
         });
 
   const setMapLevel = (map: string, level: MapPreferenceLevel | null) => {
+    // React Hook Form's watch callback is intentionally read at the event boundary.
+    // eslint-disable-next-line react-hooks/incompatible-library
     const current = watch("mapPreferences") ?? defaultMapPreferences(registrationConfig.mapPool);
     const next = registrationConfig.mapPool.map((item) => ({
       map: item,


### PR DESCRIPTION
## 概要

- 恢复 React 19.2 的 Hooks 与 Compiler diagnostics。
- 将同步 effect state 改为事件边界、渲染期 prop-state 同步或异步渲染完成回调。
- 让倒计时与协商截止基于受控时钟更新；保留 React Hook Form `watch()` 的单处行级库契约说明。

## 验证

- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`

## Changeset

无：维护性收敛，未改变发布 contract。