### PR TITLE
release: v2.8.3

### DIFF
--- a/.changeset/recovery-capability.md
+++ b/.changeset/recovery-capability.md
@@ -1,5 +1,0 @@
----
-"rivalhub": patch
----
-
-补齐 production 灾难恢复备份（Session Pooler :5432 独立连接与 read-only 契约）、R2 内容 read-back 与私有访问校验、migrations-first 隔离恢复通用 pre-import 清理与 replica 批量导入语义、Auth 恢复不变式、release 与备份串行化并发契约，以及 pre-release backup hard gate，为 destructive migration 提供发布前 backup 保护。

--- a/.changeset/stage-runtime-contract-cleanup.md
+++ b/.changeset/stage-runtime-contract-cleanup.md
@@ -1,5 +1,0 @@
----
-"rivalhub": patch
----
-
-删除 Release N 兼容保留的旧 bracket 与 Swiss schema owner，并在后续 migration 中完成 legacy relation 的物理清理。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.8.3]
+
+### Added
+
+#### Production 灾难恢复与发布前备份保护
+
+建立生产灾难恢复备份与验证契约。生产备份使用独立 Session Pooler 端口与只读契约执行导出，备份快照接入 Cloudflare R2 私有存储，并在写入后执行内容哈希回读验证。
+
+正式发布流程接入发布前备份硬门禁，并在工作流并发层面与生产发布串行化，防止发布迁移与定时备份产生竞态。隔离恢复支持 migrations-first 通用数据预清理与 replica 批量导入语义，并在恢复验证中强制校验用户身份关联完整性。
+
+生产灾备完整演练（离线私钥解密与隔离目标恢复验收）仍需后续具备真实环境时完成验证。
+
+### Changed
+
+#### 赛事阶段历史运行时数据清理
+
+移除上个版本作为兼容保留的旧版淘汰赛与瑞士轮表结构（`competition_bracket_states` 及 `swiss_standings`），并在数据库迁移中清理旧有关联。多阶段赛事的运行时状态完全统一由 StageRun 体系独立管理。
+
 ## [2.8.2]
 
 ### Fixed
@@ -2047,6 +2065,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions Cron（选秀超时 + 报名截止自动推进）
 - Vercel + Supabase 生产部署
 
+[2.8.3]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.2...v2.8.3
 [2.8.2]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/Starfie1d1272/RivalHub/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Starfie1d1272/RivalHub/compare/v2.7.8...v2.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalhub",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
## 摘要

准备发布 v2.8.3 版本。消费待发布 Changesets 并按文档惯例重写 Release Note。

### 包含变更

- **Production 灾难恢复与发布前备份保护**：建立生产灾难恢复备份与验证契约（Session Pooler :5432 独立连接与只读契约）、Cloudflare R2 私有存储与内容哈希回读验证、migrations-first 通用数据预清理与 replica 批量导入语义、Auth 用户关联一致性校验，以及 release 与定时备份串行化并发约束。正式发布流程接入发布前备份硬门禁。
- **赛事阶段历史运行时数据清理**：移除 Release N 兼容保留的旧版淘汰赛与瑞士轮表结构（`competition_bracket_states` 及 `swiss_standings`），完成阶段旧关联的物理清理。

### 待验收事项

- 生产灾备端到端真实演练（R2 真实获取、本地离线 age 私钥解密与隔离目标恢复验收）仍需在具备真实生产环境权限后进行验证。
- 本 PR 合并前等待人工检查确认。