### PR TITLE
fix(scheduler): 修复业务关键 Cron 调度漂移

### DIFF
--- a/.changeset/531-reliable-scheduler.md
+++ b/.changeset/531-reliable-scheduler.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+修复业务关键定时任务依赖 GitHub schedule 导致的调度漂移：新增 Supabase primary scheduler、GitHub watchdog、健康投影与报名开放自愈，并保留 canonical domain owner。

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,26 +9,23 @@ permissions: {}
 
 jobs:
   trigger:
-    name: Cron / ${{ matrix.name }}
+    name: Cron / ${{ matrix.job_key }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: draft-timeout
-            path: /api/cron/draft-timeout
-          - name: check-registration-deadline
-            path: /api/cron/check-registration-deadline
-          - name: match-time-auto-award
-            path: /api/cron/match-time-auto-award
-          - name: cleanup-education-evidence
-            path: /api/cron/cleanup-education-evidence
+          - job_key: draft-timeout
+          - job_key: check-registration-deadline
+          - job_key: match-time-auto-award
+          - job_key: cleanup-education-evidence
     steps:
-      - name: Invoke ${{ matrix.name }}
+      - name: Invoke ${{ matrix.job_key }}
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          CRON_PATH: ${{ matrix.path }}
+          CRON_JOB_KEY: ${{ matrix.job_key }}
+          CRON_SOURCE: ${{ github.event_name == 'workflow_dispatch' && 'github-manual' || 'github-watchdog' }}
         run: |
           curl --fail --silent --show-error \
             --connect-timeout 10 \
@@ -38,4 +35,5 @@ jobs:
             --retry-delay 5 \
             --retry-max-time 180 \
             --header "Authorization: Bearer ${CRON_SECRET}" \
-            "https://match.starfie1d.top${CRON_PATH}"
+            --header "X-RivalHub-Cron-Source: ${CRON_SOURCE}" \
+            "https://match.starfie1d.top/api/cron/${CRON_JOB_KEY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,19 @@ jobs:
             --retry 8 --retry-all-errors --retry-delay 5 \
             "https://match.starfie1d.top/" >/dev/null
 
+      - name: Provision and verify production scheduler
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          RIVALHUB_SCHEDULER_BASE_URL: https://match.starfie1d.top
+        run: |
+          if [[ -z "$CRON_SECRET" || "$CRON_SECRET" == "[SENSITIVE]" ]]; then
+            echo "GitHub production environment secret CRON_SECRET is required." >&2
+            exit 1
+          fi
+          RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision
+          pnpm db:production:scheduler:verify
+
       - name: Extract changelog for this version
         run: |
           VERSION="${RELEASE_TAG#v}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,7 @@ Major runtime 的阶段参与者和已完成比赛是推进依据；standings、
 - Supabase Auth 管理邮箱凭据；应用 session 只保存身份，当前角色和 season grants 每次从数据库读取。
 - 业务表默认 server-only；Data API/RLS terminal contract 见生成式 [`security/database-access-matrix.md`](./security/database-access-matrix.md)。新增 direct browser Data API 或 Realtime surface 必须同时定义最小 GRANT/RLS、consumer、一致性语义和正反例测试。
 - 管理 mutation 产生 `audit_logs` 业务审计；runtime logs/traces 由 `src/lib/observability/` 独立拥有。
+- 业务关键 scheduler 由 shared registry、Supabase primary dispatch、现有 Cron endpoint runner 和有界 health projection 组成；数据库 dispatch 只负责唤醒，不复制 domain transition。GitHub watchdog、participant opening recovery 和 super-admin break-glass 都复用同一 execution/domain owner。
 - local / preview / staging / production 的写权限严格分离，见 [`deployment.md`](./deployment.md)。
 - 时间持久化使用 UTC；产品展示按约定时区转换。
 
@@ -102,6 +103,7 @@ Major runtime 的阶段参与者和已完成比赛是推进依据；standings、
 | Major prestart / runtime | `src/lib/major/` |
 | Match / roster / result | `src/lib/matches/`, `src/lib/match-rosters/`, match actions |
 | Discipline / post-event / awards | corresponding `src/lib/` domain owners |
+| Scheduler / background recovery | `src/lib/scheduler/`, `src/lib/seasons/registration-recovery.ts`, protected `scripts/db/scheduler.ts` |
 | Persistence / migration | `src/db/schema/`, `drizzle/migrations/` |
 
 需要具体 owner 时先 repository search，再沿 tests 和 callers 确认；不要把本表扩成实时文件清单。

--- a/docs/auth-and-permissions.md
+++ b/docs/auth-and-permissions.md
@@ -38,6 +38,8 @@ Fresh deployment 的 owner bootstrap 只通过 `RIVALHUB_OWNER_EMAIL`：当尚�
 
 管理员邀请只给正常 Supabase 用户授予 `season_admin` scope 或 `super_admin`。invite usage、claim ledger、并发上限和重复领取由 transaction + DB constraint 保护；撤销授权读取当前数据库事实，不依赖客户端缓存。
 
+系统状态页中的 scheduler health 和“立即运行一次”属于 `requireSuperAdmin()` 保护的 break-glass 能力。人工运行通过 shared scheduler execution owner 调用 canonical runner，并写入 `scheduler.manual_trigger` audit；按钮不是授权边界，也不允许客户端直接调用数据库或 endpoint。
+
 ## Session
 
 `rivalhub-session` 只保存最小身份信息。当前 role 与 season grants 每次从数据库读取，因此撤销权限会在后续请求生效；session 不保存可长期延续的授权快照。
@@ -59,7 +61,9 @@ Fresh deployment 的 owner bootstrap 只通过 `RIVALHUB_OWNER_EMAIL`：当尚�
 
 ## Secrets
 
-- `SUPABASE_SERVICE_ROLE_KEY`、`ADMIN_SESSION_SECRET`、`CRON_SECRET`、Turnstile secret 等只在服务端使用。
+- `SUPABASE_SERVICE_ROLE_KEY`、`ADMIN_SESSION_SECRET`、`CRON_SECRET`、Turnstile secret 等只在服务端使用。`CRON_SECRET` 是 provider-neutral 的 endpoint credential；Supabase primary 另从 Vault 的 `rivalhub_scheduler_base_url` 与 `rivalhub_cron_secret` 读取同一受保护凭据，GitHub watchdog 只从 protected secret 注入。
+- `X-RivalHub-Cron-Source` 只用于 primary/watchdog/manual/legacy execution 分支与健康投影，不替代 `Authorization: Bearer CRON_SECRET`；缺失 header 兼容 legacy，未知值拒绝。
+- `scheduled_job_health` 是 server-only 的有界当前投影，默认 RLS deny 且撤销 `anon`/`authenticated` grants；不提供浏览器 Data API 或 Realtime surface。
 - secret 不进入 `NEXT_PUBLIC_*`、Client props、Issue/PR、fixture 或日志。
 - recovery/signup/token、Cookie、Authorization 和教育证据遵守相同的默认敏感边界。
 - runtime 日志的脱敏与安全序列化见 [`operations/observability.md`](./operations/observability.md)。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,6 +42,18 @@ RLS、GRANT、trigger、policy、backfill 和 custom SQL 都进入 active migrat
 
 普通本地 shell、Vercel Preview、Dashboard 手工 patch 或裸 Drizzle CLI 都不是 production/staging write path。本地工具也不能从 `.env.local` 静默 fallback 到远程数据库。
 
+## Scheduler boundary
+
+业务关键定时任务由 `src/lib/scheduler/definitions.ts` 维护唯一 registry：它同时拥有稳定 job key、Route Handler 路径、primary UTC cron 和 watchdog stale threshold。教育凭证清理的产品时间是北京时间每日 06:00，持久化为 UTC `0 22 * * *`；不要在 GitHub workflow、Vercel 配置或页面复制另一份 schedule。
+
+Production primary 使用 Supabase `pg_cron` + `pg_net`：`public.dispatch_rivalhub_scheduler_job(text)` 只校验 registry key、写入有界的 `scheduled_job_health.last_primary_triggered_at`，再从 Vault 读取固定名称的调度 base URL/credential 并异步调用现有 `/api/cron/*` endpoint。领域 transition 仍由现有 TypeScript owner 执行，数据库函数不实现业务规则。
+
+`.github/workflows/cron.yml` 保留每 5 分钟的四路调用，作为 watchdog 和人工 dispatch fallback。请求携带 `X-RivalHub-Cron-Source`；当 primary heartbeat 仍新鲜时，endpoint 只记录 watchdog 成功并返回 no-op，过期或无法读取时才执行 canonical runner。缺少该 header 的旧调用按 `legacy` 执行，未知 source fail closed。浏览器不直连健康表、Data API 或 Realtime。
+
+参与者在报名页看到“已到开放时间但 canonical opening fact 尚未落库”时，页面只触发一次受保护的 recovery Server Action；真正的 `registrationOpenedAt` 物化、重读和后续报名写入仍在同一 transaction owner 中完成。GET/RSC 本身不执行 mutation。
+
+Release workflow 在 deployment smoke 成功后，使用受保护 production environment 执行 `pnpm db:production:scheduler:provision` 和 `pnpm db:production:scheduler:verify`，幂等更新 Vault secret 与 named `cron.job`，再发布 GitHub Release。普通本地命令不 provision production scheduler。
+
 ## Operations
 
 - 本地环境：[`operations/local-development.md`](./operations/local-development.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,11 +44,11 @@ RLS、GRANT、trigger、policy、backfill 和 custom SQL 都进入 active migrat
 
 ## Scheduler boundary
 
-业务关键定时任务由 `src/lib/scheduler/definitions.ts` 维护唯一 registry：它同时拥有稳定 job key、Route Handler 路径、primary UTC cron 和 watchdog stale threshold。教育凭证清理的产品时间是北京时间每日 06:00，持久化为 UTC `0 22 * * *`；不要在 GitHub workflow、Vercel 配置或页面复制另一份 schedule。
+业务关键定时任务由 `src/lib/scheduler/definitions.ts` 维护唯一 registry：它拥有稳定 job key（Route Handler 路径由 job key 推导）、primary UTC cron 和 watchdog stale threshold。教育凭证清理的产品时间是北京时间每日 06:00，持久化为 UTC `0 22 * * *`；不要在 GitHub workflow、Vercel 配置或页面复制另一份 schedule。
 
-Production primary 使用 Supabase `pg_cron` + `pg_net`：`public.dispatch_rivalhub_scheduler_job(text)` 只校验 registry key、写入有界的 `scheduled_job_health.last_primary_triggered_at`，再从 Vault 读取固定名称的调度 base URL/credential 并异步调用现有 `/api/cron/*` endpoint。领域 transition 仍由现有 TypeScript owner 执行，数据库函数不实现业务规则。
+Production primary 使用 Supabase `pg_cron` + `pg_net`：`public.dispatch_rivalhub_scheduler_job(text)` 只接受安全的 route segment、写入有界的 `scheduled_job_health.last_primary_triggered_at`，再从 Vault 读取固定名称的调度 base URL/credential 并异步调用现有 `/api/cron/<job-key>` endpoint。哪些 job 实际被创建由受保护的 TypeScript registry/provisioning command 唯一决定；领域 transition 仍由现有 TypeScript owner 执行，数据库函数不实现业务规则。
 
-`.github/workflows/cron.yml` 保留每 5 分钟的四路调用，作为 watchdog 和人工 dispatch fallback。请求携带 `X-RivalHub-Cron-Source`；当 primary heartbeat 仍新鲜时，endpoint 只记录 watchdog 成功并返回 no-op，过期或无法读取时才执行 canonical runner。缺少该 header 的旧调用按 `legacy` 执行，未知 source fail closed。浏览器不直连健康表、Data API 或 Realtime。
+`.github/workflows/cron.yml` 保留每 5 分钟的四路调用，作为 watchdog 和人工 dispatch fallback。请求携带 `X-RivalHub-Cron-Source`；只有 primary trigger 与 primary endpoint success 都在 stale threshold 内时，watchdog 才返回 no-op，否则执行 canonical runner。缺少该 header 的旧调用按 `legacy` 执行，未知 source fail closed。浏览器不直连健康表、Data API 或 Realtime。
 
 参与者在报名页看到“已到开放时间但 canonical opening fact 尚未落库”时，页面只触发一次受保护的 recovery Server Action；真正的 `registrationOpenedAt` 物化、重读和后续报名写入仍在同一 transaction owner 中完成。GET/RSC 本身不执行 mutation。
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -83,3 +83,9 @@ pnpm db:local:stop
 数据库 bootstrap、migration、integration 和 E2E 会共享本机 Local Supabase 资源。仓库 wrapper 负责跨 worktree 串行化这些操作；普通 type-check、unit test 和 build 不需要等待数据库锁。
 
 遇到数据库相关失败时，优先确认当前目标仍是 loopback、本地服务状态正常，并通过 canonical wrapper 复现；不要为了“让测试跑起来”临时改用远程数据库。
+
+## Scheduler and registration recovery
+
+本地不启动或 provision production `pg_cron`/`pg_net`，也不把本地 workflow 当作 production scheduler evidence。active migration 在 plain PostgreSQL 上会对可用 extension 做条件处理；本地 migration replay 只证明 schema/function 文本可以回放，production named jobs、Vault secret 和 provider dispatch 由受保护 release workflow 的 `db:production:scheduler:*` 命令验证。
+
+调度 registry 的 pure contract、watchdog fresh/stale 分支、source 校验和 health projection 使用 unit tests 验证；真实 database lock、RLS、migration replay 和 HTTP dispatch 仍按 [`../testing.md`](../testing.md) 的对应层级执行。参与者报名的 due-opening recovery 只在 transaction 内 materialize opening fact，页面 GET 不承担此副作用。

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -78,7 +78,7 @@ PostgreSQL 分类必须复用 `src/db/errors.ts` 的 `extractPgError()`。日志
 - Rivals registration submit；CompetitionEntry submit/review；
 - Major prestart final entrant selection/reconciliation and lock, Major start、Swiss round finalize、stage transition、playoff start；
 - match result record、result correction plan/apply/adjudication。
-- scheduler primary dispatch、endpoint execution、watchdog no-op/fallback、人工 break-glass run。
+- scheduler endpoint failure、watchdog fallback、人工 break-glass run；正常 primary success 与 fresh watchdog no-op 不逐条写 runtime log。
 
 Span name、`rivalhub.*`、`db.*`、HTTP method/status 和 provider 等属性必须是低基数值。默认不加 user/team/entry ID、email、昵称或业务 payload。跨 provider 的 trace propagation 只对自有 deployment URL 开启；Supabase、Steam、SiliconFlow、Cloudflare Turnstile 和 Better Stack 均不接收 RivalHub trace headers。
 
@@ -130,7 +130,7 @@ return traceOperation("competition_entry.submit", {
 
 不要为正常成功路径逐条记录日志，不要复制领域 transition/错误分类，不要在 component 中配置外部 sink。Client Component 只有在存在明确 fallback 时才可输出固定、非敏感的浏览器诊断，不能输出 raw exception/payload 或用空 catch 静默吞错。新增 safeContext key 时必须同时补 redaction 单测，并检查它不会成为 ID、body、query 或 secret 的旁路。
 
-Scheduler 的 `scheduled_job_health` 只保存有界 current projection，不是 runtime log 或 execution ledger。primary trigger、primary endpoint start/success、watchdog/manual success、最近业务推进和最近失败分别由 shared scheduler owner 更新；失败只保存稳定 source/code/classification，不保存 raw error、URL、Authorization 或 Vault secret。`jobKey`、`source` 等 safeContext 仍必须经过 allowlist。
+Scheduler 的 `scheduled_job_health` 只保存有界 current projection，不是 runtime log 或 execution ledger。primary trigger、primary endpoint start/success、watchdog fallback/manual success、最近业务推进和最近失败分别由 shared scheduler owner 更新；fresh watchdog no-op 不写 projection。失败只保存稳定 source/code/classification，不保存 raw error、URL、Authorization 或 Vault secret。`jobKey`、`source` 等 safeContext 仍必须经过 allowlist。
 
 ## 告警原则
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -78,6 +78,7 @@ PostgreSQL 分类必须复用 `src/db/errors.ts` 的 `extractPgError()`。日志
 - Rivals registration submit；CompetitionEntry submit/review；
 - Major prestart final entrant selection/reconciliation and lock, Major start、Swiss round finalize、stage transition、playoff start；
 - match result record、result correction plan/apply/adjudication。
+- scheduler primary dispatch、endpoint execution、watchdog no-op/fallback、人工 break-glass run。
 
 Span name、`rivalhub.*`、`db.*`、HTTP method/status 和 provider 等属性必须是低基数值。默认不加 user/team/entry ID、email、昵称或业务 payload。跨 provider 的 trace propagation 只对自有 deployment URL 开启；Supabase、Steam、SiliconFlow、Cloudflare Turnstile 和 Better Stack 均不接收 RivalHub trace headers。
 
@@ -128,6 +129,8 @@ return traceOperation("competition_entry.submit", {
 ```
 
 不要为正常成功路径逐条记录日志，不要复制领域 transition/错误分类，不要在 component 中配置外部 sink。Client Component 只有在存在明确 fallback 时才可输出固定、非敏感的浏览器诊断，不能输出 raw exception/payload 或用空 catch 静默吞错。新增 safeContext key 时必须同时补 redaction 单测，并检查它不会成为 ID、body、query 或 secret 的旁路。
+
+Scheduler 的 `scheduled_job_health` 只保存有界 current projection，不是 runtime log 或 execution ledger。primary trigger、primary endpoint start/success、watchdog/manual success、最近业务推进和最近失败分别由 shared scheduler owner 更新；失败只保存稳定 source/code/classification，不保存 raw error、URL、Authorization 或 Vault secret。`jobKey`、`source` 等 safeContext 仍必须经过 allowlist。
 
 ## 告警原则
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -39,10 +39,11 @@ validate tag belongs to main
 → migrate + verify production database
 → deploy exact tag commit to Vercel Production
 → smoke deployment + canonical production domain
+→ provision + verify Supabase scheduler and protected Vault names
 → publish/update GitHub Release notes
 ```
 
-Production secret、target confirmation 和 remote-write authorization 只存在于受保护 production environment / canonical wrappers 中。
+Production secret、target confirmation 和 remote-write authorization 只存在于受保护 production environment / canonical wrappers 中。Scheduler provisioning 使用 `RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision`，随后运行 verify；它会幂等替换 `rivalhub-<job-key>` named jobs，确认 pg_cron/pg_net、UTC schedule、dispatch command 与 Vault secret name，但不会输出 secret。
 
 ## 4. 失败与重试
 
@@ -55,6 +56,7 @@ Production secret、target confirmation 和 remote-write authorization 只存在
 只有以下条件都成立才算完成：
 
 - production smoke 通过；
+- production scheduler provision/verify 通过，且 primary named jobs 与 endpoint credential contract 已读回；
 - GitHub Release 已发布且 notes 正确；
 - tag、release commit 与 production deployment 对齐；
 - 需要 production acceptance 的 Issue 已获得真实生产证据后再关闭。

--- a/docs/security/database-access-matrix.md
+++ b/docs/security/database-access-matrix.md
@@ -4,7 +4,7 @@
 
 ## 结论
 
-- 当前 active chain 的 71 张 application-owned `public` base table 全部归类为 `server_only`。业务数据库只由 server-side Drizzle 访问，browser Data API consumer 为零。
+- 当前 active chain 的 72 张 application-owned `public` base table 全部归类为 `server_only`。业务数据库只由 server-side Drizzle 访问，browser Data API consumer 为零。
 - `users`、`user_sessions`、`admin_invites`、`admin_invite_claims`、`season_admin_grants`、`audit_logs`、education evidence、Major prestart/runtime 和 bracket runtime 均按高敏感 server-only 处理。
 - 2026-09-03 production 只读 inventory 在 migration 前确认 `competition_bracket_states` 是明确的 anon/authenticated CRUD privilege 例外；Issue #395 的 forward migration 将其与其余表统一收口。
 - `DraftLiveRoom` 与 `CaptainVotingPanel` 的 Realtime subscription 已删除。两处继续使用既有 10 秒 polling fallback；`ResetPasswordForm` 保留 browser Supabase client，但仅调用 Supabase Auth，不调用 public table Data API。
@@ -68,6 +68,7 @@
 | recruitment_interests | 求职意向与用户关系 | Team recruitment | src/lib/recruitment/commands.ts; src/lib/recruitment/data.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 兴趣记录包含用户关系和 mutation 状态，只能由鉴权命令访问。 |
 | registration_drafts | 未提交报名草稿 | 报名 | src/actions/register.ts; src/components/admin/DraftRegistrationTable.tsx | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 草稿可能包含联系方式和未审核材料，不形成公开数据面。 |
 | season_admin_grants | 高敏感管理员授权事实 | 鉴权 / 赛季授权 | src/lib/auth/session.ts; src/actions/admin.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 管理员范围由当前数据库授权事实读取，客户端不能缓存或修改。 |
+| scheduled_job_health | 定时任务当前健康投影 | Scheduler runtime | src/lib/scheduler/health.ts; src/lib/scheduler/admin.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 只保存每个 job 的有界当前状态，供服务端调度与超级管理员系统状态页读取；不形成浏览器 Data API 或 Realtime surface。 |
 | season_registrations | 报名、资格与个人竞技资料 | Rivals 报名 | src/actions/register.ts; src/lib/qualification/service.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 报名状态和教育/竞技资料由服务端验证后投影。 |
 | seasons | 赛事生命周期与冻结配置 | 赛事配置 | src/actions/seasons.ts; src/lib/seasons/; src/db/schema/seasons.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | 赛事 capability、注册窗口和冻结配置是业务控制面，不允许 Data API 旁路。 |
 | swiss_standings | 排名 projection 与阶段事实 | Major Swiss | src/lib/swiss/data.ts; src/lib/major/swiss-runtime.ts | 无（仅服务端 Drizzle；浏览器不直连业务表） | 无（Realtime 已移除；使用现有 polling fallback） | 无 | 无 | 是 | 无（RLS deny） | 无 | server_only | Swiss standings 不是独立真相，必须随 Major runtime 服务端更新。 |

--- a/docs/ui-system.md
+++ b/docs/ui-system.md
@@ -84,6 +84,8 @@ shared layer **不拥有** allowed query、validation、SQL `WHERE/ORDER BY`、q
 
 高影响操作（比分更正、纪律、裁决/荣誉撤销、归档、名单冻结、开赛等）使用 `InlineConfirm` 或等价明确确认，并继续由服务端授权、审计和 fail-closed validation 保护；浏览器原生 `confirm()` 不替代任务语义。
 
+Super-admin 系统状态页的 scheduler health 只展示 job label、primary freshness、endpoint/fallback/manual/业务推进时间和“正常/已降级”状态；不展示 secret、raw error 或 provider response。“立即运行一次”是故障恢复 mutation，必须是可键盘到达的真实 button、可见 focus，并使用 `InlineConfirm` 解释可能推进业务状态后再调用受保护 Server Action。
+
 ## Responsive and accessibility
 
 - 320–390px 下关键任务仍可完整完成，按钮不依赖单行空间，长标识不撑破页面。

--- a/drizzle/migrations/0045_fresh_blue_blade.sql
+++ b/drizzle/migrations/0045_fresh_blue_blade.sql
@@ -15,13 +15,6 @@ CREATE TABLE "scheduled_job_health" (
 ALTER TABLE "scheduled_job_health" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 REVOKE ALL PRIVILEGES ON TABLE "scheduled_job_health" FROM anon, authenticated;--> statement-breakpoint
 
-INSERT INTO "scheduled_job_health" ("job_key") VALUES
-  ('draft-timeout'),
-  ('check-registration-deadline'),
-  ('match-time-auto-award'),
-  ('cleanup-education-evidence')
-ON CONFLICT ("job_key") DO NOTHING;--> statement-breakpoint
-
 -- Local PostgreSQL normally has neither extension. Supabase production may
 -- expose both extensions, so enable them when the server can load them while
 -- keeping plain migration replay valid. Release provisioning verifies that
@@ -53,20 +46,15 @@ SECURITY DEFINER
 SET search_path = public, pg_catalog
 AS $$
 DECLARE
-  route_segment text;
   base_url text;
   cron_secret text;
   request_id bigint;
 BEGIN
-  route_segment := CASE job_key
-    WHEN 'draft-timeout' THEN 'draft-timeout'
-    WHEN 'check-registration-deadline' THEN 'check-registration-deadline'
-    WHEN 'match-time-auto-award' THEN 'match-time-auto-award'
-    WHEN 'cleanup-education-evidence' THEN 'cleanup-education-evidence'
-    ELSE NULL
-  END;
-  IF route_segment IS NULL THEN
-    RAISE EXCEPTION 'unknown scheduler job key' USING ERRCODE = '22023';
+  -- The protected TypeScript provisioning command owns the registered job
+  -- set. Keep the DB helper limited to safe route segments so it cannot be
+  -- used to construct an arbitrary URL path or query.
+  IF job_key IS NULL OR job_key !~ '^[a-z0-9]+(-[a-z0-9]+)*$' THEN
+    RAISE EXCEPTION 'invalid scheduler job key' USING ERRCODE = '22023';
   END IF;
 
   INSERT INTO public.scheduled_job_health (job_key, last_primary_triggered_at, updated_at)
@@ -93,7 +81,7 @@ BEGIN
   EXECUTE 'SELECT net.http_get($1, $2::jsonb, $3::jsonb, $4)'
     INTO request_id
     USING
-      base_url || '/api/cron/' || route_segment,
+      base_url || '/api/cron/' || job_key,
       '{}'::jsonb,
       jsonb_build_object(
         'Authorization', 'Bearer ' || cron_secret,

--- a/drizzle/migrations/0045_fresh_blue_blade.sql
+++ b/drizzle/migrations/0045_fresh_blue_blade.sql
@@ -1,0 +1,107 @@
+CREATE TABLE "scheduled_job_health" (
+	"job_key" text PRIMARY KEY NOT NULL,
+	"last_primary_triggered_at" timestamp with time zone,
+	"last_primary_endpoint_started_at" timestamp with time zone,
+	"last_primary_endpoint_succeeded_at" timestamp with time zone,
+	"last_watchdog_succeeded_at" timestamp with time zone,
+	"last_manual_succeeded_at" timestamp with time zone,
+	"last_business_transition_at" timestamp with time zone,
+	"last_failure_at" timestamp with time zone,
+	"last_failure_source" text,
+	"last_failure_code" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+ALTER TABLE "scheduled_job_health" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "scheduled_job_health" FROM anon, authenticated;--> statement-breakpoint
+
+INSERT INTO "scheduled_job_health" ("job_key") VALUES
+  ('draft-timeout'),
+  ('check-registration-deadline'),
+  ('match-time-auto-award'),
+  ('cleanup-education-evidence')
+ON CONFLICT ("job_key") DO NOTHING;--> statement-breakpoint
+
+-- Local PostgreSQL normally has neither extension. Supabase production may
+-- expose both extensions, so enable them when the server can load them while
+-- keeping plain migration replay valid. Release provisioning verifies that
+-- the production extensions really exist before scheduling jobs.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+    BEGIN
+      EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'pg_cron is available but could not be enabled during migration';
+    END;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_net') THEN
+    BEGIN
+      EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_net';
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'pg_net is available but could not be enabled during migration';
+    END;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- The database helper only records a primary heartbeat and enqueues the
+-- canonical HTTP route. It intentionally contains no domain transition.
+CREATE OR REPLACE FUNCTION "public"."dispatch_rivalhub_scheduler_job"(job_key text)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  route_segment text;
+  base_url text;
+  cron_secret text;
+  request_id bigint;
+BEGIN
+  route_segment := CASE job_key
+    WHEN 'draft-timeout' THEN 'draft-timeout'
+    WHEN 'check-registration-deadline' THEN 'check-registration-deadline'
+    WHEN 'match-time-auto-award' THEN 'match-time-auto-award'
+    WHEN 'cleanup-education-evidence' THEN 'cleanup-education-evidence'
+    ELSE NULL
+  END;
+  IF route_segment IS NULL THEN
+    RAISE EXCEPTION 'unknown scheduler job key' USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.scheduled_job_health (job_key, last_primary_triggered_at, updated_at)
+  VALUES (job_key, clock_timestamp(), clock_timestamp())
+  ON CONFLICT (job_key) DO UPDATE SET
+    last_primary_triggered_at = EXCLUDED.last_primary_triggered_at,
+    updated_at = EXCLUDED.updated_at;
+
+  IF to_regnamespace('vault') IS NULL THEN
+    RAISE EXCEPTION 'scheduler vault is unavailable' USING ERRCODE = '0A000';
+  END IF;
+  EXECUTE 'SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = $1'
+    INTO base_url USING 'rivalhub_scheduler_base_url';
+  EXECUTE 'SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = $1'
+    INTO cron_secret USING 'rivalhub_cron_secret';
+  IF NULLIF(trim(base_url), '') IS NULL OR NULLIF(cron_secret, '') IS NULL THEN
+    RAISE EXCEPTION 'scheduler credentials are unavailable' USING ERRCODE = '22023';
+  END IF;
+
+  IF to_regnamespace('net') IS NULL THEN
+    RAISE EXCEPTION 'scheduler HTTP extension is unavailable' USING ERRCODE = '0A000';
+  END IF;
+  base_url := regexp_replace(trim(base_url), '/+$', '');
+  EXECUTE 'SELECT net.http_get($1, $2::jsonb, $3::jsonb, $4)'
+    INTO request_id
+    USING
+      base_url || '/api/cron/' || route_segment,
+      '{}'::jsonb,
+      jsonb_build_object(
+        'Authorization', 'Bearer ' || cron_secret,
+        'X-RivalHub-Cron-Source', 'supabase-primary'
+      ),
+      10000;
+  RETURN request_id;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL PRIVILEGES ON FUNCTION "public"."dispatch_rivalhub_scheduler_job"(text) FROM PUBLIC, anon, authenticated;

--- a/drizzle/migrations/meta/0045_snapshot.json
+++ b/drizzle/migrations/meta/0045_snapshot.json
@@ -1,0 +1,10374 @@
+{
+  "id": "5cbe8a91-3726-4fdd-82c6-7af726df739a",
+  "prevId": "b16c6e4e-48a2-46df-83ec-9002eaa20fd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_invite_claims": {
+      "name": "admin_invite_claims",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_invite_claims_invite_id_idx": {
+          "name": "admin_invite_claims_invite_id_idx",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_invite_claims_user_id_idx": {
+          "name": "admin_invite_claims_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invite_claims_invite_id_admin_invites_id_fk": {
+          "name": "admin_invite_claims_invite_id_admin_invites_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "tableTo": "admin_invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_invite_claims_user_id_users_id_fk": {
+          "name": "admin_invite_claims_user_id_users_id_fk",
+          "tableFrom": "admin_invite_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invite_claims_invite_user_unique": {
+          "name": "admin_invite_claims_invite_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invites": {
+      "name": "admin_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "admin_invite_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'season_admin'"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_invites_season_id_seasons_id_fk": {
+          "name": "admin_invites_season_id_seasons_id_fk",
+          "tableFrom": "admin_invites",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invites_code_unique": {
+          "name": "admin_invites_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invites_max_uses_positive": {
+          "name": "admin_invites_max_uses_positive",
+          "value": "\"admin_invites\".\"max_uses\" > 0"
+        },
+        "admin_invites_role_season_scope": {
+          "name": "admin_invites_role_season_scope",
+          "value": "(\"admin_invites\".\"role\" = 'season_admin' AND \"admin_invites\".\"season_id\" IS NOT NULL) OR (\"admin_invites\".\"role\" = 'super_admin' AND \"admin_invites\".\"season_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_season_id_created_at_idx": {
+          "name": "audit_logs_season_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_season_id_seasons_id_fk": {
+          "name": "audit_logs_season_id_seasons_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_award_evidence": {
+      "name": "community_award_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_user_id": {
+          "name": "candidate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_award_evidence_award_id_idx": {
+          "name": "community_award_evidence_award_id_idx",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_award_evidence_award_id_community_awards_id_fk": {
+          "name": "community_award_evidence_award_id_community_awards_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "community_awards",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_submitted_by_user_id_users_id_fk": {
+          "name": "community_award_evidence_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_candidate_user_id_users_id_fk": {
+          "name": "community_award_evidence_candidate_user_id_users_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "users",
+          "columnsFrom": [
+            "candidate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_award_evidence_match_id_matches_id_fk": {
+          "name": "community_award_evidence_match_id_matches_id_fk",
+          "tableFrom": "community_award_evidence",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_award_evidence_non_blank_explanation_check": {
+          "name": "community_award_evidence_non_blank_explanation_check",
+          "value": "length(trim(\"community_award_evidence\".\"explanation\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_awards": {
+      "name": "community_awards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize": {
+          "name": "prize",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplementary_note": {
+          "name": "supplementary_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_note": {
+          "name": "public_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "community_award_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_note": {
+          "name": "outcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_by_user_id": {
+          "name": "outcome_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_at": {
+          "name": "outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_awards_season_id_status_idx": {
+          "name": "community_awards_season_id_status_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_awards_season_id_seasons_id_fk": {
+          "name": "community_awards_season_id_seasons_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_awards_submitted_by_user_id_users_id_fk": {
+          "name": "community_awards_submitted_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "community_awards_reviewed_by_user_id_users_id_fk": {
+          "name": "community_awards_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_awards_recipient_user_id_users_id_fk": {
+          "name": "community_awards_recipient_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "community_awards_outcome_by_user_id_users_id_fk": {
+          "name": "community_awards_outcome_by_user_id_users_id_fk",
+          "tableFrom": "community_awards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "outcome_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_awards_non_blank_fields_check": {
+          "name": "community_awards_non_blank_fields_check",
+          "value": "length(trim(\"community_awards\".\"name\")) > 0 AND length(trim(\"community_awards\".\"condition\")) > 0 AND length(trim(\"community_awards\".\"prize\")) > 0"
+        },
+        "community_awards_review_check": {
+          "name": "community_awards_review_check",
+          "value": "(\"community_awards\".\"status\" = 'pending_review' AND ((\"community_awards\".\"reviewed_by_user_id\" IS NULL AND \"community_awards\".\"reviewed_at\" IS NULL) OR (\"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)))\n      OR (\"community_awards\".\"status\" IN ('rejected', 'approved', 'awarded', 'not_awarded', 'cancelled') AND \"community_awards\".\"reviewed_by_user_id\" IS NOT NULL AND \"community_awards\".\"reviewed_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" = 'withdrawn')"
+        },
+        "community_awards_outcome_check": {
+          "name": "community_awards_outcome_check",
+          "value": "(\"community_awards\".\"status\" = 'awarded' AND \"community_awards\".\"recipient_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('not_awarded', 'cancelled', 'withdrawn') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NOT NULL AND \"community_awards\".\"outcome_at\" IS NOT NULL)\n      OR (\"community_awards\".\"status\" IN ('pending_review', 'rejected', 'approved') AND \"community_awards\".\"recipient_user_id\" IS NULL AND \"community_awards\".\"outcome_by_user_id\" IS NULL AND \"community_awards\".\"outcome_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_bracket_states": {
+      "name": "competition_bracket_states",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_bracket_states_competition_id_seasons_id_fk": {
+          "name": "competition_bracket_states_competition_id_seasons_id_fk",
+          "tableFrom": "competition_bracket_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entries": {
+      "name": "competition_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "competition_entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_registration_id": {
+          "name": "source_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formation_order": {
+          "name": "formation_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_user_id": {
+          "name": "representative_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "competition_entry_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "perfect_team_id": {
+          "name": "perfect_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_roster_revision_id": {
+          "name": "current_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_roster_revision_id": {
+          "name": "approved_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_reason": {
+          "name": "review_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entries_competition_status_idx": {
+          "name": "competition_entries_competition_status_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_team_history_idx": {
+          "name": "competition_entries_team_history_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_one_effective_team_per_competition": {
+          "name": "competition_entries_one_effective_team_per_competition",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entries\".\"team_id\" IS NOT NULL AND \"competition_entries\".\"registration_status\" NOT IN ('rejected', 'withdrawn')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entries_competition_formation_order_unique": {
+          "name": "competition_entries_competition_formation_order_unique",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formation_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entries\".\"formation_order\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entries_competition_id_seasons_id_fk": {
+          "name": "competition_entries_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_team_id_teams_id_fk": {
+          "name": "competition_entries_team_id_teams_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_source_registration_id_season_registrations_id_fk": {
+          "name": "competition_entries_source_registration_id_season_registrations_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "source_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entries_representative_user_id_users_id_fk": {
+          "name": "competition_entries_representative_user_id_users_id_fk",
+          "tableFrom": "competition_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "representative_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entries_id_competition_id_unique": {
+          "name": "competition_entries_id_competition_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "competition_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entries_source_shape_check": {
+          "name": "competition_entries_source_shape_check",
+          "value": "(\"competition_entries\".\"source\" = 'linked_team' AND \"competition_entries\".\"team_id\" IS NOT NULL) OR (\"competition_entries\".\"source\" = 'event_native' AND \"competition_entries\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_active_claims": {
+      "name": "competition_entry_active_claims",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_active_claims_entry_idx": {
+          "name": "competition_entry_active_claims_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_active_claims_competition_id_seasons_id_fk": {
+          "name": "competition_entry_active_claims_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_user_id_users_id_fk": {
+          "name": "competition_entry_active_claims_user_id_users_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_active_claims_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_active_claims_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_entry_competition_scope_fk": {
+          "name": "competition_entry_active_claims_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_active_claims_participant_scope_fk": {
+          "name": "competition_entry_active_claims_participant_scope_fk",
+          "tableFrom": "competition_entry_active_claims",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id",
+            "entry_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_active_claims_competition_user_unique": {
+          "name": "competition_entry_active_claims_competition_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "competition_id",
+            "user_id"
+          ]
+        },
+        "competition_entry_active_claims_participant_unique": {
+          "name": "competition_entry_active_claims_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_legacy_identities": {
+      "name": "competition_entry_legacy_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_type": {
+          "name": "legacy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_legacy_identities_entry_idx": {
+          "name": "competition_entry_legacy_identities_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_legacy_identities_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_legacy_identities_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_legacy_identities",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_legacy_identities_type_id_unique": {
+          "name": "competition_entry_legacy_identities_type_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "legacy_type",
+            "legacy_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_participants": {
+      "name": "competition_entry_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_participant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competition_entry_participants_user_status_idx": {
+          "name": "competition_entry_participants_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_participants_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_participants_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_participants_user_id_users_id_fk": {
+          "name": "competition_entry_participants_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_participants_invited_by_user_id_users_id_fk": {
+          "name": "competition_entry_participants_invited_by_user_id_users_id_fk",
+          "tableFrom": "competition_entry_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_participants_entry_user_unique": {
+          "name": "competition_entry_participants_entry_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "user_id"
+          ]
+        },
+        "competition_entry_participants_id_entry_user_unique": {
+          "name": "competition_entry_participants_id_entry_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "entry_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_participants_confirmation_shape_check": {
+          "name": "competition_entry_participants_confirmation_shape_check",
+          "value": "(\"competition_entry_participants\".\"status\" = 'confirmed' AND \"competition_entry_participants\".\"confirmed_at\" IS NOT NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)\n      OR (\"competition_entry_participants\".\"status\" = 'withdrawn' AND \"competition_entry_participants\".\"withdrawn_at\" IS NOT NULL)\n      OR (\"competition_entry_participants\".\"status\" IN ('invited', 'declined') AND \"competition_entry_participants\".\"confirmed_at\" IS NULL AND \"competition_entry_participants\".\"withdrawn_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_representative_changes": {
+      "name": "competition_entry_representative_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "competition_entry_representative_changes_entry_changed_at_idx": {
+          "name": "competition_entry_representative_changes_entry_changed_at_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_representative_changes_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_representative_changes_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_representative_changes_from_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_from_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_representative_changes_to_user_id_users_id_fk": {
+          "name": "competition_entry_representative_changes_to_user_id_users_id_fk",
+          "tableFrom": "competition_entry_representative_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_members": {
+      "name": "competition_entry_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_membership_id": {
+          "name": "team_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_roster_members_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "competition_entry_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_user_id_users_id_fk": {
+          "name": "competition_entry_roster_members_user_id_users_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_roster_members_team_membership_id_team_memberships_id_fk": {
+          "name": "competition_entry_roster_members_team_membership_id_team_memberships_id_fk",
+          "tableFrom": "competition_entry_roster_members",
+          "tableTo": "team_memberships",
+          "columnsFrom": [
+            "team_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_members_revision_participant_unique": {
+          "name": "competition_entry_roster_members_revision_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision_id",
+            "participant_id"
+          ]
+        },
+        "competition_entry_roster_members_revision_user_unique": {
+          "name": "competition_entry_roster_members_revision_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "revision_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_roster_revisions": {
+      "name": "competition_entry_roster_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_entry_roster_revision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "competition_entry_roster_revision_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initial'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_roster_revisions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_roster_revisions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_roster_revisions",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_roster_revisions_entry_revision_number_unique": {
+          "name": "competition_entry_roster_revisions_entry_revision_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "revision_number"
+          ]
+        },
+        "competition_entry_roster_revisions_id_entry_id_unique": {
+          "name": "competition_entry_roster_revisions_id_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_roster_revisions_positive_check": {
+          "name": "competition_entry_roster_revisions_positive_check",
+          "value": "\"competition_entry_roster_revisions\".\"revision_number\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_submissions": {
+      "name": "competition_entry_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "competition_entry_submission_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_entry_submissions_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_submissions_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_submissions_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_submissions_roster_revision_entry_scope_fk": {
+          "name": "competition_entry_submissions_roster_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_submissions",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "competition_entry_submissions_entry_sequence_unique": {
+          "name": "competition_entry_submissions_entry_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_submissions_positive_check": {
+          "name": "competition_entry_submissions_positive_check",
+          "value": "\"competition_entry_submissions\".\"sequence\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_roster_members": {
+      "name": "event_roster_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_roster_id": {
+          "name": "event_roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_verification_id": {
+          "name": "education_verification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary_starter": {
+          "name": "is_primary_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_roster_members_roster_idx": {
+          "name": "event_roster_members_roster_idx",
+          "columns": [
+            {
+              "expression": "event_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_roster_members_event_roster_id_event_rosters_id_fk": {
+          "name": "event_roster_members_event_roster_id_event_rosters_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "event_rosters",
+          "columnsFrom": [
+            "event_roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_user_id_users_id_fk": {
+          "name": "event_roster_members_user_id_users_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_participant_id_competition_entry_participants_id_fk": {
+          "name": "event_roster_members_participant_id_competition_entry_participants_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "competition_entry_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_roster_members_education_verification_id_education_verifications_id_fk": {
+          "name": "event_roster_members_education_verification_id_education_verifications_id_fk",
+          "tableFrom": "event_roster_members",
+          "tableTo": "education_verifications",
+          "columnsFrom": [
+            "education_verification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_roster_members_roster_user_unique": {
+          "name": "event_roster_members_roster_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_roster_id",
+            "user_id"
+          ]
+        },
+        "event_roster_members_participant_unique": {
+          "name": "event_roster_members_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_roster_id",
+            "participant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_rosters": {
+      "name": "event_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_roster_revision_id": {
+          "name": "source_roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_by": {
+          "name": "frozen_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_rosters_entry_id_competition_entries_id_fk": {
+          "name": "event_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "event_rosters_source_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "source_roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_rosters_source_roster_revision_entry_scope_fk": {
+          "name": "event_rosters_source_roster_revision_entry_scope_fk",
+          "tableFrom": "event_rosters",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "source_roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_rosters_entry_unique": {
+          "name": "event_rosters_entry_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "event_rosters_freeze_shape_check": {
+          "name": "event_rosters_freeze_shape_check",
+          "value": "(\"event_rosters\".\"status\" = 'preparing' AND \"event_rosters\".\"confirmed_at\" IS NULL AND \"event_rosters\".\"confirmed_by\" IS NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'confirmed' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NULL AND \"event_rosters\".\"frozen_by\" IS NULL)\n      OR (\"event_rosters\".\"status\" = 'frozen' AND \"event_rosters\".\"confirmed_at\" IS NOT NULL AND \"event_rosters\".\"confirmed_by\" IS NOT NULL AND \"event_rosters\".\"frozen_at\" IS NOT NULL AND \"event_rosters\".\"frozen_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competition_entry_restriction_overrides": {
+      "name": "competition_entry_restriction_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_revision_id": {
+          "name": "roster_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restriction_code": {
+          "name": "restriction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_snapshot": {
+          "name": "finding_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competition_entry_restriction_overrides_active_unique": {
+          "name": "competition_entry_restriction_overrides_active_unique",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "restriction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entry_restriction_overrides_entry_idx": {
+          "name": "competition_entry_restriction_overrides_entry_idx",
+          "columns": [
+            {
+              "expression": "entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competition_entry_restriction_overrides_competition_idx": {
+          "name": "competition_entry_restriction_overrides_competition_idx",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_entry_restriction_overrides_competition_id_seasons_id_fk": {
+          "name": "competition_entry_restriction_overrides_competition_id_seasons_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk": {
+          "name": "competition_entry_restriction_overrides_entry_id_competition_entries_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk": {
+          "name": "competition_entry_restriction_overrides_roster_revision_id_competition_entry_roster_revisions_id_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_entry_competition_scope_fk": {
+          "name": "competition_entry_restriction_overrides_entry_competition_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id",
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "competition_entry_restriction_overrides_revision_entry_scope_fk": {
+          "name": "competition_entry_restriction_overrides_revision_entry_scope_fk",
+          "tableFrom": "competition_entry_restriction_overrides",
+          "tableTo": "competition_entry_roster_revisions",
+          "columnsFrom": [
+            "roster_revision_id",
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id",
+            "entry_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competition_entry_restriction_overrides_revoke_shape_check": {
+          "name": "competition_entry_restriction_overrides_revoke_shape_check",
+          "value": "(\"competition_entry_restriction_overrides\".\"revoked_at\" IS NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NULL) OR (\"competition_entry_restriction_overrides\".\"revoked_at\" IS NOT NULL AND \"competition_entry_restriction_overrides\".\"revoked_by\" IS NOT NULL)"
+        },
+        "competition_entry_restriction_overrides_code_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_code_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"restriction_code\")) > 0"
+        },
+        "competition_entry_restriction_overrides_reason_non_empty_check": {
+          "name": "competition_entry_restriction_overrides_reason_non_empty_check",
+          "value": "length(trim(\"competition_entry_restriction_overrides\".\"reason\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_ranks": {
+      "name": "competitive_platform_ranks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_key": {
+          "name": "platform_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_key": {
+          "name": "rank_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "star_min": {
+          "name": "star_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "star_max": {
+          "name": "star_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_ranks_platform_rank_key_unique": {
+          "name": "competitive_platform_ranks_platform_rank_key_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_ranks_platform_sort_order_unique": {
+          "name": "competitive_platform_ranks_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_ranks_platform_order_idx": {
+          "name": "competitive_platform_ranks_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_ranks_platform_key_competitive_platforms_key_fk": {
+          "name": "competitive_platform_ranks_platform_key_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_ranks",
+          "tableTo": "competitive_platforms",
+          "columnsFrom": [
+            "platform_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_ranks_star_range_shape": {
+          "name": "competitive_platform_ranks_star_range_shape",
+          "value": "(\"competitive_platform_ranks\".\"star_min\" IS NULL AND \"competitive_platform_ranks\".\"star_max\" IS NULL) OR \"competitive_platform_ranks\".\"star_min\" IS NOT NULL"
+        },
+        "competitive_platform_ranks_star_min_non_negative": {
+          "name": "competitive_platform_ranks_star_min_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_min\" IS NULL OR \"competitive_platform_ranks\".\"star_min\" >= 0"
+        },
+        "competitive_platform_ranks_star_max_non_negative": {
+          "name": "competitive_platform_ranks_star_max_non_negative",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= 0"
+        },
+        "competitive_platform_ranks_star_range_ordered": {
+          "name": "competitive_platform_ranks_star_range_ordered",
+          "value": "\"competitive_platform_ranks\".\"star_max\" IS NULL OR \"competitive_platform_ranks\".\"star_max\" >= \"competitive_platform_ranks\".\"star_min\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platform_seasons": {
+      "name": "competitive_platform_seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_key": {
+          "name": "season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_platform_seasons_platform_key_unique": {
+          "name": "competitive_platform_seasons_platform_key_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_one_current_per_platform": {
+          "name": "competitive_platform_seasons_one_current_per_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"competitive_platform_seasons\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_platform_order_idx": {
+          "name": "competitive_platform_seasons_platform_order_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_platform_seasons_platform_sort_order_unique": {
+          "name": "competitive_platform_seasons_platform_sort_order_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_platform_seasons_platform_competitive_platforms_key_fk": {
+          "name": "competitive_platform_seasons_platform_competitive_platforms_key_fk",
+          "tableFrom": "competitive_platform_seasons",
+          "tableTo": "competitive_platforms",
+          "columnsFrom": [
+            "platform"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_platform_seasons_current_must_be_active": {
+          "name": "competitive_platform_seasons_current_must_be_active",
+          "value": "NOT \"competitive_platform_seasons\".\"is_current\" OR \"competitive_platform_seasons\".\"active\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.competitive_platforms": {
+      "name": "competitive_platforms",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_label": {
+          "name": "rating_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitive_rank_facts": {
+      "name": "competitive_rank_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "competitive_fact_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_season_key": {
+          "name": "platform_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competitive_fact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ranked'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achieved_season_key": {
+          "name": "achieved_season_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "competitive_fact_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self_declared'"
+        },
+        "declared_at": {
+          "name": "declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "competitive_rank_facts_identity_unique": {
+          "name": "competitive_rank_facts_identity_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"platform_season_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "competitive_rank_facts_user_platform_idx": {
+          "name": "competitive_rank_facts_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitive_rank_facts_user_id_users_id_fk": {
+          "name": "competitive_rank_facts_user_id_users_id_fk",
+          "tableFrom": "competitive_rank_facts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "competitive_rank_facts_stars_non_negative": {
+          "name": "competitive_rank_facts_stars_non_negative",
+          "value": "\"competitive_rank_facts\".\"stars\" IS NULL OR \"competitive_rank_facts\".\"stars\" >= 0"
+        },
+        "competitive_rank_facts_valid_fact_shape": {
+          "name": "competitive_rank_facts_valid_fact_shape",
+          "value": "\n    (\n      \"competitive_rank_facts\".\"kind\" = 'historical_peak'\n      AND \"competitive_rank_facts\".\"status\" = 'ranked'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NULL\n      AND \"competitive_rank_facts\".\"rank\" IS NOT NULL\n      AND \"competitive_rank_facts\".\"rating\" IS NOT NULL\n    ) OR (\n      \"competitive_rank_facts\".\"kind\" = 'season_peak'\n      AND \"competitive_rank_facts\".\"platform_season_key\" IS NOT NULL\n      AND (\n        (\"competitive_rank_facts\".\"status\" = 'ranked' AND \"competitive_rank_facts\".\"rank\" IS NOT NULL AND \"competitive_rank_facts\".\"rating\" IS NOT NULL)\n        OR (\"competitive_rank_facts\".\"status\" = 'unranked' AND \"competitive_rank_facts\".\"rank\" IS NULL AND \"competitive_rank_facts\".\"stars\" IS NULL)\n      )\n    )\n  "
+        },
+        "competitive_rank_facts_achieved_season_shape": {
+          "name": "competitive_rank_facts_achieved_season_shape",
+          "value": "\n    (\"competitive_rank_facts\".\"kind\" = 'historical_peak') OR \"competitive_rank_facts\".\"achieved_season_key\" IS NULL\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_competitive_roles": {
+      "name": "user_competitive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "cs2_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_competitive_roles_one_primary_per_user": {
+          "name": "user_competitive_roles_one_primary_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_competitive_roles\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_competitive_roles_user_idx": {
+          "name": "user_competitive_roles_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_competitive_roles_user_id_users_id_fk": {
+          "name": "user_competitive_roles_user_id_users_id_fk",
+          "tableFrom": "user_competitive_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_competitive_roles_user_role_unique": {
+          "name": "user_competitive_roles_user_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "role"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_map_preferences": {
+      "name": "user_map_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_map_preferences_user_id_users_id_fk": {
+          "name": "user_map_preferences_user_id_users_id_fk",
+          "tableFrom": "user_map_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversion_policies": {
+      "name": "conversion_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_platform": {
+          "name": "target_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "conversion_policy_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversion_policies_source_target_version_unique": {
+          "name": "conversion_policies_source_target_version_unique",
+          "columns": [
+            {
+              "expression": "source_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversion_policies_one_current_per_pair": {
+          "name": "conversion_policies_one_current_per_pair",
+          "columns": [
+            {
+              "expression": "source_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversion_policies\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversion_policies_current_must_be_approved": {
+          "name": "conversion_policies_current_must_be_approved",
+          "value": "NOT \"conversion_policies\".\"is_current\" OR \"conversion_policies\".\"status\" = 'approved'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_case_idempotency": {
+      "name": "disciplinary_case_idempotency",
+      "schema": "",
+      "columns": {
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk": {
+          "name": "disciplinary_case_idempotency_case_id_disciplinary_cases_id_fk",
+          "tableFrom": "disciplinary_case_idempotency",
+          "tableTo": "disciplinary_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disciplinary_cases": {
+      "name": "disciplinary_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sanction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "effective_until": {
+          "name": "effective_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disciplinary_cases_season_subject_idx": {
+          "name": "disciplinary_cases_season_subject_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disciplinary_cases_status_idx": {
+          "name": "disciplinary_cases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disciplinary_cases_season_id_seasons_id_fk": {
+          "name": "disciplinary_cases_season_id_seasons_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "disciplinary_cases_subject_user_id_users_id_fk": {
+          "name": "disciplinary_cases_subject_user_id_users_id_fk",
+          "tableFrom": "disciplinary_cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disciplinary_cases_revocation_consistent_check": {
+          "name": "disciplinary_cases_revocation_consistent_check",
+          "value": "(\"disciplinary_cases\".\"status\" = 'revoked') = (\"disciplinary_cases\".\"revoked_at\" IS NOT NULL)"
+        },
+        "disciplinary_cases_window_sane_check": {
+          "name": "disciplinary_cases_window_sane_check",
+          "value": "\"disciplinary_cases\".\"effective_until\" IS NULL OR \"disciplinary_cases\".\"effective_until\" > \"disciplinary_cases\".\"effective_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_season_id_seasons_id_fk": {
+          "name": "draft_picks_season_id_seasons_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_entry_id_competition_entries_id_fk": {
+          "name": "draft_picks_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_picks_registration_id_season_registrations_id_fk": {
+          "name": "draft_picks_registration_id_season_registrations_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_picks_client_request_id_unique": {
+          "name": "draft_picks_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        },
+        "draft_picks_season_id_registration_id_unique": {
+          "name": "draft_picks_season_id_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_state": {
+      "name": "draft_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round": {
+          "name": "current_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_entry_id": {
+          "name": "current_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_state_season_id_seasons_id_fk": {
+          "name": "draft_state_season_id_seasons_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_state_current_entry_id_competition_entries_id_fk": {
+          "name": "draft_state_current_entry_id_competition_entries_id_fk",
+          "tableFrom": "draft_state",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "current_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_state_season_id_unique": {
+          "name": "draft_state_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.education_verifications": {
+      "name": "education_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_status": {
+          "name": "academic_status",
+          "type": "academic_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "education_evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_code": {
+          "name": "evidence_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "education_verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "education_verifications_user_status_idx": {
+          "name": "education_verifications_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "education_verifications_institution_status_idx": {
+          "name": "education_verifications_institution_status_idx",
+          "columns": [
+            {
+              "expression": "institution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "education_verifications_user_id_users_id_fk": {
+          "name": "education_verifications_user_id_users_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "education_verifications_institution_id_institutions_id_fk": {
+          "name": "education_verifications_institution_id_institutions_id_fk",
+          "tableFrom": "education_verifications",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institution_email_domains": {
+      "name": "institution_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_verify": {
+          "name": "auto_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "institution_email_domains_institution_id_institutions_id_fk": {
+          "name": "institution_email_domains_institution_id_institutions_id_fk",
+          "tableFrom": "institution_email_domains",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institution_email_domains_domain_unique": {
+          "name": "institution_email_domains_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moe_institution_code": {
+          "name": "moe_institution_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "institution_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "institutions_name_idx": {
+          "name": "institutions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_moe_institution_code_unique": {
+          "name": "institutions_moe_institution_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "moe_institution_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_link_requests": {
+      "name": "identity_link_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_email": {
+          "name": "normalized_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_token_hash": {
+          "name": "state_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "identity_link_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_link_requests_user_status_idx": {
+          "name": "identity_link_requests_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_link_requests_user_id_users_id_fk": {
+          "name": "identity_link_requests_user_id_users_id_fk",
+          "tableFrom": "identity_link_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_link_requests_state_token_hash_unique": {
+          "name": "identity_link_requests_state_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "identity_link_requests_status_shape_check": {
+          "name": "identity_link_requests_status_shape_check",
+          "value": "(\"identity_link_requests\".\"status\" = 'pending' AND \"identity_link_requests\".\"completed_at\" IS NULL)\n      OR (\"identity_link_requests\".\"status\" <> 'pending' AND \"identity_link_requests\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_identities": {
+      "name": "user_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "user_identity_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_value": {
+          "name": "normalized_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "user_identity_link_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_identity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_reason": {
+          "name": "retired_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_identities_active_provider_subject_unique": {
+          "name": "user_identities_active_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_identities\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_active_normalized_value_unique": {
+          "name": "user_identities_active_normalized_value_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_identities\".\"status\" = 'active' AND \"user_identities\".\"normalized_value\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_one_primary_per_kind_unique": {
+          "name": "user_identities_one_primary_per_kind_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_identities\".\"status\" = 'active' AND \"user_identities\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_user_status_idx": {
+          "name": "user_identities_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_users_id_fk": {
+          "name": "user_identities_user_id_users_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_identities_status_shape_check": {
+          "name": "user_identities_status_shape_check",
+          "value": "(\"user_identities\".\"status\" = 'active' AND \"user_identities\".\"retired_at\" IS NULL AND \"user_identities\".\"retired_reason\" IS NULL)\n      OR (\"user_identities\".\"status\" <> 'active' AND \"user_identities\".\"is_primary\" = false AND \"user_identities\".\"retired_at\" IS NOT NULL AND length(trim(\"user_identities\".\"retired_reason\")) > 0)"
+        },
+        "user_identities_provider_non_blank_check": {
+          "name": "user_identities_provider_non_blank_check",
+          "value": "length(trim(\"user_identities\".\"provider\")) > 0"
+        },
+        "user_identities_subject_non_blank_check": {
+          "name": "user_identities_subject_non_blank_check",
+          "value": "length(trim(\"user_identities\".\"provider_subject\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_merge_authorizations": {
+      "name": "user_merge_authorizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "initiating_user_id": {
+          "name": "initiating_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_user_id": {
+          "name": "counterparty_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proven_identity_id": {
+          "name": "proven_identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_merge_authorization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_merge_authorizations_initiating_status_idx": {
+          "name": "user_merge_authorizations_initiating_status_idx",
+          "columns": [
+            {
+              "expression": "initiating_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_merge_authorizations_initiating_user_id_users_id_fk": {
+          "name": "user_merge_authorizations_initiating_user_id_users_id_fk",
+          "tableFrom": "user_merge_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiating_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_merge_authorizations_counterparty_user_id_users_id_fk": {
+          "name": "user_merge_authorizations_counterparty_user_id_users_id_fk",
+          "tableFrom": "user_merge_authorizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "counterparty_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_merge_authorizations_proven_identity_id_user_identities_id_fk": {
+          "name": "user_merge_authorizations_proven_identity_id_user_identities_id_fk",
+          "tableFrom": "user_merge_authorizations",
+          "tableTo": "user_identities",
+          "columnsFrom": [
+            "proven_identity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_merge_authorizations_status_shape_check": {
+          "name": "user_merge_authorizations_status_shape_check",
+          "value": "(\"user_merge_authorizations\".\"status\" = 'available' AND \"user_merge_authorizations\".\"consumed_at\" IS NULL)\n      OR (\"user_merge_authorizations\".\"status\" <> 'available' AND \"user_merge_authorizations\".\"consumed_at\" IS NOT NULL)"
+        },
+        "user_merge_authorizations_distinct_users_check": {
+          "name": "user_merge_authorizations_distinct_users_check",
+          "value": "\"user_merge_authorizations\".\"initiating_user_id\" <> \"user_merge_authorizations\".\"counterparty_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_merge_ledger": {
+      "name": "user_merge_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "canonical_user_id": {
+          "name": "canonical_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_user_id": {
+          "name": "merged_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_by_user_id": {
+          "name": "executed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_class": {
+          "name": "evidence_class",
+          "type": "user_merge_evidence_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_fingerprint": {
+          "name": "plan_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_id": {
+          "name": "authorization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_summary": {
+          "name": "domain_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_merge_ledger_canonical_user_id_idx": {
+          "name": "user_merge_ledger_canonical_user_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_merge_ledger_canonical_user_id_users_id_fk": {
+          "name": "user_merge_ledger_canonical_user_id_users_id_fk",
+          "tableFrom": "user_merge_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "canonical_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_merge_ledger_merged_user_id_users_id_fk": {
+          "name": "user_merge_ledger_merged_user_id_users_id_fk",
+          "tableFrom": "user_merge_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "merged_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_merge_ledger_executed_by_user_id_users_id_fk": {
+          "name": "user_merge_ledger_executed_by_user_id_users_id_fk",
+          "tableFrom": "user_merge_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "executed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "user_merge_ledger_authorization_id_user_merge_authorizations_id_fk": {
+          "name": "user_merge_ledger_authorization_id_user_merge_authorizations_id_fk",
+          "tableFrom": "user_merge_ledger",
+          "tableTo": "user_merge_authorizations",
+          "columnsFrom": [
+            "authorization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_merge_ledger_merged_user_id_unique": {
+          "name": "user_merge_ledger_merged_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "merged_user_id"
+          ]
+        },
+        "user_merge_ledger_authorization_id_unique": {
+          "name": "user_merge_ledger_authorization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_merge_ledger_distinct_users_check": {
+          "name": "user_merge_ledger_distinct_users_check",
+          "value": "\"user_merge_ledger\".\"canonical_user_id\" <> \"user_merge_ledger\".\"merged_user_id\""
+        },
+        "user_merge_ledger_reason_non_blank_check": {
+          "name": "user_merge_ledger_reason_non_blank_check",
+          "value": "length(trim(\"user_merge_ledger\".\"reason\")) > 0"
+        },
+        "user_merge_ledger_fingerprint_shape_check": {
+          "name": "user_merge_ledger_fingerprint_shape_check",
+          "value": "\"user_merge_ledger\".\"plan_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verification_source": {
+          "name": "email_verification_source",
+          "type": "email_verification_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "merged_into_user_id": {
+          "name": "merged_into_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qq": {
+          "name": "qq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam64": {
+          "name": "steam64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_profile_url": {
+          "name": "steam_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_stream_url": {
+          "name": "live_stream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_merged_into_user_id_users_id_fk": {
+          "name": "users_merged_into_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "merged_into_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_id_unique": {
+          "name": "users_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_merge_shape_check": {
+          "name": "users_merge_shape_check",
+          "value": "(\"users\".\"status\" = 'active' AND \"users\".\"merged_into_user_id\" IS NULL AND \"users\".\"merged_at\" IS NULL)\n      OR (\"users\".\"status\" = 'merged' AND \"users\".\"merged_into_user_id\" IS NOT NULL AND \"users\".\"merged_into_user_id\" <> \"users\".\"id\" AND \"users\".\"merged_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_template": {
+          "name": "competition_template",
+          "type": "competition_template",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'solo'"
+        },
+        "has_captain_voting": {
+          "name": "has_captain_voting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_draft": {
+          "name": "has_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_community_awards": {
+          "name": "has_community_awards",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stage_plan": {
+          "name": "stage_plan",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "team_registration_config": {
+          "name": "team_registration_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "affiliation_rules": {
+          "name": "affiliation_rules",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "min_team_size": {
+          "name": "min_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "max_team_size": {
+          "name": "max_team_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 9
+        },
+        "starter_count": {
+          "name": "starter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "positions": {
+          "name": "positions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['igl','awper','opener','closer','anchor']"
+        },
+        "registration_opens_at": {
+          "name": "registration_opens_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_opened_at": {
+          "name": "registration_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_change_closes_at": {
+          "name": "roster_change_closes_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "seasons_slug_unique": {
+          "name": "seasons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_registrations": {
+      "name": "season_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_type": {
+          "name": "player_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enrolled'"
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secondary_position": {
+          "name": "secondary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank": {
+          "name": "peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rank_season": {
+          "name": "peak_rank_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peak_we": {
+          "name": "peak_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_season_peak_rank": {
+          "name": "current_season_peak_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_we": {
+          "name": "current_we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_urls": {
+          "name": "screenshot_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "map_preferences": {
+          "name": "map_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gameplay_style": {
+          "name": "gameplay_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_history": {
+          "name": "competition_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlight_video_url": {
+          "name": "highlight_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "willing_to_be_captain": {
+          "name": "willing_to_be_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_registrations_user_id_users_id_fk": {
+          "name": "season_registrations_user_id_users_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "season_registrations_season_id_seasons_id_fk": {
+          "name": "season_registrations_season_id_seasons_id_fk",
+          "tableFrom": "season_registrations",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_registrations_user_id_season_id_unique": {
+          "name": "season_registrations_user_id_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_drafts": {
+      "name": "registration_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_drafts_season_id_seasons_id_fk": {
+          "name": "registration_drafts_season_id_seasons_id_fk",
+          "tableFrom": "registration_drafts",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_drafts_season_id_email_unique": {
+          "name": "registration_drafts_season_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_captain_changes": {
+      "name": "team_captain_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_captain_changes_team_changed_at_idx": {
+          "name": "team_captain_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_captain_changes_team_id_teams_id_fk": {
+          "name": "team_captain_changes_team_id_teams_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_captain_changes_from_user_id_users_id_fk": {
+          "name": "team_captain_changes_from_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_captain_changes_to_user_id_users_id_fk": {
+          "name": "team_captain_changes_to_user_id_users_id_fk",
+          "tableFrom": "team_captain_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "team_invitation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_team_status_idx": {
+          "name": "team_invitations_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_user_status_idx": {
+          "name": "team_invitations_user_status_idx",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_token_hash_unique": {
+          "name": "team_invitations_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invitations_one_pending_direct_per_user": {
+          "name": "team_invitations_one_pending_direct_per_user",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_user_id_users_id_fk": {
+          "name": "team_invitations_invited_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_user_id_users_id_fk": {
+          "name": "team_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invitations_responded_by_user_id_users_id_fk": {
+          "name": "team_invitations_responded_by_user_id_users_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_invitations_kind_shape_check": {
+          "name": "team_invitations_kind_shape_check",
+          "value": "(\"team_invitations\".\"kind\" = 'direct' AND \"team_invitations\".\"invited_user_id\" IS NOT NULL AND \"team_invitations\".\"token_hash\" IS NULL) OR (\"team_invitations\".\"kind\" = 'share_link' AND \"team_invitations\".\"invited_user_id\" IS NULL AND \"team_invitations\".\"token_hash\" IS NOT NULL)"
+        },
+        "team_invitations_response_shape_check": {
+          "name": "team_invitations_response_shape_check",
+          "value": "(\"team_invitations\".\"status\" IN ('accepted', 'declined') AND \"team_invitations\".\"responded_at\" IS NOT NULL AND \"team_invitations\".\"responded_by_user_id\" IS NOT NULL)\n      OR (\"team_invitations\".\"status\" IN ('pending', 'revoked', 'expired') AND \"team_invitations\".\"responded_at\" IS NULL AND \"team_invitations\".\"responded_by_user_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "team_membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_reason": {
+          "name": "ended_reason",
+          "type": "team_membership_end_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_idx": {
+          "name": "team_memberships_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_user_idx": {
+          "name": "team_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_one_current_period": {
+          "name": "team_memberships_one_current_period",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_memberships_one_current_team_per_user": {
+          "name": "team_memberships_one_current_team_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_memberships\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_invited_by_user_id_users_id_fk": {
+          "name": "team_memberships_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_memberships_period_shape_check": {
+          "name": "team_memberships_period_shape_check",
+          "value": "(\"team_memberships\".\"ended_at\" IS NULL AND \"team_memberships\".\"ended_reason\" IS NULL AND \"team_memberships\".\"status\" <> 'left') OR (\"team_memberships\".\"ended_at\" IS NOT NULL AND \"team_memberships\".\"ended_reason\" IS NOT NULL AND \"team_memberships\".\"status\" = 'left')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_name_changes": {
+      "name": "team_name_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_name": {
+          "name": "old_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_name": {
+          "name": "new_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changed_by_actor_id": {
+          "name": "changed_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_name_changes_team_changed_at_idx": {
+          "name": "team_name_changes_team_changed_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_name_changes_team_id_teams_id_fk": {
+          "name": "team_name_changes_team_id_teams_id_fk",
+          "tableFrom": "team_name_changes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_slug_aliases": {
+      "name": "team_slug_aliases",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_slug_aliases_team_id_teams_id_fk": {
+          "name": "team_slug_aliases_team_id_teams_id_fk",
+          "tableFrom": "team_slug_aliases",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "team_lifecycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disbanded_at": {
+          "name": "disbanded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disbanded_by": {
+          "name": "disbanded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_one_active_captaincy_per_user": {
+          "name": "teams_one_active_captaincy_per_user",
+          "columns": [
+            {
+              "expression": "captain_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"teams\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_creator_user_id_users_id_fk": {
+          "name": "teams_creator_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_captain_user_id_users_id_fk": {
+          "name": "teams_captain_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captain_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_lifecycle_shape_check": {
+          "name": "teams_lifecycle_shape_check",
+          "value": "(\"teams\".\"status\" = 'active' AND \"teams\".\"disbanded_at\" IS NULL) OR (\"teams\".\"status\" = 'disbanded' AND \"teams\".\"disbanded_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_intents": {
+      "name": "recruitment_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "recruitment_intent_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positions": {
+          "name": "positions",
+          "type": "cs2_role[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::cs2_role[]"
+        },
+        "target_season_id": {
+          "name": "target_season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recruitment_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_intents_one_team_unique": {
+          "name": "recruitment_intents_one_team_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_one_user_unique": {
+          "name": "recruitment_intents_one_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_open_discovery_idx": {
+          "name": "recruitment_intents_open_discovery_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_intents_target_season_idx": {
+          "name": "recruitment_intents_target_season_idx",
+          "columns": [
+            {
+              "expression": "target_season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recruitment_intents_team_id_teams_id_fk": {
+          "name": "recruitment_intents_team_id_teams_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_intents_user_id_users_id_fk": {
+          "name": "recruitment_intents_user_id_users_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_intents_target_season_id_seasons_id_fk": {
+          "name": "recruitment_intents_target_season_id_seasons_id_fk",
+          "tableFrom": "recruitment_intents",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "target_season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "recruitment_intents_owner_shape_check": {
+          "name": "recruitment_intents_owner_shape_check",
+          "value": "(\"recruitment_intents\".\"kind\" = 'team_recruiting' AND \"recruitment_intents\".\"team_id\" IS NOT NULL AND \"recruitment_intents\".\"user_id\" IS NULL)\n      OR (\"recruitment_intents\".\"kind\" = 'player_lft' AND \"recruitment_intents\".\"user_id\" IS NOT NULL AND \"recruitment_intents\".\"team_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recruitment_interests": {
+      "name": "recruitment_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recruitment_intent_id": {
+          "name": "recruitment_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_interests_intent_idx": {
+          "name": "recruitment_interests_intent_idx",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_interests_user_idx": {
+          "name": "recruitment_interests_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recruitment_interests_one_user_per_intent_unique": {
+          "name": "recruitment_interests_one_user_per_intent_unique",
+          "columns": [
+            {
+              "expression": "recruitment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk": {
+          "name": "recruitment_interests_recruitment_intent_id_recruitment_intents_id_fk",
+          "tableFrom": "recruitment_interests",
+          "tableTo": "recruitment_intents",
+          "columnsFrom": [
+            "recruitment_intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recruitment_interests_user_id_users_id_fk": {
+          "name": "recruitment_interests_user_id_users_id_fk",
+          "tableFrom": "recruitment_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_issues": {
+      "name": "major_prestart_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "major_prestart_issue_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_prestart_issues_season_category_idx": {
+          "name": "major_prestart_issues_season_category_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_prestart_issues_season_id_seasons_id_fk": {
+          "name": "major_prestart_issues_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_issues",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_prestart_states": {
+      "name": "major_prestart_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrants_locked_at": {
+          "name": "entrants_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrants_locked_by": {
+          "name": "entrants_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_at": {
+          "name": "seeds_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_confirmed_by": {
+          "name": "seeds_confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed_override_reason": {
+          "name": "seed_override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_at": {
+          "name": "seeds_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seeds_locked_by": {
+          "name": "seeds_locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_prestart_states_season_id_seasons_id_fk": {
+          "name": "major_prestart_states_season_id_seasons_id_fk",
+          "tableFrom": "major_prestart_states",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_prestart_states_season_id_unique": {
+          "name": "major_prestart_states_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_prestart_states_seed_confirmation_shape_check": {
+          "name": "major_prestart_states_seed_confirmation_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_confirmed_at\" IS NULL) = (\"major_prestart_states\".\"seeds_confirmed_by\" IS NULL)"
+        },
+        "major_prestart_states_seed_lock_shape_check": {
+          "name": "major_prestart_states_seed_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"seeds_locked_at\" IS NULL) = (\"major_prestart_states\".\"seeds_locked_by\" IS NULL)"
+        },
+        "major_prestart_states_entrant_lock_shape_check": {
+          "name": "major_prestart_states_entrant_lock_shape_check",
+          "value": "(\"major_prestart_states\".\"entrants_locked_at\" IS NULL) = (\"major_prestart_states\".\"entrants_locked_by\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_seed_recommendation_snapshots": {
+      "name": "major_seed_recommendation_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entrant_set_fingerprint": {
+          "name": "entrant_set_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "major_seed_recommendation_snapshots_season_id_seasons_id_fk": {
+          "name": "major_seed_recommendation_snapshots_season_id_seasons_id_fk",
+          "tableFrom": "major_seed_recommendation_snapshots",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_seed_recommendation_snapshots_season_id_unique": {
+          "name": "major_seed_recommendation_snapshots_season_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_entrants": {
+      "name": "major_tournament_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_entry_id": {
+          "name": "competition_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_entrants_season_idx": {
+          "name": "major_tournament_entrants_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_entrants_season_id_seasons_id_fk": {
+          "name": "major_tournament_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_entrants_competition_entry_id_competition_entries_id_fk": {
+          "name": "major_tournament_entrants_competition_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "competition_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_entrants_entry_season_scope_fk": {
+          "name": "major_tournament_entrants_entry_season_scope_fk",
+          "tableFrom": "major_tournament_entrants",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "competition_entry_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_entrants_season_entry_unique": {
+          "name": "major_tournament_entrants_season_entry_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "competition_entry_id"
+          ]
+        },
+        "major_tournament_entrants_id_season_unique": {
+          "name": "major_tournament_entrants_id_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.major_tournament_seeds": {
+      "name": "major_tournament_seeds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_tournament_seeds_season_idx": {
+          "name": "major_tournament_seeds_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_tournament_seeds_season_id_seasons_id_fk": {
+          "name": "major_tournament_seeds_season_id_seasons_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_tournament_seeds_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_tournament_seeds_entrant_season_scope_fk": {
+          "name": "major_tournament_seeds_entrant_season_scope_fk",
+          "tableFrom": "major_tournament_seeds",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_tournament_seeds_season_entrant_unique": {
+          "name": "major_tournament_seeds_season_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "tournament_entrant_id"
+          ]
+        },
+        "major_tournament_seeds_season_seed_unique": {
+          "name": "major_tournament_seeds_season_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_tournament_seeds_seed_range_check": {
+          "name": "major_tournament_seeds_seed_range_check",
+          "value": "\"major_tournament_seeds\".\"seed\" BETWEEN 1 AND 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_final_results": {
+      "name": "major_final_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playoff_stage_run_id": {
+          "name": "playoff_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion_entry_id": {
+          "name": "champion_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_groups": {
+          "name": "placement_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "major_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_confirmation'"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "major_final_results_season_idx": {
+          "name": "major_final_results_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_final_results_season_id_seasons_id_fk": {
+          "name": "major_final_results_season_id_seasons_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_final_results_playoff_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_entry_id_competition_entries_id_fk": {
+          "name": "major_final_results_champion_entry_id_competition_entries_id_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "champion_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_playoff_run_season_scope_fk": {
+          "name": "major_final_results_playoff_run_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "playoff_stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_final_results_champion_entry_season_scope_fk": {
+          "name": "major_final_results_champion_entry_season_scope_fk",
+          "tableFrom": "major_final_results",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "champion_entry_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_final_results_season_unique": {
+          "name": "major_final_results_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id"
+          ]
+        },
+        "major_final_results_playoff_run_unique": {
+          "name": "major_final_results_playoff_run_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playoff_stage_run_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_final_results_confirmation_shape_check": {
+          "name": "major_final_results_confirmation_shape_check",
+          "value": "(\"major_final_results\".\"status\" = 'pending_confirmation' AND \"major_final_results\".\"confirmed_at\" IS NULL AND \"major_final_results\".\"confirmed_by\" IS NULL) OR (\"major_final_results\".\"status\" = 'confirmed' AND \"major_final_results\".\"confirmed_at\" IS NOT NULL AND \"major_final_results\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_entrants": {
+      "name": "major_stage_entrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_run_id": {
+          "name": "stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_entrant_id": {
+          "name": "tournament_entrant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_seed": {
+          "name": "stage_seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "major_stage_entrants_run_idx": {
+          "name": "major_stage_entrants_run_idx",
+          "columns": [
+            {
+              "expression": "stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_entrants_stage_run_id_major_stage_runs_id_fk": {
+          "name": "major_stage_entrants_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_season_id_seasons_id_fk": {
+          "name": "major_stage_entrants_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk": {
+          "name": "major_stage_entrants_tournament_entrant_id_major_tournament_entrants_id_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_run_season_scope_fk": {
+          "name": "major_stage_entrants_run_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "major_stage_entrants_tournament_entrant_season_scope_fk": {
+          "name": "major_stage_entrants_tournament_entrant_season_scope_fk",
+          "tableFrom": "major_stage_entrants",
+          "tableTo": "major_tournament_entrants",
+          "columnsFrom": [
+            "tournament_entrant_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_entrants_run_entrant_unique": {
+          "name": "major_stage_entrants_run_entrant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "tournament_entrant_id"
+          ]
+        },
+        "major_stage_entrants_run_seed_unique": {
+          "name": "major_stage_entrants_run_seed_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_run_id",
+            "stage_seed"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_entrants_stage_seed_range_check": {
+          "name": "major_stage_entrants_stage_seed_range_check",
+          "value": "\"major_stage_entrants\".\"stage_seed\" BETWEEN 1 AND 16"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.major_stage_runs": {
+      "name": "major_stage_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_key": {
+          "name": "stage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_snapshot": {
+          "name": "rule_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized_round": {
+          "name": "finalized_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "major_stage_runs_season_idx": {
+          "name": "major_stage_runs_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "major_stage_runs_season_id_seasons_id_fk": {
+          "name": "major_stage_runs_season_id_seasons_id_fk",
+          "tableFrom": "major_stage_runs",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "major_stage_runs_season_stage_unique": {
+          "name": "major_stage_runs_season_stage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage_key"
+          ]
+        },
+        "major_stage_runs_id_season_unique": {
+          "name": "major_stage_runs_id_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "major_stage_runs_finalized_round_range_check": {
+          "name": "major_stage_runs_finalized_round_range_check",
+          "value": "\"major_stage_runs\".\"finalized_round\" BETWEEN 0 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.captain_votes": {
+      "name": "captain_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voter_registration_id": {
+          "name": "voter_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_registration_id": {
+          "name": "candidate_registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "captain_votes_voter_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_voter_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "voter_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "captain_votes_candidate_registration_id_season_registrations_id_fk": {
+          "name": "captain_votes_candidate_registration_id_season_registrations_id_fk",
+          "tableFrom": "captain_votes",
+          "tableTo": "season_registrations",
+          "columnsFrom": [
+            "candidate_registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "captain_votes_voter_registration_id_candidate_registration_id_unique": {
+          "name": "captain_votes_voter_registration_id_candidate_registration_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "voter_registration_id",
+            "candidate_registration_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_a_id": {
+          "name": "entry_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_b_id": {
+          "name": "entry_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "match_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bo1'"
+        },
+        "entry_round": {
+          "name": "entry_round",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "match_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "is_forfeit": {
+          "name": "is_forfeit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bracket_node_id": {
+          "name": "bracket_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "match_ownership",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "major_stage_run_id": {
+          "name": "major_stage_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_key": {
+          "name": "managed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_deadline": {
+          "name": "completion_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mvp_winner_user_id": {
+          "name": "mvp_winner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "matches_major_stage_run_managed_key_unique": {
+          "name": "matches_major_stage_run_managed_key_unique",
+          "columns": [
+            {
+              "expression": "major_stage_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"matches\".\"ownership\" = 'major_stage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_season_status_scheduled_at_idx": {
+          "name": "matches_season_status_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_entry_a_id_idx": {
+          "name": "matches_entry_a_id_idx",
+          "columns": [
+            {
+              "expression": "entry_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "matches_entry_b_id_idx": {
+          "name": "matches_entry_b_id_idx",
+          "columns": [
+            {
+              "expression": "entry_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "matches_season_id_seasons_id_fk": {
+          "name": "matches_season_id_seasons_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_a_id_competition_entries_id_fk": {
+          "name": "matches_entry_a_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_b_id_competition_entries_id_fk": {
+          "name": "matches_entry_b_id_competition_entries_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_id_major_stage_runs_id_fk": {
+          "name": "matches_major_stage_run_id_major_stage_runs_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_a_season_scope_fk": {
+          "name": "matches_entry_a_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_a_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_entry_b_season_scope_fk": {
+          "name": "matches_entry_b_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_b_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "competition_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_major_stage_run_season_scope_fk": {
+          "name": "matches_major_stage_run_season_scope_fk",
+          "tableFrom": "matches",
+          "tableTo": "major_stage_runs",
+          "columnsFrom": [
+            "major_stage_run_id",
+            "season_id"
+          ],
+          "columnsTo": [
+            "id",
+            "season_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "matches_entries_different": {
+          "name": "matches_entries_different",
+          "value": "\"matches\".\"entry_a_id\" != \"matches\".\"entry_b_id\""
+        },
+        "matches_score_a_nonneg": {
+          "name": "matches_score_a_nonneg",
+          "value": "\"matches\".\"score_a\" IS NULL OR \"matches\".\"score_a\" >= 0"
+        },
+        "matches_score_b_nonneg": {
+          "name": "matches_score_b_nonneg",
+          "value": "\"matches\".\"score_b\" IS NULL OR \"matches\".\"score_b\" >= 0"
+        },
+        "matches_score_pair_complete": {
+          "name": "matches_score_pair_complete",
+          "value": "(\"matches\".\"score_a\" IS NULL AND \"matches\".\"score_b\" IS NULL) OR (\"matches\".\"score_a\" IS NOT NULL AND \"matches\".\"score_b\" IS NOT NULL)"
+        },
+        "matches_series_score_shape": {
+          "name": "matches_series_score_shape",
+          "value": "(\"matches\".\"score_a\" IS NULL AND \"matches\".\"score_b\" IS NULL)\n      OR (\"matches\".\"format\" = 'bo1' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 1 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 0)\n      OR (\"matches\".\"format\" = 'bo3' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 2 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") BETWEEN 0 AND 1)\n      OR (\"matches\".\"format\" = 'bo5' AND GREATEST(\"matches\".\"score_a\", \"matches\".\"score_b\") = 3 AND LEAST(\"matches\".\"score_a\", \"matches\".\"score_b\") BETWEEN 0 AND 2)"
+        },
+        "matches_managed_major_match_shape": {
+          "name": "matches_managed_major_match_shape",
+          "value": "(\"matches\".\"ownership\" = 'manual' AND \"matches\".\"major_stage_run_id\" IS NULL AND \"matches\".\"managed_key\" IS NULL)\n      OR (\"matches\".\"ownership\" = 'major_stage' AND \"matches\".\"major_stage_run_id\" IS NOT NULL AND \"matches\".\"managed_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_maps": {
+      "name": "match_maps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_order": {
+          "name": "map_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_by_entry_id": {
+          "name": "picked_by_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_a_start_side": {
+          "name": "team_a_start_side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_a": {
+          "name": "score_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score_b": {
+          "name": "score_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_maps_match_id_matches_id_fk": {
+          "name": "match_maps_match_id_matches_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_maps_picked_by_entry_id_competition_entries_id_fk": {
+          "name": "match_maps_picked_by_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_maps",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "picked_by_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_maps_match_id_map_order_unique": {
+          "name": "match_maps_match_id_map_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "map_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_maps_order_range": {
+          "name": "match_maps_order_range",
+          "value": "\"match_maps\".\"map_order\" >= 1 AND \"match_maps\".\"map_order\" <= 5"
+        },
+        "match_maps_score_a_nonneg": {
+          "name": "match_maps_score_a_nonneg",
+          "value": "\"match_maps\".\"score_a\" IS NULL OR \"match_maps\".\"score_a\" >= 0"
+        },
+        "match_maps_score_b_nonneg": {
+          "name": "match_maps_score_b_nonneg",
+          "value": "\"match_maps\".\"score_b\" IS NULL OR \"match_maps\".\"score_b\" >= 0"
+        },
+        "match_maps_score_pair_complete": {
+          "name": "match_maps_score_pair_complete",
+          "value": "(\"match_maps\".\"score_a\" IS NULL AND \"match_maps\".\"score_b\" IS NULL) OR (\"match_maps\".\"score_a\" IS NOT NULL AND \"match_maps\".\"score_b\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.season_admin_grants": {
+      "name": "season_admin_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "season_admin_grants_user_id_idx": {
+          "name": "season_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "season_admin_grants_season_id_idx": {
+          "name": "season_admin_grants_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "season_admin_grants_user_id_users_id_fk": {
+          "name": "season_admin_grants_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "season_admin_grants_season_id_seasons_id_fk": {
+          "name": "season_admin_grants_season_id_seasons_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "season_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "season_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "season_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "season_admin_grants_user_season_unique": {
+          "name": "season_admin_grants_user_season_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "season_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_player_stats": {
+      "name": "match_player_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perfect_name": {
+          "name": "perfect_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hs_percent": {
+          "name": "hs_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_kills": {
+          "name": "first_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multi_kills": {
+          "name": "multi_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clutches": {
+          "name": "clutches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adr": {
+          "name": "adr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rws": {
+          "name": "rws",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_pro": {
+          "name": "rating_pro",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "we": {
+          "name": "we",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_admin": {
+          "name": "verified_by_admin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_player_stats_match_id_idx": {
+          "name": "match_player_stats_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_player_stats_user_id_idx": {
+          "name": "match_player_stats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_player_stats_match_id_matches_id_fk": {
+          "name": "match_player_stats_match_id_matches_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_map_id_match_maps_id_fk": {
+          "name": "match_player_stats_map_id_match_maps_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "match_maps",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_player_stats_user_id_users_id_fk": {
+          "name": "match_player_stats_user_id_users_id_fk",
+          "tableFrom": "match_player_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_player_stats_map_id_perfect_name_unique": {
+          "name": "match_player_stats_map_id_perfect_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "map_id",
+            "perfect_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.swiss_standings": {
+      "name": "swiss_standings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bu_score": {
+          "name": "bu_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "swiss_standings_season_id_seasons_id_fk": {
+          "name": "swiss_standings_season_id_seasons_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "swiss_standings_entry_id_competition_entries_id_fk": {
+          "name": "swiss_standings_entry_id_competition_entries_id_fk",
+          "tableFrom": "swiss_standings",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "swiss_standings_season_id_stage_entry_id_unique": {
+          "name": "swiss_standings_season_id_stage_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "season_id",
+            "stage",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_mvp_votes": {
+      "name": "match_mvp_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_user_id": {
+          "name": "player_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_user_id": {
+          "name": "voter_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_mvp_votes_match_id_matches_id_fk": {
+          "name": "match_mvp_votes_match_id_matches_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_player_user_id_users_id_fk": {
+          "name": "match_mvp_votes_player_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "player_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_mvp_votes_voter_user_id_users_id_fk": {
+          "name": "match_mvp_votes_voter_user_id_users_id_fk",
+          "tableFrom": "match_mvp_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_mvp_votes_match_id_voter_user_id_unique": {
+          "name": "match_mvp_votes_match_id_voter_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "voter_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_time_proposals": {
+      "name": "match_time_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "force_assigned_by": {
+          "name": "force_assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_at": {
+          "name": "response_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reason": {
+          "name": "reject_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_time_proposals_match_id_idx": {
+          "name": "match_time_proposals_match_id_idx",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_time_proposals_match_id_matches_id_fk": {
+          "name": "match_time_proposals_match_id_matches_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_proposed_by_users_id_fk": {
+          "name": "match_time_proposals_proposed_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_time_proposals_force_assigned_by_users_id_fk": {
+          "name": "match_time_proposals_force_assigned_by_users_id_fk",
+          "tableFrom": "match_time_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "force_assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_roster_players": {
+      "name": "match_roster_players",
+      "schema": "",
+      "columns": {
+        "roster_id": {
+          "name": "roster_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_roster_member_id": {
+          "name": "event_roster_member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_roster_players_roster_id_match_rosters_id_fk": {
+          "name": "match_roster_players_roster_id_match_rosters_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "match_rosters",
+          "columnsFrom": [
+            "roster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_roster_players_event_roster_member_id_event_roster_members_id_fk": {
+          "name": "match_roster_players_event_roster_member_id_event_roster_members_id_fk",
+          "tableFrom": "match_roster_players",
+          "tableTo": "event_roster_members",
+          "columnsFrom": [
+            "event_roster_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_roster_players_roster_id_event_roster_member_id_unique": {
+          "name": "match_roster_players_roster_id_event_roster_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "roster_id",
+            "event_roster_member_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "match_roster_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "status": {
+          "name": "status",
+          "type": "match_roster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_rosters_match_id_matches_id_fk": {
+          "name": "match_rosters_match_id_matches_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_entry_id_competition_entries_id_fk": {
+          "name": "match_rosters_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_rosters_submitted_by_users_id_fk": {
+          "name": "match_rosters_submitted_by_users_id_fk",
+          "tableFrom": "match_rosters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_rosters_match_id_entry_id_unique": {
+          "name": "match_rosters_match_id_entry_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "entry_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "match_rosters_metadata_shape_check": {
+          "name": "match_rosters_metadata_shape_check",
+          "value": "(\"match_rosters\".\"source\" = 'participant' AND \"match_rosters\".\"submitted_by\" IS NOT NULL) OR (\"match_rosters\".\"source\" = 'admin_select' AND \"match_rosters\".\"submitted_by\" IS NULL)"
+        },
+        "match_rosters_confirmation_shape_check": {
+          "name": "match_rosters_confirmation_shape_check",
+          "value": "(\"match_rosters\".\"status\" = 'submitted' AND \"match_rosters\".\"confirmed_at\" IS NULL AND \"match_rosters\".\"confirmed_by\" IS NULL) OR (\"match_rosters\".\"status\" = 'confirmed' AND \"match_rosters\".\"confirmed_at\" IS NOT NULL AND \"match_rosters\".\"confirmed_by\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_veto_steps": {
+      "name": "match_veto_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "map_name": {
+          "name": "map_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_veto_steps_match_id_matches_id_fk": {
+          "name": "match_veto_steps_match_id_matches_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_veto_steps_entry_id_competition_entries_id_fk": {
+          "name": "match_veto_steps_entry_id_competition_entries_id_fk",
+          "tableFrom": "match_veto_steps",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "match_veto_steps_match_id_step_order_unique": {
+          "name": "match_veto_steps_match_id_step_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "step_order"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_adjudications": {
+      "name": "post_event_adjudications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "adjudication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "adjudication_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "adjudication_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impacts": {
+          "name": "impacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_entry_id": {
+          "name": "target_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_match_id": {
+          "name": "target_match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_explanation": {
+          "name": "public_explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_evidence": {
+          "name": "internal_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "post_event_adjudications_season_idx": {
+          "name": "post_event_adjudications_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_event_adjudications_season_id_seasons_id_fk": {
+          "name": "post_event_adjudications_season_id_seasons_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_entry_id_competition_entries_id_fk": {
+          "name": "post_event_adjudications_target_entry_id_competition_entries_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "target_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_user_id_users_id_fk": {
+          "name": "post_event_adjudications_target_user_id_users_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_event_adjudications_target_match_id_matches_id_fk": {
+          "name": "post_event_adjudications_target_match_id_matches_id_fk",
+          "tableFrom": "post_event_adjudications",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "target_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_event_adjudications_client_request_id_unique": {
+          "name": "post_event_adjudications_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "post_event_adjudications_target_check": {
+          "name": "post_event_adjudications_target_check",
+          "value": "(\"post_event_adjudications\".\"target\" = 'season' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'entry' AND \"post_event_adjudications\".\"target_entry_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'user' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NOT NULL AND \"post_event_adjudications\".\"target_match_id\" IS NULL)\n      OR (\"post_event_adjudications\".\"target\" = 'match' AND \"post_event_adjudications\".\"target_entry_id\" IS NULL AND \"post_event_adjudications\".\"target_user_id\" IS NULL AND \"post_event_adjudications\".\"target_match_id\" IS NOT NULL)"
+        },
+        "post_event_adjudications_revocation_check": {
+          "name": "post_event_adjudications_revocation_check",
+          "value": "(\"post_event_adjudications\".\"status\" = 'revoked') = (\"post_event_adjudications\".\"revoked_at\" IS NOT NULL)"
+        },
+        "post_event_adjudications_impacts_array_check": {
+          "name": "post_event_adjudications_impacts_array_check",
+          "value": "jsonb_typeof(\"post_event_adjudications\".\"impacts\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tournament_honors": {
+      "name": "tournament_honors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "honor_key": {
+          "name": "honor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "honor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "honor_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "basis": {
+          "name": "basis",
+          "type": "honor_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_from": {
+          "name": "placement_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_to": {
+          "name": "placement_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_final_result_id": {
+          "name": "source_final_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjudication_id": {
+          "name": "adjudication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_by": {
+          "name": "awarded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tournament_honors_season_idx": {
+          "name": "tournament_honors_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tournament_honors_one_valid_slot_unique": {
+          "name": "tournament_honors_one_valid_slot_unique",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "honor_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tournament_honors\".\"state\" = 'valid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tournament_honors_season_id_seasons_id_fk": {
+          "name": "tournament_honors_season_id_seasons_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_entry_id_competition_entries_id_fk": {
+          "name": "tournament_honors_entry_id_competition_entries_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "competition_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_user_id_users_id_fk": {
+          "name": "tournament_honors_user_id_users_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_source_final_result_id_major_final_results_id_fk": {
+          "name": "tournament_honors_source_final_result_id_major_final_results_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "major_final_results",
+          "columnsFrom": [
+            "source_final_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tournament_honors_adjudication_id_post_event_adjudications_id_fk": {
+          "name": "tournament_honors_adjudication_id_post_event_adjudications_id_fk",
+          "tableFrom": "tournament_honors",
+          "tableTo": "post_event_adjudications",
+          "columnsFrom": [
+            "adjudication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tournament_honors_client_request_id_unique": {
+          "name": "tournament_honors_client_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tournament_honors_recipient_check": {
+          "name": "tournament_honors_recipient_check",
+          "value": "(\"tournament_honors\".\"state\" IN ('valid', 'revoked') AND ((\"tournament_honors\".\"entry_id\" IS NOT NULL)::int + (\"tournament_honors\".\"user_id\" IS NOT NULL)::int) = 1)\n      OR (\"tournament_honors\".\"state\" IN ('vacant', 'not_awarded') AND \"tournament_honors\".\"entry_id\" IS NULL AND \"tournament_honors\".\"user_id\" IS NULL)"
+        },
+        "tournament_honors_placement_check": {
+          "name": "tournament_honors_placement_check",
+          "value": "(\"tournament_honors\".\"type\" = 'placement' AND \"tournament_honors\".\"placement_from\" IS NOT NULL AND \"tournament_honors\".\"placement_to\" IS NOT NULL AND \"tournament_honors\".\"placement_from\" > 0 AND \"tournament_honors\".\"placement_to\" >= \"tournament_honors\".\"placement_from\")\n      OR (\"tournament_honors\".\"type\" <> 'placement' AND \"tournament_honors\".\"placement_from\" IS NULL AND \"tournament_honors\".\"placement_to\" IS NULL)"
+        },
+        "tournament_honors_revocation_check": {
+          "name": "tournament_honors_revocation_check",
+          "value": "(\"tournament_honors\".\"state\" = 'revoked') = (\"tournament_honors\".\"revoked_at\" IS NOT NULL)"
+        },
+        "tournament_honors_non_blank_key_check": {
+          "name": "tournament_honors_non_blank_key_check",
+          "value": "length(trim(\"tournament_honors\".\"honor_key\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.match_commentators": {
+      "name": "match_commentators",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_commentators_user_id_idx": {
+          "name": "match_commentators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_commentators_match_id_matches_id_fk": {
+          "name": "match_commentators_match_id_matches_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_commentators_user_id_users_id_fk": {
+          "name": "match_commentators_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "match_commentators_added_by_user_id_users_id_fk": {
+          "name": "match_commentators_added_by_user_id_users_id_fk",
+          "tableFrom": "match_commentators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_commentators_match_id_user_id_pk": {
+          "name": "match_commentators_match_id_user_id_pk",
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_match_reports": {
+      "name": "post_match_reports",
+      "schema": "",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_match_reports_submitted_by_user_id_idx": {
+          "name": "post_match_reports_submitted_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "submitted_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_match_reports_match_id_matches_id_fk": {
+          "name": "post_match_reports_match_id_matches_id_fk",
+          "tableFrom": "post_match_reports",
+          "tableTo": "matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_match_reports_submitted_by_user_id_users_id_fk": {
+          "name": "post_match_reports_submitted_by_user_id_users_id_fk",
+          "tableFrom": "post_match_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_job_health": {
+      "name": "scheduled_job_health",
+      "schema": "",
+      "columns": {
+        "job_key": {
+          "name": "job_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_primary_triggered_at": {
+          "name": "last_primary_triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_primary_endpoint_started_at": {
+          "name": "last_primary_endpoint_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_primary_endpoint_succeeded_at": {
+          "name": "last_primary_endpoint_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_watchdog_succeeded_at": {
+          "name": "last_watchdog_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_manual_succeeded_at": {
+          "name": "last_manual_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_business_transition_at": {
+          "name": "last_business_transition_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_source": {
+          "name": "last_failure_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.admin_invite_role": {
+      "name": "admin_invite_role",
+      "schema": "public",
+      "values": [
+        "season_admin",
+        "super_admin"
+      ]
+    },
+    "public.community_award_status": {
+      "name": "community_award_status",
+      "schema": "public",
+      "values": [
+        "pending_review",
+        "rejected",
+        "approved",
+        "withdrawn",
+        "awarded",
+        "not_awarded",
+        "cancelled"
+      ]
+    },
+    "public.competition_entry_participant_status": {
+      "name": "competition_entry_participant_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "confirmed",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_registration_status": {
+      "name": "competition_entry_registration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.competition_entry_roster_revision_origin": {
+      "name": "competition_entry_roster_revision_origin",
+      "schema": "public",
+      "values": [
+        "initial",
+        "admin_remediation",
+        "self_roster_change"
+      ]
+    },
+    "public.competition_entry_roster_revision_status": {
+      "name": "competition_entry_roster_revision_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "superseded"
+      ]
+    },
+    "public.competition_entry_source": {
+      "name": "competition_entry_source",
+      "schema": "public",
+      "values": [
+        "linked_team",
+        "event_native"
+      ]
+    },
+    "public.competition_entry_submission_decision": {
+      "name": "competition_entry_submission_decision",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "changes_requested",
+        "waitlisted",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.event_roster_status": {
+      "name": "event_roster_status",
+      "schema": "public",
+      "values": [
+        "preparing",
+        "confirmed",
+        "frozen"
+      ]
+    },
+    "public.competitive_fact_kind": {
+      "name": "competitive_fact_kind",
+      "schema": "public",
+      "values": [
+        "historical_peak",
+        "season_peak"
+      ]
+    },
+    "public.competitive_fact_provenance": {
+      "name": "competitive_fact_provenance",
+      "schema": "public",
+      "values": [
+        "self_declared"
+      ]
+    },
+    "public.competitive_fact_status": {
+      "name": "competitive_fact_status",
+      "schema": "public",
+      "values": [
+        "ranked",
+        "unranked"
+      ]
+    },
+    "public.cs2_role": {
+      "name": "cs2_role",
+      "schema": "public",
+      "values": [
+        "igl",
+        "awper",
+        "opener",
+        "closer",
+        "anchor"
+      ]
+    },
+    "public.conversion_policy_status": {
+      "name": "conversion_policy_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "retired"
+      ]
+    },
+    "public.sanction_effect": {
+      "name": "sanction_effect",
+      "schema": "public",
+      "values": [
+        "registration_block",
+        "roster_block",
+        "match_participation_block"
+      ]
+    },
+    "public.sanction_status": {
+      "name": "sanction_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "revoked"
+      ]
+    },
+    "public.academic_status": {
+      "name": "academic_status",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "graduated"
+      ]
+    },
+    "public.education_evidence_type": {
+      "name": "education_evidence_type",
+      "schema": "public",
+      "values": [
+        "institutional_email",
+        "chsi_enrollment_report",
+        "chsi_education_report",
+        "manual_other"
+      ]
+    },
+    "public.education_verification_status": {
+      "name": "education_verification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.institution_source": {
+      "name": "institution_source",
+      "schema": "public",
+      "values": [
+        "moe",
+        "manual",
+        "other_official"
+      ]
+    },
+    "public.identity_link_request_status": {
+      "name": "identity_link_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "merge_required",
+        "blocked",
+        "cancelled"
+      ]
+    },
+    "public.user_identity_kind": {
+      "name": "user_identity_kind",
+      "schema": "public",
+      "values": [
+        "email",
+        "auth",
+        "oauth",
+        "external"
+      ]
+    },
+    "public.user_identity_link_provenance": {
+      "name": "user_identity_link_provenance",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "user_verified_link",
+        "merge",
+        "admin_migration"
+      ]
+    },
+    "public.user_identity_status": {
+      "name": "user_identity_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "revoked",
+        "retired"
+      ]
+    },
+    "public.user_merge_authorization_status": {
+      "name": "user_merge_authorization_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "consumed",
+        "cancelled"
+      ]
+    },
+    "public.user_merge_evidence_class": {
+      "name": "user_merge_evidence_class",
+      "schema": "public",
+      "values": [
+        "dual_identity_control",
+        "super_admin_review"
+      ]
+    },
+    "public.email_verification_source": {
+      "name": "email_verification_source",
+      "schema": "public",
+      "values": [
+        "signup_confirmation",
+        "existing_account_reverification",
+        "admin_migration"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "super_admin"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "merged"
+      ]
+    },
+    "public.competition_template": {
+      "name": "competition_template",
+      "schema": "public",
+      "values": [
+        "rivals",
+        "major",
+        "custom"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "solo",
+        "team"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "registration",
+        "voting",
+        "drafting",
+        "playing",
+        "finished",
+        "archived"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "waitlisted"
+      ]
+    },
+    "public.team_invitation_kind": {
+      "name": "team_invitation_kind",
+      "schema": "public",
+      "values": [
+        "direct",
+        "share_link"
+      ]
+    },
+    "public.team_invitation_status": {
+      "name": "team_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.team_lifecycle": {
+      "name": "team_lifecycle",
+      "schema": "public",
+      "values": [
+        "active",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_end_reason": {
+      "name": "team_membership_end_reason",
+      "schema": "public",
+      "values": [
+        "left",
+        "kicked",
+        "disbanded"
+      ]
+    },
+    "public.team_membership_status": {
+      "name": "team_membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "benched",
+        "left"
+      ]
+    },
+    "public.recruitment_intent_kind": {
+      "name": "recruitment_intent_kind",
+      "schema": "public",
+      "values": [
+        "team_recruiting",
+        "player_lft"
+      ]
+    },
+    "public.recruitment_intent_status": {
+      "name": "recruitment_intent_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.major_prestart_issue_category": {
+      "name": "major_prestart_issue_category",
+      "schema": "public",
+      "values": [
+        "qualification",
+        "administration"
+      ]
+    },
+    "public.major_result_status": {
+      "name": "major_result_status",
+      "schema": "public",
+      "values": [
+        "pending_confirmation",
+        "confirmed"
+      ]
+    },
+    "public.match_format": {
+      "name": "match_format",
+      "schema": "public",
+      "values": [
+        "bo1",
+        "bo3",
+        "bo5"
+      ]
+    },
+    "public.match_ownership": {
+      "name": "match_ownership",
+      "schema": "public",
+      "values": [
+        "manual",
+        "major_stage"
+      ]
+    },
+    "public.match_status": {
+      "name": "match_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "in_progress",
+        "finished",
+        "cancelled"
+      ]
+    },
+    "public.side": {
+      "name": "side",
+      "schema": "public",
+      "values": [
+        "t",
+        "ct"
+      ]
+    },
+    "public.match_roster_source": {
+      "name": "match_roster_source",
+      "schema": "public",
+      "values": [
+        "participant",
+        "admin_select"
+      ]
+    },
+    "public.match_roster_status": {
+      "name": "match_roster_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "confirmed"
+      ]
+    },
+    "public.adjudication_impact": {
+      "name": "adjudication_impact",
+      "schema": "public",
+      "values": [
+        "canonical_matches",
+        "final_result",
+        "official_placements",
+        "honors",
+        "none"
+      ]
+    },
+    "public.adjudication_kind": {
+      "name": "adjudication_kind",
+      "schema": "public",
+      "values": [
+        "team_sanction",
+        "result_statement",
+        "placement_statement",
+        "honor_directive"
+      ]
+    },
+    "public.adjudication_status": {
+      "name": "adjudication_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "revoked"
+      ]
+    },
+    "public.adjudication_target": {
+      "name": "adjudication_target",
+      "schema": "public",
+      "values": [
+        "season",
+        "entry",
+        "user",
+        "match"
+      ]
+    },
+    "public.honor_basis": {
+      "name": "honor_basis",
+      "schema": "public",
+      "values": [
+        "final_result",
+        "manual",
+        "adjudication"
+      ]
+    },
+    "public.honor_state": {
+      "name": "honor_state",
+      "schema": "public",
+      "values": [
+        "valid",
+        "revoked",
+        "vacant",
+        "not_awarded"
+      ]
+    },
+    "public.honor_type": {
+      "name": "honor_type",
+      "schema": "public",
+      "values": [
+        "champion",
+        "runner_up",
+        "placement",
+        "manual_award"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1788890094250,
       "tag": "0044_cultured_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1788925356007,
+      "tag": "0045_fresh_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/knip.json
+++ b/knip.json
@@ -46,6 +46,7 @@
     "scripts/db/release-compat.ts!",
     "scripts/db/staging.ts!",
     "scripts/db/production.ts!",
+    "scripts/db/scheduler.ts!",
     "scripts/db/production-preflight.ts!",
     "scripts/db/production-identity-merge-preflight.ts!",
     "scripts/db/identity-merge-preflight.ts!",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "db:staging:verify": "tsx scripts/db/staging.ts verify",
     "db:production:migrate": "tsx scripts/db/production.ts migrate",
     "db:production:verify": "tsx scripts/db/production.ts verify",
+    "db:production:scheduler:provision": "tsx scripts/db/scheduler.ts provision",
+    "db:production:scheduler:verify": "tsx scripts/db/scheduler.ts verify",
     "db:production:identity-merge-preflight": "tsx scripts/db/production-identity-merge-preflight.ts",
     "db:studio": "tsx scripts/db/local.ts studio",
     "db:local:start": "tsx scripts/db/local.ts start",

--- a/scripts/db/access-matrix.ts
+++ b/scripts/db/access-matrix.ts
@@ -608,8 +608,9 @@ export function validateDatabaseAccessMatrixConfig(
 export async function verifyDatabaseAccessMatrix(
   pool: Pick<Pool, "query">,
   context: string,
+  entries: readonly DatabaseAccessEntry[] = DATABASE_ACCESS_MATRIX,
 ): Promise<readonly DatabaseAccessFacts[]> {
-  validateDatabaseAccessMatrixConfig();
+  validateDatabaseAccessMatrixConfig(entries);
 
   const roleResult = await pool.query<{ rolname: string }>(
     "SELECT rolname FROM pg_roles WHERE rolname = ANY($1::text[]) ORDER BY rolname",
@@ -677,10 +678,11 @@ export async function verifyDatabaseAccessMatrix(
   assertDatabaseAccessMatrixFacts(
     tableResult.rows.map((row) => row.table_name),
     facts,
+    entries,
   );
 
   console.log(
-    `${context} database access matrix passed: ${DATABASE_ACCESS_MATRIX.length} public base tables, deny-by-default, RLS/policy/publication contract aligned.`,
+    `${context} database access matrix passed: ${entries.length} public base tables, deny-by-default, RLS/policy/publication contract aligned.`,
   );
   return facts;
 }
@@ -688,12 +690,14 @@ export async function verifyDatabaseAccessMatrix(
 export function assertDatabaseAccessMatrixFacts(
   actualTables: readonly string[],
   actualFacts: readonly DatabaseAccessFacts[],
+  entries: readonly DatabaseAccessEntry[] = DATABASE_ACCESS_MATRIX,
 ): void {
-  const tableDiff = diffNames([...DATABASE_ACCESS_TABLES].sort(), [...actualTables].sort());
+  const expectedTables = entries.map((entry) => entry.table);
+  const tableDiff = diffNames([...expectedTables].sort(), [...actualTables].sort());
   const actualByTable = new Map(actualFacts.map((row) => [row.table_name, row]));
   const failures = [...tableDiff.map((item) => `public table ${item}`)];
 
-  for (const entry of DATABASE_ACCESS_MATRIX) {
+  for (const entry of entries) {
     const actual = actualByTable.get(entry.table);
     if (!actual) {
       failures.push(`${entry.table}: table missing from PostgreSQL`);

--- a/scripts/db/access-matrix.ts
+++ b/scripts/db/access-matrix.ts
@@ -448,6 +448,13 @@ export const DATABASE_ACCESS_MATRIX: readonly DatabaseAccessEntry[] = [
     "管理员范围由当前数据库授权事实读取，客户端不能缓存或修改。",
   ),
   serverOnly(
+    "scheduled_job_health",
+    "Scheduler runtime",
+    "定时任务当前健康投影",
+    "src/lib/scheduler/health.ts; src/lib/scheduler/admin.ts",
+    "只保存每个 job 的有界当前状态，供服务端调度与超级管理员系统状态页读取；不形成浏览器 Data API 或 Realtime surface。",
+  ),
+  serverOnly(
     "season_registrations",
     "Rivals 报名",
     "报名、资格与个人竞技资料",

--- a/scripts/db/scheduler.ts
+++ b/scripts/db/scheduler.ts
@@ -1,0 +1,138 @@
+import { Pool } from "pg";
+import { pathToFileURL } from "node:url";
+import { buildProductionEnvironment } from "./production-environment";
+import {
+  SCHEDULER_JOB_DEFINITIONS,
+  schedulerJobName,
+  type SchedulerJobDefinition,
+} from "../../src/lib/scheduler/definitions";
+
+const BASE_URL_ENV = "RIVALHUB_SCHEDULER_BASE_URL";
+const VAULT_SECRET_NAMES = ["rivalhub_scheduler_base_url", "rivalhub_cron_secret"] as const;
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  if (command !== "provision" && command !== "verify") {
+    throw new Error("用法：tsx scripts/db/scheduler.ts <provision|verify>");
+  }
+
+  const environment = buildProductionEnvironment(process.env, {
+    requiresWriteAuthorization: command === "provision",
+  });
+  const databaseUrl = required(environment.DATABASE_URL, "DATABASE_URL");
+  const pool = new Pool({ connectionString: databaseUrl, ssl: { rejectUnauthorized: false }, max: 1 });
+
+  try {
+    await assertProviderContract(pool);
+    if (command === "provision") {
+      const baseUrl = validateBaseUrl(required(environment[BASE_URL_ENV], BASE_URL_ENV));
+      const cronSecret = required(environment.CRON_SECRET, "CRON_SECRET");
+      await upsertVaultSecret(pool, "rivalhub_scheduler_base_url", baseUrl, "RivalHub scheduler public base URL");
+      await upsertVaultSecret(pool, "rivalhub_cron_secret", cronSecret, "RivalHub scheduler shared credential");
+      await replaceCronJobs(pool);
+      console.log(`Production scheduler provisioned: ${SCHEDULER_JOB_DEFINITIONS.length} named jobs.`);
+    }
+    await verifyCronJobs(pool);
+    await verifyVaultNames(pool);
+    console.log("Production scheduler verification passed: named jobs, UTC schedules, dispatch command, and Vault names are present.");
+  } finally {
+    await pool.end();
+  }
+}
+
+async function assertProviderContract(pool: Pool): Promise<void> {
+  const result = await pool.query<{ cron_extension: string | null; net_extension: string | null; cron_schema: string | null; net_schema: string | null; cron_timezone: string | null }>(`
+    SELECT
+      (SELECT extname FROM pg_extension WHERE extname = 'pg_cron') AS cron_extension,
+      (SELECT extname FROM pg_extension WHERE extname = 'pg_net') AS net_extension,
+      to_regnamespace('cron')::text AS cron_schema,
+      to_regnamespace('net')::text AS net_schema,
+      current_setting('cron.timezone', true) AS cron_timezone
+  `);
+  const facts = result.rows[0];
+  const cronTimezone = facts?.cron_timezone?.trim().toUpperCase();
+  if (facts?.cron_extension !== "pg_cron" || facts?.net_extension !== "pg_net" || !facts?.cron_schema || !facts?.net_schema) {
+    throw new Error("Production scheduler extensions pg_cron/pg_net 未完整启用；拒绝配置 named jobs。");
+  }
+  if (!cronTimezone || !["UTC", "GMT", "ETC/UTC"].includes(cronTimezone)) {
+    throw new Error("Production scheduler cron.timezone 必须保持 UTC；拒绝配置 named jobs。");
+  }
+}
+
+async function upsertVaultSecret(pool: Pool, name: string, value: string, description: string): Promise<void> {
+  const existing = await pool.query<{ id: string }>(
+    "SELECT id::text FROM vault.decrypted_secrets WHERE name = $1 LIMIT 1",
+    [name],
+  );
+  if (existing.rows[0]?.id) {
+    await pool.query("SELECT vault.update_secret($1::uuid, $2, $3, $4)", [existing.rows[0].id, value, name, description]);
+  } else {
+    await pool.query("SELECT vault.create_secret($1, $2, $3)", [value, name, description]);
+  }
+}
+
+async function replaceCronJobs(pool: Pool): Promise<void> {
+  for (const definition of SCHEDULER_JOB_DEFINITIONS) {
+    const name = schedulerJobName(definition.key);
+    await pool.query("SELECT cron.unschedule($1::text)", [name]);
+    await pool.query("SELECT cron.schedule($1::text, $2::text, $3::text)", [name, definition.primaryCron, dispatchCommand(definition)]);
+  }
+}
+
+async function verifyCronJobs(pool: Pool): Promise<void> {
+  const names = SCHEDULER_JOB_DEFINITIONS.map((definition) => schedulerJobName(definition.key));
+  const result = await pool.query<{ jobname: string; schedule: string; command: string; active: boolean }>(
+    "SELECT jobname, schedule, command, active FROM cron.job WHERE jobname = ANY($1::text[])",
+    [names],
+  );
+  if (result.rows.length !== SCHEDULER_JOB_DEFINITIONS.length) {
+    throw new Error("Production scheduler named jobs 数量不完整。");
+  }
+  const rows = new Map(result.rows.map((row) => [row.jobname, row]));
+  for (const definition of SCHEDULER_JOB_DEFINITIONS) {
+    const row = rows.get(schedulerJobName(definition.key));
+    if (!row || !row.active || row.schedule !== definition.primaryCron || row.command !== dispatchCommand(definition)) {
+      throw new Error(`Production scheduler job ${schedulerJobName(definition.key)} contract 不匹配。`);
+    }
+  }
+}
+
+async function verifyVaultNames(pool: Pool): Promise<void> {
+  const result = await pool.query<{ name: string }>(
+    "SELECT name FROM vault.decrypted_secrets WHERE name = ANY($1::text[])",
+    [VAULT_SECRET_NAMES],
+  );
+  const names = new Set(result.rows.map((row) => row.name));
+  if (VAULT_SECRET_NAMES.some((name) => !names.has(name))) {
+    throw new Error("Production scheduler Vault names 不完整。");
+  }
+}
+
+export function dispatchCommand(definition: SchedulerJobDefinition): string {
+  return `SELECT public.dispatch_rivalhub_scheduler_job('${definition.key}');`;
+}
+
+export function validateBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error(`${BASE_URL_ENV} 必须是有效的 HTTPS origin。`);
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new Error(`${BASE_URL_ENV} 必须是无凭据、无路径的 HTTPS origin。`);
+  }
+  return url.origin;
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value?.trim()) throw new Error(`${name} 未设置；拒绝继续。`);
+  return value.trim();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/actions/register.ts
+++ b/src/actions/register.ts
@@ -19,6 +19,7 @@ import { assertUsersNotBlockedInTx } from "@/lib/discipline/service";
 import { updatePublicPlayerTag } from "@/lib/revalidation";
 import { traceOperation } from "@/lib/observability/server";
 import { normalizePlayerDeclaredProfile } from "@/lib/player-declared-profile";
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
 
 const draftSchema = z.object({
   seasonId: z.guid("赛季 ID 格式不正确"),
@@ -61,10 +62,9 @@ export async function saveRegistrationDraft(input: unknown) {
     if (!season) {
       throw new AppError(ErrorCode.SEASON_NOT_FOUND, ERROR_MESSAGES.SEASON_NOT_FOUND);
     }
-
-    const windowState = getRegistrationWindowState(season);
-    if (!windowState.canSaveDraft) {
-      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+    const initialWindow = getRegistrationWindowState(season);
+    if (!initialWindow.canSaveDraft && !initialWindow.needsOpeningRecovery) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, initialWindow.message);
     }
 
     const payload = {
@@ -73,19 +73,29 @@ export async function saveRegistrationDraft(input: unknown) {
       email,
     };
 
-    await db
-      .insert(registrationDrafts)
-      .values({
-        seasonId: parsed.data.seasonId,
-        email,
-        payload,
-      })
-      .onConflictDoUpdate({
-        target: [registrationDrafts.seasonId, registrationDrafts.email],
-        set: { payload, updatedAt: new Date() },
-      });
+    const currentSeason = await db.transaction(async (tx) => {
+      const materializedSeason = initialWindow.needsOpeningRecovery
+        ? (await ensureRegistrationOpenForParticipantInTx(tx, parsed.data.seasonId)).season
+        : season;
+      const windowState = getRegistrationWindowState(materializedSeason);
+      if (!windowState.canSaveDraft) {
+        throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+      }
+      await tx
+        .insert(registrationDrafts)
+        .values({
+          seasonId: parsed.data.seasonId,
+          email,
+          payload,
+        })
+        .onConflictDoUpdate({
+          target: [registrationDrafts.seasonId, registrationDrafts.email],
+          set: { payload, updatedAt: new Date() },
+        });
+      return materializedSeason;
+    });
 
-    revalidatePath(`/${season.slug}/register`);
+    revalidatePath(`/${currentSeason.slug}/register`);
     return ok({ email });
   } catch (e) {
     return actionError("saveRegistrationDraft", e);
@@ -164,7 +174,7 @@ export async function submitRegistration(input: RegistrationFormData) {
   }
 
   try {
-    const season = await db.query.seasons.findFirst({
+    let season = await db.query.seasons.findFirst({
       where: eq(seasons.id, seedParsed.data.seasonId),
     });
     if (!season) {
@@ -176,17 +186,27 @@ export async function submitRegistration(input: RegistrationFormData) {
         "队伍报名尚未开放，请联系赛事管理员",
       );
     }
-    const windowState = getRegistrationWindowState(season);
-    if (!windowState.canSubmit) {
-      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
+    const initialWindow = getRegistrationWindowState(season);
+    if (!initialWindow.canSubmit && !initialWindow.needsOpeningRecovery) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, initialWindow.message);
     }
-
     const session = await getUserSession();
     if (!session) {
       return fail({
         code: ErrorCode.UNAUTHORIZED,
         message: "请先登录或注册账号后再报名",
       });
+    }
+
+    // Materialize the same canonical opening fact before doing validation and
+    // then repeat the gate inside the final mutation transaction below.
+    const seasonId = season.id;
+    if (initialWindow.needsOpeningRecovery) {
+      season = (await db.transaction((tx) => ensureRegistrationOpenForParticipantInTx(tx, seasonId))).season;
+    }
+    const windowState = getRegistrationWindowState(season);
+    if (!windowState.canSubmit) {
+      throw new AppError(ErrorCode.REGISTRATION_CLOSED, windowState.message);
     }
 
     const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
@@ -282,6 +302,13 @@ export async function submitRegistration(input: RegistrationFormData) {
       attributes: { "rivalhub.workflow": "rivals_registration" },
     }, async () => {
       return db.transaction(async (tx) => {
+        const currentSeason = initialWindow.needsOpeningRecovery
+          ? (await ensureRegistrationOpenForParticipantInTx(tx, data.seasonId)).season
+          : season;
+        const currentWindow = getRegistrationWindowState(currentSeason);
+        if (!currentWindow.canSubmit) {
+          throw new AppError(ErrorCode.REGISTRATION_CLOSED, currentWindow.message);
+        }
         const declaredProfile = normalizePlayerDeclaredProfile(data);
         const [updatedUser] = await tx
           .update(users)
@@ -362,13 +389,13 @@ export async function submitRegistration(input: RegistrationFormData) {
           meta: { email: data.email, primaryPosition: data.primaryPosition },
         });
 
-        return savedRegistration;
+        return { registration: savedRegistration, seasonSlug: currentSeason.slug };
       });
     });
 
     updatePublicPlayerTag(user.id);
-    revalidatePath(`/${season.slug}/register`);
-    return ok({ registrationId: registration.id, email: data.email });
+    revalidatePath(`/${registration.seasonSlug}/register`);
+    return ok({ registrationId: registration.registration.id, email: data.email });
   } catch (e) {
     return actionError("submitRegistration", e);
   }

--- a/src/actions/registration-opening.ts
+++ b/src/actions/registration-opening.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { actionError, failValidation } from "@/lib/action-utils";
+import { requireAuth } from "@/lib/auth/session";
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
+import { ok, type ActionResult } from "@/types/action";
+
+export async function recoverRegistrationOpening(input: unknown): Promise<ActionResult<{ opened: boolean }>> {
+  const parsed = z.object({ seasonId: z.guid() }).safeParse(input);
+  if (!parsed.success) return failValidation("赛事标识无效。");
+
+  try {
+    await requireAuth();
+    const result = await db.transaction((tx) => ensureRegistrationOpenForParticipantInTx(tx, parsed.data.seasonId));
+    revalidatePath(`/${result.season.slug}/register`);
+    return ok({ opened: result.opened });
+  } catch (error) {
+    return actionError("recoverRegistrationOpening", error);
+  }
+}

--- a/src/actions/scheduler.ts
+++ b/src/actions/scheduler.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db } from "@/db/client";
+import { auditLogs } from "@/db/schema";
+import { actionError, failValidation } from "@/lib/action-utils";
+import { auditActorId, requireSuperAdmin } from "@/lib/auth/session";
+import { executeScheduledJobManually } from "@/lib/scheduler/execution";
+import { getSchedulerJobDefinition, SCHEDULER_JOB_KEYS, type SchedulerJobKey } from "@/lib/scheduler/definitions";
+import { runSchedulerJobByKey } from "@/lib/scheduler/runners";
+import { ok, type ActionResult } from "@/types/action";
+
+const jobKeySchema = z.enum(SCHEDULER_JOB_KEYS);
+
+export async function runSchedulerJobManually(input: unknown): Promise<ActionResult<{ jobKey: SchedulerJobKey; businessTransitions: number }>> {
+  const parsed = z.object({ jobKey: jobKeySchema }).safeParse(input);
+  if (!parsed.success) return failValidation("定时任务标识无效。");
+
+  try {
+    const admin = await requireSuperAdmin();
+    const jobKey = parsed.data.jobKey;
+    const definition = getSchedulerJobDefinition(jobKey);
+    if (!definition) return failValidation("定时任务标识无效。");
+
+    await db.insert(auditLogs).values({
+      seasonId: null,
+      action: "scheduler.manual_trigger",
+      actorId: auditActorId(admin),
+      targetId: jobKey,
+      targetType: "scheduler_job",
+      meta: { jobKey, force: true, source: "super-admin-manual" },
+    });
+
+    const result = await executeScheduledJobManually(jobKey, () => runSchedulerJobByKey(jobKey));
+    revalidatePath("/admin/settings");
+    return ok({ jobKey, businessTransitions: result.businessTransitions });
+  } catch (error) {
+    return actionError("runSchedulerJobManually", error);
+  }
+}

--- a/src/actions/transitions.ts
+++ b/src/actions/transitions.ts
@@ -28,7 +28,7 @@ export async function maybeAdvanceFromRegistration(
   tx: TxDb,
   seasonId: string,
   options: { invalidation?: "action" | "route" } = {},
-): Promise<void> {
+): Promise<boolean> {
   const season = await tx.query.seasons.findFirst({
     where: eq(seasons.id, seasonId),
   });
@@ -37,7 +37,7 @@ export async function maybeAdvanceFromRegistration(
     season.status !== "registration" ||
     season.registrationMode !== "solo" ||
     !season.registrationOpenedAt
-  ) return;
+  ) return false;
 
   const registrationConfig = normalizeRegistrationConfig(season.registrationConfig);
   const approvedCount = await getApprovedCountInTx(tx, seasonId);
@@ -47,7 +47,7 @@ export async function maybeAdvanceFromRegistration(
     season.registrationClosesAt != null &&
     new Date(season.registrationClosesAt).getTime() <= Date.now();
 
-  if (!full && !deadlinePassed) return;
+  if (!full && !deadlinePassed) return false;
 
   const nextStatus = season.hasCaptainVoting ? "voting" : "playing";
 
@@ -79,6 +79,7 @@ export async function maybeAdvanceFromRegistration(
   }
   revalidatePath(`/${season.slug}`);
   revalidatePath(`/admin/${season.slug}/registrations`);
+  return true;
 }
 
 /**

--- a/src/app/[seasonSlug]/register/page.tsx
+++ b/src/app/[seasonSlug]/register/page.tsx
@@ -33,6 +33,7 @@ import { evaluateRosterQualificationFromFacts, getParticipantReadinessBatch, isH
 import { getPublicOrAuthorizedDraftSeason, getPublicSeasonBySlug } from "@/lib/data/public-seasons";
 import { presentRegistrationSchedule } from "@/lib/seasons/presentation";
 import { RegistrationScheduleCountdown } from "@/components/seasons/RegistrationScheduleCountdown";
+import { RegistrationOpeningRecovery } from "@/components/register/RegistrationOpeningRecovery";
 
 import { publicCompetitionEntryCondition } from "@/lib/competition-entries/public-visibility";
 import { getCompetitionEntryCapabilities } from "@/lib/competition-entries/capabilities";
@@ -95,6 +96,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
   const registrationWindow = getRegistrationWindowState(season);
   const registrationSchedule = presentRegistrationSchedule(season);
   if (registrationWindow.phase === "unscheduled" || registrationWindow.phase === "upcoming") {
+    const recoverySession = registrationWindow.needsOpeningRecovery ? await getUserSession() : null;
     return (
       <div className="container mx-auto max-w-2xl px-4 py-16">
         <Panel contentClassName="p-10">
@@ -105,6 +107,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
           />
           <div className="mt-3 text-center">
             <RegistrationScheduleCountdown target={registrationSchedule?.countdownTarget ?? null} />
+            {recoverySession && <RegistrationOpeningRecovery seasonId={season.id} />}
           </div>
         </Panel>
       </div>

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -6,6 +6,8 @@ import { resolveAdminPageAccess } from "@/lib/auth/admin-access";
 import { getDisplayName } from "@/lib/identity/display-name";
 import { PageHeader, Panel, StatusPill } from "@/components/rivalhub";
 import { AdminAccessDenied } from "@/components/admin/AdminAccessDenied";
+import { SchedulerHealthPanel } from "@/components/admin/SchedulerHealthPanel";
+import { getSchedulerHealthView } from "@/lib/scheduler/admin";
 
 const ENV_VARS = [
   {
@@ -16,8 +18,8 @@ const ENV_VARS = [
   },
   {
     key: "CRON_SECRET",
-    label: "Vercel Cron Secret",
-    description: "生产环境选秀超时自动 pick 所需，本地开发可不填。",
+    label: "定时任务服务凭据",
+    description: "用于生产环境业务定时任务；只展示是否配置，不展示凭据值。",
     required: false,
   },
   {
@@ -36,6 +38,7 @@ export default async function AdminSettingsPage() {
     columns: { steamName: true, displayName: true, perfectName: true },
   });
   const adminDisplayName = adminUser ? getDisplayName(adminUser) : admin.email;
+  const schedulerHealth = await getSchedulerHealthView();
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl space-y-10">
@@ -77,6 +80,14 @@ export default async function AdminSettingsPage() {
               );
             })}
           </Panel>
+        </section>
+
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-[var(--color-fg)]">定时任务健康</h2>
+            <p className="text-xs text-[var(--color-fg-mid)]">展示当前健康投影；“立即运行一次”仅用于故障恢复，会检查并可能推进对应业务状态。</p>
+          </div>
+          <SchedulerHealthPanel jobs={schedulerHealth} />
         </section>
     </div>
   );

--- a/src/app/api/cron/check-registration-deadline/route.ts
+++ b/src/app/api/cron/check-registration-deadline/route.ts
@@ -1,36 +1,17 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
-import { db } from "@/db/client";
-import { seasons } from "@/db/schema";
-import { maybeAdvanceFromRegistration } from "@/actions/transitions";
 import { validateCronAuth } from "@/lib/cron-auth";
-import { openSeasonRegistrationInTx } from "@/lib/seasons/lifecycle";
 import { withRouteObservability } from "@/lib/observability/route";
+import { executeScheduledJob } from "@/lib/scheduler/execution";
+import { runRegistrationDeadlineJob } from "@/lib/scheduler/runners";
 
 export async function GET(request: Request) {
   return withRouteObservability(request, "/api/cron/check-registration-deadline", async () => {
     const authError = validateCronAuth(request);
     if (authError) return authError;
 
-    const activeSeasons = await db
-      .select({ id: seasons.id })
-      .from(seasons)
-      .where(eq(seasons.status, "registration"));
-
-    let advanced = 0;
-    let opened = 0;
-
-    for (const s of activeSeasons) {
-      await db.transaction(async (tx) => {
-        const openResult = await openSeasonRegistrationInTx(tx, { seasonId: s.id, actorId: "system" });
-        if (openResult.opened) opened++;
-        await maybeAdvanceFromRegistration(tx, s.id, { invalidation: "route" });
-      });
-      advanced++;
-    }
-
-    const skipped = activeSeasons.length - advanced;
-
-    return NextResponse.json({ ok: true, opened, advanced, skipped });
+    const result = await executeScheduledJob(request, "check-registration-deadline", runRegistrationDeadlineJob);
+    if (result instanceof Response) return result;
+    if (result.skipped) return NextResponse.json({ ok: true, skipped: result.skipReason });
+    return NextResponse.json({ ok: true, ...result.result });
   });
 }

--- a/src/app/api/cron/cleanup-education-evidence/route.ts
+++ b/src/app/api/cron/cleanup-education-evidence/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from "next/server";
-import { purgeExpiredEducationEvidence } from "@/lib/education/retention";
 import { validateCronAuth } from "@/lib/cron-auth";
 import { withRouteObservability } from "@/lib/observability/route";
+import { executeScheduledJob } from "@/lib/scheduler/execution";
+import { runEducationEvidenceCleanupJob } from "@/lib/scheduler/runners";
 
 export async function GET(request: Request) {
   return withRouteObservability(request, "/api/cron/cleanup-education-evidence", async () => {
     const authError = validateCronAuth(request);
     if (authError) return authError;
 
-    const cleared = await purgeExpiredEducationEvidence();
-    return NextResponse.json({ ok: true, cleared });
+    const result = await executeScheduledJob(request, "cleanup-education-evidence", runEducationEvidenceCleanupJob);
+    if (result instanceof Response) return result;
+    if (result.skipped) return NextResponse.json({ ok: true, skipped: result.skipReason });
+    return NextResponse.json({ ok: true, ...result.result });
   });
 }

--- a/src/app/api/cron/draft-timeout/route.ts
+++ b/src/app/api/cron/draft-timeout/route.ts
@@ -1,16 +1,17 @@
 import { NextResponse } from "next/server";
-import { runDraftTimeoutCron } from "@/actions/draft";
 import { validateCronAuth } from "@/lib/cron-auth";
 import { withRouteObservability } from "@/lib/observability/route";
+import { executeScheduledJob } from "@/lib/scheduler/execution";
+import { runDraftTimeoutJob } from "@/lib/scheduler/runners";
 
 export async function GET(request: Request) {
   return withRouteObservability(request, "/api/cron/draft-timeout", async () => {
     const authError = validateCronAuth(request);
     if (authError) return authError;
 
-    const result = await runDraftTimeoutCron();
-    return NextResponse.json(
-      { ok: true, processed: result.picked + result.skipped, picked: result.picked, skipped: result.skipped },
-    );
+    const result = await executeScheduledJob(request, "draft-timeout", runDraftTimeoutJob);
+    if (result instanceof Response) return result;
+    if (result.skipped) return NextResponse.json({ ok: true, skipped: result.skipReason });
+    return NextResponse.json({ ok: true, ...result.result });
   });
 }

--- a/src/app/api/cron/match-time-auto-award/route.ts
+++ b/src/app/api/cron/match-time-auto-award/route.ts
@@ -1,15 +1,17 @@
 import { NextResponse } from "next/server";
-import { runMatchTimeAutoAwardCron } from "@/actions/matches";
 import { validateCronAuth } from "@/lib/cron-auth";
 import { withRouteObservability } from "@/lib/observability/route";
+import { executeScheduledJob } from "@/lib/scheduler/execution";
+import { runMatchTimeAutoAwardJob } from "@/lib/scheduler/runners";
 
 export async function GET(request: Request) {
   return withRouteObservability(request, "/api/cron/match-time-auto-award", async () => {
     const authError = validateCronAuth(request);
     if (authError) return authError;
 
-    const result = await runMatchTimeAutoAwardCron();
-
-    return NextResponse.json({ ok: true, ...result });
+    const result = await executeScheduledJob(request, "match-time-auto-award", runMatchTimeAutoAwardJob);
+    if (result instanceof Response) return result;
+    if (result.skipped) return NextResponse.json({ ok: true, skipped: result.skipReason });
+    return NextResponse.json({ ok: true, ...result.result });
   });
 }

--- a/src/components/admin/SchedulerHealthPanel.tsx
+++ b/src/components/admin/SchedulerHealthPanel.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { runSchedulerJobManually } from "@/actions/scheduler";
+import { InlineConfirm, Panel, StatusPill } from "@/components/rivalhub";
+import type { SchedulerHealthView } from "@/lib/scheduler/admin";
+
+function formatHealthTime(value: string | null): string {
+  return value ? new Date(value).toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" }) : "暂无记录";
+}
+
+export function SchedulerHealthPanel({ jobs }: { jobs: SchedulerHealthView[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  function run(jobKey: SchedulerHealthView["jobKey"]): void {
+    startTransition(async () => {
+      const result = await runSchedulerJobManually({ jobKey });
+      setConfirming(null);
+      if (result.success) {
+        toast.success("定时任务已运行。");
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      {jobs.map((job) => (
+        <Panel key={job.jobKey} contentClassName="space-y-3 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-sm font-semibold text-[var(--color-fg)]">{job.label}</h3>
+                <StatusPill label={job.status === "normal" ? "正常" : "已降级"} tone={job.status === "normal" ? "success" : "warn"} />
+              </div>
+              <p className="mt-1 text-xs text-[var(--color-fg-mid)]">最近主调度唤醒：{formatHealthTime(job.primaryTriggeredAt)}</p>
+            </div>
+            <button type="button" className="text-sm font-medium text-[var(--color-accent)] underline-offset-4 hover:underline disabled:opacity-50" disabled={pending} onClick={() => setConfirming(job.jobKey)}>
+              立即运行一次
+            </button>
+          </div>
+          <dl className="grid gap-2 text-xs text-[var(--color-fg-mid)] sm:grid-cols-2">
+            <div><dt className="inline">最近任务接口成功：</dt><dd className="inline">{formatHealthTime(job.endpointSucceededAt)}</dd></div>
+            <div><dt className="inline">最近真实推进：</dt><dd className="inline">{formatHealthTime(job.businessTransitionAt)}</dd></div>
+            <div><dt className="inline">最近兜底运行：</dt><dd className="inline">{formatHealthTime(job.watchdogSucceededAt)}</dd></div>
+            <div><dt className="inline">最近人工运行：</dt><dd className="inline">{formatHealthTime(job.manualSucceededAt)}</dd></div>
+            {job.failureAt && <div className="sm:col-span-2"><dt className="inline text-[var(--color-warn)]">最近失败：</dt><dd className="inline">{formatHealthTime(job.failureAt)}</dd></div>}
+          </dl>
+          {confirming === job.jobKey && <InlineConfirm title={`运行“${job.label}”？`} sub="这会检查并可能推进对应业务状态，仅用于故障恢复。" confirmLabel="确认运行" onCancel={() => setConfirming(null)} onConfirm={() => run(job.jobKey)} />}
+        </Panel>
+      ))}
+    </div>
+  );
+}

--- a/src/components/register/RegistrationOpeningRecovery.tsx
+++ b/src/components/register/RegistrationOpeningRecovery.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useRef, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { recoverRegistrationOpening } from "@/actions/registration-opening";
+
+export function RegistrationOpeningRecovery({ seasonId }: { seasonId: string }) {
+  const router = useRouter();
+  const attempted = useRef(false);
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+    startTransition(async () => {
+      const result = await recoverRegistrationOpening({ seasonId });
+      if (result.success) {
+        router.refresh();
+      } else if (!result.success) {
+        toast.error(result.error.message);
+      }
+    });
+  }, [router, seasonId]);
+
+  return <p className="mt-3 text-center text-xs text-[var(--color-fg-mid)]">页面会自动确认开放状态。</p>;
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -32,3 +32,4 @@ export * from "./discipline";
 export * from "./postevent";
 export * from "./postmatch";
 export * from "./community-awards";
+export * from "./scheduler";

--- a/src/db/schema/scheduler.ts
+++ b/src/db/schema/scheduler.ts
@@ -1,0 +1,22 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Bounded current health projection for the scheduler. This is deliberately
+ * not an execution/event ledger and is never exposed through the Data API.
+ */
+export const scheduledJobHealth = pgTable("scheduled_job_health", {
+  jobKey: text("job_key").primaryKey(),
+  lastPrimaryTriggeredAt: timestamp("last_primary_triggered_at", { withTimezone: true }),
+  lastPrimaryEndpointStartedAt: timestamp("last_primary_endpoint_started_at", { withTimezone: true }),
+  lastPrimaryEndpointSucceededAt: timestamp("last_primary_endpoint_succeeded_at", { withTimezone: true }),
+  lastWatchdogSucceededAt: timestamp("last_watchdog_succeeded_at", { withTimezone: true }),
+  lastManualSucceededAt: timestamp("last_manual_succeeded_at", { withTimezone: true }),
+  lastBusinessTransitionAt: timestamp("last_business_transition_at", { withTimezone: true }),
+  lastFailureAt: timestamp("last_failure_at", { withTimezone: true }),
+  lastFailureSource: text("last_failure_source"),
+  lastFailureCode: text("last_failure_code"),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type ScheduledJobHealth = typeof scheduledJobHealth.$inferSelect;
+export type NewScheduledJobHealth = typeof scheduledJobHealth.$inferInsert;

--- a/src/lib/competition-entries/commands.ts
+++ b/src/lib/competition-entries/commands.ts
@@ -39,6 +39,7 @@ import { canMutateCompetitionEntryRoster } from "@/lib/competition-entries/remed
 import { reconcileMajorPrestartRosterAfterApprovalInTx } from "@/lib/major/prestart-roster";
 import { normalizeAffiliationRules, normalizeTeamRegistrationConfig } from "@/lib/seasons/compatibility";
 import { assessEntryRosterReadiness } from "@/lib/competition-entries/readiness";
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
 
 const editableStatuses = ["draft", "changes_requested"] as const;
 
@@ -181,8 +182,14 @@ export async function validateApprovedCompetitionEntryRosterInTx(
 }
 
 export async function createCompetitionEntryInTx(tx: TxDb, input: { competitionId: string; teamId: string; userId: string; actorId: string }): Promise<{ entryId: string; seasonSlug: string }> {
-  const season = await loadSeasonOrThrow(tx, input.competitionId);
+  let season = await loadSeasonOrThrow(tx, input.competitionId);
   if (!isTeamRegistration(season)) throw new AppError(ErrorCode.SEASON_CAPABILITY_DISABLED, "当前赛事不使用队伍报名。");
+  const [teamScope] = await tx.select({ status: teams.status, captainUserId: teams.captainUserId }).from(teams).where(eq(teams.id, input.teamId));
+  if (!teamScope || teamScope.status !== "active") throw new AppError(ErrorCode.NOT_FOUND, "队伍不存在或已解散。");
+  if (teamScope.captainUserId !== input.userId) throw new AppError(ErrorCode.FORBIDDEN, "只有队伍队长可以创建参赛条目。");
+  if (getRegistrationWindowState(season).needsOpeningRecovery) {
+    season = (await ensureRegistrationOpenForParticipantInTx(tx, input.competitionId)).season;
+  }
   const window = getRegistrationWindowState(season);
   if (!window.canSubmit) throw new AppError(ErrorCode.REGISTRATION_CLOSED, window.message);
   const [team] = await tx.select().from(teams).where(eq(teams.id, input.teamId)).for("update");
@@ -202,11 +209,14 @@ export async function saveCompetitionEntryRosterInTx(tx: TxDb, input: { entryId:
   const entry = await lockRepresentativeEntry(tx, input.entryId, input.userId);
   if (!editableStatuses.includes(entry.registrationStatus as typeof editableStatuses[number])) throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前报名版本不可编辑。");
   if (!entry.teamId) throw new AppError(ErrorCode.VALIDATION_FAILED, "赛事组队报名不能通过队伍名单编辑入口修改。");
-  const season = await loadSeasonOrThrow(tx, entry.competitionId);
-  const currentMemberships = await tx.select().from(teamMemberships).where(and(eq(teamMemberships.teamId, entry.teamId), inArray(teamMemberships.userId, input.userIds), isNull(teamMemberships.endedAt)));
-  if (currentMemberships.length !== input.userIds.length) throw new AppError(ErrorCode.VALIDATION_FAILED, "新选择的名单成员必须当前仍属于这支队伍。");
+  let season = await loadSeasonOrThrow(tx, entry.competitionId);
   const [revision] = await tx.select().from(competitionEntryRosterRevisions).where(and(eq(competitionEntryRosterRevisions.id, entry.currentRosterRevisionId), eq(competitionEntryRosterRevisions.entryId, entry.id))).for("update");
   if (!revision || revision.status !== "draft") throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前名单版本不可编辑。");
+  if (revision.origin !== "admin_remediation" && getRegistrationWindowState(season).needsOpeningRecovery) {
+    season = (await ensureRegistrationOpenForParticipantInTx(tx, entry.competitionId)).season;
+  }
+  const currentMemberships = await tx.select().from(teamMemberships).where(and(eq(teamMemberships.teamId, entry.teamId), inArray(teamMemberships.userId, input.userIds), isNull(teamMemberships.endedAt)));
+  if (currentMemberships.length !== input.userIds.length) throw new AppError(ErrorCode.VALIDATION_FAILED, "新选择的名单成员必须当前仍属于这支队伍。");
   const window = getRegistrationWindowState(season);
   if (!canMutateCompetitionEntryRoster(entry.registrationStatus as "draft" | "changes_requested", revision.origin, season)) throw new AppError(ErrorCode.REGISTRATION_CLOSED, window.message);
   const existingParticipants = await tx.select().from(competitionEntryParticipants).where(eq(competitionEntryParticipants.entryId, entry.id));
@@ -240,9 +250,12 @@ export async function confirmCompetitionEntryParticipationInTx(tx: TxDb, input: 
   if (!editableStatuses.includes(entry.registrationStatus as typeof editableStatuses[number])) throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前报名阶段不能确认新成员。");
   const [participant] = await tx.select().from(competitionEntryParticipants).where(and(eq(competitionEntryParticipants.entryId, entry.id), eq(competitionEntryParticipants.userId, input.userId))).for("update");
   if (!participant) throw new AppError(ErrorCode.NOT_FOUND, "你不在当前本届名单中。");
-  const season = await loadSeasonOrThrow(tx, entry.competitionId);
+  let season = await loadSeasonOrThrow(tx, entry.competitionId);
   const [revision] = await tx.select().from(competitionEntryRosterRevisions).where(and(eq(competitionEntryRosterRevisions.id, entry.currentRosterRevisionId), eq(competitionEntryRosterRevisions.entryId, entry.id))).for("update");
   if (!revision || revision.status !== "draft") throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前名单版本不可编辑。");
+  if (revision.origin !== "admin_remediation" && getRegistrationWindowState(season).needsOpeningRecovery) {
+    season = (await ensureRegistrationOpenForParticipantInTx(tx, entry.competitionId)).season;
+  }
   const window = getRegistrationWindowState(season);
   if (!canMutateCompetitionEntryRoster(entry.registrationStatus as "draft" | "changes_requested", revision.origin, season)) throw new AppError(ErrorCode.REGISTRATION_CLOSED, window.message);
   if (participant.status === "confirmed") return { seasonSlug: season.slug, alreadyConfirmed: true };
@@ -298,7 +311,12 @@ export async function withdrawCompetitionEntryInTx(tx: TxDb, input: { entryId: s
 export async function submitCompetitionEntryInTx(tx: TxDb, input: { entryId: string; userId: string; actorId: string }): Promise<{ seasonSlug: string }> {
   const entry = await lockRepresentativeEntry(tx, input.entryId, input.userId);
   if (!editableStatuses.includes(entry.registrationStatus as typeof editableStatuses[number])) throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前报名状态不能提交。");
-  const season = await loadSeasonOrThrow(tx, entry.competitionId);
+  let season = await loadSeasonOrThrow(tx, entry.competitionId);
+  const [currentRevision] = await tx.select({ origin: competitionEntryRosterRevisions.origin }).from(competitionEntryRosterRevisions).where(and(eq(competitionEntryRosterRevisions.id, entry.currentRosterRevisionId), eq(competitionEntryRosterRevisions.entryId, entry.id))).for("update");
+  if (!currentRevision) throw new AppError(ErrorCode.REGISTRATION_INVALID_TRANSITION, "当前名单版本不可用于此操作。");
+  if (currentRevision.origin !== "admin_remediation" && getRegistrationWindowState(season).needsOpeningRecovery) {
+    season = (await ensureRegistrationOpenForParticipantInTx(tx, entry.competitionId)).season;
+  }
   const window = getRegistrationWindowState(season);
   const validated = await validateEntryRoster(tx, entry, season, ["draft"], { requireCurrentTeamMembership: true, requireActiveRestrictionOverrides: false });
   if (!canMutateCompetitionEntryRoster(entry.registrationStatus as "draft" | "changes_requested", validated.revision.origin, season)) throw new AppError(ErrorCode.REGISTRATION_CLOSED, window.message);

--- a/src/lib/competition-entries/roster-change.ts
+++ b/src/lib/competition-entries/roster-change.ts
@@ -6,10 +6,10 @@ import {
   competitionEntryRosterMembers,
   competitionEntryRosterRevisions,
   eventRosters,
-  seasons,
 } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
 import { canSelfChangeApprovedRoster } from "@/lib/registration/window";
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
 
 /**
  * Canonical approved-roster change transition: the Entry representative reopens
@@ -28,12 +28,11 @@ export async function requestCompetitionEntryRosterChangeInTx(
   // atomic audit insert below references seasons; this keeps the full order
   // compatible with Major start/save while preserving Entry → eventRoster →
   // prestart entrant within the roster-remediation aggregate.
-  const [entryScope] = await tx.select({ competitionId: competitionEntries.competitionId })
+  const [entryScope] = await tx.select({ competitionId: competitionEntries.competitionId, representativeUserId: competitionEntries.representativeUserId })
     .from(competitionEntries).where(eq(competitionEntries.id, input.entryId));
   if (!entryScope) throw new AppError(ErrorCode.NOT_FOUND, "赛事参赛条目不存在。");
-  const [season] = await tx.select({ slug: seasons.slug, status: seasons.status, registrationOpensAt: seasons.registrationOpensAt, registrationOpenedAt: seasons.registrationOpenedAt, registrationClosesAt: seasons.registrationClosesAt, rosterChangeClosesAt: seasons.rosterChangeClosesAt })
-    .from(seasons).where(eq(seasons.id, entryScope.competitionId)).for("update");
-  if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛事不存在。");
+  if (entryScope.representativeUserId !== input.representativeUserId) throw new AppError(ErrorCode.FORBIDDEN, "只有本届赛事负责人可以执行此操作。");
+  const { season } = await ensureRegistrationOpenForParticipantInTx(tx, entryScope.competitionId);
   const [entry] = await tx.select().from(competitionEntries)
     .where(eq(competitionEntries.id, input.entryId)).for("update");
   if (!entry) throw new AppError(ErrorCode.NOT_FOUND, "赛事参赛条目不存在。");

--- a/src/lib/observability/redact.ts
+++ b/src/lib/observability/redact.ts
@@ -36,6 +36,7 @@ const SAFE_CONTEXT_KEYS = new Set([
   "host",
   "httpStatus",
   "imageBytes",
+  "jobKey",
   "kind",
   "method",
   "mimeType",
@@ -57,6 +58,7 @@ const SAFE_CONTEXT_KEYS = new Set([
   "spanKind",
   "stage",
   "status",
+  "source",
   "table",
   "workflow",
 ]);

--- a/src/lib/registration/window.ts
+++ b/src/lib/registration/window.ts
@@ -20,6 +20,8 @@ export interface RegistrationWindowState {
   canViewForm: boolean;
   canSaveDraft: boolean;
   canSubmit: boolean;
+  /** The scheduled opening is due, but the canonical fact is not materialized yet. */
+  needsOpeningRecovery: boolean;
   message: string;
 }
 
@@ -66,6 +68,7 @@ export function getRegistrationWindowState(
       canViewForm: false,
       canSaveDraft: false,
       canSubmit: false,
+      needsOpeningRecovery: false,
       message: "报名通道当前不可用。",
     };
   }
@@ -81,6 +84,7 @@ export function getRegistrationWindowState(
       canViewForm: true,
       canSaveDraft: false,
       canSubmit: false,
+      needsOpeningRecovery: false,
       message: "报名开放时间待定。",
     };
   }
@@ -91,6 +95,7 @@ export function getRegistrationWindowState(
       canViewForm: true,
       canSaveDraft: false,
       canSubmit: false,
+      needsOpeningRecovery: false,
       message: "报名提交已截止。",
     };
   }
@@ -101,6 +106,7 @@ export function getRegistrationWindowState(
       canViewForm: true,
       canSaveDraft: false,
       canSubmit: false,
+      needsOpeningRecovery: false,
       message: "报名尚未开放。",
     };
   }
@@ -111,7 +117,8 @@ export function getRegistrationWindowState(
       canViewForm: true,
       canSaveDraft: false,
       canSubmit: false,
-      message: "报名开放正在确认中，请稍后刷新。",
+      needsOpeningRecovery: true,
+      message: "报名正在开放，请稍候…",
     };
   }
 
@@ -120,6 +127,7 @@ export function getRegistrationWindowState(
     canViewForm: true,
     canSaveDraft: true,
     canSubmit: true,
+    needsOpeningRecovery: false,
     message: "报名提交已开放。",
   };
 }

--- a/src/lib/scheduler/admin.ts
+++ b/src/lib/scheduler/admin.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { readAllSchedulerHealth, type SchedulerHealthRecord } from "./health";
+import { SCHEDULER_JOB_DEFINITIONS, type SchedulerJobKey } from "./definitions";
+import { isFresh } from "./execution";
+
+export interface SchedulerHealthView {
+  jobKey: SchedulerJobKey;
+  label: string;
+  status: "normal" | "degraded";
+  primaryTriggeredAt: string | null;
+  endpointSucceededAt: string | null;
+  businessTransitionAt: string | null;
+  watchdogSucceededAt: string | null;
+  manualSucceededAt: string | null;
+  failureAt: string | null;
+}
+
+export async function getSchedulerHealthView(now = new Date()): Promise<SchedulerHealthView[]> {
+  const records = await readAllSchedulerHealth();
+  const byKey = new Map(records.map((record) => [record.jobKey, record]));
+  return SCHEDULER_JOB_DEFINITIONS.map((definition) => {
+    const record = byKey.get(definition.key);
+    const primaryFresh = Boolean(record?.lastPrimaryTriggeredAt && isFresh(record.lastPrimaryTriggeredAt, definition.staleAfterMs, now));
+    return {
+      jobKey: definition.key,
+      label: definition.label,
+      status: primaryFresh ? "normal" : "degraded",
+      primaryTriggeredAt: record?.lastPrimaryTriggeredAt?.toISOString() ?? null,
+      endpointSucceededAt: record?.lastPrimaryEndpointSucceededAt?.toISOString() ?? null,
+      businessTransitionAt: record?.lastBusinessTransitionAt?.toISOString() ?? null,
+      watchdogSucceededAt: record?.lastWatchdogSucceededAt?.toISOString() ?? null,
+      manualSucceededAt: record?.lastManualSucceededAt?.toISOString() ?? null,
+      failureAt: record?.lastFailureAt?.toISOString() ?? null,
+    };
+  });
+}
+
+export type { SchedulerHealthRecord };

--- a/src/lib/scheduler/admin.ts
+++ b/src/lib/scheduler/admin.ts
@@ -1,8 +1,7 @@
 import "server-only";
 
-import { readAllSchedulerHealth, type SchedulerHealthRecord } from "./health";
+import { isPrimaryHealthy, readAllSchedulerHealth, type SchedulerHealthRecord } from "./health";
 import { SCHEDULER_JOB_DEFINITIONS, type SchedulerJobKey } from "./definitions";
-import { isFresh } from "./execution";
 
 export interface SchedulerHealthView {
   jobKey: SchedulerJobKey;
@@ -21,11 +20,11 @@ export async function getSchedulerHealthView(now = new Date()): Promise<Schedule
   const byKey = new Map(records.map((record) => [record.jobKey, record]));
   return SCHEDULER_JOB_DEFINITIONS.map((definition) => {
     const record = byKey.get(definition.key);
-    const primaryFresh = Boolean(record?.lastPrimaryTriggeredAt && isFresh(record.lastPrimaryTriggeredAt, definition.staleAfterMs, now));
+    const primaryHealthy = isPrimaryHealthy(record, definition, now);
     return {
       jobKey: definition.key,
       label: definition.label,
-      status: primaryFresh ? "normal" : "degraded",
+      status: primaryHealthy ? "normal" : "degraded",
       primaryTriggeredAt: record?.lastPrimaryTriggeredAt?.toISOString() ?? null,
       endpointSucceededAt: record?.lastPrimaryEndpointSucceededAt?.toISOString() ?? null,
       businessTransitionAt: record?.lastBusinessTransitionAt?.toISOString() ?? null,

--- a/src/lib/scheduler/definitions.ts
+++ b/src/lib/scheduler/definitions.ts
@@ -1,0 +1,71 @@
+const SCHEDULER_SOURCES = [
+  "supabase-primary",
+  "github-watchdog",
+  "github-manual",
+  "super-admin-manual",
+  "legacy",
+] as const;
+
+export type SchedulerSource = (typeof SCHEDULER_SOURCES)[number];
+
+export const SCHEDULER_JOB_KEYS = [
+  "draft-timeout",
+  "check-registration-deadline",
+  "match-time-auto-award",
+  "cleanup-education-evidence",
+] as const;
+
+export const SCHEDULER_JOB_DEFINITIONS = [
+  {
+    key: SCHEDULER_JOB_KEYS[0],
+    label: "选秀超时处理",
+    routeSegment: "draft-timeout",
+    primaryCron: "* * * * *",
+    staleAfterMs: 3 * 60 * 1000,
+  },
+  {
+    key: SCHEDULER_JOB_KEYS[1],
+    label: "报名状态推进",
+    routeSegment: "check-registration-deadline",
+    primaryCron: "* * * * *",
+    staleAfterMs: 3 * 60 * 1000,
+  },
+  {
+    key: SCHEDULER_JOB_KEYS[2],
+    label: "比赛时间自动裁定",
+    routeSegment: "match-time-auto-award",
+    primaryCron: "*/5 * * * *",
+    staleAfterMs: 15 * 60 * 1000,
+  },
+  {
+    key: SCHEDULER_JOB_KEYS[3],
+    label: "教育凭证清理",
+    routeSegment: "cleanup-education-evidence",
+    // 06:00 Asia/Shanghai, persisted as UTC because pg_cron uses UTC.
+    primaryCron: "0 22 * * *",
+    staleAfterMs: 36 * 60 * 60 * 1000,
+  },
+] as const;
+
+export type SchedulerJobKey = (typeof SCHEDULER_JOB_DEFINITIONS)[number]["key"];
+export type SchedulerJobDefinition = (typeof SCHEDULER_JOB_DEFINITIONS)[number];
+
+const definitionsByKey = new Map<SchedulerJobKey, SchedulerJobDefinition>(
+  SCHEDULER_JOB_DEFINITIONS.map((definition) => [definition.key, definition]),
+);
+
+export function getSchedulerJobDefinition(key: string): SchedulerJobDefinition | undefined {
+  return definitionsByKey.get(key as SchedulerJobKey);
+}
+
+export function getSchedulerRoute(definition: SchedulerJobDefinition): string {
+  return `/api/cron/${definition.routeSegment}`;
+}
+
+export function isSchedulerSource(value: string | null): value is SchedulerSource {
+  return value !== null && (SCHEDULER_SOURCES as readonly string[]).includes(value);
+}
+
+export function schedulerJobName(key: SchedulerJobKey): string {
+  return `rivalhub-${key}`;
+}

--- a/src/lib/scheduler/definitions.ts
+++ b/src/lib/scheduler/definitions.ts
@@ -19,28 +19,24 @@ export const SCHEDULER_JOB_DEFINITIONS = [
   {
     key: SCHEDULER_JOB_KEYS[0],
     label: "选秀超时处理",
-    routeSegment: "draft-timeout",
     primaryCron: "* * * * *",
     staleAfterMs: 3 * 60 * 1000,
   },
   {
     key: SCHEDULER_JOB_KEYS[1],
     label: "报名状态推进",
-    routeSegment: "check-registration-deadline",
     primaryCron: "* * * * *",
     staleAfterMs: 3 * 60 * 1000,
   },
   {
     key: SCHEDULER_JOB_KEYS[2],
     label: "比赛时间自动裁定",
-    routeSegment: "match-time-auto-award",
     primaryCron: "*/5 * * * *",
     staleAfterMs: 15 * 60 * 1000,
   },
   {
     key: SCHEDULER_JOB_KEYS[3],
     label: "教育凭证清理",
-    routeSegment: "cleanup-education-evidence",
     // 06:00 Asia/Shanghai, persisted as UTC because pg_cron uses UTC.
     primaryCron: "0 22 * * *",
     staleAfterMs: 36 * 60 * 60 * 1000,
@@ -58,8 +54,8 @@ export function getSchedulerJobDefinition(key: string): SchedulerJobDefinition |
   return definitionsByKey.get(key as SchedulerJobKey);
 }
 
-export function getSchedulerRoute(definition: SchedulerJobDefinition): string {
-  return `/api/cron/${definition.routeSegment}`;
+export function getSchedulerRoute(key: SchedulerJobKey): string {
+  return `/api/cron/${key}`;
 }
 
 export function isSchedulerSource(value: string | null): value is SchedulerSource {

--- a/src/lib/scheduler/execution.ts
+++ b/src/lib/scheduler/execution.ts
@@ -1,0 +1,137 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import { captureException, logEvent } from "@/lib/observability/server";
+import {
+  getSchedulerJobDefinition,
+  getSchedulerRoute,
+  isSchedulerSource,
+  type SchedulerJobKey,
+  type SchedulerSource,
+} from "./definitions";
+import {
+  markBusinessTransition,
+  markEndpointStarted,
+  markJobFailed,
+  markJobSucceeded,
+  readSchedulerHealth,
+} from "./health";
+
+export interface SchedulerRunnerResult<T> {
+  result: T;
+  /** Number of committed domain facts changed by this run. */
+  businessTransitions: number;
+}
+
+export interface SchedulerExecutionResult<T> {
+  source: SchedulerSource;
+  skipped: boolean;
+  skipReason?: "primary_fresh";
+  result?: T;
+  businessTransitions: number;
+}
+
+export async function executeScheduledJob<T>(
+  request: Request,
+  jobKey: SchedulerJobKey,
+  runner: () => Promise<SchedulerRunnerResult<T>>,
+): Promise<SchedulerExecutionResult<T> | Response> {
+  const source = parseSchedulerSource(request);
+  if (source instanceof Response) return source;
+
+  return executeScheduledJobCore({ jobKey, source, runner });
+}
+
+/** Shared runner used by the super-admin break-glass action. */
+export async function executeScheduledJobManually<T>(
+  jobKey: SchedulerJobKey,
+  runner: () => Promise<SchedulerRunnerResult<T>>,
+): Promise<SchedulerExecutionResult<T>> {
+  return executeScheduledJobCore({ jobKey, source: "super-admin-manual", runner });
+}
+
+async function executeScheduledJobCore<T>(input: {
+  jobKey: SchedulerJobKey;
+  source: SchedulerSource;
+  runner: () => Promise<SchedulerRunnerResult<T>>;
+}): Promise<SchedulerExecutionResult<T>> {
+  const definition = getSchedulerJobDefinition(input.jobKey);
+  if (!definition) {
+    // This is a programmer/configuration invariant, not an untrusted request
+    // error. The public route never reaches this branch with a typed key.
+    throw new Error("Unknown scheduler job definition");
+  }
+
+  const now = new Date();
+  if (input.source === "github-watchdog") {
+    const health = await readSchedulerHealth(input.jobKey);
+    if (health?.lastPrimaryTriggeredAt && isFresh(health.lastPrimaryTriggeredAt, definition.staleAfterMs, now)) {
+      await markJobSucceeded(input.jobKey, input.source, now);
+      logEvent({
+        level: "info",
+        event: "scheduler.watchdog.noop",
+        scope: "scheduler",
+        operation: "watchdog",
+        safeContext: { jobKey: input.jobKey, source: input.source, outcome: "primary_fresh" },
+      });
+      return {
+        source: input.source,
+        skipped: true,
+        skipReason: "primary_fresh",
+        businessTransitions: 0,
+      };
+    }
+  }
+
+  await markEndpointStarted(input.jobKey, input.source, now);
+  try {
+    const run = await input.runner();
+    const businessTransitions = normalizeTransitionCount(run.businessTransitions);
+    await markJobSucceeded(input.jobKey, input.source, new Date());
+    await markBusinessTransition(input.jobKey, businessTransitions, new Date());
+    logEvent({
+      level: "info",
+      event: "scheduler.job.succeeded",
+      scope: "scheduler",
+      operation: "job.execute",
+      safeContext: {
+        jobKey: input.jobKey,
+        source: input.source,
+        outcome: "success",
+        count: businessTransitions,
+      },
+    });
+    return {
+      source: input.source,
+      skipped: false,
+      result: run.result,
+      businessTransitions,
+    };
+  } catch (error) {
+    await markJobFailed(input.jobKey, input.source, error, new Date());
+    captureException("scheduler.job.failure", error, {
+      scope: "scheduler",
+      operation: "job.execute",
+      route: getSchedulerRoute(definition),
+      safeContext: { jobKey: input.jobKey, source: input.source },
+    });
+    throw error;
+  }
+}
+
+function parseSchedulerSource(request: Request): SchedulerSource | Response {
+  const value = request.headers.get("x-rivalhub-cron-source");
+  if (value === null || value.trim() === "") return "legacy";
+  const source = value.trim();
+  if (isSchedulerSource(source)) return source;
+  return NextResponse.json({ error: "Invalid scheduler source" }, { status: 400 });
+}
+
+export function isFresh(lastTriggeredAt: Date, staleAfterMs: number, now = new Date()): boolean {
+  const age = now.getTime() - lastTriggeredAt.getTime();
+  return age >= 0 && age <= staleAfterMs;
+}
+
+function normalizeTransitionCount(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}

--- a/src/lib/scheduler/execution.ts
+++ b/src/lib/scheduler/execution.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
-import { captureException, logEvent } from "@/lib/observability/server";
+import { captureException } from "@/lib/observability/server";
 import {
   getSchedulerJobDefinition,
   getSchedulerRoute,
@@ -14,6 +14,7 @@ import {
   markEndpointStarted,
   markJobFailed,
   markJobSucceeded,
+  isPrimaryHealthy,
   readSchedulerHealth,
 } from "./health";
 
@@ -65,15 +66,7 @@ async function executeScheduledJobCore<T>(input: {
   const now = new Date();
   if (input.source === "github-watchdog") {
     const health = await readSchedulerHealth(input.jobKey);
-    if (health?.lastPrimaryTriggeredAt && isFresh(health.lastPrimaryTriggeredAt, definition.staleAfterMs, now)) {
-      await markJobSucceeded(input.jobKey, input.source, now);
-      logEvent({
-        level: "info",
-        event: "scheduler.watchdog.noop",
-        scope: "scheduler",
-        operation: "watchdog",
-        safeContext: { jobKey: input.jobKey, source: input.source, outcome: "primary_fresh" },
-      });
+    if (isPrimaryHealthy(health, definition, now)) {
       return {
         source: input.source,
         skipped: true,
@@ -89,18 +82,6 @@ async function executeScheduledJobCore<T>(input: {
     const businessTransitions = normalizeTransitionCount(run.businessTransitions);
     await markJobSucceeded(input.jobKey, input.source, new Date());
     await markBusinessTransition(input.jobKey, businessTransitions, new Date());
-    logEvent({
-      level: "info",
-      event: "scheduler.job.succeeded",
-      scope: "scheduler",
-      operation: "job.execute",
-      safeContext: {
-        jobKey: input.jobKey,
-        source: input.source,
-        outcome: "success",
-        count: businessTransitions,
-      },
-    });
     return {
       source: input.source,
       skipped: false,
@@ -112,7 +93,7 @@ async function executeScheduledJobCore<T>(input: {
     captureException("scheduler.job.failure", error, {
       scope: "scheduler",
       operation: "job.execute",
-      route: getSchedulerRoute(definition),
+      route: getSchedulerRoute(input.jobKey),
       safeContext: { jobKey: input.jobKey, source: input.source },
     });
     throw error;
@@ -125,11 +106,6 @@ function parseSchedulerSource(request: Request): SchedulerSource | Response {
   const source = value.trim();
   if (isSchedulerSource(source)) return source;
   return NextResponse.json({ error: "Invalid scheduler source" }, { status: 400 });
-}
-
-export function isFresh(lastTriggeredAt: Date, staleAfterMs: number, now = new Date()): boolean {
-  const age = now.getTime() - lastTriggeredAt.getTime();
-  return age >= 0 && age <= staleAfterMs;
 }
 
 function normalizeTransitionCount(value: number): number {

--- a/src/lib/scheduler/health.ts
+++ b/src/lib/scheduler/health.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { scheduledJobHealth } from "@/db/schema";
 import { classifyError } from "@/lib/observability/errors";
-import { captureException, logEvent } from "@/lib/observability/server";
+import { captureException } from "@/lib/observability/server";
 import type { SchedulerJobDefinition, SchedulerJobKey, SchedulerSource } from "./definitions";
 
 export type SchedulerHealthRecord = typeof scheduledJobHealth.$inferSelect;
@@ -122,15 +122,6 @@ async function updateHealth(
 
 function recordHealthStorageFailure(operation: string, jobKey: string, error: unknown): void {
   captureException("scheduler.health_projection.failure", error, {
-    scope: "scheduler",
-    operation: `health.${operation}`,
-    errorClass: "database",
-    retryable: true,
-    safeContext: { jobKey },
-  });
-  logEvent({
-    level: "warn",
-    event: "scheduler.health_projection.unavailable",
     scope: "scheduler",
     operation: `health.${operation}`,
     errorClass: "database",

--- a/src/lib/scheduler/health.ts
+++ b/src/lib/scheduler/health.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { scheduledJobHealth } from "@/db/schema";
+import { classifyError } from "@/lib/observability/errors";
+import { captureException, logEvent } from "@/lib/observability/server";
+import type { SchedulerJobKey, SchedulerSource } from "./definitions";
+
+export type SchedulerHealthRecord = typeof scheduledJobHealth.$inferSelect;
+
+const databaseConfigured = (): boolean => Boolean(process.env.DATABASE_URL?.trim());
+
+/**
+ * Health is intentionally best effort. A missing/temporarily unavailable
+ * health table must never turn a canonical business cron into a second failure.
+ */
+export async function readSchedulerHealth(jobKey: SchedulerJobKey): Promise<SchedulerHealthRecord | null> {
+  if (!databaseConfigured()) return null;
+  try {
+    return await db.query.scheduledJobHealth.findFirst({ where: eq(scheduledJobHealth.jobKey, jobKey) }) ?? null;
+  } catch (error) {
+    recordHealthStorageFailure("read", jobKey, error);
+    return null;
+  }
+}
+
+export async function readAllSchedulerHealth(): Promise<SchedulerHealthRecord[]> {
+  if (!databaseConfigured()) return [];
+  try {
+    return await db.select().from(scheduledJobHealth);
+  } catch (error) {
+    recordHealthStorageFailure("read_all", "scheduler", error);
+    return [];
+  }
+}
+
+export async function markEndpointStarted(
+  jobKey: SchedulerJobKey,
+  source: SchedulerSource,
+  at = new Date(),
+): Promise<void> {
+  if (source !== "supabase-primary") return;
+  await updateHealth(jobKey, { lastPrimaryEndpointStartedAt: at, updatedAt: at }, "endpoint_start");
+}
+
+export async function markJobSucceeded(
+  jobKey: SchedulerJobKey,
+  source: SchedulerSource,
+  at = new Date(),
+): Promise<void> {
+  const values = {
+    updatedAt: at,
+    ...(source === "supabase-primary" ? { lastPrimaryEndpointSucceededAt: at } : {}),
+    ...(source === "github-watchdog" ? { lastWatchdogSucceededAt: at } : {}),
+    ...(["github-manual", "super-admin-manual"].includes(source) ? { lastManualSucceededAt: at } : {}),
+  };
+  await updateHealth(jobKey, values, "job_success");
+}
+
+export async function markBusinessTransition(
+  jobKey: SchedulerJobKey,
+  transitionCount: number,
+  at = new Date(),
+): Promise<void> {
+  if (!Number.isFinite(transitionCount) || transitionCount <= 0) return;
+  await updateHealth(jobKey, { lastBusinessTransitionAt: at, updatedAt: at }, "business_transition");
+}
+
+export async function markJobFailed(
+  jobKey: SchedulerJobKey,
+  source: SchedulerSource,
+  error: unknown,
+  at = new Date(),
+): Promise<void> {
+  const classification = classifyError(error);
+  await updateHealth(jobKey, {
+    lastFailureAt: at,
+    lastFailureSource: source,
+    lastFailureCode: classification.errorCode ?? classification.errorClass,
+    updatedAt: at,
+  }, "job_failure");
+}
+
+async function updateHealth(
+  jobKey: SchedulerJobKey,
+  values: Partial<typeof scheduledJobHealth.$inferInsert>,
+  operation: string,
+): Promise<void> {
+  if (!databaseConfigured()) return;
+  try {
+    await db
+      .insert(scheduledJobHealth)
+      .values({ jobKey, ...values })
+      .onConflictDoUpdate({
+        target: scheduledJobHealth.jobKey,
+        set: values,
+      });
+  } catch (error) {
+    recordHealthStorageFailure(operation, jobKey, error);
+  }
+}
+
+function recordHealthStorageFailure(operation: string, jobKey: string, error: unknown): void {
+  captureException("scheduler.health_projection.failure", error, {
+    scope: "scheduler",
+    operation: `health.${operation}`,
+    errorClass: "database",
+    retryable: true,
+    safeContext: { jobKey },
+  });
+  logEvent({
+    level: "warn",
+    event: "scheduler.health_projection.unavailable",
+    scope: "scheduler",
+    operation: `health.${operation}`,
+    errorClass: "database",
+    retryable: true,
+    safeContext: { jobKey },
+  });
+}

--- a/src/lib/scheduler/health.ts
+++ b/src/lib/scheduler/health.ts
@@ -5,9 +5,28 @@ import { db } from "@/db/client";
 import { scheduledJobHealth } from "@/db/schema";
 import { classifyError } from "@/lib/observability/errors";
 import { captureException, logEvent } from "@/lib/observability/server";
-import type { SchedulerJobKey, SchedulerSource } from "./definitions";
+import type { SchedulerJobDefinition, SchedulerJobKey, SchedulerSource } from "./definitions";
 
 export type SchedulerHealthRecord = typeof scheduledJobHealth.$inferSelect;
+
+function isFresh(lastAt: Date, staleAfterMs: number, now = new Date()): boolean {
+  const age = now.getTime() - lastAt.getTime();
+  return age >= 0 && age <= staleAfterMs;
+}
+
+/** Primary is healthy only after both dispatch and endpoint execution are fresh. */
+export function isPrimaryHealthy(
+  record: Pick<SchedulerHealthRecord, "lastPrimaryTriggeredAt" | "lastPrimaryEndpointSucceededAt"> | null | undefined,
+  definition: Pick<SchedulerJobDefinition, "staleAfterMs">,
+  now = new Date(),
+): boolean {
+  return Boolean(
+    record?.lastPrimaryTriggeredAt &&
+    record.lastPrimaryEndpointSucceededAt &&
+    isFresh(record.lastPrimaryTriggeredAt, definition.staleAfterMs, now) &&
+    isFresh(record.lastPrimaryEndpointSucceededAt, definition.staleAfterMs, now),
+  );
+}
 
 const databaseConfigured = (): boolean => Boolean(process.env.DATABASE_URL?.trim());
 

--- a/src/lib/scheduler/runners.ts
+++ b/src/lib/scheduler/runners.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { maybeAdvanceFromRegistration } from "@/actions/transitions";
+import { runDraftTimeoutCron } from "@/actions/draft";
+import { runMatchTimeAutoAwardCron } from "@/actions/matches";
+import { purgeExpiredEducationEvidence } from "@/lib/education/retention";
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
+import type { SchedulerJobKey } from "./definitions";
+import type { SchedulerRunnerResult } from "./execution";
+
+export async function runRegistrationDeadlineJob(): Promise<SchedulerRunnerResult<{
+  processed: number;
+  opened: number;
+  advanced: number;
+  skipped: number;
+}>> {
+  const activeSeasons = await db
+    .select({ id: seasons.id })
+    .from(seasons)
+    .where(eq(seasons.status, "registration"));
+
+  let advanced = 0;
+  let opened = 0;
+
+  for (const season of activeSeasons) {
+    await db.transaction(async (tx) => {
+      const openResult = await ensureRegistrationOpenForParticipantInTx(tx, season.id);
+      if (openResult.opened) opened += 1;
+      if (await maybeAdvanceFromRegistration(tx, season.id, { invalidation: "route" })) advanced += 1;
+    });
+  }
+
+  return {
+    result: {
+      processed: activeSeasons.length,
+      opened,
+      advanced,
+      skipped: Math.max(0, activeSeasons.length - opened - advanced),
+    },
+    businessTransitions: opened + advanced,
+  };
+}
+
+export async function runDraftTimeoutJob() {
+  const result = await runDraftTimeoutCron();
+  return {
+    result: {
+      processed: result.picked + result.skipped,
+      picked: result.picked,
+      skipped: result.skipped,
+    },
+    businessTransitions: result.picked,
+  } satisfies SchedulerRunnerResult<{
+    processed: number;
+    picked: number;
+    skipped: number;
+  }>;
+}
+
+export async function runMatchTimeAutoAwardJob() {
+  const result = await runMatchTimeAutoAwardCron();
+  return {
+    result,
+    businessTransitions: result.awarded,
+  } satisfies SchedulerRunnerResult<typeof result>;
+}
+
+export async function runEducationEvidenceCleanupJob() {
+  const cleared = await purgeExpiredEducationEvidence();
+  return {
+    result: { cleared },
+    businessTransitions: cleared,
+  } satisfies SchedulerRunnerResult<{ cleared: number }>;
+}
+
+export async function runSchedulerJobByKey(key: SchedulerJobKey): Promise<SchedulerRunnerResult<unknown>> {
+  switch (key) {
+    case "draft-timeout": return runDraftTimeoutJob();
+    case "check-registration-deadline": return runRegistrationDeadlineJob();
+    case "match-time-auto-award": return runMatchTimeAutoAwardJob();
+    case "cleanup-education-evidence": return runEducationEvidenceCleanupJob();
+  }
+}

--- a/src/lib/seasons/registration-recovery.ts
+++ b/src/lib/seasons/registration-recovery.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import type { TxDb } from "@/db/client";
+import { seasons } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { openSeasonRegistrationInTx } from "@/lib/seasons/lifecycle";
+
+export async function ensureRegistrationOpenForParticipantInTx(
+  tx: TxDb,
+  seasonId: string,
+  now = new Date(),
+): Promise<{ season: typeof seasons.$inferSelect; opened: boolean }> {
+  const [season] = await tx
+    .select()
+    .from(seasons)
+    .where(eq(seasons.id, seasonId))
+    .for("update");
+  if (!season) throw new AppError(ErrorCode.SEASON_NOT_FOUND, "赛事不存在。");
+
+  const scheduledOpeningIsDue =
+    season.status === "registration" &&
+    season.registrationOpenedAt === null &&
+    season.registrationOpensAt !== null &&
+    season.registrationOpensAt.getTime() <= now.getTime();
+  const beforeClosingDeadline =
+    season.registrationClosesAt === null || now.getTime() < season.registrationClosesAt.getTime();
+
+  if (!scheduledOpeningIsDue || !beforeClosingDeadline) {
+    return { season, opened: false };
+  }
+
+  const result = await openSeasonRegistrationInTx(tx, {
+    seasonId,
+    actorId: "system",
+    now,
+  });
+  const [currentSeason] = await tx
+    .select()
+    .from(seasons)
+    .where(eq(seasons.id, seasonId));
+  return { season: currentSeason ?? season, opened: result.opened };
+}

--- a/tests/integration/db/major-start.test.ts
+++ b/tests/integration/db/major-start.test.ts
@@ -1253,7 +1253,7 @@ async function exerciseSelfRosterChangeDeadline(
   const representativeUserId = fixture.userIds[0]!;
   await pool.query("UPDATE seasons SET registration_opened_at = NULL WHERE id = $1", [fixture.seasonId]);
   await expect(database.transaction((tx) => requestCompetitionEntryRosterChangeInTx(tx, { entryId, representativeUserId, actorId: representativeUserId })))
-    .rejects.toMatchObject({ code: ErrorCode.REGISTRATION_CLOSED });
+    .rejects.toMatchObject({ code: ErrorCode.VALIDATION_FAILED });
   await pool.query("UPDATE seasons SET registration_opened_at = now() WHERE id = $1", [fixture.seasonId]);
   await database.transaction((tx) => requestCompetitionEntryRosterChangeInTx(tx, { entryId, representativeUserId, actorId: representativeUserId }));
   const origin = await pool.query<{ origin: string }>("SELECT r.origin::text AS origin FROM competition_entries e INNER JOIN competition_entry_roster_revisions r ON r.id = e.current_roster_revision_id WHERE e.id = $1", [entryId]);

--- a/tests/integration/db/migrations/conversion-policies.test.ts
+++ b/tests/integration/db/migrations/conversion-policies.test.ts
@@ -1,10 +1,11 @@
 import { Client } from "pg";
 import { describe, expect, it } from "vitest";
-import { verifyDatabaseAccessMatrix } from "../../../../scripts/db/access-matrix";
+import { DATABASE_ACCESS_MATRIX, verifyDatabaseAccessMatrix } from "../../../../scripts/db/access-matrix";
 import { capturePostgresError } from "../harness/database";
 import { migrationFiles, replayMigration, withScratchDatabase } from "../harness/migration-replay";
 
 const TARGET_MIGRATION = "0042_identity_foundation.sql";
+const ACCESS_MATRIX_AT_TARGET = DATABASE_ACCESS_MATRIX.filter((entry) => entry.table !== "scheduled_job_health");
 
 describe("conversion policies migration", () => {
   it("creates server-only conversion_policies table with RLS, denies anon/authenticated access, and seeds lead-approved 2026.09 policy", async () => {
@@ -14,7 +15,7 @@ describe("conversion policies migration", () => {
         await replayMigration(client, migration);
       }
 
-      await verifyDatabaseAccessMatrix(client, "0038 conversion policies replay");
+      await verifyDatabaseAccessMatrix(client, "0038 conversion policies replay", ACCESS_MATRIX_AT_TARGET);
 
       const table = await client.query<{ relrowsecurity: boolean }>(
         `SELECT relrowsecurity FROM pg_class

--- a/tests/unit/actions/scheduler.test.ts
+++ b/tests/unit/actions/scheduler.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  requireSuperAdminMock,
+  auditActorIdMock,
+  insertMock,
+  executeScheduledJobManuallyMock,
+  runSchedulerJobByKeyMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  requireSuperAdminMock: vi.fn(),
+  auditActorIdMock: vi.fn(),
+  insertMock: vi.fn(),
+  executeScheduledJobManuallyMock: vi.fn(),
+  runSchedulerJobByKeyMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireSuperAdmin: requireSuperAdminMock,
+  auditActorId: auditActorIdMock,
+}));
+vi.mock("@/db/client", () => ({ db: { insert: insertMock } }));
+vi.mock("@/db/schema", () => ({ auditLogs: {} }));
+vi.mock("@/lib/scheduler/execution", () => ({
+  executeScheduledJobManually: executeScheduledJobManuallyMock,
+}));
+vi.mock("@/lib/scheduler/runners", () => ({
+  runSchedulerJobByKey: runSchedulerJobByKeyMock,
+}));
+vi.mock("next/cache", () => ({ revalidatePath: revalidatePathMock }));
+
+import { runSchedulerJobManually } from "@/actions/scheduler";
+
+describe("manual scheduler action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireSuperAdminMock.mockResolvedValue({ userId: "admin-1", email: "admin@example.com", role: "super_admin", seasonIds: [] });
+    auditActorIdMock.mockReturnValue("admin-1");
+    insertMock.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+    runSchedulerJobByKeyMock.mockResolvedValue({ result: {}, businessTransitions: 2 });
+    executeScheduledJobManuallyMock.mockImplementation(async (jobKey: string, runner: () => Promise<unknown>) => {
+      await runner();
+      return { source: "super-admin-manual", skipped: false, businessTransitions: 2, jobKey };
+    });
+  });
+
+  it("requires super-admin, writes low-sensitivity audit, and runs the shared runner directly", async () => {
+    const result = await runSchedulerJobManually({ jobKey: "draft-timeout" });
+
+    expect(result).toEqual({ success: true, data: { jobKey: "draft-timeout", businessTransitions: 2 } });
+    expect(requireSuperAdminMock).toHaveBeenCalledOnce();
+    expect(insertMock).toHaveBeenCalledOnce();
+    const values = insertMock.mock.results[0]?.value.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values).toMatchObject({
+      action: "scheduler.manual_trigger",
+      actorId: "admin-1",
+      targetId: "draft-timeout",
+      targetType: "scheduler_job",
+      meta: { jobKey: "draft-timeout", force: true, source: "super-admin-manual" },
+    });
+    expect(executeScheduledJobManuallyMock).toHaveBeenCalledWith("draft-timeout", expect.any(Function));
+    expect(runSchedulerJobByKeyMock).toHaveBeenCalledWith("draft-timeout");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/admin/settings");
+  });
+});

--- a/tests/unit/app/admin-settings-page.test.tsx
+++ b/tests/unit/app/admin-settings-page.test.tsx
@@ -2,10 +2,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { resolveAdminPageAccessMock, requireSuperAdminMock, userFindFirstMock } = vi.hoisted(() => ({
+const { resolveAdminPageAccessMock, requireSuperAdminMock, userFindFirstMock, schedulerHealthMock } = vi.hoisted(() => ({
   resolveAdminPageAccessMock: vi.fn(),
   requireSuperAdminMock: vi.fn(),
   userFindFirstMock: vi.fn(),
+  schedulerHealthMock: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/admin-access", () => ({
@@ -17,6 +18,12 @@ vi.mock("@/lib/auth/session", () => ({
 vi.mock("@/db/client", () => ({
   db: { query: { users: { findFirst: userFindFirstMock } } },
 }));
+vi.mock("@/lib/scheduler/admin", () => ({
+  getSchedulerHealthView: schedulerHealthMock,
+}));
+vi.mock("@/components/admin/SchedulerHealthPanel", () => ({
+  SchedulerHealthPanel: () => React.createElement("div", null, "scheduler-health"),
+}));
 
 import AdminSettingsPage from "@/app/admin/settings/page";
 
@@ -24,6 +31,7 @@ describe("global system status access boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("React", React);
+    schedulerHealthMock.mockResolvedValue([]);
   });
 
   it("uses the super-admin authorization owner", async () => {

--- a/tests/unit/app/register-page.test.tsx
+++ b/tests/unit/app/register-page.test.tsx
@@ -11,6 +11,7 @@ const {
   getApprovedCountMock,
   getUserSessionMock,
   registrationFormMock,
+  registrationOpeningRecoveryMock,
   publicSeasonMock,
 } = vi.hoisted(() => ({
   seasonFindFirstMock: vi.fn(),
@@ -21,6 +22,7 @@ const {
   getApprovedCountMock: vi.fn(),
   getUserSessionMock: vi.fn(),
   registrationFormMock: vi.fn(() => null),
+  registrationOpeningRecoveryMock: vi.fn(() => null),
   publicSeasonMock: vi.fn(),
 }));
 
@@ -48,6 +50,9 @@ vi.mock("@/lib/data/public-seasons", () => ({
 
 vi.mock("@/components/register/RegistrationForm", () => ({
   RegistrationForm: registrationFormMock,
+}));
+vi.mock("@/components/register/RegistrationOpeningRecovery", () => ({
+  RegistrationOpeningRecovery: registrationOpeningRecoveryMock,
 }));
 
 import RegisterPage from "@/app/[seasonSlug]/register/page";
@@ -122,5 +127,27 @@ describe("team registration page", () => {
       gameplayStyle: "长期控图型",
       competitionHistory: "参加过校赛",
     }));
+  });
+
+  it("offers one-shot participant recovery when opening is due but not materialized", async () => {
+    publicSeasonMock.mockResolvedValue({
+      id: "season-1",
+      slug: "major",
+      name: "RivalHub Major",
+      status: "registration",
+      registrationMode: "solo",
+      registrationOpensAt: new Date("2026-09-09T04:00:00.000Z"),
+      registrationOpenedAt: null,
+      registrationClosesAt: new Date("2026-09-10T04:00:00.000Z"),
+      rosterChangeClosesAt: null,
+      registrationConfig: null,
+      positions: ["opener", "closer", "anchor"],
+    });
+    getUserSessionMock.mockResolvedValue({ userId: "user-1", email: "player@example.com" });
+
+    const page = await RegisterPage({ params: Promise.resolve({ seasonSlug: "major" }) });
+    renderToStaticMarkup(page);
+
+    expect(registrationOpeningRecoveryMock).toHaveBeenCalledWith({ seasonId: "season-1" }, undefined);
   });
 });

--- a/tests/unit/components/register/RegistrationForm.test.tsx
+++ b/tests/unit/components/register/RegistrationForm.test.tsx
@@ -37,6 +37,7 @@ const baseProps = {
     canViewForm: true,
     canSaveDraft: true,
     canSubmit: true,
+    needsOpeningRecovery: false,
     message: "报名提交已开放。",
   },
 };

--- a/tests/unit/db/access-matrix.test.ts
+++ b/tests/unit/db/access-matrix.test.ts
@@ -32,7 +32,11 @@ const identityMigration = readFileSync(
   join(root, "drizzle/migrations/0042_identity_foundation.sql"),
   "utf8",
 );
-const migration = `${terminalMigration}\n${restrictionOverrideMigration}\n${conversionPolicyMigration}\n${seedRecommendationSnapshotMigration}\n${identityMigration}`;
+const schedulerMigration = readFileSync(
+  join(root, "drizzle/migrations/0045_fresh_blue_blade.sql"),
+  "utf8",
+);
+const migration = `${terminalMigration}\n${restrictionOverrideMigration}\n${conversionPolicyMigration}\n${seedRecommendationSnapshotMigration}\n${identityMigration}\n${schedulerMigration}`;
 
 function expectedFacts(): DatabaseAccessFacts[] {
   return DATABASE_ACCESS_MATRIX.map((entry) => ({
@@ -48,13 +52,13 @@ function expectedFacts(): DatabaseAccessFacts[] {
 describe("database access matrix", () => {
   it("classifies every current public application table and keeps the generated document aligned", () => {
     const snapshot = JSON.parse(
-      readFileSync(join(root, "drizzle/migrations/meta/0042_snapshot.json"), "utf8"),
+      readFileSync(join(root, "drizzle/migrations/meta/0045_snapshot.json"), "utf8"),
     ) as { tables: Record<string, unknown> };
     const snapshotTables = Object.keys(snapshot.tables)
       .map((table) => table.replace(/^public\./, ""))
       .sort();
 
-    expect(DATABASE_ACCESS_MATRIX).toHaveLength(71);
+    expect(DATABASE_ACCESS_MATRIX).toHaveLength(72);
     expect(new Set(DATABASE_ACCESS_TABLES).size).toBe(DATABASE_ACCESS_TABLES.length);
     expect(snapshotTables).toEqual([...DATABASE_ACCESS_TABLES].sort());
     expect(renderDatabaseAccessMatrixMarkdown()).toBe(
@@ -86,6 +90,7 @@ describe("database access matrix", () => {
             "user_identities",
             "user_merge_authorizations",
             "user_merge_ledger",
+            "scheduled_job_health",
           ].includes(table),
         )
         .sort(),

--- a/tests/unit/db/scheduler-contract.test.ts
+++ b/tests/unit/db/scheduler-contract.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { dispatchCommand, validateBaseUrl } from "../../../scripts/db/scheduler";
+import { SCHEDULER_JOB_DEFINITIONS, schedulerJobName } from "../../../src/lib/scheduler/definitions";
+
+describe("production scheduler contract", () => {
+  it("validates a public HTTPS origin and rejects credentials or paths", () => {
+    expect(validateBaseUrl("https://match.starfie1d.top/")).toBe("https://match.starfie1d.top");
+    expect(() => validateBaseUrl("http://match.starfie1d.top")).toThrow();
+    expect(() => validateBaseUrl("https://user:pass@match.starfie1d.top")).toThrow();
+    expect(() => validateBaseUrl("https://match.starfie1d.top/api")).toThrow();
+  });
+
+  it("uses stable named jobs and DB dispatch commands derived from the registry", () => {
+    for (const definition of SCHEDULER_JOB_DEFINITIONS) {
+      expect(schedulerJobName(definition.key)).toBe(`rivalhub-${definition.key}`);
+      expect(dispatchCommand(definition)).toBe(
+        `SELECT public.dispatch_rivalhub_scheduler_job('${definition.key}');`,
+      );
+    }
+  });
+});

--- a/tests/unit/db/scheduler-migration.test.ts
+++ b/tests/unit/db/scheduler-migration.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  join(process.cwd(), "drizzle/migrations/0045_fresh_blue_blade.sql"),
+  "utf8",
+);
+
+describe("scheduler migration contract", () => {
+  it("keeps health and dispatch server-only", () => {
+    expect(migration).toContain('ALTER TABLE "scheduled_job_health" ENABLE ROW LEVEL SECURITY;');
+    expect(migration).toContain('REVOKE ALL PRIVILEGES ON TABLE "scheduled_job_health" FROM anon, authenticated;');
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION "public"."dispatch_rivalhub_scheduler_job"(job_key text)');
+    expect(migration).toContain("SECURITY DEFINER");
+    expect(migration).toContain('REVOKE ALL PRIVILEGES ON FUNCTION "public"."dispatch_rivalhub_scheduler_job"(text) FROM PUBLIC, anon, authenticated;');
+  });
+
+  it("delegates to Vault and pg_net without embedding the credential", () => {
+    expect(migration).toContain("rivalhub_scheduler_base_url");
+    expect(migration).toContain("rivalhub_cron_secret");
+    expect(migration).toContain("net.http_get");
+    expect(migration).toContain("X-RivalHub-Cron-Source");
+    expect(migration).not.toContain("CRON_SECRET :=");
+  });
+});

--- a/tests/unit/db/scheduler-migration.test.ts
+++ b/tests/unit/db/scheduler-migration.test.ts
@@ -21,6 +21,9 @@ describe("scheduler migration contract", () => {
     expect(migration).toContain("rivalhub_cron_secret");
     expect(migration).toContain("net.http_get");
     expect(migration).toContain("X-RivalHub-Cron-Source");
+    expect(migration).toContain("base_url || '/api/cron/' || job_key");
+    expect(migration).not.toContain("route_segment := CASE");
+    expect(migration).not.toContain("INSERT INTO \"scheduled_job_health\" (\"job_key\") VALUES");
     expect(migration).not.toContain("CRON_SECRET :=");
   });
 });

--- a/tests/unit/lib/observability/redact.test.ts
+++ b/tests/unit/lib/observability/redact.test.ts
@@ -40,13 +40,15 @@ describe("observability redaction", () => {
     const safe = sanitizeSafeContext({
       provider: "turnstile",
       count: 2,
+      jobKey: "draft-timeout",
+      source: "github-watchdog",
       password: "do-not-log",
       query: "select * from users where id = $1",
       raw: { educationCode: "private" },
       errorCodes: ["invalid-input-response"],
     });
 
-    expect(safe).toEqual({ provider: "turnstile", count: 2, errorCodes: ["invalid-input-response"] });
+    expect(safe).toEqual({ provider: "turnstile", count: 2, jobKey: "draft-timeout", source: "github-watchdog", errorCodes: ["invalid-input-response"] });
     expect(JSON.stringify(safe)).not.toContain("do-not-log");
     expect(JSON.stringify(safe)).not.toContain("educationCode");
   });

--- a/tests/unit/lib/registration-window.test.ts
+++ b/tests/unit/lib/registration-window.test.ts
@@ -87,6 +87,8 @@ describe("getRegistrationWindowState", () => {
 
     expect(state.phase).toBe("upcoming");
     expect(state.canSubmit).toBe(false);
+    expect(state.needsOpeningRecovery).toBe(true);
+    expect(state.message).toBe("报名正在开放，请稍候…");
   });
 });
 

--- a/tests/unit/lib/scheduler/definitions.test.ts
+++ b/tests/unit/lib/scheduler/definitions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  SCHEDULER_JOB_DEFINITIONS,
+  getSchedulerJobDefinition,
+  getSchedulerRoute,
+  isSchedulerSource,
+  schedulerJobName,
+} from "@/lib/scheduler/definitions";
+
+describe("scheduler definitions", () => {
+  it("keeps one provider-neutral registry with the Beijing cleanup schedule", () => {
+    expect(SCHEDULER_JOB_DEFINITIONS).toHaveLength(4);
+    expect(getSchedulerJobDefinition("cleanup-education-evidence")).toMatchObject({
+      primaryCron: "0 22 * * *",
+      staleAfterMs: 36 * 60 * 60 * 1000,
+    });
+    expect(getSchedulerRoute(SCHEDULER_JOB_DEFINITIONS[0]!)).toBe("/api/cron/draft-timeout");
+    expect(schedulerJobName("draft-timeout")).toBe("rivalhub-draft-timeout");
+  });
+
+  it("accepts only registered scheduler sources", () => {
+    expect(isSchedulerSource("supabase-primary")).toBe(true);
+    expect(isSchedulerSource("legacy")).toBe(true);
+    expect(isSchedulerSource("browser")).toBe(false);
+    expect(isSchedulerSource(null)).toBe(false);
+  });
+});

--- a/tests/unit/lib/scheduler/definitions.test.ts
+++ b/tests/unit/lib/scheduler/definitions.test.ts
@@ -14,7 +14,7 @@ describe("scheduler definitions", () => {
       primaryCron: "0 22 * * *",
       staleAfterMs: 36 * 60 * 60 * 1000,
     });
-    expect(getSchedulerRoute(SCHEDULER_JOB_DEFINITIONS[0]!)).toBe("/api/cron/draft-timeout");
+    expect(getSchedulerRoute(SCHEDULER_JOB_DEFINITIONS[0]!.key)).toBe("/api/cron/draft-timeout");
     expect(schedulerJobName("draft-timeout")).toBe("rivalhub-draft-timeout");
   });
 

--- a/tests/unit/lib/scheduler/execution.test.ts
+++ b/tests/unit/lib/scheduler/execution.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const healthMocks = vi.hoisted(() => ({
+  markBusinessTransition: vi.fn(),
+  markEndpointStarted: vi.fn(),
+  markJobFailed: vi.fn(),
+  markJobSucceeded: vi.fn(),
+  readSchedulerHealth: vi.fn(),
+}));
+
+vi.mock("@/lib/scheduler/health", () => healthMocks);
+vi.mock("@/lib/observability/server", () => ({
+  captureException: vi.fn(),
+  logEvent: vi.fn(),
+}));
+
+import { executeScheduledJob } from "@/lib/scheduler/execution";
+
+describe("scheduler execution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    healthMocks.markBusinessTransition.mockResolvedValue(undefined);
+    healthMocks.markEndpointStarted.mockResolvedValue(undefined);
+    healthMocks.markJobFailed.mockResolvedValue(undefined);
+    healthMocks.markJobSucceeded.mockResolvedValue(undefined);
+    healthMocks.readSchedulerHealth.mockResolvedValue(null);
+  });
+
+  it("runs a legacy request and records only positive business progress", async () => {
+    const runner = vi.fn().mockResolvedValue({ result: { processed: 0 }, businessTransitions: 0 });
+
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout"),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toMatchObject({ source: "legacy", skipped: false, businessTransitions: 0 });
+    expect(runner).toHaveBeenCalledOnce();
+    expect(healthMocks.markEndpointStarted).toHaveBeenCalledWith("draft-timeout", "legacy", expect.any(Date));
+    expect(healthMocks.markJobSucceeded).toHaveBeenCalledWith("draft-timeout", "legacy", expect.any(Date));
+    expect(healthMocks.markBusinessTransition).toHaveBeenCalledWith("draft-timeout", 0, expect.any(Date));
+  });
+
+  it("lets a watchdog no-op while the primary heartbeat is fresh", async () => {
+    healthMocks.readSchedulerHealth.mockResolvedValue({
+      lastPrimaryTriggeredAt: new Date(),
+    });
+    const runner = vi.fn();
+
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout", {
+        headers: { "x-rivalhub-cron-source": "github-watchdog" },
+      }),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toEqual({
+      source: "github-watchdog",
+      skipped: true,
+      skipReason: "primary_fresh",
+      businessTransitions: 0,
+    });
+    expect(runner).not.toHaveBeenCalled();
+    expect(healthMocks.markJobSucceeded).toHaveBeenCalledWith("draft-timeout", "github-watchdog", expect.any(Date));
+    expect(healthMocks.markEndpointStarted).not.toHaveBeenCalled();
+  });
+
+  it("reconciles when the primary heartbeat is stale", async () => {
+    healthMocks.readSchedulerHealth.mockResolvedValue({
+      lastPrimaryTriggeredAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    const runner = vi.fn().mockResolvedValue({ result: { picked: 1 }, businessTransitions: 1 });
+
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout", {
+        headers: { "x-rivalhub-cron-source": "github-watchdog" },
+      }),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toMatchObject({ source: "github-watchdog", skipped: false, businessTransitions: 1 });
+    expect(runner).toHaveBeenCalledOnce();
+    expect(healthMocks.markEndpointStarted).toHaveBeenCalledWith("draft-timeout", "github-watchdog", expect.any(Date));
+  });
+
+  it("always runs an explicit GitHub manual dispatch even when primary is fresh", async () => {
+    healthMocks.readSchedulerHealth.mockResolvedValue({
+      lastPrimaryTriggeredAt: new Date(),
+    });
+    const runner = vi.fn().mockResolvedValue({ result: { picked: 0 }, businessTransitions: 0 });
+
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout", {
+        headers: { "x-rivalhub-cron-source": "github-manual" },
+      }),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toMatchObject({ source: "github-manual", skipped: false });
+    expect(runner).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an unknown source without invoking the runner", async () => {
+    const runner = vi.fn();
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout", {
+        headers: { "x-rivalhub-cron-source": "browser" },
+      }),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(400);
+    expect(runner).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/scheduler/execution.test.ts
+++ b/tests/unit/lib/scheduler/execution.test.ts
@@ -5,6 +5,7 @@ const healthMocks = vi.hoisted(() => ({
   markEndpointStarted: vi.fn(),
   markJobFailed: vi.fn(),
   markJobSucceeded: vi.fn(),
+  isPrimaryHealthy: vi.fn(),
   readSchedulerHealth: vi.fn(),
 }));
 
@@ -23,6 +24,7 @@ describe("scheduler execution", () => {
     healthMocks.markEndpointStarted.mockResolvedValue(undefined);
     healthMocks.markJobFailed.mockResolvedValue(undefined);
     healthMocks.markJobSucceeded.mockResolvedValue(undefined);
+    healthMocks.isPrimaryHealthy.mockReturnValue(false);
     healthMocks.readSchedulerHealth.mockResolvedValue(null);
   });
 
@@ -43,8 +45,10 @@ describe("scheduler execution", () => {
   });
 
   it("lets a watchdog no-op while the primary heartbeat is fresh", async () => {
+    healthMocks.isPrimaryHealthy.mockReturnValue(true);
     healthMocks.readSchedulerHealth.mockResolvedValue({
       lastPrimaryTriggeredAt: new Date(),
+      lastPrimaryEndpointSucceededAt: new Date(),
     });
     const runner = vi.fn();
 
@@ -63,8 +67,27 @@ describe("scheduler execution", () => {
       businessTransitions: 0,
     });
     expect(runner).not.toHaveBeenCalled();
-    expect(healthMocks.markJobSucceeded).toHaveBeenCalledWith("draft-timeout", "github-watchdog", expect.any(Date));
+    expect(healthMocks.markJobSucceeded).not.toHaveBeenCalled();
     expect(healthMocks.markEndpointStarted).not.toHaveBeenCalled();
+  });
+
+  it("reconciles when the primary trigger is fresh but endpoint success is stale", async () => {
+    healthMocks.readSchedulerHealth.mockResolvedValue({
+      lastPrimaryTriggeredAt: new Date(),
+      lastPrimaryEndpointSucceededAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    const runner = vi.fn().mockResolvedValue({ result: { picked: 1 }, businessTransitions: 1 });
+
+    const result = await executeScheduledJob(
+      new Request("https://example.test/api/cron/draft-timeout", {
+        headers: { "x-rivalhub-cron-source": "github-watchdog" },
+      }),
+      "draft-timeout",
+      runner,
+    );
+
+    expect(result).toMatchObject({ source: "github-watchdog", skipped: false, businessTransitions: 1 });
+    expect(runner).toHaveBeenCalledOnce();
   });
 
   it("reconciles when the primary heartbeat is stale", async () => {
@@ -89,6 +112,7 @@ describe("scheduler execution", () => {
   it("always runs an explicit GitHub manual dispatch even when primary is fresh", async () => {
     healthMocks.readSchedulerHealth.mockResolvedValue({
       lastPrimaryTriggeredAt: new Date(),
+      lastPrimaryEndpointSucceededAt: new Date(),
     });
     const runner = vi.fn().mockResolvedValue({ result: { picked: 0 }, businessTransitions: 0 });
 

--- a/tests/unit/lib/scheduler/health.test.ts
+++ b/tests/unit/lib/scheduler/health.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { insertMock, captureExceptionMock, logEventMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  logEventMock: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: { insert: insertMock },
+}));
+vi.mock("@/db/schema", () => ({
+  scheduledJobHealth: { jobKey: "job_key" },
+}));
+vi.mock("@/lib/observability/server", () => ({
+  captureException: captureExceptionMock,
+  logEvent: logEventMock,
+}));
+
+import { markBusinessTransition, markJobFailed } from "@/lib/scheduler/health";
+
+describe("scheduler health projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("DATABASE_URL", "postgres://unit.test");
+    insertMock.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      }),
+    });
+  });
+
+  it("does not create a fake business transition for zero work", async () => {
+    await markBusinessTransition("draft-timeout", 0, new Date());
+
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("stores only a bounded failure classification, never raw exception text", async () => {
+    await markJobFailed(
+      "cleanup-education-evidence",
+      "supabase-primary",
+      new Error("Authorization: Bearer super-secret-token"),
+      new Date("2026-09-09T06:00:00.000Z"),
+    );
+
+    const values = insertMock.mock.results[0]?.value.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.lastFailureSource).toBe("supabase-primary");
+    expect(values.lastFailureCode).toBe("application");
+    expect(JSON.stringify(values)).not.toContain("super-secret-token");
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/scheduler/health.test.ts
+++ b/tests/unit/lib/scheduler/health.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/observability/server", () => ({
   logEvent: logEventMock,
 }));
 
-import { markBusinessTransition, markJobFailed } from "@/lib/scheduler/health";
+import { isPrimaryHealthy, markBusinessTransition, markJobFailed } from "@/lib/scheduler/health";
 
 describe("scheduler health projection", () => {
   beforeEach(() => {
@@ -28,6 +28,19 @@ describe("scheduler health projection", () => {
         onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
       }),
     });
+  });
+
+  it("requires both a fresh primary trigger and a fresh endpoint success", () => {
+    const definition = { staleAfterMs: 3 * 60 * 1000 };
+    const now = new Date("2026-09-09T06:00:00.000Z");
+    expect(isPrimaryHealthy({
+      lastPrimaryTriggeredAt: new Date("2026-09-09T05:59:00.000Z"),
+      lastPrimaryEndpointSucceededAt: new Date("2026-09-09T05:59:30.000Z"),
+    }, definition, now)).toBe(true);
+    expect(isPrimaryHealthy({
+      lastPrimaryTriggeredAt: new Date("2026-09-09T05:59:00.000Z"),
+      lastPrimaryEndpointSucceededAt: new Date("2026-09-09T05:55:00.000Z"),
+    }, definition, now)).toBe(false);
   });
 
   it("does not create a fake business transition for zero work", async () => {

--- a/tests/unit/lib/seasons/registration-recovery.test.ts
+++ b/tests/unit/lib/seasons/registration-recovery.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { eqMock, openSeasonRegistrationInTxMock } = vi.hoisted(() => ({
+  eqMock: vi.fn(() => "season-filter"),
+  openSeasonRegistrationInTxMock: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: eqMock }));
+vi.mock("@/db/schema", () => ({ seasons: { id: "seasons.id" } }));
+vi.mock("@/lib/seasons/lifecycle", () => ({
+  openSeasonRegistrationInTx: openSeasonRegistrationInTxMock,
+}));
+
+import { ensureRegistrationOpenForParticipantInTx } from "@/lib/seasons/registration-recovery";
+
+function txWithRows(...rows: unknown[]) {
+  const selectMock = vi.fn();
+  rows.forEach((row, index) => {
+    const query = index === 0
+      ? {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          for: vi.fn().mockResolvedValue(row ? [row] : []),
+        }
+      : {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockResolvedValue(row ? [row] : []),
+        };
+    selectMock.mockReturnValueOnce(query);
+  });
+  return { select: selectMock };
+}
+
+const baseSeason = {
+  id: "season-1",
+  status: "registration",
+  registrationOpensAt: new Date("2026-09-09T05:00:00.000Z"),
+  registrationOpenedAt: null,
+  registrationClosesAt: null,
+};
+
+describe("registration opening recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not open before the scheduled time", async () => {
+    const tx = txWithRows(baseSeason);
+
+    const result = await ensureRegistrationOpenForParticipantInTx(
+      tx as never,
+      baseSeason.id,
+      new Date("2026-09-09T04:59:59.000Z"),
+    );
+
+    expect(result).toEqual({ season: baseSeason, opened: false });
+    expect(openSeasonRegistrationInTxMock).not.toHaveBeenCalled();
+  });
+
+  it("opens a due season inside the caller transaction and rereads the fact", async () => {
+    const openedSeason = { ...baseSeason, registrationOpenedAt: new Date("2026-09-09T05:00:00.000Z") };
+    const tx = txWithRows(baseSeason, openedSeason);
+    openSeasonRegistrationInTxMock.mockResolvedValue({ opened: true });
+
+    const result = await ensureRegistrationOpenForParticipantInTx(
+      tx as never,
+      baseSeason.id,
+      new Date("2026-09-09T05:00:00.000Z"),
+    );
+
+    expect(openSeasonRegistrationInTxMock).toHaveBeenCalledWith(tx, {
+      seasonId: baseSeason.id,
+      actorId: "system",
+      now: new Date("2026-09-09T05:00:00.000Z"),
+    });
+    expect(result).toEqual({ season: openedSeason, opened: true });
+  });
+
+  it("fails closed after the registration deadline", async () => {
+    const season = {
+      ...baseSeason,
+      registrationClosesAt: new Date("2026-09-09T04:00:00.000Z"),
+    };
+    const tx = txWithRows(season);
+
+    const result = await ensureRegistrationOpenForParticipantInTx(
+      tx as never,
+      season.id,
+      new Date("2026-09-09T05:00:00.000Z"),
+    );
+
+    expect(result).toEqual({ season, opened: false });
+    expect(openSeasonRegistrationInTxMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -154,18 +154,18 @@ describe("deployment and operations contracts", () => {
 
   it("runs each production Cron endpoint independently with bounded retries", () => {
     const workflow = readProjectFile(".github/workflows/cron.yml");
-    const paths = [
-      "/api/cron/draft-timeout",
-      "/api/cron/check-registration-deadline",
-      "/api/cron/match-time-auto-award",
-      "/api/cron/cleanup-education-evidence",
+    const jobKeys = [
+      "draft-timeout",
+      "check-registration-deadline",
+      "match-time-auto-award",
+      "cleanup-education-evidence",
     ];
 
     expect(workflow).toContain("fail-fast: false");
     expect(workflow).toContain("timeout-minutes: 5");
     expect(workflow).toContain("matrix:");
-    for (const path of paths) expect(workflow).toContain(`path: ${path}`);
-    expect((workflow.match(/path: \/api\/cron\//g) ?? [])).toHaveLength(4);
+    for (const jobKey of jobKeys) expect(workflow).toContain(`- job_key: ${jobKey}`);
+    expect(workflow).toContain("/api/cron/${CRON_JOB_KEY}");
     expect(workflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
     expect(workflow).toContain('Authorization: Bearer ${CRON_SECRET}');
     expect(workflow).toContain("--fail");
@@ -179,5 +179,16 @@ describe("deployment and operations contracts", () => {
     expect(workflow).toContain("--retry-max-time 180");
     expect(workflow).not.toContain("continue-on-error");
     expect(workflow).not.toContain("|| true");
+  });
+
+  it("provisions the primary scheduler only after production smoke", () => {
+    const release = readProjectFile(".github/workflows/release.yml");
+
+    expect(release).toContain("Provision and verify production scheduler");
+    expect(release).toContain("RIVALHUB_SCHEDULER_BASE_URL: https://match.starfie1d.top");
+    expect(release).toContain("RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision");
+    expect(release).toContain("pnpm db:production:scheduler:verify");
+    expect(release.indexOf("Smoke test production deployment")).toBeLessThan(release.indexOf("Provision and verify production scheduler"));
+    expect(release.indexOf("Provision and verify production scheduler")).toBeLessThan(release.indexOf("Extract changelog for this version"));
   });
 });


### PR DESCRIPTION
## Summary

- 新增 Supabase pg_cron + pg_net primary scheduler、稳定 registry、健康投影与 GitHub watchdog/manual fallback。
- 让报名开放 recovery 与报名/队伍写入复用 canonical transaction owner，避免调度漂移留下不可用窗口。
- 增加 super-admin break-glass、生产 scheduler provision/verify、迁移、文档与 contract/unit tests。
- 教育凭证清理保持北京时间每日 06:00，生产 UTC cron 为 `0 22 * * *`。

## Validation

- `pnpm test`
- `pnpm type-check:app`
- `pnpm type-check:tests`
- `pnpm type-check:scripts`
- `pnpm lint`
- `pnpm db:check`
- `pnpm db:release-compat`
- `pnpm knip --production --reporter compact`
- `env -u DATABASE_URL pnpm build`

Refs #531