### PR TITLE
test: 稳定移动端公开发现历史导航

### DIFF
--- a/tests/e2e/flows/public-discovery.spec.ts
+++ b/tests/e2e/flows/public-discovery.spec.ts
@@ -8,10 +8,10 @@ test("移动端公开发现列表可操作共享筛选工具栏", async ({ page 
   await expect(page.getByLabel("队伍状态")).toHaveValue("active");
   await page.goto("/teams?status=history");
   await expect(page.getByLabel("队伍状态")).toHaveValue("history");
-  await page.goBack();
+  await page.goBack({ waitUntil: "commit" });
   await expect(page).toHaveURL(/\/teams$/);
   await expect(page.getByLabel("队伍状态")).toHaveValue("active");
-  await page.goForward();
+  await page.goForward({ waitUntil: "commit" });
   await expect(page).toHaveURL(/\/teams\?status=history$/);
   await expect(page.getByLabel("队伍状态")).toHaveValue("history");
   await page.goto("/teams");


### PR DESCRIPTION
## 内容

- 将移动端公开发现流程中的前进、后退等待条件收敛到导航 commit，避免 Next 导航完成时 `load` 等待被中断。

## 验证

- `pnpm exec eslint tests/e2e/flows/public-discovery.spec.ts`
- `pnpm type-check:tests`

Refs #591
