### PR TITLE
fix(release): 修复 v2.8.1 历史迁移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.8.1]
+
+### Fixed
+
+#### 2026 Rivals 历史淘汰赛迁移
+
+修复历史淘汰赛状态迁移在 PostgreSQL 上无法执行的问题。阶段范围的对阵状态现在会安全回填到对应的 2026 Rivals 比赛身份，旧状态保留为兼容壳。
+
 ## [2.8.0]
 
 ### Changed
@@ -2031,6 +2039,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.8.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.8...v2.8.0
 [2.7.8]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.7...v2.7.8
 [2.7.7]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.6...v2.7.7

--- a/drizzle/migrations/0048_same_epoch.sql
+++ b/drizzle/migrations/0048_same_epoch.sql
@@ -48,6 +48,7 @@ DECLARE
   candidate_count bigint;
   candidate_entry uuid;
   participant_count bigint;
+  mapping_count bigint;
   mapping jsonb := '{}'::jsonb;
 BEGIN
   SELECT "id" INTO rivals_id FROM "seasons" WHERE "slug" = '2026-nju-rivals';
@@ -129,7 +130,8 @@ BEGIN
     mapping := mapping || jsonb_build_object(participant_id::text, candidate_entry::text);
   END LOOP;
 
-  IF participant_count <> jsonb_object_length(mapping) THEN
+  SELECT count(*) INTO mapping_count FROM jsonb_object_keys(mapping);
+  IF participant_count <> mapping_count THEN
     RAISE EXCEPTION '2026 Rivals participant metadata backfill is incomplete';
   END IF;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/tests/integration/db/migrations/competition-stage-bracket-backfill.test.ts
+++ b/tests/integration/db/migrations/competition-stage-bracket-backfill.test.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { describe, expect, it } from "vitest";
+import { migrationFiles, replayMigration, withScratchDatabase } from "../harness/migration-replay";
+
+const TARGET_MIGRATION = "0048_same_epoch.sql";
+const HISTORICAL_PARTICIPANTS = Array.from({ length: 8 }, (_, index) => ({
+  id: index + 1,
+  name: `Historical entrant ${index + 1}`,
+}));
+const HISTORICAL_MATCHUPS: ReadonlyArray<readonly [number, number]> = [
+  [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7], [7, 8], [8, 1],
+  [1, 3], [2, 4], [3, 5], [4, 6], [5, 7], [6, 8],
+];
+
+async function replayBeforeTarget(client: Client): Promise<void> {
+  for (const migration of migrationFiles((name) => name.endsWith(".sql") && name < TARGET_MIGRATION)) {
+    await replayMigration(client, migration);
+  }
+}
+
+describe("2026 Rivals stage-scoped bracket backfill", () => {
+  it("migrates the complete historical playoff fixture into the stage owner", async () => {
+    await withScratchDatabase("rivalhub_0048_rivals_backfill", async (client) => {
+      await replayBeforeTarget(client);
+
+      const seasonId = randomUUID();
+      const userIds = HISTORICAL_PARTICIPANTS.map(() => randomUUID());
+      const entryIds = HISTORICAL_PARTICIPANTS.map(() => randomUUID());
+      const revisionIds = HISTORICAL_PARTICIPANTS.map(() => randomUUID());
+      const updatedAt = "2026-09-09T12:00:00.000Z";
+      const sourceData = {
+        stage: [],
+        match: HISTORICAL_MATCHUPS.map(([opponent1, opponent2], index) => ({
+          id: `historical-playoff-${index + 1}`,
+          opponent1: { id: opponent1 },
+          opponent2: { id: opponent2 },
+        })),
+        match_game: [],
+        participant: HISTORICAL_PARTICIPANTS,
+        group: [],
+        round: [],
+      };
+
+      await client.query("BEGIN");
+      try {
+        await client.query(
+          "INSERT INTO seasons (id, slug, name, kind, status) VALUES ($1, '2026-nju-rivals', 'NJU Rivals 2026', 'Rivals', 'finished')",
+          [seasonId],
+        );
+
+        for (const [index, participant] of HISTORICAL_PARTICIPANTS.entries()) {
+          await client.query("INSERT INTO users (id, email) VALUES ($1, $2)", [
+            userIds[index],
+            `historical-rivals-${participant.id}@local.test`,
+          ]);
+          await client.query(
+            `INSERT INTO competition_entries (
+               id, competition_id, source, name, representative_user_id,
+               current_roster_revision_id, approved_roster_revision_id, registration_status
+             ) VALUES ($1, $2, 'event_native', $3, $4, $5, $5, 'approved')`,
+            [entryIds[index], seasonId, participant.name, userIds[index], revisionIds[index]],
+          );
+          await client.query(
+            `INSERT INTO competition_entry_representative_changes (entry_id, from_user_id, to_user_id, changed_by_actor_id)
+             VALUES ($1, NULL, $2, '0048-backfill-test')`,
+            [entryIds[index], userIds[index]],
+          );
+          await client.query(
+            `INSERT INTO competition_entry_roster_revisions (id, entry_id, revision_number, status, created_by, approved_at)
+             VALUES ($1, $2, 1, 'approved', '0048-backfill-test', now())`,
+            [revisionIds[index], entryIds[index]],
+          );
+        }
+
+        for (const [index, [opponent1, opponent2]] of HISTORICAL_MATCHUPS.entries()) {
+          await client.query(
+            `INSERT INTO matches (id, season_id, entry_a_id, entry_b_id, stage, bracket_node_id)
+             VALUES ($1, $2, $3, $4, 'playoff', $5)`,
+            [randomUUID(), seasonId, entryIds[opponent1 - 1], entryIds[opponent2 - 1], `historical-playoff-${index + 1}`],
+          );
+        }
+
+        await client.query(
+          "INSERT INTO competition_bracket_states (competition_id, data, updated_at) VALUES ($1, $2::jsonb, $3)",
+          [seasonId, JSON.stringify(sourceData), updatedAt],
+        );
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      }
+
+      await replayMigration(client, TARGET_MIGRATION);
+
+      const stageState = await client.query<{ competition_id: string; stage_key: string; data: unknown; updated_at: Date }>(
+        "SELECT competition_id, stage_key, data, updated_at FROM competition_stage_bracket_states",
+      );
+      expect(stageState.rows).toHaveLength(1);
+      expect(stageState.rows[0]?.competition_id).toBe(seasonId);
+      expect(stageState.rows[0]?.stage_key).toBe("playoff");
+      expect(stageState.rows[0]?.updated_at.toISOString()).toBe(updatedAt);
+      expect(stageState.rows[0]?.data).toEqual({
+        ...sourceData,
+        participant: HISTORICAL_PARTICIPANTS.map((participant) => ({
+          ...participant,
+          rivalhubEntryId: entryIds[participant.id - 1],
+        })),
+      });
+
+      const legacyState = await client.query<{ data: unknown }>(
+        "SELECT data FROM competition_bracket_states WHERE competition_id = $1",
+        [seasonId],
+      );
+      expect(legacyState.rows[0]?.data).toEqual(sourceData);
+    });
+  });
+});


### PR DESCRIPTION
## 摘要

- 修复尚未进入 production ledger 的 `0048_same_epoch`：以 PostgreSQL 原生对象键枚举完成回填完整性检查。
- 新增真实 PostgreSQL 回归 fixture，构造 2026 Rivals 的 14 个 playoff provider 节点与稳定赛事参赛身份，并验证进入历史回填分支后的新旧状态。
- 准备 v2.8.1 patch release、CHANGELOG 与 compare 链接。

## Production 边界

- `v2.8.0` 保持原有 immutable tag；不移动、不重打。
- 未手工修改 production schema 或 migration ledger；受保护 release workflow 将推进唯一的 active migration path。

## 已验证

- `pnpm type-check`
- `pnpm lint`
- `pnpm db:check`
- `pnpm db:release-compat`
- `pnpm exec vitest run --project unit-server-node tests/unit/db/access-matrix.test.ts tests/unit/db/migration-risk.test.ts`

PostgreSQL fixture replay 由 Ready PR 的 FULL postgres CI lane 执行。