### PR TITLE
fix(auth): 修复第二邮箱 OTP 类型识别

### DIFF
--- a/.changeset/fix-secondary-email-otp-type.md
+++ b/.changeset/fix-secondary-email-otp-type.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复绑定第二邮箱时正确验证 Supabase 签发的邮箱确认 OTP 类型。

--- a/src/actions/identity.ts
+++ b/src/actions/identity.ts
@@ -8,6 +8,7 @@ import { db } from "@/db/client";
 import { identityLinkRequests } from "@/db/schema";
 import { actionError } from "@/lib/action-utils";
 import { createPublicAuthClient } from "@/lib/auth/supabase-server";
+import { isSecondaryEmailOtpType } from "@/lib/auth/secondary-email-otp";
 import { requireAuth } from "@/lib/auth/session";
 import {
   completeSecondaryIdentityLinkInTx,
@@ -67,17 +68,23 @@ export async function confirmSecondaryEmailIdentity(input: {
   requestId: string;
   stateToken: string;
   tokenHash: string;
+  otpType: string;
 }): Promise<ActionResult<CompleteIdentityLinkOutcome & { redirectTo: string }>> {
-  const parsed = z.object({ requestId: uuidSchema, stateToken: z.string().min(20).max(200), tokenHash: z.string().min(1) }).safeParse(input);
+  const parsed = z.object({
+    requestId: uuidSchema,
+    stateToken: z.string().min(20).max(200),
+    tokenHash: z.string().min(1),
+    otpType: z.string().refine(isSecondaryEmailOtpType),
+  }).safeParse(input);
   if (!parsed.success) return fail({ code: ErrorCode.VALIDATION_FAILED, message: "邮箱绑定链接无效，请重新发起。" });
   try {
     const session = await requireAuth();
     const { data, error } = await createPublicAuthClient().auth.verifyOtp({
       token_hash: parsed.data.tokenHash,
-      type: "magiclink",
+      type: parsed.data.otpType,
     });
     if (error || !data.user?.email || !data.user.email_confirmed_at) {
-      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "邮箱绑定链接已失效或已被使用，请重新发起。" });
+      return fail({ code: ErrorCode.VALIDATION_FAILED, message: "无法验证这个邮箱绑定链接。链接可能已过期、已完成验证或验证信息不匹配，请重新发起绑定。" });
     }
     const outcome = await db.transaction((tx) => completeSecondaryIdentityLinkInTx(tx, {
       requestId: parsed.data.requestId,

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { safeLocalRedirect } from "@/lib/auth/redirect";
+import { isSecondaryEmailOtpType } from "@/lib/auth/secondary-email-otp";
 import { withRouteObservability } from "@/lib/observability/route";
 
 export async function GET(request: NextRequest) {
@@ -19,9 +20,11 @@ export async function GET(request: NextRequest) {
     if (flow === "link_identity") {
       const requestId = url.searchParams.get("request");
       const state = url.searchParams.get("state");
-      if (!requestId || !state) return confirmationFailure(applicationOrigin);
+      const otpType = url.searchParams.get("type");
+      if (!requestId || !state || !isSecondaryEmailOtpType(otpType)) return confirmationFailure(applicationOrigin);
       confirmationUrl.searchParams.set("request", requestId);
       confirmationUrl.searchParams.set("state", state);
+      confirmationUrl.searchParams.set("type", otpType);
     }
     return NextResponse.redirect(confirmationUrl);
   });

--- a/src/app/auth/confirmation/page.tsx
+++ b/src/app/auth/confirmation/page.tsx
@@ -1,18 +1,19 @@
 import Link from "next/link";
 import { EmailConfirmationForm } from "@/components/auth/EmailConfirmationForm";
 import { SecondaryIdentityConfirmationForm } from "@/components/auth/SecondaryIdentityConfirmationForm";
+import { isSecondaryEmailOtpType } from "@/lib/auth/secondary-email-otp";
 
 export const instant = false;
 
 export default async function ConfirmationPage({
   searchParams,
 }: {
-  searchParams: Promise<{ flow?: string; token_hash?: string; next?: string; request?: string; state?: string }>;
+  searchParams: Promise<{ flow?: string; token_hash?: string; next?: string; request?: string; state?: string; type?: string }>;
 }) {
-  const { flow, token_hash: tokenHash, next, request, state } = await searchParams;
+  const { flow, token_hash: tokenHash, next, request, state, type } = await searchParams;
   const confirmationFlow = flow === "signup" || flow === "reverify" ? flow : null;
-  const identityLink = flow === "link_identity" && tokenHash && request && state
-    ? { tokenHash, requestId: request, stateToken: state }
+  const identityLink = flow === "link_identity" && tokenHash && request && state && isSecondaryEmailOtpType(type)
+    ? { tokenHash, requestId: request, stateToken: state, otpType: type }
     : null;
 
   return (

--- a/src/components/auth/SecondaryIdentityConfirmationForm.tsx
+++ b/src/components/auth/SecondaryIdentityConfirmationForm.tsx
@@ -9,17 +9,19 @@ export function SecondaryIdentityConfirmationForm({
   tokenHash,
   requestId,
   stateToken,
+  otpType,
 }: {
   tokenHash: string;
   requestId: string;
   stateToken: string;
+  otpType: "email" | "magiclink";
 }) {
   const [pending, startTransition] = useTransition();
   const [failure, setFailure] = useState<string | null>(null);
 
   function confirm() {
     startTransition(async () => {
-      const result = await confirmSecondaryEmailIdentity({ tokenHash, requestId, stateToken });
+      const result = await confirmSecondaryEmailIdentity({ tokenHash, requestId, stateToken, otpType });
       if (!result.success) {
         setFailure(result.error.message);
         return;

--- a/src/lib/auth/secondary-email-otp.ts
+++ b/src/lib/auth/secondary-email-otp.ts
@@ -1,0 +1,8 @@
+const SECONDARY_EMAIL_OTP_TYPES = ["email", "magiclink"] as const;
+
+export type SecondaryEmailOtpType = (typeof SECONDARY_EMAIL_OTP_TYPES)[number];
+
+/** Only proof types issued by the secondary-email sign-in flow may reach verifyOtp. */
+export function isSecondaryEmailOtpType(value: unknown): value is SecondaryEmailOtpType {
+  return typeof value === "string" && (SECONDARY_EMAIL_OTP_TYPES as readonly string[]).includes(value);
+}

--- a/tests/unit/actions/identity.test.ts
+++ b/tests/unit/actions/identity.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode } from "@/lib/errors";
+
+const {
+  verifyOtpMock,
+  requireAuthMock,
+  dbTransactionMock,
+  completeSecondaryIdentityLinkInTxMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  verifyOtpMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+  dbTransactionMock: vi.fn(),
+  completeSecondaryIdentityLinkInTxMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/supabase-server", () => ({
+  createPublicAuthClient: () => ({ auth: { verifyOtp: verifyOtpMock } }),
+}));
+vi.mock("@/lib/auth/session", () => ({ requireAuth: requireAuthMock }));
+vi.mock("@/lib/identity/linking", () => ({
+  completeSecondaryIdentityLinkInTx: completeSecondaryIdentityLinkInTxMock,
+  hashIdentityLinkState: vi.fn(),
+  revokeSecondaryEmailIdentityInTx: vi.fn(),
+}));
+vi.mock("@/db/client", () => ({ db: { transaction: dbTransactionMock } }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import { confirmSecondaryEmailIdentity } from "@/actions/identity";
+
+const requestId = "11111111-1111-4111-8111-111111111111";
+const session = { userId: "22222222-2222-4222-8222-222222222222" };
+
+function confirmedUser() {
+  return {
+    data: {
+      user: {
+        id: "33333333-3333-4333-8333-333333333333",
+        email: "secondary@example.test",
+        email_confirmed_at: "2026-09-08T03:05:00.000Z",
+      },
+    },
+    error: null,
+  };
+}
+
+function input(otpType: string) {
+  return { requestId, stateToken: "a-state-token-with-at-least-twenty-characters", tokenHash: "opaque-token", otpType };
+}
+
+describe("confirmSecondaryEmailIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuthMock.mockResolvedValue(session);
+    dbTransactionMock.mockImplementation((callback: (tx: unknown) => unknown) => callback("tx"));
+    completeSecondaryIdentityLinkInTxMock.mockResolvedValue({ kind: "linked" });
+  });
+
+  it("以 confirmation_token 的 email 类型验证并直接绑定第二邮箱", async () => {
+    verifyOtpMock.mockResolvedValue(confirmedUser());
+
+    await expect(confirmSecondaryEmailIdentity(input("email"))).resolves.toEqual({
+      success: true,
+      data: { kind: "linked", redirectTo: "/settings/education" },
+    });
+    expect(verifyOtpMock).toHaveBeenCalledWith({ token_hash: "opaque-token", type: "email" });
+    expect(completeSecondaryIdentityLinkInTxMock).toHaveBeenCalledWith("tx", expect.objectContaining({
+      requestId,
+      currentUserId: session.userId,
+      authId: "33333333-3333-4333-8333-333333333333",
+      email: "secondary@example.test",
+    }));
+  });
+
+  it("保留已确认邮箱的 magiclink proof，并继续进入归并预检", async () => {
+    verifyOtpMock.mockResolvedValue(confirmedUser());
+    completeSecondaryIdentityLinkInTxMock.mockResolvedValue({
+      kind: "merge_required",
+      authorizationId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    await expect(confirmSecondaryEmailIdentity(input("magiclink"))).resolves.toEqual({
+      success: true,
+      data: {
+        kind: "merge_required",
+        authorizationId: "44444444-4444-4444-8444-444444444444",
+        redirectTo: "/settings/security/merge?authorization=44444444-4444-4444-8444-444444444444",
+      },
+    });
+    expect(verifyOtpMock).toHaveBeenCalledWith({ token_hash: "opaque-token", type: "magiclink" });
+  });
+
+  it("对篡改的 OTP 类型 fail closed，且不调用 provider 或完成绑定请求", async () => {
+    await expect(confirmSecondaryEmailIdentity(input("recovery"))).resolves.toMatchObject({
+      success: false,
+      error: { code: ErrorCode.VALIDATION_FAILED },
+    });
+
+    expect(verifyOtpMock).not.toHaveBeenCalled();
+    expect(dbTransactionMock).not.toHaveBeenCalled();
+    expect(completeSecondaryIdentityLinkInTxMock).not.toHaveBeenCalled();
+  });
+
+  it("provider proof 失败时不消费绑定请求，并给出可恢复的准确提示", async () => {
+    verifyOtpMock.mockResolvedValue({ data: { user: null }, error: { message: "expired" } });
+
+    await expect(confirmSecondaryEmailIdentity(input("email"))).resolves.toEqual({
+      success: false,
+      error: {
+        code: ErrorCode.VALIDATION_FAILED,
+        message: "无法验证这个邮箱绑定链接。链接可能已过期、已完成验证或验证信息不匹配，请重新发起绑定。",
+      },
+    });
+
+    expect(dbTransactionMock).not.toHaveBeenCalled();
+    expect(completeSecondaryIdentityLinkInTxMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/auth-callback.test.ts
+++ b/tests/unit/app/auth-callback.test.ts
@@ -57,6 +57,26 @@ describe("legacy email confirmation callback", () => {
     expect(createUserSessionMock).not.toHaveBeenCalled();
   });
 
+  it("为第二邮箱绑定保留 provider 签发的受限 OTP 类型", async () => {
+    const response = await GET(new NextRequest(
+      "http://127.0.0.1:3000/auth/callback/link_identity?token_hash=ok&type=email&request=11111111-1111-4111-8111-111111111111&state=opaque-state-token",
+    ));
+
+    expect(response.headers.get("location")).toBe(
+      "http://127.0.0.1:3000/auth/confirmation?flow=link_identity&token_hash=ok&request=11111111-1111-4111-8111-111111111111&state=opaque-state-token&type=email",
+    );
+    expect(verifyOtpMock).not.toHaveBeenCalled();
+  });
+
+  it("拒绝把未允许的 OTP 类型带入第二邮箱确认页", async () => {
+    const response = await GET(new NextRequest(
+      "http://127.0.0.1:3000/auth/callback/link_identity?token_hash=ok&type=recovery&request=11111111-1111-4111-8111-111111111111&state=opaque-state-token",
+    ));
+
+    expect(response.headers.get("location")).toBe("http://127.0.0.1:3000/auth/confirmation");
+    expect(verifyOtpMock).not.toHaveBeenCalled();
+  });
+
   it("缺少 token 或 flow 时进入可操作的失败页，仍无副作用", async () => {
     const missingToken = await GET(new NextRequest("http://127.0.0.1:3000/auth/callback/signup"));
     const invalidFlow = await GET(new NextRequest("http://127.0.0.1:3000/auth/callback/unknown?token_hash=bad"));

--- a/tests/unit/app/auth-confirmation-page.test.tsx
+++ b/tests/unit/app/auth-confirmation-page.test.tsx
@@ -3,9 +3,13 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 const emailConfirmationFormMock = vi.hoisted(() => vi.fn(() => null));
+const secondaryIdentityConfirmationFormMock = vi.hoisted(() => vi.fn(() => null));
 
 vi.mock("@/components/auth/EmailConfirmationForm", () => ({
   EmailConfirmationForm: emailConfirmationFormMock,
+}));
+vi.mock("@/components/auth/SecondaryIdentityConfirmationForm", () => ({
+  SecondaryIdentityConfirmationForm: secondaryIdentityConfirmationFormMock,
 }));
 
 import ConfirmationPage from "@/app/auth/confirmation/page";
@@ -32,5 +36,46 @@ describe("email confirmation page", () => {
       { flow: "reverify", tokenHash: "opaque-token", next: "/settings/education" },
       undefined,
     );
+  });
+
+  it("把第二邮箱的受限 provider OTP 类型传给确认表单", async () => {
+    vi.stubGlobal("React", React);
+    const page = await ConfirmationPage({
+      searchParams: Promise.resolve({
+        flow: "link_identity",
+        token_hash: "opaque-token",
+        request: "11111111-1111-4111-8111-111111111111",
+        state: "opaque-state-token",
+        type: "email",
+      }),
+    });
+    renderToStaticMarkup(page);
+
+    expect(secondaryIdentityConfirmationFormMock).toHaveBeenCalledWith(
+      {
+        tokenHash: "opaque-token",
+        requestId: "11111111-1111-4111-8111-111111111111",
+        stateToken: "opaque-state-token",
+        otpType: "email",
+      },
+      undefined,
+    );
+  });
+
+  it("不为未允许的第二邮箱 OTP 类型渲染确认表单", async () => {
+    vi.stubGlobal("React", React);
+    const page = await ConfirmationPage({
+      searchParams: Promise.resolve({
+        flow: "link_identity",
+        token_hash: "opaque-token",
+        request: "11111111-1111-4111-8111-111111111111",
+        state: "opaque-state-token",
+        type: "recovery",
+      }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("邮箱验证未完成");
+    expect(secondaryIdentityConfirmationFormMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 摘要

- 保留并受限校验第二邮箱 proof 的 Supabase OTP 类型，支持 `email` 与 `magiclink`。
- 将允许类型从回调/确认页传至 server action，未知类型在调用 provider 前 fail closed。
- 改善 provider proof 失败时的可恢复提示，并补齐回调、确认页与 action 回归测试。

## 验证

- `pnpm exec vitest run tests/unit/actions/identity.test.ts tests/unit/app/auth-callback.test.ts tests/unit/app/auth-confirmation-page.test.tsx`
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`
- `pnpm exec changeset status`

含中文 patch Changeset。

Closes #517