### PR TITLE
ci: 分离 PR metadata 校验

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   release:
     types: [published]
@@ -50,19 +50,6 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
           FORCE_FULL: ${{ github.event_name != 'pull_request' }}
-
-  pr_title:
-    name: pr-title
-    if: ${{ github.event_name == 'pull_request' && needs.plan.result == 'success' }}
-    needs: plan
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Validate pull request title
-        run: node scripts/ci/validate-pr-title.mjs
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
 
   static:
     name: static / ${{ matrix.task }}
@@ -186,7 +173,7 @@ jobs:
   ci-gate:
     name: ci-gate
     if: ${{ always() }}
-    needs: [plan, pr_title, static, postgres, system, dependency-review]
+    needs: [plan, static, postgres, system, dependency-review]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -226,6 +213,5 @@ jobs:
           POSTGRES_RESULT: ${{ needs.postgres.result }}
           SYSTEM_RESULT: ${{ needs.system.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
-          TITLE_RESULT: ${{ needs.pr_title.result }}
           EVENT_NAME: ${{ github.event_name }}
           REQUIRED_JOBS: ${{ needs.plan.outputs.required_jobs }}

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,25 @@
+name: PR metadata
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+concurrency:
+  group: pr-metadata-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate pull request title
+        run: node scripts/ci/validate-pr-title.mjs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -11,7 +11,7 @@ plan ─→ static ─────┐
    └─→ dependency-review（PR）
 ```
 
-`ci-gate` 是最终 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。
+`ci-gate` 是代码正确性 evidence 的 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。PR metadata policy 由独立的 `pr-title` check 负责；要使其阻断合并，Main ruleset 需与 `ci-gate` 一起要求该 check。
 
 ## Capabilities
 
@@ -61,6 +61,8 @@ Pull Request 使用 changed-surface planner：
 - rename/delete、workflow/toolchain、无法分类的变化 fail closed 到 full。
 
 `push` 到 `main`、merge queue、release 和手动 workflow 运行完整 convergence gate。
+
+`ci.yml` 只响应会改变代码 evidence 的 PR event（opened、synchronize、reopened、ready_for_review）。`.github/workflows/pr-metadata.yml` 在上述事件和 `edited` 上独立运行 `pr-title`；因此 title/body 编辑不会取消、覆盖或重跑当前 head 的 `ci-gate`，而新 commit 的 `synchronize` 仍会为其 SHA 重新产生 title check。
 
 不要在本文复制每个路径匹配规则；需要修改 planner 时同时更新 `scripts/ci/plan.mjs` 和对应 regression tests。
 

--- a/scripts/ci/gate.mjs
+++ b/scripts/ci/gate.mjs
@@ -6,7 +6,6 @@ const statuses = {
   system: process.env.SYSTEM_RESULT,
 };
 const dependencyReviewStatus = process.env.DEPENDENCY_REVIEW_RESULT;
-const titleStatus = process.env.TITLE_RESULT;
 const eventName = process.env.EVENT_NAME || process.env.GITHUB_EVENT_NAME;
 
 if (statuses.plan !== "success") {
@@ -14,21 +13,14 @@ if (statuses.plan !== "success") {
 }
 
 if (eventName === "pull_request") {
-  if (titleStatus !== "success") {
-    fail(`pull_request 的 pr-title 未成功：${titleStatus ?? "missing"}`);
-  }
-  console.log("required pr-title: success");
   if (dependencyReviewStatus !== "success") {
     fail(`pull_request 的 dependency-review 未成功：${dependencyReviewStatus ?? "missing"}`);
   }
   console.log("required dependency-review: success");
 } else if (dependencyReviewStatus !== "skipped" && dependencyReviewStatus !== "success") {
   fail(`非 pull_request 的 dependency-review 出现异常状态：${dependencyReviewStatus ?? "missing"}`);
-} else if (titleStatus !== undefined && titleStatus !== "skipped" && titleStatus !== "success") {
-  fail(`非 pull_request 的 pr-title 出现异常状态：${titleStatus}`);
 } else {
   console.log(`optional dependency-review: ${dependencyReviewStatus}`);
-  console.log(`optional pr-title: ${titleStatus ?? "not applicable"}`);
 }
 
 for (const job of ["static", "postgres", "system"]) {

--- a/tests/unit/ci/gate.test.mjs
+++ b/tests/unit/ci/gate.test.mjs
@@ -14,7 +14,6 @@ function runGate(overrides) {
       POSTGRES_RESULT: "skipped",
       SYSTEM_RESULT: "skipped",
       DEPENDENCY_REVIEW_RESULT: "skipped",
-      TITLE_RESULT: "skipped",
       EVENT_NAME: "push",
       REQUIRED_JOBS: "[]",
       ...overrides,
@@ -29,21 +28,13 @@ describe("ci-gate", () => {
   });
 
   it("requires dependency review on pull requests", () => {
-    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "success" });
+    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success" });
     expect(passed.status).toBe(0);
 
     for (const status of ["skipped", "failure", "cancelled", undefined]) {
-      const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: status, TITLE_RESULT: "success" });
+      const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: status });
       expect(result.status, status).not.toBe(0);
     }
-  });
-
-  it("requires PR title validation on pull requests", () => {
-    const passed = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "success" });
-    expect(passed.status).toBe(0);
-
-    const result = runGate({ EVENT_NAME: "pull_request", DEPENDENCY_REVIEW_RESULT: "success", TITLE_RESULT: "failure" });
-    expect(result.status).not.toBe(0);
   });
 
   it("accepts the expected skipped dependency review outside pull requests", () => {

--- a/tests/unit/ci/pr-metadata-workflow.test.mjs
+++ b/tests/unit/ci/pr-metadata-workflow.test.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = resolve(process.cwd());
+const readWorkflow = (path) => readFileSync(resolve(projectRoot, path), "utf8");
+
+describe("PR metadata workflow ownership", () => {
+  it("keeps edited out of code CI and runs title validation on every relevant PR SHA or edit", () => {
+    const codeCi = readWorkflow(".github/workflows/ci.yml");
+    const metadata = readWorkflow(".github/workflows/pr-metadata.yml");
+
+    expect(codeCi).toContain("types: [opened, synchronize, reopened, ready_for_review]");
+    expect(codeCi).not.toContain("pr_title:");
+    expect(codeCi).not.toContain("TITLE_RESULT:");
+    expect(metadata).toContain("types: [opened, synchronize, reopened, edited, ready_for_review]");
+    expect(metadata).toContain("name: pr-title");
+    expect(metadata).toContain("PR_TITLE: ${{ github.event.pull_request.title }}");
+  });
+});


### PR DESCRIPTION
## 目标

将 PR metadata policy 从代码正确性 gate 中独立出来：body/title 编辑只验证标题，不影响当前 SHA 的代码 evidence。

## 变更

- `ci.yml` 不再监听 `pull_request.edited`，只在 opened、synchronize、reopened、ready_for_review 时运行代码 CI。
- 新增 `pr-metadata.yml`：在上述事件与 `edited` 时运行独立 `pr-title`。synchronize 也会产生新 SHA 的 title check。
- `ci-gate` 仅拥有 plan/static/postgres/system/dependency-review 的代码 evidence，不再依赖 `pr-title`。
- 加入 workflow ownership regression test，并更新 CI operation contract。

## 本地验证

- `pnpm exec vitest run tests/unit/ci/gate.test.mjs tests/unit/ci/validate-pr-title.test.mjs tests/unit/ci/pr-metadata-workflow.test.mjs`
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`（262 files / 1602 tests）
- `pnpm db:check`
- 两份 workflow YAML 解析

未添加 Changeset：仅调整 CI/开发工具 contract，不改变 shipped behavior。

## 合并后管理员收尾

在 workflow 合入且本 PR 已产生 `pr-title` check 后，将 Main ruleset 的 required status checks 从 `ci-gate` 更新为 `ci-gate` + `pr-title`。本 PR 不直接修改远端 ruleset。