### PR TITLE
fix(release): 修复受保护部署 smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,17 +113,17 @@ jobs:
       - name: Smoke test production deployment
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          curl --fail --silent --show-error \
-            --retry 8 --retry-all-errors --retry-delay 5 \
-            "$DEPLOYMENT_URL/" >/dev/null
+          vercel curl / --deployment "$DEPLOYMENT_URL" >/dev/null
           curl --fail --silent --show-error \
             --retry 8 --retry-all-errors --retry-delay 5 \
             "https://match.starfie1d.top/" >/dev/null
-          for BASE_URL in "$DEPLOYMENT_URL" "https://match.starfie1d.top"; do
-            identity="$(curl --fail --silent --show-error \
-              --retry 8 --retry-all-errors --retry-delay 5 \
-              "$BASE_URL/api/system/release")"
+          deployment_identity="$(vercel curl /api/system/release --deployment "$DEPLOYMENT_URL")"
+          canonical_identity="$(curl --fail --silent --show-error \
+            --retry 8 --retry-all-errors --retry-delay 5 \
+            "https://match.starfie1d.top/api/system/release")"
+          for identity in "$deployment_identity" "$canonical_identity"; do
             jq -e --arg tag "$RELEASE_TAG" --arg commit "$RELEASE_SHA" '
               (keys | sort) == ["releaseCommit", "releaseTag"]
               and .releaseTag == $tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.8.2]
+
+### Fixed
+
+#### Production 发布身份校验
+
+修复启用 deployment protection 的 Vercel Production 部署无法完成精确发布身份读回的问题。发布流程现在通过受保护的 Vercel CLI 通道校验部署地址，同时保留正式域名的独立校验。
+
 ## [2.8.1]
 
 ### Fixed
@@ -2039,6 +2047,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.8.2]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.8...v2.8.0
 [2.7.8]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.7...v2.7.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -85,7 +85,8 @@ describe("deployment and operations contracts", () => {
 
     expect(release).toContain('--build-env RIVALHUB_RELEASE_TAG="$RELEASE_TAG"');
     expect(release).toContain('--build-env RIVALHUB_RELEASE_COMMIT="$RELEASE_SHA"');
-    expect(release).toContain("$BASE_URL/api/system/release");
+    expect(release).toContain('vercel curl /api/system/release --deployment "$DEPLOYMENT_URL"');
+    expect(release).toContain("https://match.starfie1d.top/api/system/release");
     expect(release).toContain('(keys | sort) == ["releaseCommit", "releaseTag"]');
     expect(nextConfig).toContain('RIVALHUB_RELEASE_TAG: process.env.RIVALHUB_RELEASE_TAG ?? ""');
     expect(nextConfig).toContain('RIVALHUB_RELEASE_COMMIT: process.env.RIVALHUB_RELEASE_COMMIT ?? ""');


### PR DESCRIPTION
## 摘要

- 通过 Vercel CLI 的受保护访问通道读取 exact deployment identity。
- 保留 canonical domain 的独立 HTTP identity 校验。
- 准备 v2.8.2 patch release 与 compare 链接。

## 边界

- 不关闭或降低 Vercel deployment protection。
- 不修改 production schema、migration ledger 或 `v2.8.0` / `v2.8.1` immutable tags。

## 已验证

- `pnpm type-check`
- `pnpm lint`
- `pnpm db:check`
- `pnpm exec vitest run --project unit-server-node tests/unit/release/runtime-contract.test.ts`