### PR TITLE
ci(release): 收敛 CI/CD 发布链路与 exact-SHA release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,11 @@ on:
   merge_group:
   schedule:
     - cron: '0 2 * * *'
-  release:
-    types: [published]
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || (github.event_name == 'push' && github.sha || github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -66,7 +64,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
-          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'release' || github.event_name == 'merge_group' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == '')) }}
+          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'merge_group' || (github.event_name == 'push' && (github.event.before == '0000000000000000000000000000000000000000' || github.event.before == '')) }}
           PR_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft || 'false' }}
 
   static:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,7 @@ jobs:
             exit 1
           fi
           node scripts/ci/timing.mjs "scheduler provision/verify" -- bash -c '
+            set -euo pipefail
             RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision
             pnpm db:production:scheduler:verify
           '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,17 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: production
     permissions:
+      actions: read
       contents: write
       id-token: write
     env:
       NEXT_TELEMETRY_DISABLED: 1
+      CI: true
+      RIVALHUB_TIMING: 1
+      RIVALHUB_TIMING_TITLE: "Release phase timing"
       # Fixed non-secret Vercel target. VERCEL_TOKEN is the project-scoped
       # deployment credential. Protected smoke obtains a short-lived GitHub
       # OIDC token at runtime. DATABASE_URL is a GitHub production Environment
@@ -38,6 +42,9 @@ jobs:
       RIVALHUB_PRODUCTION_DB_HOST_CONFIRM: aws-0-ap-northeast-1.pooler.supabase.com:6543
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
+      - name: Capture workflow timing start
+        run: echo "RELEASE_WORKFLOW_START_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag || github.ref }}
@@ -64,6 +71,15 @@ jobs:
           fi
           echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
+      - name: Verify exact-SHA CI prerequisite
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/timing.mjs "preflight exact-SHA CI wait" -- pnpm release:ci-prerequisite
+
+      - name: Start bootstrap/install timing
+        run: echo "RELEASE_BOOTSTRAP_START_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
+
       - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
@@ -71,6 +87,9 @@ jobs:
 
       - name: Install pinned Vercel CLI
         run: pnpm add --global vercel@59.11.7
+
+      - name: Record bootstrap/install timing
+        run: node scripts/ci/timing.mjs record --label "bootstrap/install" --start-ms "$RELEASE_BOOTSTRAP_START_MS"
 
       - name: Require Vercel deploy credential
         env:
@@ -86,10 +105,10 @@ jobs:
       - name: Validate active migration chain locally
         run: |
           pnpm db:check
-          pnpm db:local:start
+          node scripts/ci/timing.mjs "DB-only local readiness" -- pnpm db:local:start-db
 
       - name: Validate previous release compatibility
-        run: pnpm db:release-compat
+        run: node scripts/ci/timing.mjs "migration rehearsal" -- pnpm db:release-compat
 
       - name: Install age encryption tool
         run: |
@@ -107,7 +126,7 @@ jobs:
           RIVALHUB_R2_BUCKET: ${{ vars.RIVALHUB_R2_BUCKET }}
           RIVALHUB_R2_ACCESS_KEY_ID: ${{ secrets.RIVALHUB_R2_ACCESS_KEY_ID }}
           RIVALHUB_R2_SECRET_ACCESS_KEY: ${{ secrets.RIVALHUB_R2_SECRET_ACCESS_KEY }}
-        run: pnpm db:recovery:backup pre-release
+        run: node scripts/ci/timing.mjs "fresh backup total" -- pnpm db:recovery:backup pre-release
 
       - name: Migrate and verify production database
         env:
@@ -117,19 +136,22 @@ jobs:
             echo "GitHub production environment secret DATABASE_URL is required." >&2
             exit 1
           fi
-          RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:migrate
-          pnpm db:production:verify
+          node scripts/ci/timing.mjs "production migration" -- env RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:migrate
+          node scripts/ci/timing.mjs "production verify" -- pnpm db:production:verify
 
-      - name: Deploy exact release commit to Vercel Production
+      - name: Deploy candidate to Vercel Production (staged)
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          DEPLOYMENT_URL="$(vercel deploy --prod --yes --token="$VERCEL_TOKEN" \
+          DEPLOY_START="$(date +%s%3N)"
+          DEPLOYMENT_URL="$(vercel deploy --prod --skip-domain --yes --token="$VERCEL_TOKEN" \
             --build-env RIVALHUB_RELEASE_TAG="$RELEASE_TAG" \
             --build-env RIVALHUB_RELEASE_COMMIT="$RELEASE_SHA")"
+          DEPLOY_END="$(date +%s%3N)"
+          node scripts/ci/timing.mjs record --label "Vercel candidate build/deploy" --start-ms "$DEPLOY_START" --end-ms "$DEPLOY_END"
           echo "url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
-          echo "Production deployment: $DEPLOYMENT_URL"
+          echo "Staged candidate deployment: $DEPLOYMENT_URL"
 
       - name: Mint GitHub OIDC token for Vercel Trusted Sources
         id: oidc
@@ -149,12 +171,13 @@ jobs:
           echo "::add-mask::$oidc_token"
           echo "token=$oidc_token" >> "$GITHUB_OUTPUT"
 
-      - name: Smoke test production deployment
+      - name: Smoke test candidate deployment
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
           VERCEL_TRUSTED_OIDC_IDP_TOKEN: ${{ steps.oidc.outputs.token }}
         run: |
           set -euo pipefail
+          SMOKE_START="$(date +%s%3N)"
           if [[ ! "$DEPLOYMENT_URL" =~ ^https://[a-z0-9][a-z0-9-]*\.vercel\.app/?$ ]]; then
             echo "Vercel deployment URL is not an exact *.vercel.app HTTPS target: $DEPLOYMENT_URL" >&2
             exit 1
@@ -167,19 +190,86 @@ jobs:
             --retry 8 --retry-all-errors --retry-delay 5 \
             -H "x-vercel-trusted-oidc-idp-token: $VERCEL_TRUSTED_OIDC_IDP_TOKEN" \
             "$DEPLOYMENT_URL/api/system/release")"
-          curl --fail --silent --show-error \
-            --retry 8 --retry-all-errors --retry-delay 5 \
-            "$RIVALHUB_PRODUCTION_BASE_URL/" >/dev/null
-          canonical_identity="$(curl --fail --silent --show-error \
-            --retry 8 --retry-all-errors --retry-delay 5 \
-            "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")"
-          for identity in "$deployment_identity" "$canonical_identity"; do
+          jq -e --arg tag "$RELEASE_TAG" --arg commit "$RELEASE_SHA" '
+            (keys | sort) == ["releaseCommit", "releaseTag"]
+            and .releaseTag == $tag
+            and .releaseCommit == $commit
+          ' <<<"$deployment_identity" >/dev/null
+          SMOKE_END="$(date +%s%3N)"
+          node scripts/ci/timing.mjs record --label "exact deployment smoke" --start-ms "$SMOKE_START" --end-ms "$SMOKE_END"
+          echo "Candidate deployment smoke verified identity: $deployment_identity"
+
+      - name: Promote candidate to canonical production
+        id: promote
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          # 记录 promote 前 canonical production 的 release identity，供失败回滚验证
+          PREVIOUS_IDENTITY="$(curl --fail --silent --show-error \
+            --retry 5 --retry-all-errors --retry-delay 3 \
+            "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release" || true)"
+          PREVIOUS_TAG="$(jq -r .releaseTag <<<"$PREVIOUS_IDENTITY" 2>/dev/null || true)"
+          PREVIOUS_COMMIT="$(jq -r .releaseCommit <<<"$PREVIOUS_IDENTITY" 2>/dev/null || true)"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "previous_commit=$PREVIOUS_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "Previous canonical production identity: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT"
+
+          PROMOTE_START="$(date +%s%3N)"
+          vercel promote "$DEPLOYMENT_URL" --yes --token="$VERCEL_TOKEN"
+          PROMOTE_END="$(date +%s%3N)"
+          node scripts/ci/timing.mjs record --label "promotion" --start-ms "$PROMOTE_START" --end-ms "$PROMOTE_END"
+          echo "Promoted $DEPLOYMENT_URL to canonical production."
+
+      - name: Smoke test canonical production
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PREVIOUS_TAG: ${{ steps.promote.outputs.previous_tag }}
+          PREVIOUS_COMMIT: ${{ steps.promote.outputs.previous_commit }}
+        run: |
+          set -euo pipefail
+          CANONICAL_START="$(date +%s%3N)"
+          smoke_canonical() {
+            curl --fail --silent --show-error \
+              --retry 8 --retry-all-errors --retry-delay 5 \
+              "$RIVALHUB_PRODUCTION_BASE_URL/" >/dev/null
+            canonical_identity="$(curl --fail --silent --show-error \
+              --retry 8 --retry-all-errors --retry-delay 5 \
+              "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")"
             jq -e --arg tag "$RELEASE_TAG" --arg commit "$RELEASE_SHA" '
               (keys | sort) == ["releaseCommit", "releaseTag"]
               and .releaseTag == $tag
               and .releaseCommit == $commit
-            ' <<<"$identity" >/dev/null
-          done
+            ' <<<"$canonical_identity" >/dev/null
+            echo "Canonical production identity confirmed: $canonical_identity"
+          }
+
+          if ! smoke_canonical; then
+            echo "::error::Canonical production smoke failed after promotion; initiating Vercel routing rollback..." >&2
+            if vercel rollback --yes --token="$VERCEL_TOKEN"; then
+              echo "Vercel rollback command succeeded; verifying canonical domain restored previous release identity..."
+              sleep 5
+              reverted_identity="$(curl --fail --silent --show-error \
+                --retry 5 --retry-all-errors --retry-delay 3 \
+                "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release" || true)"
+              echo "Reverted canonical identity: $reverted_identity"
+              if [[ -n "$PREVIOUS_TAG" && -n "$PREVIOUS_COMMIT" ]]; then
+                if jq -e --arg tag "$PREVIOUS_TAG" --arg commit "$PREVIOUS_COMMIT" '
+                  .releaseTag == $tag and .releaseCommit == $commit
+                ' <<<"$reverted_identity" >/dev/null 2>&1; then
+                  echo "Canonical domain successfully restored previous identity: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT."
+                else
+                  echo "::warning::Canonical domain did not immediately reflect previous identity ($reverted_identity vs expected $PREVIOUS_TAG/$PREVIOUS_COMMIT)." >&2
+                fi
+              fi
+            else
+              echo "::error::Vercel rollback command failed! Manual intervention required." >&2
+            fi
+            exit 1
+          fi
+          CANONICAL_END="$(date +%s%3N)"
+          node scripts/ci/timing.mjs record --label "canonical smoke" --start-ms "$CANONICAL_START" --end-ms "$CANONICAL_END"
 
       - name: Provision and verify production scheduler
         env:
@@ -191,8 +281,10 @@ jobs:
             echo "GitHub production environment secret CRON_SECRET is required." >&2
             exit 1
           fi
-          RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision
-          pnpm db:production:scheduler:verify
+          node scripts/ci/timing.mjs "scheduler provision/verify" -- bash -c '
+            RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision
+            pnpm db:production:scheduler:verify
+          '
 
       - name: Extract changelog for this version
         run: |
@@ -208,6 +300,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          RELEASE_PUB_START="$(date +%s%3N)"
           VERSION="${RELEASE_TAG#v}"
           if [[ "$VERSION" == *-* ]]; then
             RELEASE_FLAGS=(--prerelease --latest=false)
@@ -230,7 +323,13 @@ jobs:
               --notes-file /tmp/release-notes.md \
               "${RELEASE_FLAGS[@]}"
           fi
+          RELEASE_PUB_END="$(date +%s%3N)"
+          node scripts/ci/timing.mjs record --label "GitHub Release publish" --start-ms "$RELEASE_PUB_START" --end-ms "$RELEASE_PUB_END"
 
-      - name: Stop Local Supabase
+      - name: Record workflow total wall time and summary
         if: always()
-        run: pnpm db:local:stop || true
+        run: |
+          if [[ -n "$RELEASE_WORKFLOW_START_MS" ]]; then
+            node scripts/ci/timing.mjs record --label "TOTAL wall time" --start-ms "$RELEASE_WORKFLOW_START_MS"
+          fi
+          node scripts/ci/timing.mjs summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,6 @@ jobs:
           fi
           echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
-      - name: Verify exact-SHA CI prerequisite
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts/ci/timing.mjs "preflight exact-SHA CI wait" -- pnpm release:ci-prerequisite
-
       - name: Start bootstrap/install timing
         run: echo "RELEASE_BOOTSTRAP_START_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
 
@@ -90,6 +84,12 @@ jobs:
 
       - name: Record bootstrap/install timing
         run: node scripts/ci/timing.mjs record --label "bootstrap/install" --start-ms "$RELEASE_BOOTSTRAP_START_MS"
+
+      - name: Verify exact-SHA CI prerequisite
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ci/timing.mjs "preflight exact-SHA CI wait" -- pnpm release:ci-prerequisite
 
       - name: Require Vercel deploy credential
         env:
@@ -206,15 +206,20 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           set -euo pipefail
-          # 记录 promote 前 canonical production 的 release identity，供失败回滚验证
+          # 严格获取并校验 promote 前 canonical production 的 release identity，fail-closed 防止盲切
           PREVIOUS_IDENTITY="$(curl --fail --silent --show-error \
             --retry 5 --retry-all-errors --retry-delay 3 \
-            "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release" || true)"
-          PREVIOUS_TAG="$(jq -r .releaseTag <<<"$PREVIOUS_IDENTITY" 2>/dev/null || true)"
-          PREVIOUS_COMMIT="$(jq -r .releaseCommit <<<"$PREVIOUS_IDENTITY" 2>/dev/null || true)"
+            "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")"
+          jq -e '
+            (keys | sort) == ["releaseCommit", "releaseTag"]
+            and (.releaseTag | test("^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"))
+            and (.releaseCommit | test("^[0-9a-fA-F]{40}$"))
+          ' <<<"$PREVIOUS_IDENTITY" >/dev/null
+          PREVIOUS_TAG="$(jq -r .releaseTag <<<"$PREVIOUS_IDENTITY")"
+          PREVIOUS_COMMIT="$(jq -r .releaseCommit <<<"$PREVIOUS_IDENTITY")"
           echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
           echo "previous_commit=$PREVIOUS_COMMIT" >> "$GITHUB_OUTPUT"
-          echo "Previous canonical production identity: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT"
+          echo "Previous canonical production identity confirmed: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT"
 
           PROMOTE_START="$(date +%s%3N)"
           vercel promote "$DEPLOYMENT_URL" --yes --token="$VERCEL_TOKEN"
@@ -233,16 +238,17 @@ jobs:
           smoke_canonical() {
             curl --fail --silent --show-error \
               --retry 8 --retry-all-errors --retry-delay 5 \
-              "$RIVALHUB_PRODUCTION_BASE_URL/" >/dev/null
+              "$RIVALHUB_PRODUCTION_BASE_URL/" >/dev/null || return 1
             canonical_identity="$(curl --fail --silent --show-error \
               --retry 8 --retry-all-errors --retry-delay 5 \
-              "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")"
+              "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")" || return 1
             jq -e --arg tag "$RELEASE_TAG" --arg commit "$RELEASE_SHA" '
               (keys | sort) == ["releaseCommit", "releaseTag"]
               and .releaseTag == $tag
               and .releaseCommit == $commit
-            ' <<<"$canonical_identity" >/dev/null
+            ' <<<"$canonical_identity" >/dev/null || return 1
             echo "Canonical production identity confirmed: $canonical_identity"
+            return 0
           }
 
           if ! smoke_canonical; then
@@ -252,17 +258,14 @@ jobs:
               sleep 5
               reverted_identity="$(curl --fail --silent --show-error \
                 --retry 5 --retry-all-errors --retry-delay 3 \
-                "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release" || true)"
+                "$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")"
               echo "Reverted canonical identity: $reverted_identity"
-              if [[ -n "$PREVIOUS_TAG" && -n "$PREVIOUS_COMMIT" ]]; then
-                if jq -e --arg tag "$PREVIOUS_TAG" --arg commit "$PREVIOUS_COMMIT" '
-                  .releaseTag == $tag and .releaseCommit == $commit
-                ' <<<"$reverted_identity" >/dev/null 2>&1; then
-                  echo "Canonical domain successfully restored previous identity: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT."
-                else
-                  echo "::warning::Canonical domain did not immediately reflect previous identity ($reverted_identity vs expected $PREVIOUS_TAG/$PREVIOUS_COMMIT)." >&2
-                fi
-              fi
+              jq -e --arg tag "$PREVIOUS_TAG" --arg commit "$PREVIOUS_COMMIT" '
+                (keys | sort) == ["releaseCommit", "releaseTag"]
+                and .releaseTag == $tag
+                and .releaseCommit == $commit
+              ' <<<"$reverted_identity" >/dev/null
+              echo "Canonical domain successfully restored previous identity: tag=$PREVIOUS_TAG, commit=$PREVIOUS_COMMIT."
             else
               echo "::error::Vercel rollback command failed! Manual intervention required." >&2
             fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@
 
 ## Release identity
 
-`main` 是唯一长期 releasable trunk；不可移动的 `vX.Y.Z` tag 才是 shipped production identity。正式发布围绕同一个 tag commit 完成 migration、verify、exact-source deployment、smoke 与 GitHub Release；失败时重试同一安全步骤，不移动已公开 tag。
+`main` 是唯一长期 releasable trunk；不可移动的 `vX.Y.Z` tag 才是 shipped production identity。正式发布在验证 exact tag SHA 拥有成功的 canonical CI 证据后，围绕同一个 tag commit 完成 pre-release backup、DB-only migration rehearsal、production migration/verify、staged production deployment (`--prod --skip-domain`)、candidate smoke、promotion、canonical domain smoke 与 GitHub Release；失败时重试同一安全步骤，不移动已公开 tag。
 
 Production 对外提供 public、no-store 的 `/api/system/release` read-back endpoint，只返回 deployed `releaseTag` 与 `releaseCommit`；受保护 backup runner 以该响应作为 production source identity，并在本地 checkout 验证 tag 到 commit 的关系。
 

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -12,7 +12,7 @@ plan ─→ static ─────┐
    └─→ dependency-review（PR）
 ```
 
-`draft-gate` 汇总 Draft PR 的 affected evidence，用于开发中快速反馈，不能满足 ruleset 的 merge requirement。`ci-gate` 由 Ready PR、`main` push、merge queue、release、nightly schedule 和手动运行产生；它是代码正确性 evidence 的 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。PR metadata policy 由独立的 `pr-title` check 负责；要使其阻断合并，Main ruleset 需与 `ci-gate` 一起要求该 check。
+`draft-gate` 汇总 Draft PR 的 affected evidence，用于开发中快速反馈，不能满足 ruleset 的 merge requirement。`ci-gate` 由 Ready PR、`main` push、merge queue、nightly schedule 和手动运行产生；它是代码正确性 evidence 的 required check：planner 明确允许跳过的 job 可以 skipped；本应运行却 failure / cancelled / unexpected skipped 的 capability 会阻断合并。PR metadata policy 由独立的 `pr-title` check 负责；要使其阻断合并，Main ruleset 需与 `ci-gate` 一起要求该 check。
 
 ## Capabilities
 
@@ -63,7 +63,7 @@ CI 遵循 L0–L4 风险分层与最低且足够可信证据原则：
 - **L1 Static**：pure rule、formatter、presenter、component、UI/layout 等不跨 persistence/provider 边界的变化，运行 affected type/lint/architecture/unit。
 - **L2 PostgreSQL**：Server Action persistence、DB query、transaction、migration 等，运行 L1 + real PostgreSQL。
 - **L3 System**：Auth、Session、Storage provider 或 browser/provider glue，运行 L1/L2 + Local Supabase + targeted E2E。
-- **L4 Full convergence**：CI/toolchain/harness/unknown/destructive 改动、手动 FULL、release 发布或 nightly 定时收敛，运行完整 static + postgres + system。
+- **L4 Full convergence**：CI/toolchain/harness/unknown/destructive 改动、手动 FULL 或 nightly 定时收敛，运行完整 static + postgres + system。Release 直接消费 exact release SHA 在 `main` 上的 canonical CI evidence，不重复触发或等待第二套 FULL CI。
 
 Pull Request 的 Draft / Ready 仅代表协作与合并准入状态，不直接决定测试深度：
 
@@ -74,7 +74,15 @@ Pull Request 的 Draft / Ready 仅代表协作与合并准入状态，不直接�
 
 `scripts/ci/timing.mjs` 的 command wrapper 是 project wall-time owner。`vitest-timing-reporter.ts` 只输出 per-project facts 与 top 15 per-file diagnostic duration，Step Summary 会明确区分两者。
 
-`push` 到 `main`、merge queue、release 和手动 workflow 运行完整 convergence gate。
+`push` 到 `main` 同样采用 changed-surface 规划 affected evidence 并产生 exact-SHA CI evidence，遇到未知/破坏性/工具链变更时 fail closed 到 FULL；merge queue、nightly 与手动 workflow 运行完整 convergence gate。Release 消费 exact tag commit SHA 的 push CI 成功证据，不重复执行代码正确性 CI。
+
+## Concurrency 与 exact-SHA 证据隔离
+
+CI 的 concurrency 分组策略兼顾 PR 快速取消与 release exact-SHA 证据保护：
+
+- **Pull Request**：按 PR 编号独立分组（`ci-CI-pull_request-<number>`），启用 `cancel-in-progress: true`；同 PR 的新 push 立即取消旧 SHA 的在途 run，避免积压 CI 资源。
+- **main push**：按 exact commit SHA 独立分组（`ci-CI-push-<sha>`），配置 `cancel-in-progress: false`；每个进入 main 的 commit run 独立执行，不被后续 main push 误取消，确保 release 所需的 exact-SHA CI 证据永久可靠。
+- **schedule / merge queue / workflow_dispatch**：按各自 event 语义稳定分组。
 
 `ci.yml` 只响应会改变代码 evidence 的 PR event（opened、synchronize、reopened、ready_for_review）。`.github/workflows/pr-metadata.yml` 在上述事件和 `edited` 上独立运行 `pr-title`；因此 title/body 编辑不会取消、覆盖或重跑当前 head 的 `ci-gate`，而新 commit 的 `synchronize` 仍会为其 SHA 重新产生 title check。Ready PR 的新 push 必须等待该 SHA 的 FULL CI 完成，不能沿用旧 SHA 的成功结果。
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -14,7 +14,7 @@ pnpm exec changeset version
 
 ## 2. Release commit 与 tag
 
-合并后从远端 `main` read back 实际 squash commit SHA，并确认该 exact commit 的完整 convergence CI 通过。只在这个 commit 上创建 immutable `vX.Y.Z` 或显式 semver prerelease tag；普通 `main` merge 不会自动 production deploy。
+合并后从远端 `main` read back 实际 squash commit SHA，并确认该 exact commit 在 `main` 上的 canonical CI workflow run（event=push, branch=main, head_sha=RELEASE_SHA）已通过。只在这个 commit 上创建 immutable `vX.Y.Z` 或显式 semver prerelease tag；普通 `main` merge 不会自动 production deploy。即使提前打 tag，Release workflow 自身的 preflight 也会 machine-enforce 此项 exact-SHA prerequisite。
 
 ## 3. Protected Release workflow
 
@@ -22,14 +22,25 @@ Push tag 或显式 retry 已存在 tag 后，GitHub Actions **Release** 围绕�
 
 ```text
 validate tag belongs to main
-→ validate active migration chain + previous-release compatibility
+→ verify exact-SHA CI prerequisite (canonical push run on main = success)
+→ validate active migration chain (DB-only local rehearsal) + previous-release compatibility
 → fresh pre-release backup + R2 read-back
 → migrate + verify production database
-→ deploy exact tag commit to Vercel Production
-→ protected deployment smoke + canonical production identity read-back
+→ deploy staged candidate to Vercel Production (--prod --skip-domain)
+→ smoke exact candidate deployment (OIDC token)
+→ promote candidate to canonical production (no rebuild)
+→ smoke canonical production identity + release read-back (rollback routing on failure)
 → provision + verify production scheduler
 → publish/update GitHub Release notes
 ```
+
+关键安全与执行边界：
+
+1. **Exact-SHA CI prerequisite**：在任何 backup、migration 或 deploy 之前，Release 必须验证当前 immutable tag 对应的 `RELEASE_SHA` 在 `main` 上的 canonical CI push run 结果为 `completed && success`；在途 run 进行 bounded poll，missing/failed/cancelled/timed out 全部 fail closed。
+2. **DB-only migration rehearsal**：本地 migration rehearsal 仅启动 PostgreSQL 容器（`pnpm db:local:start-db`），不启动 Local Supabase 的 Auth/Storage/browser 等无关服务；CI ephemeral runner 结束时自动回收容器，不再支付无意义的 stop 开销。
+3. **Staged Production deployment**：使用 `vercel deploy --prod --skip-domain` 在 Production 环境完成构建，但不将生产域名指向该 candidate；先用短期 GitHub OIDC token 对 exact candidate URL 完成 `/` 与 `/api/system/release` smoke 验证。
+4. **Promotion 与 Rollback 边界**：Candidate smoke 通过后，执行 `vercel promote <deployment> --yes` 将生产流量切换至该 deployment，无需二次构建。Promote 前记录旧版本 identity；若切换后 canonical smoke 失败，release 自动触发 `vercel rollback` 将 Vercel 路由恢复至 previous deployment 并校验域名恢复，但**绝不自动回滚 PostgreSQL migration**（旧版本兼容性由 `db:release-compat` 保证）。
+5. **Phase timing evidence**：各阶段耗时由 `scripts/ci/timing.mjs` 统一记录并写入 Step Summary，包含 backup 内部子阶段（DB dump、Storage snapshot、encrypt/archive、R2 upload/readback）及各部署步骤。
 
 production secrets、target confirmations 与 remote-write authorization 只存在于 protected production Environment/canonical wrappers。`VERCEL_TOKEN` 必须是 project-scoped deploy credential，只负责 exact production deploy。Release job 使用 `id-token: write`，在运行时向 GitHub OIDC endpoint 申请短期 token，audience 为 `https://github.com/Starfie1d1272`；protected exact `https://<deployment>.vercel.app` smoke 只发送 `x-vercel-trusted-oidc-idp-token`。canonical `https://match.starfie1d.top` 使用普通 HTTPS read-back，不携带 OIDC header。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,7 +36,7 @@ PR CI 保留 `static`、`postgres`、`system` 三条 capability lane，按 L0–
 - Draft 与 Ready PR 均使用同一个 Evidence Planner 根据 changed surface 计算所需的 affected capability 与 task。Draft PR 汇总为非 required 的 `draft-gate`，用于开发阶段快速反馈；Ready PR 产生 ruleset required 的 `ci-gate`，作为合并所需的代码正确性证据。Ready 状态不自动将测试深度升级为 FULL。
 - 普通业务变更（L1 Static、L2 PostgreSQL）仅运行对应 affected tests，不再仅因涉及报名、队伍或页面重要性自动触发 Local Supabase / browser system flow。
 - System（L3）仅在真实 Auth、Session、Storage provider 或 browser/provider glue 变更时进入 critical path。
-- FULL（L4）不再是普通 Ready PR 或 `main` push 的默认行为，仅作为明确的收敛事件（CI/toolchain/harness/unknown/destructive 改动、手动 `workflow_dispatch`、release 发布或 nightly 定时收敛）。
+- FULL（L4）不再是普通 Ready PR 或 `main` push 的默认行为，仅作为明确的收敛事件（CI/toolchain/harness/unknown/destructive 改动、手动 `workflow_dispatch` 或 nightly 定时收敛）。Release 直接消费 exact tag commit SHA 在 `main` 上的 canonical CI evidence，不在 production activation 后补跑第二套代码正确性 CI。
 - `main` push 采用 changed-surface 规划 affected smoke，不默认重复执行 FULL。精确 planner 与 job 以 `.github/workflows/ci.yml`、`scripts/ci/plan.mjs` 为 authority，排障见 [`operations/ci.md`](./operations/ci.md)。
 
 CI 只负责选择和阻断 evidence，不成为业务测试语义的第二 owner。

--- a/knip.json
+++ b/knip.json
@@ -36,6 +36,8 @@
     "scripts/ci/timing.mjs!",
     "scripts/ci/validate-pr-title.mjs!",
     "scripts/ci/vitest-timing-reporter.ts!",
+    "scripts/release/ci-prerequisite.ts!",
+    "scripts/release/production-deployment.ts!",
     "scripts/architecture/check.ts!",
     "scripts/db/block-drizzle-push.ts!",
     "scripts/db/local.ts!",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "db:production:scheduler:provision": "tsx scripts/db/scheduler.ts provision",
     "db:production:scheduler:verify": "tsx scripts/db/scheduler.ts verify",
     "db:production:identity-merge-preflight": "tsx scripts/db/production-identity-merge-preflight.ts",
+    "release:ci-prerequisite": "tsx scripts/release/ci-prerequisite.ts",
     "db:recovery:backup": "tsx scripts/db/recovery/backup.ts",
     "db:recovery:fetch": "tsx scripts/db/recovery/fetch.ts",
     "db:recovery:restore": "tsx scripts/db/recovery/restore.ts",

--- a/scripts/ci/plan.mjs
+++ b/scripts/ci/plan.mjs
@@ -89,7 +89,7 @@ export function classifyChangedFiles(entries, options = {}) {
   const gateName = draft ? "draft-gate" : "ci-gate";
   const result = (...args) => ({ ...resultFor(...args), gateName });
   if (forceFull) {
-    return result(CAPABILITIES, true, "受保护分支、merge queue、release 或手动运行，强制 full gate");
+    return result(CAPABILITIES, true, "受保护分支、merge queue、schedule 或手动运行，强制 full gate");
   }
   if (entries.length === 0) {
     return result(CAPABILITIES, true, "无法取得 changed-surface，fail closed 到 full gate");

--- a/scripts/ci/timing.mjs
+++ b/scripts/ci/timing.mjs
@@ -82,8 +82,9 @@ function renderSummary() {
   const summaryPath = env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
 
+  const heading = env.RIVALHUB_TIMING_TITLE ?? `CI timing${env.GITHUB_JOB ? ` · ${env.GITHUB_JOB}` : ""}`;
   const lines = [
-    `## CI timing${env.GITHUB_JOB ? ` · ${env.GITHUB_JOB}` : ""}`,
+    `## ${heading}`,
     "",
     "| metric | wall time | evidence |",
     "| --- | ---: | --- |",

--- a/scripts/db/recovery/backup.ts
+++ b/scripts/db/recovery/backup.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -52,13 +53,20 @@ async function main(): Promise<void> {
     const migration = await readProductionMigrationIdentity(environment.databaseUrl);
     const source = await resolveProductionSourceIdentity();
     const activeStorageReferencesBeforeSnapshot = await readManagedStorageReferencesFromProduction(environment.databaseUrl);
+    const dbDumpStart = performance.now();
     const databaseRoot = await createDatabaseSnapshot(environment.databaseUrl, stagingRoot);
+    const dbDumpDuration = Math.round(performance.now() - dbDumpStart);
+    console.log(`timing DB dump: ${dbDumpDuration}ms`);
+
+    const storageStart = performance.now();
     const storage = await snapshotStorage(
       createClient(environment.supabaseUrl, environment.supabaseSecretKey, {
         auth: { autoRefreshToken: false, persistSession: false },
       }),
       join(stagingRoot, "storage"),
     );
+    const storageDuration = Math.round(performance.now() - storageStart);
+    console.log(`timing Storage snapshot: ${storageDuration}ms`);
     const activeStorageReferencesAfterSnapshot = await readManagedStorageReferencesFromProduction(environment.databaseUrl);
     assertActiveStorageReferencesStable(activeStorageReferencesBeforeSnapshot, activeStorageReferencesAfterSnapshot);
     assertActiveStorageReferencesCaptured(activeStorageReferencesBeforeSnapshot, storage.records);
@@ -100,10 +108,13 @@ async function main(): Promise<void> {
 
     const manifestPath = join(stagingRoot, "manifest.json");
     writeFileSync(manifestPath, serializeManifest(manifest), { flag: "wx" });
+    const encryptStart = performance.now();
     const archivePath = join(tempRoot, `${runId}.tar.gz`);
     runCommand("tar", ["-czf", archivePath, "-C", tempRoot, "backup"]);
     const artifactPath = join(tempRoot, `${runId}.tar.gz.age`);
     runCommand("age", ["-r", environment.ageRecipient, "-o", artifactPath, archivePath]);
+    const encryptDuration = Math.round(performance.now() - encryptStart);
+    console.log(`timing encrypt/archive: ${encryptDuration}ms`);
 
     const artifactBytes = readFileSync(artifactPath).byteLength;
     const artifactSha256 = sha256File(artifactPath);
@@ -134,6 +145,7 @@ async function main(): Promise<void> {
     };
     writeFileSync(completionPath, serializeCompletionMarker(completion), { flag: "wx" });
 
+    const r2Start = performance.now();
     const r2 = createR2Client(environment.r2);
     r2.put(artifactPath, keys.artifact, {
       contentType: "application/octet-stream",
@@ -153,6 +165,8 @@ async function main(): Promise<void> {
       metadata: { sha256: completionSha256, "run-id": runId, "backup-class": backupClass },
     });
     verifyR2Object(r2, keys.completion, completionPath, join(tempRoot, "completion.readback"));
+    const r2Duration = Math.round(performance.now() - r2Start);
+    console.log(`timing R2 upload/readback: ${r2Duration}ms`);
 
     console.log(
       `Production backup complete: class=${backupClass}, run=${runId}, artifactBytes=${artifactBytes}, storageObjects=${storage.objectCount}, storageBytes=${storage.totalBytes}, artifactSha256=${artifactSha256}.`,

--- a/scripts/release/ci-prerequisite.ts
+++ b/scripts/release/ci-prerequisite.ts
@@ -67,10 +67,16 @@ export function validateRunMatchesReleasePrerequisites(
       reason: `event 不是 push：实际 ${run.event}（拒绝 PR run / schedule / workflow_dispatch / other 冒充）`,
     };
   }
-  if (run.path && !run.path.endsWith(".github/workflows/ci.yml") && run.name !== "CI") {
+  if (run.name !== "CI") {
     return {
       valid: false,
-      reason: `workflow 并非 CI：实际 name=${run.name}, path=${run.path}`,
+      reason: `workflow name 并非 CI：实际 name=${run.name}`,
+    };
+  }
+  if (run.path && run.path !== ".github/workflows/ci.yml") {
+    return {
+      valid: false,
+      reason: `workflow path 并非 .github/workflows/ci.yml：实际 path=${run.path}`,
     };
   }
   return { valid: true };
@@ -106,7 +112,7 @@ export async function fetchCiWorkflowRuns(
   token: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<GitHubWorkflowRun[]> {
-  const url = `https://api.github.com/repos/${repository}/actions/runs?head_sha=${commitSha}&event=push&branch=main`;
+  const url = `https://api.github.com/repos/${repository}/actions/workflows/ci.yml/runs?head_sha=${commitSha}&event=push&branch=main`;
   const response = await fetchFn(url, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -234,7 +240,6 @@ async function cliMain(): Promise<void> {
     ? Number(process.env.CI_POLL_TIMEOUT_MS)
     : DEFAULT_POLL_TIMEOUT_MS;
 
-  const startMs = performance.now();
   try {
     await verifyExactShaCiPrerequisite({
       repository,
@@ -244,8 +249,6 @@ async function cliMain(): Promise<void> {
       pollIntervalMs,
       pollTimeoutMs,
     });
-    const duration = Math.round(performance.now() - startMs);
-    console.log(`timing preflight exact-SHA CI wait: ${duration}ms`);
     process.exit(0);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/scripts/release/ci-prerequisite.ts
+++ b/scripts/release/ci-prerequisite.ts
@@ -1,0 +1,258 @@
+import { performance } from "node:perf_hooks";
+
+export interface GitHubWorkflowRun {
+  id: number;
+  name: string;
+  head_branch: string;
+  head_sha: string;
+  path?: string;
+  event: string;
+  status: string;
+  conclusion: string | null;
+  run_attempt?: number;
+  created_at?: string;
+  updated_at?: string;
+  html_url?: string;
+}
+
+export interface WorkflowRunsApiResponse {
+  total_count: number;
+  workflow_runs: GitHubWorkflowRun[];
+}
+
+export interface CiPrerequisiteOptions {
+  repository: string;
+  releaseSha: string;
+  releaseTag: string;
+  githubToken: string;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+  logFn?: (message: string) => void;
+  errorFn?: (message: string) => void;
+}
+
+export interface CiPrerequisiteResult {
+  runId: number;
+  runAttempt: number;
+  htmlUrl: string;
+  headSha: string;
+  durationMs: number;
+  pollCount: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_POLL_TIMEOUT_MS = 900_000; // 15 minutes
+
+export function validateRunMatchesReleasePrerequisites(
+  run: GitHubWorkflowRun,
+  expectedSha: string,
+): { valid: true } | { valid: false; reason: string } {
+  if (run.head_sha.toLowerCase() !== expectedSha.toLowerCase()) {
+    return {
+      valid: false,
+      reason: `head_sha 不匹配：预期 ${expectedSha}，实际 ${run.head_sha}`,
+    };
+  }
+  if (run.head_branch !== "main") {
+    return {
+      valid: false,
+      reason: `head_branch 不是 main：实际 ${run.head_branch}`,
+    };
+  }
+  if (run.event !== "push") {
+    return {
+      valid: false,
+      reason: `event 不是 push：实际 ${run.event}（拒绝 PR run / schedule / workflow_dispatch / other 冒充）`,
+    };
+  }
+  if (run.path && !run.path.endsWith(".github/workflows/ci.yml") && run.name !== "CI") {
+    return {
+      valid: false,
+      reason: `workflow 并非 CI：实际 name=${run.name}, path=${run.path}`,
+    };
+  }
+  return { valid: true };
+}
+
+export function pickLatestCandidateRun(
+  runs: readonly GitHubWorkflowRun[],
+  expectedSha: string,
+): GitHubWorkflowRun | null {
+  const matches = runs.filter((run) => {
+    const check = validateRunMatchesReleasePrerequisites(run, expectedSha);
+    return check.valid;
+  });
+
+  if (matches.length === 0) return null;
+
+  // Sort descending by run_attempt or created_at
+  const sorted = [...matches].sort((a, b) => {
+    const attemptA = a.run_attempt ?? 1;
+    const attemptB = b.run_attempt ?? 1;
+    if (attemptB !== attemptA) return attemptB - attemptA;
+    const timeA = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const timeB = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return timeB - timeA;
+  });
+
+  return sorted[0];
+}
+
+export async function fetchCiWorkflowRuns(
+  repository: string,
+  commitSha: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<GitHubWorkflowRun[]> {
+  const url = `https://api.github.com/repos/${repository}/actions/runs?head_sha=${commitSha}&event=push&branch=main`;
+  const response = await fetchFn(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "RivalHub-Release-Preflight",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `GitHub Actions API 请求失败：HTTP ${response.status} ${response.statusText} (${url}) ${body}`,
+    );
+  }
+
+  const data = (await response.json()) as WorkflowRunsApiResponse;
+  return data.workflow_runs ?? [];
+}
+
+export async function verifyExactShaCiPrerequisite(
+  options: CiPrerequisiteOptions,
+): Promise<CiPrerequisiteResult> {
+  const {
+    repository,
+    releaseSha,
+    releaseTag,
+    githubToken,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    pollTimeoutMs = DEFAULT_POLL_TIMEOUT_MS,
+    fetchFn = fetch,
+    sleepFn = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+    logFn = console.log,
+    errorFn = console.error,
+  } = options;
+
+  if (!releaseSha || !/^[0-9a-f]{40}$/i.test(releaseSha)) {
+    throw new Error(`RELEASE_SHA 无效或缺失：${releaseSha}`);
+  }
+  if (!releaseTag || !releaseTag.startsWith("v")) {
+    throw new Error(`RELEASE_TAG 无效或缺失：${releaseTag}`);
+  }
+  if (!repository || !repository.includes("/")) {
+    throw new Error(`GITHUB_REPOSITORY 无效或缺失：${repository}`);
+  }
+  if (!githubToken) {
+    throw new Error("GITHUB_TOKEN 未设置；无法验证 exact-SHA CI evidence。");
+  }
+
+  const startTime = performance.now();
+  let pollCount = 0;
+
+  logFn(
+    `[Release Preflight] 开始验证 exact-SHA CI evidence: tag=${releaseTag}, sha=${releaseSha}, repo=${repository}`,
+  );
+
+  while (true) {
+    pollCount++;
+    const elapsedMs = performance.now() - startTime;
+
+    if (elapsedMs > pollTimeoutMs) {
+      throw new Error(
+        `[Release Preflight] 等待 exact-SHA CI 完成超时（已等待 ${Math.round(elapsedMs / 1000)}s，上限 ${Math.round(pollTimeoutMs / 1000)}s）。fail-closed 阻断发版。`,
+      );
+    }
+
+    const runs = await fetchCiWorkflowRuns(repository, releaseSha, githubToken, fetchFn);
+    const run = pickLatestCandidateRun(runs, releaseSha);
+
+    if (!run) {
+      logFn(
+        `[Release Preflight] 未找到 commit ${releaseSha} 的 canonical CI push run (poll #${pollCount}, elapsed ${Math.round(elapsedMs / 1000)}s)。将在 ${Math.round(pollIntervalMs / 1000)}s 后重试...`,
+      );
+      await sleepFn(pollIntervalMs);
+      continue;
+    }
+
+    logFn(
+      `[Release Preflight] 找到 CI run id=${run.id} (attempt=${run.run_attempt ?? 1}): status=${run.status}, conclusion=${run.conclusion ?? "null"}`,
+    );
+
+    if (run.status === "completed") {
+      if (run.conclusion === "success") {
+        const totalDuration = performance.now() - startTime;
+        logFn(
+          `[Release Preflight] ✅ Exact-SHA CI evidence 通过！runId=${run.id}, conclusion=success, url=${run.html_url ?? ""}`,
+        );
+        return {
+          runId: run.id,
+          runAttempt: run.run_attempt ?? 1,
+          htmlUrl: run.html_url ?? "",
+          headSha: run.head_sha,
+          durationMs: totalDuration,
+          pollCount,
+        };
+      }
+
+      // Completed with non-success conclusion
+      errorFn(
+        `[Release Preflight] ❌ Exact-SHA CI 未通过：runId=${run.id}, conclusion=${run.conclusion} (${run.html_url ?? ""})`,
+      );
+      throw new Error(
+        `Release 阻断：exact release commit ${releaseSha} 的 canonical CI push run 结果为 ${run.conclusion}，未满足 success prerequisite。`,
+      );
+    }
+
+    // Still in progress / queued / waiting
+    logFn(
+      `[Release Preflight] CI run 正在运行中 (status=${run.status})，进入 bounded poll (已等待 ${Math.round(elapsedMs / 1000)}s / 最大 ${Math.round(pollTimeoutMs / 1000)}s)... 下次检查在 ${Math.round(pollIntervalMs / 1000)}s 后`,
+    );
+    await sleepFn(pollIntervalMs);
+  }
+}
+
+async function cliMain(): Promise<void> {
+  const repository = process.env.GITHUB_REPOSITORY ?? "";
+  const releaseSha = process.env.RELEASE_SHA ?? "";
+  const releaseTag = process.env.RELEASE_TAG ?? "";
+  const githubToken = process.env.GITHUB_TOKEN ?? "";
+
+  const pollIntervalMs = process.env.CI_POLL_INTERVAL_MS
+    ? Number(process.env.CI_POLL_INTERVAL_MS)
+    : DEFAULT_POLL_INTERVAL_MS;
+  const pollTimeoutMs = process.env.CI_POLL_TIMEOUT_MS
+    ? Number(process.env.CI_POLL_TIMEOUT_MS)
+    : DEFAULT_POLL_TIMEOUT_MS;
+
+  const startMs = performance.now();
+  try {
+    await verifyExactShaCiPrerequisite({
+      repository,
+      releaseSha,
+      releaseTag,
+      githubToken,
+      pollIntervalMs,
+      pollTimeoutMs,
+    });
+    const duration = Math.round(performance.now() - startMs);
+    console.log(`timing preflight exact-SHA CI wait: ${duration}ms`);
+    process.exit(0);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/"))) {
+  void cliMain();
+}

--- a/tests/unit/release/ci-prerequisite.test.ts
+++ b/tests/unit/release/ci-prerequisite.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  pickLatestCandidateRun,
+  validateRunMatchesReleasePrerequisites,
+  verifyExactShaCiPrerequisite,
+  type GitHubWorkflowRun,
+} from "../../../scripts/release/ci-prerequisite";
+
+const TEST_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+describe("release CI prerequisite validator", () => {
+  it("accepts a matching canonical CI push run", () => {
+    const run: GitHubWorkflowRun = {
+      id: 101,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      run_attempt: 1,
+    };
+    expect(validateRunMatchesReleasePrerequisites(run, TEST_SHA)).toEqual({ valid: true });
+  });
+
+  it("rejects run with mismatched SHA", () => {
+    const run: GitHubWorkflowRun = {
+      id: 102,
+      name: "CI",
+      head_branch: "main",
+      head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+    };
+    const result = validateRunMatchesReleasePrerequisites(run, TEST_SHA);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("head_sha 不匹配");
+    }
+  });
+
+  it("rejects PR runs, schedules, and workflow_dispatch", () => {
+    for (const event of ["pull_request", "schedule", "workflow_dispatch", "release"]) {
+      const run: GitHubWorkflowRun = {
+        id: 103,
+        name: "CI",
+        head_branch: "main",
+        head_sha: TEST_SHA,
+        path: ".github/workflows/ci.yml",
+        event,
+        status: "completed",
+        conclusion: "success",
+      };
+      const result = validateRunMatchesReleasePrerequisites(run, TEST_SHA);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toContain("event 不是 push");
+      }
+    }
+  });
+
+  it("rejects runs from non-main branches", () => {
+    const run: GitHubWorkflowRun = {
+      id: 104,
+      name: "CI",
+      head_branch: "feat/my-feature",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+    };
+    const result = validateRunMatchesReleasePrerequisites(run, TEST_SHA);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("head_branch 不是 main");
+    }
+  });
+
+  it("rejects runs from non-CI workflows", () => {
+    const run: GitHubWorkflowRun = {
+      id: 105,
+      name: "Release",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/release.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+    };
+    const result = validateRunMatchesReleasePrerequisites(run, TEST_SHA);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("workflow 并非 CI");
+    }
+  });
+});
+
+describe("pickLatestCandidateRun", () => {
+  it("picks the latest attempt when multiple runs exist for same SHA", () => {
+    const runs: GitHubWorkflowRun[] = [
+      {
+        id: 201,
+        name: "CI",
+        head_branch: "main",
+        head_sha: TEST_SHA,
+        path: ".github/workflows/ci.yml",
+        event: "push",
+        status: "completed",
+        conclusion: "failure",
+        run_attempt: 1,
+      },
+      {
+        id: 201,
+        name: "CI",
+        head_branch: "main",
+        head_sha: TEST_SHA,
+        path: ".github/workflows/ci.yml",
+        event: "push",
+        status: "completed",
+        conclusion: "success",
+        run_attempt: 2,
+      },
+    ];
+    const picked = pickLatestCandidateRun(runs, TEST_SHA);
+    expect(picked?.run_attempt).toBe(2);
+    expect(picked?.conclusion).toBe("success");
+  });
+
+  it("returns null when no matching run exists", () => {
+    const runs: GitHubWorkflowRun[] = [
+      {
+        id: 202,
+        name: "CI",
+        head_branch: "main",
+        head_sha: "other-sha-00000000000000000000000000000000",
+        path: ".github/workflows/ci.yml",
+        event: "push",
+        status: "completed",
+        conclusion: "success",
+      },
+    ];
+    expect(pickLatestCandidateRun(runs, TEST_SHA)).toBeNull();
+  });
+});
+
+describe("verifyExactShaCiPrerequisite orchestration", () => {
+  it("fails fast if arguments are missing or malformed", async () => {
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "Starfie1d1272/RivalHub",
+        releaseSha: "short",
+        releaseTag: "v2.9.0",
+        githubToken: "fake-token",
+      }),
+    ).rejects.toThrow(/RELEASE_SHA 无效或缺失/);
+
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "Starfie1d1272/RivalHub",
+        releaseSha: TEST_SHA,
+        releaseTag: "not-a-tag",
+        githubToken: "fake-token",
+      }),
+    ).rejects.toThrow(/RELEASE_TAG 无效或缺失/);
+
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "",
+        releaseSha: TEST_SHA,
+        releaseTag: "v2.9.0",
+        githubToken: "fake-token",
+      }),
+    ).rejects.toThrow(/GITHUB_REPOSITORY 无效或缺失/);
+
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "Starfie1d1272/RivalHub",
+        releaseSha: TEST_SHA,
+        releaseTag: "v2.9.0",
+        githubToken: "",
+      }),
+    ).rejects.toThrow(/GITHUB_TOKEN 未设置/);
+  });
+
+  it("succeeds when candidate run has status=completed and conclusion=success", async () => {
+    const mockRun: GitHubWorkflowRun = {
+      id: 301,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+      run_attempt: 1,
+      html_url: "https://github.com/Starfie1d1272/RivalHub/actions/runs/301",
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_count: 1, workflow_runs: [mockRun] }),
+    });
+
+    const result = await verifyExactShaCiPrerequisite({
+      repository: "Starfie1d1272/RivalHub",
+      releaseSha: TEST_SHA,
+      releaseTag: "v2.9.0",
+      githubToken: "fake-token",
+      fetchFn: mockFetch as unknown as typeof fetch,
+      logFn: vi.fn(),
+    });
+
+    expect(result.runId).toBe(301);
+    expect(result.pollCount).toBe(1);
+    expect(result.htmlUrl).toBe(mockRun.html_url);
+  });
+
+  it("polls boundedly when status is in_progress then succeeds", async () => {
+    let callCount = 0;
+    const inProgressRun: GitHubWorkflowRun = {
+      id: 302,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "in_progress",
+      conclusion: null,
+      run_attempt: 1,
+    };
+    const completedRun: GitHubWorkflowRun = {
+      ...inProgressRun,
+      status: "completed",
+      conclusion: "success",
+    };
+
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return {
+        ok: true,
+        json: async () => ({
+          total_count: 1,
+          workflow_runs: [callCount >= 2 ? completedRun : inProgressRun],
+        }),
+      };
+    });
+
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await verifyExactShaCiPrerequisite({
+      repository: "Starfie1d1272/RivalHub",
+      releaseSha: TEST_SHA,
+      releaseTag: "v2.9.0",
+      githubToken: "fake-token",
+      pollIntervalMs: 100,
+      pollTimeoutMs: 5000,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      sleepFn,
+      logFn: vi.fn(),
+    });
+
+    expect(result.runId).toBe(302);
+    expect(result.pollCount).toBe(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when run conclusion is failure", async () => {
+    const failedRun: GitHubWorkflowRun = {
+      id: 303,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "failure",
+      run_attempt: 1,
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_count: 1, workflow_runs: [failedRun] }),
+    });
+
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "Starfie1d1272/RivalHub",
+        releaseSha: TEST_SHA,
+        releaseTag: "v2.9.0",
+        githubToken: "fake-token",
+        fetchFn: mockFetch as unknown as typeof fetch,
+        logFn: vi.fn(),
+        errorFn: vi.fn(),
+      }),
+    ).rejects.toThrow(/未满足 success prerequisite/);
+  });
+
+  it("fails closed when run conclusion is cancelled", async () => {
+    const cancelledRun: GitHubWorkflowRun = {
+      id: 304,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "cancelled",
+      run_attempt: 1,
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_count: 1, workflow_runs: [cancelledRun] }),
+    });
+
+    await expect(
+      verifyExactShaCiPrerequisite({
+        repository: "Starfie1d1272/RivalHub",
+        releaseSha: TEST_SHA,
+        releaseTag: "v2.9.0",
+        githubToken: "fake-token",
+        fetchFn: mockFetch as unknown as typeof fetch,
+        logFn: vi.fn(),
+        errorFn: vi.fn(),
+      }),
+    ).rejects.toThrow(/未满足 success prerequisite/);
+  });
+});

--- a/tests/unit/release/ci-prerequisite.test.ts
+++ b/tests/unit/release/ci-prerequisite.test.ts
@@ -80,8 +80,9 @@ describe("release CI prerequisite validator", () => {
     }
   });
 
-  it("rejects runs from non-CI workflows", () => {
-    const run: GitHubWorkflowRun = {
+  it("rejects runs from non-CI workflows or mismatched workflow paths", () => {
+    // Both wrong
+    const runBothWrong: GitHubWorkflowRun = {
       id: 105,
       name: "Release",
       head_branch: "main",
@@ -91,11 +92,42 @@ describe("release CI prerequisite validator", () => {
       status: "completed",
       conclusion: "success",
     };
-    const result = validateRunMatchesReleasePrerequisites(run, TEST_SHA);
-    expect(result.valid).toBe(false);
-    if (!result.valid) {
-      expect(result.reason).toContain("workflow 并非 CI");
-    }
+    expect(validateRunMatchesReleasePrerequisites(runBothWrong, TEST_SHA)).toEqual({
+      valid: false,
+      reason: "workflow name 并非 CI：实际 name=Release",
+    });
+
+    // Name matches CI but path is different
+    const runWrongPath: GitHubWorkflowRun = {
+      id: 106,
+      name: "CI",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/other.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+    };
+    expect(validateRunMatchesReleasePrerequisites(runWrongPath, TEST_SHA)).toEqual({
+      valid: false,
+      reason: "workflow path 并非 .github/workflows/ci.yml：实际 path=.github/workflows/other.yml",
+    });
+
+    // Path matches ci.yml but name is not CI
+    const runWrongName: GitHubWorkflowRun = {
+      id: 107,
+      name: "Nightly",
+      head_branch: "main",
+      head_sha: TEST_SHA,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      status: "completed",
+      conclusion: "success",
+    };
+    expect(validateRunMatchesReleasePrerequisites(runWrongName, TEST_SHA)).toEqual({
+      valid: false,
+      reason: "workflow name 并非 CI：实际 name=Nightly",
+    });
   });
 });
 
@@ -217,6 +249,14 @@ describe("verifyExactShaCiPrerequisite orchestration", () => {
     expect(result.runId).toBe(301);
     expect(result.pollCount).toBe(1);
     expect(result.htmlUrl).toBe(mockRun.html_url);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.github.com/repos/Starfie1d1272/RivalHub/actions/workflows/ci.yml/runs?head_sha=${TEST_SHA}&event=push&branch=main`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer fake-token",
+        }),
+      }),
+    );
   });
 
   it("polls boundedly when status is in_progress then succeeds", async () => {

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -328,13 +328,26 @@ describe("deployment and operations contracts", () => {
     expect(release).toContain("runs-on: ubuntu-24.04");
     expect(release).toContain("actions: read\n      contents: write\n      id-token: write");
 
-    // Ordering: CI prerequisite before backup and DB mutations
+    // Ordering: dependency setup before preflight, preflight before backup and DB mutations
+    const pnpmSetupIdx = release.indexOf("uses: pnpm/setup");
     const ciPrereqIdx = release.indexOf("Verify exact-SHA CI prerequisite");
     const backupIdx = release.indexOf("Create protected pre-release backup");
     const migrateIdx = release.indexOf("Migrate and verify production database");
-    expect(ciPrereqIdx).toBeGreaterThan(0);
+    expect(pnpmSetupIdx).toBeGreaterThan(0);
+    expect(pnpmSetupIdx).toBeLessThan(ciPrereqIdx);
     expect(ciPrereqIdx).toBeLessThan(backupIdx);
     expect(backupIdx).toBeLessThan(migrateIdx);
+
+    // Knip entries registration
+    const knipConfig = JSON.parse(readProjectFile("knip.json")) as { entry: string[] };
+    expect(knipConfig.entry).toContain("scripts/release/ci-prerequisite.ts!");
+    expect(knipConfig.entry).toContain("scripts/release/production-deployment.ts!");
+
+    // Shell safety: fail-closed previous identity and no error swallowing in smoke
+    expect(release).toContain('PREVIOUS_IDENTITY="$(curl --fail');
+    expect(release).not.toMatch(/PREVIOUS_IDENTITY=.*\|\|\s*true/);
+    expect(release).toContain('"$RIVALHUB_PRODUCTION_BASE_URL/" >/dev/null || return 1');
+    expect(release).toContain('"$RIVALHUB_PRODUCTION_BASE_URL/api/system/release")" || return 1');
 
     // DB-only local rehearsal
     expect(release).toContain("pnpm db:local:start-db");

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -130,11 +130,13 @@ describe("deployment and operations contracts", () => {
     expect(release).not.toContain("VERCEL_AUTOMATION_BYPASS_SECRET");
     expect(release).not.toContain("protection-bypass");
     expect(release).not.toContain("x-vercel-protection-bypass");
-    const smokeStart = release.indexOf("      - name: Smoke test production deployment");
+    const smokeStart = release.indexOf("      - name: Smoke test candidate deployment");
     const schedulerStart = release.indexOf("      - name: Provision and verify production scheduler");
     const smoke = release.slice(smokeStart, schedulerStart);
     expect(smoke).toContain("^https://[a-z0-9][a-z0-9-]*\\.vercel\\.app/?$");
-    expect(smoke).not.toContain("VERCEL_TOKEN");
+    const candidateSmoke = smoke.slice(0, smoke.indexOf("- name: Promote candidate"));
+    expect(candidateSmoke).not.toContain("VERCEL_TOKEN");
+    expect(candidateSmoke).toContain("x-vercel-trusted-oidc-idp-token: $VERCEL_TRUSTED_OIDC_IDP_TOKEN");
     const canonicalIdentity = smoke.slice(smoke.indexOf("canonical_identity="));
     expect(canonicalIdentity).not.toContain("x-vercel-trusted-oidc-idp-token");
     const productionSerialization = "concurrency:\n  group: rivalhub-production-state-serialization\n  queue: max\n  cancel-in-progress: false";
@@ -258,8 +260,8 @@ describe("deployment and operations contracts", () => {
 
     expect(release).toContain("fetch-depth: 0");
     expect(release).toContain("RIVALHUB_PRODUCTION_STABLE_REF: origin/main");
-    expect(release).toContain("run: pnpm db:release-compat");
-    expect(release.indexOf("run: pnpm db:release-compat")).toBeLessThan(release.indexOf("pnpm db:production:migrate"));
+    expect(release).toContain("pnpm db:release-compat");
+    expect(release.indexOf("pnpm db:release-compat")).toBeLessThan(release.indexOf("pnpm db:production:migrate"));
   });
 
   it("retries an immutable GitHub Release without editing its published metadata", () => {
@@ -285,7 +287,6 @@ describe("deployment and operations contracts", () => {
 
     expect(workflow).toContain("fail-fast: false");
     expect(workflow).toContain("timeout-minutes: 5");
-    expect(workflow).toContain("matrix:");
     for (const jobKey of jobKeys) expect(workflow).toContain(`- job_key: ${jobKey}`);
     expect(workflow).toContain("/api/cron/${CRON_JOB_KEY}");
     expect(workflow).toContain("CRON_SECRET: ${{ secrets.CRON_SECRET }}");
@@ -310,7 +311,43 @@ describe("deployment and operations contracts", () => {
     expect(release).toContain("RIVALHUB_SCHEDULER_BASE_URL: https://match.starfie1d.top");
     expect(release).toContain("RIVALHUB_ALLOW_REMOTE_DB_WRITE=production pnpm db:production:scheduler:provision");
     expect(release).toContain("pnpm db:production:scheduler:verify");
-    expect(release.indexOf("Smoke test production deployment")).toBeLessThan(release.indexOf("Provision and verify production scheduler"));
+    expect(release.indexOf("Smoke test canonical production")).toBeLessThan(release.indexOf("Provision and verify production scheduler"));
     expect(release.indexOf("Provision and verify production scheduler")).toBeLessThan(release.indexOf("Extract changelog for this version"));
+  });
+
+  it("enforces Issue #603 release orchestration and CI convergence contract", () => {
+    const ci = readProjectFile(".github/workflows/ci.yml");
+    const release = readProjectFile(".github/workflows/release.yml");
+
+    // CI triggers & concurrency
+    expect(ci).not.toMatch(/^\s+release:\s*$/m);
+    expect(ci).toContain("group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || (github.event_name == 'push' && github.sha || github.ref) }}");
+    expect(ci).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
+
+    // Release runner & permissions
+    expect(release).toContain("runs-on: ubuntu-24.04");
+    expect(release).toContain("actions: read\n      contents: write\n      id-token: write");
+
+    // Ordering: CI prerequisite before backup and DB mutations
+    const ciPrereqIdx = release.indexOf("Verify exact-SHA CI prerequisite");
+    const backupIdx = release.indexOf("Create protected pre-release backup");
+    const migrateIdx = release.indexOf("Migrate and verify production database");
+    expect(ciPrereqIdx).toBeGreaterThan(0);
+    expect(ciPrereqIdx).toBeLessThan(backupIdx);
+    expect(backupIdx).toBeLessThan(migrateIdx);
+
+    // DB-only local rehearsal
+    expect(release).toContain("pnpm db:local:start-db");
+    expect(release).not.toContain("pnpm db:local:start\n");
+    expect(release).not.toContain("pnpm db:local:stop");
+
+    // Staged production deployment and promotion
+    expect(release).toContain("vercel deploy --prod --skip-domain");
+    expect(release).toContain('vercel promote "$DEPLOYMENT_URL" --yes');
+    expect(release).toContain("vercel rollback --yes");
+
+    // Phase timing evidence
+    expect(release).toContain('RIVALHUB_TIMING_TITLE: "Release phase timing"');
+    expect(release).toContain('node scripts/ci/timing.mjs summary');
   });
 });

--- a/tests/unit/release/runtime-contract.test.ts
+++ b/tests/unit/release/runtime-contract.test.ts
@@ -304,7 +304,7 @@ describe("deployment and operations contracts", () => {
     expect(workflow).not.toContain("|| true");
   });
 
-  it("provisions the primary scheduler only after production smoke", () => {
+  it("provisions the primary scheduler only after production smoke with strict fail-fast", () => {
     const release = readProjectFile(".github/workflows/release.yml");
 
     expect(release).toContain("Provision and verify production scheduler");
@@ -313,6 +313,13 @@ describe("deployment and operations contracts", () => {
     expect(release).toContain("pnpm db:production:scheduler:verify");
     expect(release.indexOf("Smoke test canonical production")).toBeLessThan(release.indexOf("Provision and verify production scheduler"));
     expect(release.indexOf("Provision and verify production scheduler")).toBeLessThan(release.indexOf("Extract changelog for this version"));
+
+    // Verify bash -c fail-fast safety
+    const schedulerStep = release.slice(
+      release.indexOf("Provision and verify production scheduler"),
+      release.indexOf("Extract changelog for this version"),
+    );
+    expect(schedulerStep).toMatch(/bash -c '\s*set -euo pipefail/);
   });
 
   it("enforces Issue #603 release orchestration and CI convergence contract", () => {


### PR DESCRIPTION
## 概要

Refs #603

按照 Issue #603 及 2026-09-11 补充意见，从当前真实代码出发完成 CI/CD 发布链路收敛与 exact-SHA release gate 实现：

1. **Exact-SHA CI prerequisite**：新增单一 release preflight owner ，在任何 production backup / migration / deploy 之前，强制要求当前 immutable tag 对应的  在  上的 canonical CI push workflow run 为 ；若在途则进入 bounded poll，missing/failed/cancelled/timed out 全部 fail closed。
2. **CI Concurrency 隔离**：PR 采用 PR identity 分组且 ；main push 采用 commit SHA 独立分组且 ，确保进入 main 的 commit 拥有的 exact-SHA CI evidence 不被后续 commit 误取消。
3. **删除  CI 伪 owner**：移除  中的 release trigger，并在 、、、、 中统一终态语义，不再让 Release 在 production activation 之后补跑第二套 CI。
4. **Staged Vercel Production Deployment**：Release workflow 改用 ，先验证 exact candidate URL 的  与 （携带 OIDC token）；通过后再执行 （无须 rebuild）；promote 成功后再单独 smoke canonical domain。
5. **Promote 失败回滚保护**：promote 前记录 previous canonical production identity；若切换后 canonical smoke 失败，自动触发  恢复路由并校验域名恢复，fail closed 阻断后续步骤，且绝不自动回滚 PostgreSQL migration。
6. **DB-only rehearsal**：Release workflow 中的 local migration rehearsal 从完整 Local Supabase 改为复用已有 ，并在 ephemeral runner 上移除多余的 stop 开销。
7. **Release Phase Timing 永久 evidence**：通过  记录并输出 release 各 phase 的 wall-time 到 GitHub Step Summary，并在  中内部打点 DB dump、Storage snapshot、encrypt/archive、R2 upload/readback 等子阶段耗时。

## Changeset

纯 CI/CD orchestration、release preflight 检查、运维测试与 canonical 文档更新，不改变 shipped 用户/管理员功能与数据库 migration，按 CONTRIBUTING.md 说明免除 Changeset。

## 验证

- Generating route types...
✓ Types generated successfully 通过（app, tests, scripts）
-  通过（0 errors, 0 warnings）
- Architecture contract passed. 通过
- migration-risk: no changed active migrations; historical SQL remains under Drizzle ledger/replay checks.
No config path provided, using default 'drizzle.config.ts'
Reading config file '/Users/starfie1d/GitHub/RivalHub/drizzle.config.ts'
Everything's fine 🐶🔥 通过
-  全量通过（91/91 tests）
