### PR TITLE
release: 发布 v2.8.0

### DIFF
--- a/.changeset/page-layout-ownership.md
+++ b/.changeset/page-layout-ownership.md
@@ -1,5 +1,0 @@
----
-"rivalhub": patch
----
-
-统一全站页面宽度与 gutter 的 ownership，修复赛事后台报名审核和公开比赛详情被旧式 page shell 锁窄的问题，并让页面的空态、加载态与错误态保持一致布局。

--- a/.changeset/stage-runtime-convergence.md
+++ b/.changeset/stage-runtime-convergence.md
@@ -1,5 +1,0 @@
----
-"rivalhub": minor
----
-
-收口多阶段赛事的运行时归属：通用 bracket 按阶段隔离并保留稳定参赛身份，Major Swiss 改由 StageRun 与官方比赛事实投影，管理员和公开赛程页面共享阶段化 read model。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [2.8.0]
+
+### Changed
+
+#### 多阶段赛事运行时
+
+多阶段赛事的运行时归属完成收口。通用赛事的淘汰赛与循环赛状态现在按具体阶段独立管理，参赛队使用稳定的赛事身份关联，不再依赖队名或第三方内部编号。
+
+Major Swiss 的排名、轮次与晋级展示统一由 StageRun、阶段参赛队和正式比赛事实生成；公开赛程与管理后台共享同一套阶段化数据模型。阶段推进也统一经过赛事运行时，不再依赖页面中的独立“生成正赛”或手工同步入口。
+
+本版本保留旧赛事运行时数据结构作为兼容壳，不删除历史数据；后续版本将在生产稳定验证后完成最终清理。
+
+#### 全站页面布局
+
+统一全站页面宽度、水平留白和基础页面间距的管理方式，修复赛事后台报名审核、比赛详情等页面被旧式页面容器异常锁窄的问题。
+
+页面正常态、加载态、错误态和空态现在使用一致的布局规则，并改善桌面端与移动端的页面宽度一致性。
+
+### Added
+
+#### Production 发布身份校验
+
+Production 部署现在提供可验证的 release identity。每次正式发布会将不可变的版本 Tag 与 Commit 固化进部署产物，并在发布完成时同时从实际部署地址和正式域名读回校验。
+
+这为后续 production 灾难恢复、备份来源确认和发布前保护机制提供可信的线上版本基准。
+
 ## [2.7.8]
 
 ### Fixed
@@ -2005,6 +2031,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.8...v2.8.0
 [2.7.8]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.7...v2.7.8
 [2.7.7]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.5...v2.7.6

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -38,12 +38,12 @@ validate tag belongs to main
 → validate previous-release compatibility
 → migrate + verify production database
 → deploy exact tag commit to Vercel Production
-→ smoke deployment + canonical production domain
+→ smoke deployment + canonical production domain，并从两者读回 exact release identity
 → provision + verify Supabase scheduler and protected Vault names
 → publish/update GitHub Release notes
 ```
 
-Production secret、target confirmation 和 remote-write authorization 只存在于受保护 production environment / canonical wrappers 中。Scheduler provisioning 使用 `RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision`，通过 pg_cron named schedule upsert 幂等收敛 `rivalhub-<job-key>` jobs，随后运行 verify。Verify 会确认 pg_cron/pg_net、UTC schedule、dispatch command 与 Vault secret name，实际 dispatch 每个 registry job，并在有界窗口内等待 fresh primary trigger、endpoint success 与分钟级 cron success；任一失败都阻止发布 GitHub Release，且全程不输出 secret。
+Production secret、target confirmation 和 remote-write authorization 只存在于受保护 production environment / canonical wrappers 中。deployment URL 与 canonical production domain 都必须通过 `/api/system/release` 返回仅含 `releaseTag` 和 `releaseCommit` 的 identity，且分别精确等于当前 immutable tag 与该 tag commit；任一读回失败都阻止后续发布。Scheduler provisioning 使用 `RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision`，通过 pg_cron named schedule upsert 幂等收敛 `rivalhub-<job-key>` jobs，随后运行 verify。Verify 会确认 pg_cron/pg_net、UTC schedule、dispatch command 与 Vault secret name，实际 dispatch 每个 registry job，并在有界窗口内等待 fresh primary trigger、endpoint success 与分钟级 cron success；任一失败都阻止发布 GitHub Release，且全程不输出 secret。
 
 ## 4. 失败与重试
 
@@ -55,7 +55,7 @@ Production secret、target confirmation 和 remote-write authorization 只存在
 
 只有以下条件都成立才算完成：
 
-- production smoke 通过；
+- production smoke 通过，且 deployment URL 与 canonical production domain 的 `/api/system/release` 均精确读回该 immutable tag 与 tag commit；
 - production scheduler provision/verify 通过，且 primary named jobs、真实 dispatch、endpoint success 与分钟级 cron execution 已读回；
 - GitHub Release 已发布且 notes 正确；
 - tag、release commit 与 production deployment 对齐；

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.7.8",
+  "version": "2.8.0",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
发布 v2.8.0：消费 #575 与 #580 的已批准 Changesets，按正式 release-note 结构整理 CHANGELOG，并补入 #581 的 production release identity。同步 canonical release SOP，使 deployment URL 与正式域名的 exact tag/commit read-back 成为明确完成条件。#576 为内部工程维护，不写入面向用户的 Release Notes。