### PR TITLE
ci: 按风险分层重构 Evidence Planner，收窄 System / FULL critical path

### DIFF
--- a/.changeset/issue-597-ci-evidence-planner.md
+++ b/.changeset/issue-597-ci-evidence-planner.md
@@ -1,5 +1,0 @@
----
-"rivalhub": patch
----
-
-按风险分层重构 CI Evidence Planner：解耦 Draft/Ready 状态与测试深度、收窄 System provider 边界，并将 main 分支 push 调整为 affected smoke 规划，避免普通业务变更进入不必要的 System / FULL critical path。

--- a/.changeset/issue-597-ci-evidence-planner.md
+++ b/.changeset/issue-597-ci-evidence-planner.md
@@ -1,0 +1,5 @@
+---
+"rivalhub": patch
+---
+
+按风险分层重构 CI Evidence Planner：解耦 Draft/Ready 状态与测试深度、收窄 System provider 边界，并将 main 分支 push 调整为 affected smoke 规划，避免普通业务变更进入不必要的 System / FULL critical path。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,16 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+  schedule:
+    - cron: '0 2 * * *'
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      force_full:
+        description: 'Force full evidence matrix'
+        type: boolean
+        default: true
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -64,7 +71,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-          FORCE_FULL: ${{ github.event_name != 'pull_request' }}
+          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' && (inputs.force_full != false) || github.event_name == 'schedule' || github.event_name == 'release' || github.event_name == 'merge_group' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == '')) }}
           PR_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
 
   static:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      force_full:
-        description: 'Force full evidence matrix'
-        type: boolean
-        default: true
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -71,7 +66,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' && (inputs.force_full != false) || github.event_name == 'schedule' || github.event_name == 'release' || github.event_name == 'merge_group' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == '')) }}
+          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'release' || github.event_name == 'merge_group' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == '')) }}
           PR_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
 
   static:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ RivalHub 是基于 Next.js App Router、TypeScript、Drizzle/PostgreSQL、Supaba
 
 按风险选择 [`docs/testing.md`](docs/testing.md) 中的最小 evidence。日常优先使用与 changed surface 匹配的 `pnpm type-check:*`、定向 Vitest 和文件级 ESLint；`pnpm type-check`、`pnpm lint`、`pnpm test`、`pnpm db:check`、`pnpm knip`、`pnpm knip --production`、`pnpm verify` 是按风险选择的 broad host-only 或最终检查，不是每次迭代默认全跑。提交前检查完整 diff、未跟踪文件、敏感信息和临时产物。
 
-默认开发与交付流程是 Draft → Ready：开发阶段使用 Draft PR，push 后由 Evidence Planner 只运行与 changed surface 匹配的 affected evidence；本地只执行匹配改动的 host-only 快速检查，不为每次迭代默认启动 PostgreSQL、Local Supabase 或 browser 重型环境。准备交付时将 PR 标记为 Ready for review；`ready_for_review` 及 Ready PR 后续每次 push 必须触发该 commit 的 FULL CI。只有最新 FULL CI 与 required checks 全绿后才能 merge；新 push 会使旧 commit 的最终 evidence 失效。
+默认开发与交付流程是 Draft → Ready：开发阶段使用 Draft PR，push 后由 Evidence Planner 运行与 changed surface 匹配的 affected evidence 并产生 `draft-gate`；本地只执行匹配改动的 host-only 快速检查，不为每次迭代默认启动 PostgreSQL、Local Supabase 或 browser 重型环境。准备交付时将 PR 标记为 Ready for review；Ready PR 使用同一个 Evidence Planner 运行匹配改动风险的 affected evidence 并产生 required 的 `ci-gate`（不因 Ready 状态机械升级为 FULL）。只有最新 required checks 全绿后才能 merge；新 push 会使旧 commit 的 evidence 失效。
 
 本地 `pnpm check` / `pnpm verify` 是可选 broad host-only gate，不是每次迭代或每次 push 的默认要求。需要真实数据库、Supabase 或 browser 复现时，按 [`docs/operations/local-development.md`](docs/operations/local-development.md) 只启动最小层级。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@
 ## Draft → Ready 开发与 CI
 
 - 新功能、修复和文档工作默认以 **Draft PR** 开始。Draft 期间每次 push 由 Evidence Planner 根据 changed surface 选择 affected static、PostgreSQL integration spec 和 semantic browser flow，并以 `draft-gate` 汇总；该结果用于快速反馈，不是最终 merge evidence。
-- 本地迭代只执行与当前改动匹配的 host-only 快速检查。不要为了每次修改重复启动 PostgreSQL、Local Supabase 或 browser 重型环境；对应真实环境证据由 Draft CI 按需运行，失败复现时再按 [`docs/operations/local-development.md`](docs/operations/local-development.md) 启动最小层级。
-- 实现和本地快速检查完成、准备交付时，才将 PR 标记为 **Ready for review**。`ready_for_review` 事件必须触发一次不受 affected planner 削减的 FULL CI，覆盖完整 static、postgres、system capability；Ready PR 后续每次 push 也必须重新产生该 commit 的 FULL CI。
-- 只有最新 commit 的 FULL CI、required `ci-gate` / `pr-title` 及 ruleset 要求的其它 checks 全部成功，且 strict up-to-date 与 review thread 条件满足后，才可以 merge。Ready PR 的新 push 会使旧 commit 的 FULL evidence 失效，不能沿用旧结果。
+- 本地迭代只执行与当前改动匹配的 host-only 快速检查。不要为了每次修改重复启动 PostgreSQL、Local Supabase 或 browser 重型环境；对应真实环境证据由 CI 按需运行，失败复现时再按 [`docs/operations/local-development.md`](docs/operations/local-development.md) 启动最小层级。
+- 实现和本地快速检查完成、准备交付时，将 PR 标记为 **Ready for review**。Ready PR 使用同一个 Evidence Planner 规划与变更风险相匹配的最低充分 evidence（遵循 L0–L4 风险分层，不机械升级为 FULL），并产生 ruleset required 的 `ci-gate`。
+- 只有最新 commit 的 required `ci-gate` / `pr-title` 及 ruleset 要求的其它 checks 全部成功，且 strict up-to-date 与 review thread 条件满足后，才可以 merge。新 push 会使旧 commit 的 evidence 失效，不能沿用旧结果。
 
 ## Changeset and release
 

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -12,7 +12,7 @@ plan ─→ static ─────┐
    └─→ dependency-review（PR）
 ```
 
-`draft-gate` 只汇总 Draft affected evidence，不能满足 ruleset 的 merge requirement。`ci-gate` 只由 Ready PR、Ready 后新 push、`main`、merge queue、release 和手动 FULL 运行产生；它是代码正确性 evidence 的 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。PR metadata policy 由独立的 `pr-title` check 负责；要使其阻断合并，Main ruleset 需与 `ci-gate` 一起要求该 check。
+`draft-gate` 汇总 Draft PR 的 affected evidence，用于开发中快速反馈，不能满足 ruleset 的 merge requirement。`ci-gate` 由 Ready PR、`main` push、merge queue、release、nightly schedule 和手动运行产生；它是代码正确性 evidence 的 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。PR metadata policy 由独立的 `pr-title` check 负责；要使其阻断合并，Main ruleset 需与 `ci-gate` 一起要求该 check。
 
 ## Capabilities
 
@@ -57,21 +57,20 @@ Pull Request 额外运行 dependency review；达到 workflow 设定的严重度
 
 ## Selective vs full
 
-Pull Request 使用 Draft → Ready 两阶段流程。新 PR 默认保持 Draft：
+CI 遵循 L0–L4 风险分层与最低且足够可信证据原则：
 
-1. Draft 的 `opened` / `synchronize` 由 changed-surface planner 选择本次改动需要的 capability 和 evidence task，并以 `draft-gate` 汇总。static 可以只跑 affected Vitest project 与 changed-file lint，postgres/system 可以只跑明确的 integration spec 或 semantic E2E flow；只有真实 `*.test.*` / `*.spec.*` 文件可作为 direct selector，fixture、helper、snapshot 与 harness 改动会保留对应 lane 的 full suite。
-2. 实现完成并标记 Ready for review 时，`ready_for_review` 以 `PR_DRAFT=false` 重新运行 planner，直接输出 FULL matrix。该事件必须产生完整 static、postgres、system evidence，不得被 affected heuristic 削减。
-3. Ready PR 后续的每次 `synchronize` 仍然是 FULL；新 commit 产生后，旧 commit 的 FULL CI 不再是当前 merge evidence。
+- **L0 Metadata**：docs、Changeset、纯 release metadata，仅保留 planner + gate，不启动测试容器。
+- **L1 Static**：pure rule、formatter、presenter、component、UI/layout 等不跨 persistence/provider 边界的变化，运行 affected type/lint/architecture/unit。
+- **L2 PostgreSQL**：Server Action persistence、DB query、transaction、migration 等，运行 L1 + real PostgreSQL。
+- **L3 System**：Auth、Session、Storage provider 或 browser/provider glue，运行 L1/L2 + Local Supabase + targeted E2E。
+- **L4 Full convergence**：CI/toolchain/harness/unknown/destructive 改动、手动 FULL、release 发布或 nightly 定时收敛，运行完整 static + postgres + system。
 
-Draft planner 的 capability 规则为：
+Pull Request 的 Draft / Ready 仅代表协作与合并准入状态，不直接决定测试深度：
 
-- docs-only 可以只保留 planner + gate；
-- pure app/domain/presentation 通常需要 static；
-- DB-backed code / schema / migration 需要 postgres；
-- Auth、Supabase service 或 browser critical path 需要 system；
-- rename/delete、workflow/toolchain、无法分类的变化 fail closed 到 full。
-
-Draft PR 还会由同一个 planner 输出 static matrix、related source、explicit test、PG integration spec 和 semantic E2E flow；Vitest project 只把 source 交给 `vitest related`，而变更的 unit test 与 global contract 以 `vitest run <test path>` 直接执行。affected plan 只用于 Draft 快速反馈，不降低最终 merge evidence。只有最新 commit 的 FULL CI、required `ci-gate` / `pr-title` 和 ruleset 要求的其它 checks 全绿，才能 merge。
+1. Draft PR 由 changed-surface planner 输出本次改动所需最低充分 evidence，以 `draft-gate` 汇总，供开发阶段快速迭代。
+2. Ready PR 使用同一个 changed-surface planner 输出匹配风险的 evidence，并以 required `ci-gate` 汇总；不因 Ready 状态机械升级为 FULL。普通 UI / Server Action PR 仅支付对应静态或 PG 验证时间，不进入昂贵的 system 冷启动。
+3. `push` 到 `main` 同样使用 changed-surface 规划 affected smoke，不默认重复跑 FULL。
+4. 无法分类的变化、rename/delete、CI/toolchain/harness 改动 fail closed 到 FULL。
 
 `scripts/ci/timing.mjs` 的 command wrapper 是 project wall-time owner。`vitest-timing-reporter.ts` 只输出 per-project facts 与 top 15 per-file diagnostic duration，Step Summary 会明确区分两者。
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -36,7 +36,7 @@ RIVALHUB_ALLOW_LOCAL_CONTAINERS=1 pnpm dev:local
 - tests：`pnpm type-check:tests`；scripts：`pnpm type-check:scripts`；
 - 当前改动涉及的 TypeScript/JSON 文件：`pnpm exec eslint path/to/changed-file.ts`。
 
-`pnpm check` / `pnpm verify` 可以在需要时作为 broad host-only 检查，但不要求每次迭代或每次 push 都运行。真实 PostgreSQL、Local Supabase 和 browser evidence 由 Draft CI 按需运行；服务层本地复现只在排查失败、验证 migration/constraint，或需要检查真实浏览器组合行为时启动最小层级。准备交付时将 PR 标记为 Ready for review，由 `ready_for_review` 触发最终 FULL CI；Ready 后的新 push 还必须等待对应新 commit 的 FULL CI。
+`pnpm check` / `pnpm verify` 可以在需要时作为 broad host-only 检查，但不要求每次迭代或每次 push 都运行。真实 PostgreSQL、Local Supabase 和 browser evidence 由 CI 按需运行；服务层本地复现只在排查失败、验证 migration/constraint，或需要检查真实浏览器组合行为时启动最小层级。准备交付时将 PR 标记为 Ready for review，由 Evidence Planner 按变更风险产生 required 的 `ci-gate`；Ready 后的新 push 会使旧 commit 的 evidence 失效，需等待新 commit 的 CI 检查。
 
 ## 只启动需要的层级
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,12 +31,13 @@ DB unique/FK、transaction、row lock、migration/backfill 不用 mock 代替。
 
 ## CI
 
-PR CI 保留 `static`、`postgres`、`system` 三条 capability lane，并按 Draft → Ready 分为两个阶段：
+PR CI 保留 `static`、`postgres`、`system` 三条 capability lane，按 L0–L4 风险分层运行最低且足够的 evidence：
 
-1. Draft PR 的每次 push 使用 Evidence Planner 根据 changed surface 选择 affected Vitest project、changed-file lint、明确的 PostgreSQL integration spec 和 semantic Playwright flow，并汇总为非 required 的 `draft-gate`。它用于快速反馈；unknown、rename/delete、toolchain、workflow 或 harness surface 仍 fail closed 到 FULL。
-2. PR 标记为 Ready for review 时，`ready_for_review` 必须触发一次 FULL matrix，不再使用 affected heuristic，并产生 ruleset required 的 `ci-gate`。Ready PR 后续每次 push 也运行该 commit 的 FULL matrix。
-
-只有最新 commit 的 FULL CI 与 required checks 全部成功，才能作为 merge evidence；新 push 会使之前 commit 的 FULL evidence 失效。`main`、merge queue、release 和手动运行同样强制 FULL。精确 planner 与 job 以 `.github/workflows/ci.yml`、`scripts/ci/plan.mjs` 为 authority，排障见 [`operations/ci.md`](./operations/ci.md)。
+- Draft 与 Ready PR 均使用同一个 Evidence Planner 根据 changed surface 计算所需的 affected capability 与 task。Draft PR 汇总为非 required 的 `draft-gate`，用于开发阶段快速反馈；Ready PR 产生 ruleset required 的 `ci-gate`，作为合并所需的代码正确性证据。Ready 状态不自动将测试深度升级为 FULL。
+- 普通业务变更（L1 Static、L2 PostgreSQL）仅运行对应 affected tests，不再仅因涉及报名、队伍或页面重要性自动触发 Local Supabase / browser system flow。
+- System（L3）仅在真实 Auth、Session、Storage provider 或 browser/provider glue 变更时进入 critical path。
+- FULL（L4）不再是普通 Ready PR 或 `main` push 的默认行为，仅作为明确的收敛事件（CI/toolchain/harness/unknown/destructive 改动、手动 `workflow_dispatch`、release 发布或 nightly 定时收敛）。
+- `main` push 采用 changed-surface 规划 affected smoke，不默认重复执行 FULL。精确 planner 与 job 以 `.github/workflows/ci.yml`、`scripts/ci/plan.mjs` 为 authority，排障见 [`operations/ci.md`](./operations/ci.md)。
 
 CI 只负责选择和阻断 evidence，不成为业务测试语义的第二 owner。
 

--- a/scripts/ci/plan.mjs
+++ b/scripts/ci/plan.mjs
@@ -38,25 +38,15 @@ const SYSTEM_APP_PREFIXES = [
   "src/app/login/",
   "src/app/forgot-password/",
   "src/app/reset-password/",
-  "src/app/my/",
-  "src/app/team-invites/",
-  "src/app/teams/",
-  "src/app/[seasonSlug]/register/",
   "src/app/api/test/e2e/",
 ];
 const SYSTEM_ACTION_PREFIXES = [
   "src/actions/auth",
-  "src/actions/competition-entries.ts",
-  "src/actions/major-prestart.ts",
-  "src/actions/register.ts",
 ];
 
 const SYSTEM_FLOW_MAP = [
-  { prefixes: ["src/app/auth/", "src/app/login/", "src/actions/auth", "src/lib/auth/", "src/lib/session/"], specs: ["tests/e2e/flows/major-entry.spec.ts"] },
+  { prefixes: ["src/app/auth/", "src/app/login/", "src/app/forgot-password/", "src/app/reset-password/", "src/actions/auth", "src/lib/auth/", "src/lib/session/"], specs: ["tests/e2e/flows/major-entry.spec.ts"] },
   { prefixes: ["src/app/settings/education", "src/actions/education", "src/lib/education/"], specs: ["tests/e2e/flows/education-manual-fallback.spec.ts"] },
-  { prefixes: ["src/app/team-invites/", "src/app/teams/", "src/actions/team"], specs: ["tests/e2e/flows/team-invitations.spec.ts"] },
-  { prefixes: ["src/app/[seasonSlug]/register/", "src/actions/competition-entries.ts", "src/actions/register.ts", "src/actions/major-prestart.ts"], specs: ["tests/e2e/flows/major-entry.spec.ts"] },
-  { prefixes: ["src/app/teams/", "src/app/players/"], specs: ["tests/e2e/flows/public-discovery.spec.ts"] },
 ];
 
 const CODE_EXTENSIONS = /\.(?:[cm]?[jt]sx?|vue|svelte)$/;
@@ -68,10 +58,8 @@ export function classifyChangedFiles(entries, options = {}) {
   const { forceFull = false, draft = true } = options;
   const gateName = draft ? "draft-gate" : "ci-gate";
   const result = (...args) => ({ ...resultFor(...args), gateName });
-  if (forceFull || !draft) {
-    return result(CAPABILITIES, true, forceFull
-      ? "受保护分支、merge queue、release 或手动运行，强制 full gate"
-      : "Ready for review PR 使用 FULL evidence gate");
+  if (forceFull) {
+    return result(CAPABILITIES, true, "受保护分支、merge queue、release 或手动运行，强制 full gate");
   }
   if (entries.length === 0) {
     return result(CAPABILITIES, true, "无法取得 changed-surface，fail closed 到 full gate");
@@ -108,7 +96,7 @@ export function classifyChangedFiles(entries, options = {}) {
 
   if (capabilities.size === 0) {
     return docsOnly
-      ? result([], false, "docs-only surface：只保留 planner + draft-gate")
+      ? result([], false, `docs-only surface：只保留 planner + ${gateName}`)
       : result(CAPABILITIES, true, "changed-surface 未命中已声明 capability，fail closed 到 full gate");
   }
 
@@ -414,8 +402,7 @@ function gitChangedFiles() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const eventName = process.env.GITHUB_EVENT_NAME ?? "";
-  const forceFull = process.env.FORCE_FULL === "1" || process.env.FORCE_FULL === "true" || eventName !== "pull_request";
+  const forceFull = process.env.FORCE_FULL === "1" || process.env.FORCE_FULL === "true";
   const draft = process.env.PR_DRAFT !== "false";
   const entries = gitChangedFiles();
   const plan = classifyChangedFiles(entries, { forceFull, draft });

--- a/scripts/ci/plan.mjs
+++ b/scripts/ci/plan.mjs
@@ -45,9 +45,39 @@ const SYSTEM_ACTION_PREFIXES = [
 ];
 
 const SYSTEM_FLOW_MAP = [
-  { prefixes: ["src/app/auth/", "src/app/login/", "src/app/forgot-password/", "src/app/reset-password/", "src/actions/auth", "src/lib/auth/", "src/lib/session/"], specs: ["tests/e2e/flows/major-entry.spec.ts"] },
-  { prefixes: ["src/app/settings/education", "src/actions/education", "src/lib/education/"], specs: ["tests/e2e/flows/education-manual-fallback.spec.ts"] },
+  {
+    prefixes: [
+      "src/app/auth/",
+      "src/app/login/",
+      "src/app/forgot-password/",
+      "src/app/reset-password/",
+      "src/actions/auth",
+      "src/lib/auth/",
+      "src/lib/session/",
+    ],
+    specs: ["tests/e2e/flows/major-entry.spec.ts"],
+  },
+  {
+    prefixes: [
+      "src/lib/education/storage.ts",
+      "src/lib/education/commands.ts",
+      "src/actions/education-verifications.ts",
+      "src/components/settings/EducationVerificationPanel.tsx",
+      "src/app/settings/education",
+    ],
+    specs: ["tests/e2e/flows/education-manual-fallback.spec.ts"],
+  },
 ];
+
+function systemSpecsForPath(path) {
+  const specs = new Set();
+  for (const mapping of SYSTEM_FLOW_MAP) {
+    if (mapping.prefixes.some((prefix) => path === prefix || path.startsWith(prefix))) {
+      for (const spec of mapping.specs) specs.add(spec);
+    }
+  }
+  return [...specs];
+}
 
 const CODE_EXTENSIONS = /\.(?:[cm]?[jt]sx?|vue|svelte)$/;
 const LINT_EXTENSIONS = /\.[cm]?[jt]sx?$/;
@@ -92,6 +122,10 @@ export function classifyChangedFiles(entries, options = {}) {
     for (const capability of classification.capabilities) capabilities.add(capability);
     reasons.add(classification.reason);
     collectEvidence(path, classification, evidence);
+  }
+
+  if (evidence.e2eSpecs.size > 0) {
+    capabilities.add("system");
   }
 
   if (capabilities.size === 0) {
@@ -188,9 +222,11 @@ function classifyPath(path) {
 
   if (path.startsWith("scripts/")) return classifyScriptPath(path);
 
+  const flowSpecs = systemSpecsForPath(path);
+
   if (path.startsWith("src/actions/")) {
     const capabilities = ["static", "postgres"];
-    if (SYSTEM_ACTION_PREFIXES.some((prefix) => path.startsWith(prefix)) || source.usesSupabase) {
+    if (SYSTEM_ACTION_PREFIXES.some((prefix) => path.startsWith(prefix)) || source.usesSupabase || flowSpecs.length > 0) {
       capabilities.push("system");
     }
     return {
@@ -204,7 +240,7 @@ function classifyPath(path) {
     if (DB_BACKED_APP_PREFIXES.some((prefix) => path.startsWith(prefix)) || source.usesDatabase) {
       capabilities.push("postgres");
     }
-    if (SYSTEM_APP_PREFIXES.some((prefix) => path.startsWith(prefix)) || source.usesSupabase) {
+    if (SYSTEM_APP_PREFIXES.some((prefix) => path.startsWith(prefix)) || source.usesSupabase || flowSpecs.length > 0) {
       capabilities.push("system");
     }
     return { capabilities, reason: `App Router surface: ${path}` };
@@ -213,7 +249,7 @@ function classifyPath(path) {
   if (path.startsWith("src/components/")) {
     const capabilities = ["static"];
     if (source.usesDatabase) capabilities.push("postgres");
-    if (source.usesSupabase) capabilities.push("system");
+    if (source.usesSupabase || flowSpecs.length > 0) capabilities.push("system");
     return { capabilities, reason: `UI surface: ${path}` };
   }
 
@@ -224,7 +260,7 @@ function classifyPath(path) {
   if (path.startsWith("src/lib/")) {
     const capabilities = ["static"];
     if (source.usesDatabase) capabilities.push("postgres");
-    if (source.usesSupabase || path === "src/lib/auth/session.ts" || path.startsWith("src/lib/session/")) {
+    if (source.usesSupabase || path === "src/lib/auth/session.ts" || path.startsWith("src/lib/session/") || flowSpecs.length > 0) {
       capabilities.push("system");
     }
     return { capabilities, reason: `library surface: ${path}` };
@@ -283,10 +319,8 @@ function collectEvidence(path, classification, evidence) {
     evidence.unitExplicitTests.get("unit-domain-node").add(GLOBAL_CONTRACTS.productLanguage.path);
   }
 
-  for (const mapping of SYSTEM_FLOW_MAP) {
-    if (mapping.prefixes.some((prefix) => path.startsWith(prefix))) {
-      for (const spec of mapping.specs) evidence.e2eSpecs.add(spec);
-    }
+  for (const spec of systemSpecsForPath(path)) {
+    evidence.e2eSpecs.add(spec);
   }
 }
 

--- a/tests/unit/ci/plan.test.mjs
+++ b/tests/unit/ci/plan.test.mjs
@@ -30,7 +30,10 @@ describe("changed-surface planner", () => {
   it.each([
     ["src/actions/auth.ts", ["static", "postgres", "system"]],
     ["src/lib/auth/supabase.ts", ["static", "system"]],
-    ["src/app/[seasonSlug]/register/page.tsx", ["static", "postgres", "system"]],
+    ["src/app/[seasonSlug]/register/page.tsx", ["static", "postgres"]],
+    ["src/actions/register.ts", ["static", "postgres"]],
+    ["src/actions/competition-entries.ts", ["static", "postgres"]],
+    ["src/lib/education/storage.ts", ["static", "system"]],
     ["src/app/api/test/e2e/auth/route.ts", ["static", "system"]],
     ["scripts/ci/timing.mjs", ["static"]],
     ["scripts/db/pg17-integration.ts", ["static", "postgres"]],
@@ -50,31 +53,98 @@ describe("changed-surface planner", () => {
     expect(classifyChangedFiles([]).requiredJobs).toEqual(["static", "postgres", "system"]);
   });
 
-  it("uses the full evidence plan for a Ready PR while Draft PRs stay affected", () => {
-    const entry = [{ status: "M", paths: ["tests/unit/components/Foo.test.tsx"] }];
-    const draft = classifyChangedFiles(entry, { draft: true });
+  it("decouples Draft and Ready PR from evidence depth and only alters gateName", () => {
+    const pureUiEntry = [{ status: "M", paths: ["src/components/layout/Footer.tsx"] }];
+    
+    // Draft pure UI -> affected static + draft-gate
+    const draft = classifyChangedFiles(pureUiEntry, { draft: true });
     expect(draft.full).toBe(false);
+    expect(draft.requiredJobs).toEqual(["static"]);
     expect(draft.gateName).toBe("draft-gate");
-    expect(draft.staticMatrix).toEqual(expect.arrayContaining([
-      expect.objectContaining({ task: "type-tests" }),
-      expect.objectContaining({ task: "unit-explicit-unit-react-jsdom", mode: "explicit", explicitTests: ["tests/unit/components/Foo.test.tsx"] }),
-    ]));
 
-    const ready = classifyChangedFiles(entry, { draft: false });
-    expect(ready.full).toBe(true);
+    // Ready pure UI -> same affected static + ci-gate, NOT full
+    const ready = classifyChangedFiles(pureUiEntry, { draft: false });
+    expect(ready.full).toBe(false);
+    expect(ready.requiredJobs).toEqual(["static"]);
     expect(ready.gateName).toBe("ci-gate");
-    expect(ready.staticMatrix.map(({ task }) => task)).toContain("unit-react");
-    expect(ready.staticMatrix.map(({ task }) => task)).toContain("build");
   });
 
-  it("keeps Draft full fallback separate from the final merge gate", () => {
-    const draftFallback = classifyChangedFiles([{ status: "M", paths: ["pnpm-lock.yaml"] }], { draft: true });
-    const finalGate = classifyChangedFiles([{ status: "M", paths: ["docs/testing.md"] }], { forceFull: true, draft: false });
+  it("keeps Ready Server Action / registration transaction on static + PG without triggering system", () => {
+    const registrationAction = [{ status: "M", paths: ["src/actions/register.ts"] }];
+    const plan = classifyChangedFiles(registrationAction, { draft: false });
+    expect(plan.full).toBe(false);
+    expect(plan.requiredJobs).toEqual(["static", "postgres"]);
+    expect(plan.runSystem).toBe(false);
+    expect(plan.gateName).toBe("ci-gate");
+  });
 
-    expect(draftFallback.full).toBe(true);
-    expect(draftFallback.gateName).toBe("draft-gate");
-    expect(finalGate.full).toBe(true);
-    expect(finalGate.gateName).toBe("ci-gate");
+  it("routes Auth and Storage providers to system", () => {
+    const authProvider = classifyChangedFiles([{ status: "M", paths: ["src/lib/auth/supabase.ts"] }], { draft: false });
+    expect(authProvider.requiredJobs).toContain("system");
+    expect(authProvider.e2eSpecs).toEqual(["tests/e2e/flows/major-entry.spec.ts"]);
+
+    const storageProvider = classifyChangedFiles([{ status: "M", paths: ["src/lib/education/storage.ts"] }], { draft: false });
+    expect(storageProvider.requiredJobs).toContain("system");
+    expect(storageProvider.e2eSpecs).toEqual(["tests/e2e/flows/education-manual-fallback.spec.ts"]);
+  });
+
+  it("keeps migration on PG without triggering system", () => {
+    const migration = classifyChangedFiles([{ status: "A", paths: ["drizzle/migrations/0048_new_feature.sql"] }], { draft: false });
+    expect(migration.full).toBe(false);
+    expect(migration.requiredJobs).toEqual(["postgres"]);
+    expect(migration.runSystem).toBe(false);
+  });
+
+  it("selects targeted system for E2E spec and falls back to full system / L4 for shared harness", () => {
+    const e2eSpec = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/flows/major-entry.spec.ts"] }], { draft: false });
+    expect(e2eSpec.full).toBe(false);
+    expect(e2eSpec.requiredJobs).toEqual(["static", "system"]);
+    expect(e2eSpec.e2eSpecs).toEqual(["tests/e2e/flows/major-entry.spec.ts"]);
+
+    const e2eFixture = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/fixtures.ts"] }], { draft: false });
+    expect(e2eFixture.requiredJobs).toEqual(["static", "system"]);
+    expect(e2eFixture.e2eSpecs).toEqual([]); // full system suite fallback
+  });
+
+  it("fails closed to FULL for workflow, planner, toolchain, unknown, and rename/delete", () => {
+    expect(classifyChangedFiles([{ status: "M", paths: [".github/workflows/ci.yml"] }]).full).toBe(true);
+    expect(classifyChangedFiles([{ status: "M", paths: ["package.json"] }]).full).toBe(true);
+    expect(classifyChangedFiles([{ status: "M", paths: ["unknown-tooling/something.bin"] }]).full).toBe(true);
+    expect(classifyChangedFiles([{ status: "R100", paths: ["src/a.ts", "src/b.ts"] }]).full).toBe(true);
+    expect(classifyChangedFiles([{ status: "D", paths: ["src/old.ts"] }]).full).toBe(true);
+  });
+
+  it("treats docs and Changeset as L0 metadata with planner + gate only", () => {
+    const docsPlan = classifyChangedFiles([{ status: "M", paths: ["docs/testing.md"] }], { draft: true });
+    expect(docsPlan.full).toBe(false);
+    expect(docsPlan.requiredJobs).toEqual([]);
+    expect(docsPlan.runStatic).toBe(false);
+    expect(docsPlan.gateName).toBe("draft-gate");
+
+    const readyDocsPlan = classifyChangedFiles([{ status: "M", paths: ["docs/testing.md"] }], { draft: false });
+    expect(readyDocsPlan.full).toBe(false);
+    expect(readyDocsPlan.requiredJobs).toEqual([]);
+    expect(readyDocsPlan.gateName).toBe("ci-gate");
+  });
+
+  it("plans main ordinary business merge as affected instead of FULL", () => {
+    const mainPushChanges = [
+      { status: "M", paths: ["src/actions/register.ts"] },
+      { status: "M", paths: ["src/components/ui/Button.tsx"] },
+    ];
+    // on main push: forceFull=false, draft=false
+    const mainPlan = classifyChangedFiles(mainPushChanges, { forceFull: false, draft: false });
+    expect(mainPlan.full).toBe(false);
+    expect(mainPlan.requiredJobs).toEqual(["static", "postgres"]);
+    expect(mainPlan.runSystem).toBe(false);
+    expect(mainPlan.gateName).toBe("ci-gate");
+  });
+
+  it("forces FULL for manual, release, or scheduled convergence", () => {
+    const plan = classifyChangedFiles([{ status: "M", paths: ["src/components/ui/Button.tsx"] }], { forceFull: true, draft: false });
+    expect(plan.full).toBe(true);
+    expect(plan.requiredJobs).toEqual(["static", "postgres", "system"]);
+    expect(plan.gateName).toBe("ci-gate");
   });
 
   it("separates related sources from explicit tests and keeps global contracts executable", () => {
@@ -91,20 +161,6 @@ describe("changed-surface planner", () => {
     ]));
   });
 
-  it("selects conservative PG and browser evidence for affected draft changes", () => {
-    const result = classifyChangedFiles([
-      { status: "M", paths: ["tests/integration/db/team-registration.test.ts"] },
-      { status: "M", paths: ["src/app/team-invites/[token]/page.tsx"] },
-    ], { draft: true });
-
-    expect(result.integrationSpecs).toEqual(["tests/integration/db/team-registration.test.ts"]);
-    expect(result.e2eSpecs).toEqual(["tests/e2e/flows/team-invitations.spec.ts"]);
-    expect(result.staticMatrix).toEqual(expect.arrayContaining([
-      expect.objectContaining({ task: "type-app" }),
-      expect.objectContaining({ task: "type-tests" }),
-    ]));
-  });
-
   it("does not send generated migration metadata to eslint", () => {
     const result = classifyChangedFiles([
       { status: "A", paths: ["drizzle/migrations/meta/0047_snapshot.json"] },
@@ -115,23 +171,5 @@ describe("changed-surface planner", () => {
     expect(result.staticMatrix).toEqual(expect.arrayContaining([
       expect.objectContaining({ task: "lint-changed", changedPaths: ["scripts/db/scheduler.ts"] }),
     ]));
-  });
-
-  it("direct-selects only test specs and falls back to full lane evidence for support files", () => {
-    const e2eSpec = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/flows/major-entry.spec.ts"] }], { draft: true });
-    const e2eFixture = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/fixtures.ts"] }], { draft: true });
-    const e2eHelper = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/helpers/session.ts"] }], { draft: true });
-    const e2eSnapshot = classifyChangedFiles([{ status: "M", paths: ["tests/e2e/visual/ui-system.spec.ts-snapshots/privacy-1440x900-chromium.png"] }], { draft: true });
-    const integrationSpec = classifyChangedFiles([{ status: "M", paths: ["tests/integration/db/team-registration.test.ts"] }], { draft: true });
-    const integrationSupport = classifyChangedFiles([{ status: "M", paths: ["tests/integration/db/support.ts"] }], { draft: true });
-
-    expect(e2eSpec.e2eSpecs).toEqual(["tests/e2e/flows/major-entry.spec.ts"]);
-    for (const plan of [e2eFixture, e2eHelper, e2eSnapshot]) {
-      expect(plan.requiredJobs).toEqual(["static", "system"]);
-      expect(plan.e2eSpecs).toEqual([]);
-    }
-    expect(integrationSpec.integrationSpecs).toEqual(["tests/integration/db/team-registration.test.ts"]);
-    expect(integrationSupport.requiredJobs).toEqual(["static", "postgres"]);
-    expect(integrationSupport.integrationSpecs).toEqual([]);
   });
 });

--- a/tests/unit/ci/plan.test.mjs
+++ b/tests/unit/ci/plan.test.mjs
@@ -130,7 +130,7 @@ describe("changed-surface planner", () => {
   it("plans main ordinary business merge as affected instead of FULL", () => {
     const mainPushChanges = [
       { status: "M", paths: ["src/actions/register.ts"] },
-      { status: "M", paths: ["src/components/ui/Button.tsx"] },
+      { status: "M", paths: ["src/components/ui/button.tsx"] },
     ];
     // on main push: forceFull=false, draft=false
     const mainPlan = classifyChangedFiles(mainPushChanges, { forceFull: false, draft: false });
@@ -141,7 +141,7 @@ describe("changed-surface planner", () => {
   });
 
   it("forces FULL for manual, release, or scheduled convergence", () => {
-    const plan = classifyChangedFiles([{ status: "M", paths: ["src/components/ui/Button.tsx"] }], { forceFull: true, draft: false });
+    const plan = classifyChangedFiles([{ status: "M", paths: ["src/components/ui/button.tsx"] }], { forceFull: true, draft: false });
     expect(plan.full).toBe(true);
     expect(plan.requiredJobs).toEqual(["static", "postgres", "system"]);
     expect(plan.gateName).toBe("ci-gate");

--- a/tests/unit/ci/plan.test.mjs
+++ b/tests/unit/ci/plan.test.mjs
@@ -86,6 +86,29 @@ describe("changed-surface planner", () => {
     const storageProvider = classifyChangedFiles([{ status: "M", paths: ["src/lib/education/storage.ts"] }], { draft: false });
     expect(storageProvider.requiredJobs).toContain("system");
     expect(storageProvider.e2eSpecs).toEqual(["tests/e2e/flows/education-manual-fallback.spec.ts"]);
+
+    const educationCommands = classifyChangedFiles([{ status: "M", paths: ["src/lib/education/commands.ts"] }], { draft: false });
+    expect(educationCommands.requiredJobs).toContain("system");
+    expect(educationCommands.e2eSpecs).toEqual(["tests/e2e/flows/education-manual-fallback.spec.ts"]);
+
+    const educationAction = classifyChangedFiles([{ status: "M", paths: ["src/actions/education-verifications.ts"] }], { draft: false });
+    expect(educationAction.requiredJobs).toContain("system");
+    expect(educationAction.e2eSpecs).toEqual(["tests/e2e/flows/education-manual-fallback.spec.ts"]);
+
+    const educationPanel = classifyChangedFiles([{ status: "M", paths: ["src/components/settings/EducationVerificationPanel.tsx"] }], { draft: false });
+    expect(educationPanel.requiredJobs).toContain("system");
+    expect(educationPanel.e2eSpecs).toEqual(["tests/e2e/flows/education-manual-fallback.spec.ts"]);
+
+    const educationValidation = classifyChangedFiles([{ status: "M", paths: ["src/lib/education/validation.ts"] }], { draft: false });
+    expect(educationValidation.runSystem).toBe(false);
+    expect(educationValidation.requiredJobs).not.toContain("system");
+  });
+
+  it("enforces invariant: any evidence with e2eSpecs must activate system capability", () => {
+    const plan = classifyChangedFiles([{ status: "M", paths: ["src/actions/education-verifications.ts"] }], { draft: true });
+    expect(plan.e2eSpecs.length).toBeGreaterThan(0);
+    expect(plan.runSystem).toBe(true);
+    expect(plan.requiredJobs).toContain("system");
   });
 
   it("keeps migration on PG without triggering system", () => {


### PR DESCRIPTION
## 概述

按 Issue #597 定稿方案重构 CI Evidence Planner，解耦 PR 协作状态（Draft / Ready）与测试深度，收窄 System provider 边界，并将 main push 调整为基于 changed-surface 的 affected smoke，避免普通业务 PR 进入不必要的 System / FULL critical path。

Refs #597

## 主要变更

1. **L0–L4 风险分层与 Draft/Ready 解耦** (`scripts/ci/plan.mjs`)
   - 彻底删除 `!draft => FULL` 强绑逻辑。
   - Draft 与 Ready 使用同一个 affected Evidence Planner；Draft 输出 `draft-gate`，Ready 输出 required 的 `ci-gate`。
   - Docs 变更保持 L0 Metadata，只保留 planner + gate，不启动额外测试容器。
   - 无法分类的变化、rename/delete、CI/toolchain/harness 改动继续 fail closed 到 FULL。

2. **收窄 System Provider 边界并保证单一 Owner** (`scripts/ci/plan.mjs`)
   - 移除普通业务路径对 system 的 blanket mapping。
   - System 仅保留真实的 Auth、Session、Storage provider 或 browser/provider glue。
   - 将 Education 的 L3 映射收窄到真实 Storage 链（`storage.ts`、`commands.ts`、`education-verifications.ts`、`EducationVerificationPanel.tsx`），而纯 validation / helpers 保持 static。
   - 确立结构性不变量：任何带有 `e2eSpecs` 的证据必然激活 `system` capability，消灭 `e2eSpecs > 0 && runSystem == false` 的漂移可能。

3. **解耦 main push 与 FULL，完善操作语义** (`.github/workflows/ci.yml`)
   - `push: main` 使用 `before..sha` 规划 affected smoke。
   - 引入 nightly 定时收敛 workflow（`cron: '0 2 * * *'`）。
   - 将 concurrency group 补充 `${{ github.event_name }}`，防止 nightly schedule 与 push main 互相取消。
   - 移除 `workflow_dispatch` 的假 `force_full` input，使 manual dispatch 成为可靠的显式 FULL 入口。

4. **全量 Active Docs 与契约收口** (`CONTRIBUTING.md`, `docs/operations/local-development.md`, `docs/operations/ci.md`, `docs/testing.md`, `AGENTS.md`)
   - 全面清理并统一 active docs 中的 CI 口径，明确 Draft/Ready 仅区分 gate 与 mergeability，测试深度纯由风险分层驱动。
   - 移除内部维护性质的 Changeset，保持 release note 纯净。

## 验证

- **本地回归测试**：`pnpm vitest run tests/unit/ci/plan.test.mjs`（39 项测试全过，覆盖 L0–L4 及 Education/Invariant 场景）。
- **静态类型与边界检查**：`pnpm type-check:scripts`、`pnpm type-check:tests` 均通过。
- **首次 Hosted CI（commit `cb9db3cb`）**：Run ID [34567781798](https://github.com/Starfie1d1272/RivalHub/actions/runs/34567781798)，因触碰 `.github/**` 成功验证 L4 FULL fail-closed 路径，所有 15 个 jobs + gate 均全绿通过。

