### PR TITLE
docs(release): 补充 CHANGELOG 整理门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,26 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Validate current changelog compare link
+      - name: Validate current changelog release shape
         shell: bash
         run: |
           VERSION="$(node -p "require('./package.json').version")"
+          HEADING="## [$VERSION]"
+          if ! grep -Fxq "$HEADING" CHANGELOG.md; then
+            echo "CHANGELOG.md must contain heading $HEADING." >&2
+            exit 1
+          fi
+
+          SECTION="$(awk -v heading="$HEADING" '
+            $0 == heading { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)"
+          if grep -Eq '^### (Patch|Minor|Major) Changes$' <<< "$SECTION"; then
+            echo "CHANGELOG.md current version still contains a default Changesets heading; perform editorial cleanup before merge." >&2
+            exit 1
+          fi
+
           PREFIX="[$VERSION]: https://github.com/Starfie1d1272/RivalHub/compare/"
           LINE="$(grep -F "$PREFIX" CHANGELOG.md || true)"
           if [[ -z "$LINE" || "$LINE" != *"...v$VERSION" ]]; then

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -15,7 +15,7 @@ pnpm exec changeset version
 提交 PR 前确认：
 
 - `package.json` version 正确，未手工维护第二份版本号；
-- 当前版本 CHANGELOG 文案面向用户/管理员，不复制内部实现清单；
+- `changeset version` 产物只作初稿：按仓库既有 CHANGELOG 结构整理当前版本，按实际内容使用 `Added` / `Changed` / `Fixed` 等分类和必要的中文主题，合并重复条目、删除内部实现噪音，不保留 `Patch Changes` / `Minor Changes` / `Major Changes` 等默认标题；
 - release-relevant feat / fix / security / migration 无遗漏；
 - CHANGELOG 底部存在当前版本 compare 链接，例如 `[X.Y.Z]: https://github.com/Starfie1d1272/RivalHub/compare/vPREVIOUS...vX.Y.Z`；
 - 仍需 production / external acceptance 的事项已明确，不把未验收状态写成已完成。


### PR DESCRIPTION
## Changes

- `docs/operations/release.md` 明确 `changeset version` 只产生 CHANGELOG 初稿；release PR 前必须按仓库既有结构做 editorial cleanup，整理分类/中文主题、合并重复项并删除内部实现噪音。
- 扩展现有 `ci-gate` CHANGELOG 检查：要求当前版本 `## [X.Y.Z]` 标题存在，当前版本 section 不得残留 Changesets 默认的 `Patch Changes` / `Minor Changes` / `Major Changes` 标题，并继续校验 compare link。
- 不尝试机器判断文案质量，也不新增脚本或第二套 release authority。

## Context

2.7.3 release 中 `pnpm exec changeset version` 首次生成了 `### Patch Changes`，在人工回看历史 CHANGELOG 后才整理为仓库既有的 `### Fixed` + 中文主题结构。本 PR 将这个已经验证过的流程补进 canonical runbook，并只对明显未整理状态加机器门禁。

## Evidence

- 基于已发布 `v2.7.3` 后的最新 `main`（`c5e10eee`）。
- Diff 仅 2 个文件：release runbook + CI guard，无 runtime/schema 变化。
- 当前 2.7.3 CHANGELOG 已满足新增 invariant。

## Changeset

不需要：纯文档与 CI guard，不改变 shipped behavior。