### PR TITLE
fix(ops): 固化 production release identity bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,16 @@ jobs:
           curl --fail --silent --show-error \
             --retry 8 --retry-all-errors --retry-delay 5 \
             "https://match.starfie1d.top/" >/dev/null
+          for BASE_URL in "$DEPLOYMENT_URL" "https://match.starfie1d.top"; do
+            identity="$(curl --fail --silent --show-error \
+              --retry 8 --retry-all-errors --retry-delay 5 \
+              "$BASE_URL/api/system/release")"
+            jq -e --arg tag "$RELEASE_TAG" --arg commit "$RELEASE_SHA" '
+              (keys | sort) == ["releaseCommit", "releaseTag"]
+              and .releaseTag == $tag
+              and .releaseCommit == $commit
+            ' <<<"$identity" >/dev/null
+          done
 
       - name: Provision and verify production scheduler
         env:

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,13 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   serverExternalPackages: ["pg"],
   typedRoutes: true,
+  // The release endpoint is public, but the identity must be frozen into the
+  // exact Vercel build because --build-env is not a runtime environment
+  // contract. Missing markers remain invalid and make the endpoint fail closed.
+  env: {
+    RIVALHUB_RELEASE_TAG: process.env.RIVALHUB_RELEASE_TAG ?? "",
+    RIVALHUB_RELEASE_COMMIT: process.env.RIVALHUB_RELEASE_COMMIT ?? "",
+  },
   typescript: {
     ignoreBuildErrors: true,
     tsconfigPath: "tsconfig.app.json",

--- a/scripts/release/production-deployment.ts
+++ b/scripts/release/production-deployment.ts
@@ -1,6 +1,6 @@
-export type ReleaseEnvironment = Readonly<Record<string, string | undefined>>;
+import { RELEASE_TAG_PATTERN } from "../../src/lib/release/identity";
 
-const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+export type ReleaseEnvironment = Readonly<Record<string, string | undefined>>;
 
 /**
  * Production Vercel builds are release-only. The repository disables main's

--- a/src/app/api/system/release/route.ts
+++ b/src/app/api/system/release/route.ts
@@ -1,0 +1,20 @@
+import { assertReleaseIdentity } from "@/lib/release/identity";
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "private, no-cache, no-store, max-age=0, must-revalidate",
+};
+
+export function GET(): Response {
+  try {
+    const identity = assertReleaseIdentity({
+      releaseTag: process.env.RIVALHUB_RELEASE_TAG,
+      releaseCommit: process.env.RIVALHUB_RELEASE_COMMIT,
+    }, "production release identity");
+    return Response.json(identity, { headers: NO_STORE_HEADERS });
+  } catch {
+    return Response.json(
+      { error: "Production release identity unavailable." },
+      { status: 503, headers: NO_STORE_HEADERS },
+    );
+  }
+}

--- a/src/lib/release/identity.ts
+++ b/src/lib/release/identity.ts
@@ -1,0 +1,29 @@
+export const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export interface ReleaseIdentity {
+  releaseTag: string;
+  releaseCommit: string;
+}
+
+export function assertReleaseIdentity(value: unknown, label = "release identity"): ReleaseIdentity {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} 必须是 object。`);
+  }
+
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length !== 2 || keys[0] !== "releaseCommit" || keys[1] !== "releaseTag") {
+    throw new Error(`${label} 只能包含 releaseTag 与 releaseCommit。`);
+  }
+
+  const releaseTag = record.releaseTag;
+  const releaseCommit = record.releaseCommit;
+  if (typeof releaseTag !== "string" || !RELEASE_TAG_PATTERN.test(releaseTag)) {
+    throw new Error(`${label} releaseTag 无效。`);
+  }
+  if (typeof releaseCommit !== "string" || !/^[0-9a-f]{40}$/i.test(releaseCommit)) {
+    throw new Error(`${label} releaseCommit 无效。`);
+  }
+
+  return { releaseTag, releaseCommit: releaseCommit.toLowerCase() };
+}

--- a/tests/unit/api/system-release-route.test.ts
+++ b/tests/unit/api/system-release-route.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "../../../src/app/api/system/release/route";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("GET /api/system/release", () => {
+  it("returns only the immutable release identity with no-store headers", async () => {
+    vi.stubEnv("RIVALHUB_RELEASE_TAG", "v2.7.8");
+    vi.stubEnv("RIVALHUB_RELEASE_COMMIT", "ABCDEF0123456789ABCDEF0123456789ABCDEF01");
+
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(await response.json()).toEqual({
+      releaseTag: "v2.7.8",
+      releaseCommit: "abcdef0123456789abcdef0123456789abcdef01",
+    });
+  });
+
+  it("fails closed without exposing build environment values", async () => {
+    vi.stubEnv("RIVALHUB_RELEASE_TAG", undefined);
+    vi.stubEnv("RIVALHUB_RELEASE_COMMIT", "not-a-sha");
+
+    const response = GET();
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "Production release identity unavailable." });
+  });
+
+  it("rejects a malformed production identity instead of serving partial data", async () => {
+    vi.stubEnv("RIVALHUB_RELEASE_TAG", "main");
+    vi.stubEnv("RIVALHUB_RELEASE_COMMIT", "0123456789abcdef0123456789abcdef01234567");
+
+    const response = GET();
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "Production release identity unavailable." });
+  });
+});

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -79,6 +79,18 @@ describe("deployment and operations contracts", () => {
     expect(readWorkflowJob(ci, "dependency-review")).not.toContain("pnpm/setup");
   });
 
+  it("freezes the exact release identity into Vercel builds and reads it back after deploy", () => {
+    const release = readProjectFile(".github/workflows/release.yml");
+    const nextConfig = readProjectFile("next.config.ts");
+
+    expect(release).toContain('--build-env RIVALHUB_RELEASE_TAG="$RELEASE_TAG"');
+    expect(release).toContain('--build-env RIVALHUB_RELEASE_COMMIT="$RELEASE_SHA"');
+    expect(release).toContain("$BASE_URL/api/system/release");
+    expect(release).toContain('(keys | sort) == ["releaseCommit", "releaseTag"]');
+    expect(nextConfig).toContain('RIVALHUB_RELEASE_TAG: process.env.RIVALHUB_RELEASE_TAG ?? ""');
+    expect(nextConfig).toContain('RIVALHUB_RELEASE_COMMIT: process.env.RIVALHUB_RELEASE_COMMIT ?? ""');
+  });
+
   it("uses main as the sole long-lived CI ref", () => {
     const ci = readProjectFile(".github/workflows/ci.yml");
 


### PR DESCRIPTION
## 摘要

为首次 production 上线提供最小 release identity bootstrap，使发布后的 endpoint read-back 不依赖后续灾备能力。

## 本 PR 仅包含

- 共享 `release identity` helper 与 fail-closed `/api/system/release`；
- 将 `RIVALHUB_RELEASE_TAG` / `RIVALHUB_RELEASE_COMMIT` 固化进 exact Vercel build；
- Vercel production guard 复用共享 tag 校验；
- 对应 route/runtime tests；
- release 后对 deployment URL 与 canonical domain 的 identity smoke read-back。

## 明确不包含

- recovery workflow；
- R2、备份/恢复脚本；
- pre-release backup hard gate。

这些内容继续留在 #577，待本 bootstrap PR 完成首次发布后再处理。#559 不在本 PR 范围内。

## 验证

- 16/16 定向 Vitest tests；
- `pnpm type-check:app`、`pnpm type-check:tests`、`pnpm type-check:scripts`；
- `pnpm lint`、`pnpm architecture:check`；
- 带 release markers 的 `pnpm build`，并确认生成的 endpoint artifact 包含 exact tag/commit。

Refs #577