### PR TITLE
fix(preview): 固定公开 Preview persona 密码

### DIFF
--- a/.github/workflows/refresh-preview-data.yml
+++ b/.github/workflows/refresh-preview-data.yml
@@ -99,7 +99,6 @@ jobs:
           RIVALHUB_PREVIEW_RESET_CONFIRM: cueazphyskstwdhnzsxx
           RIVALHUB_STAGING_DB_PASSWORD: ${{ secrets.RIVALHUB_STAGING_DB_PASSWORD }}
           RIVALHUB_PREVIEW_DEV_SECRET_KEY: ${{ secrets.RIVALHUB_PREVIEW_DEV_SECRET_KEY }}
-          RIVALHUB_PREVIEW_PERSONA_PASSWORD: ${{ secrets.RIVALHUB_PREVIEW_PERSONA_PASSWORD }}
           RIVALHUB_PREVIEW_APPLY_CURRENT_MIGRATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.apply_current_migrations || 'false' }}
           GITHUB_ACTIONS: true
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/docs/auth-and-permissions.md
+++ b/docs/auth-and-permissions.md
@@ -67,11 +67,12 @@ Fresh deployment 的 owner bootstrap 只通过 `RIVALHUB_OWNER_EMAIL`：当尚�
 - `X-RivalHub-Cron-Source` 只用于 primary/watchdog/manual/legacy execution 分支与健康投影，不替代 `Authorization: Bearer CRON_SECRET`；缺失 header 兼容 legacy，未知值拒绝。
 - `scheduled_job_health` 是 server-only 的有界当前投影，默认 RLS deny 且撤销 `anon`/`authenticated` grants；不提供浏览器 Data API 或 Realtime surface。
 - secret 不进入 `NEXT_PUBLIC_*`、Client props、Issue/PR、fixture 或日志。
+- Preview persona password 是公开的 disposable fixture credential，不属于 secret contract；具体账号和统一密码由 [`operations/preview-mirror.md`](./operations/preview-mirror.md) 维护。
 - recovery/signup/token、Cookie、Authorization 和教育证据遵守相同的默认敏感边界。
 - runtime 日志的脱敏与安全序列化见 [`operations/observability.md`](./operations/observability.md)。
 
 ## Preview personas
 
-Preview 固定使用 `rivalhub-dev` 的 Auth。refresh 会提供 deterministic `player`、`invited`、`captain`、`season-admin`、`super-admin` 便捷测试账号：队长优先绑定当前赛事 linked Team 的 captain，season-admin 获得当前赛季 grant，super-admin 独立选择。它们不是唯一允许登录的账号；正常 dev 注册、登录、重置和业务写入都可用。
+Preview 固定使用 `rivalhub-dev` 的 Auth。refresh 会提供 deterministic `player`、`invited`、`captain`、`season-admin`、`super-admin` 便捷测试账号：队长优先绑定当前赛事 linked Team 的 captain，season-admin 获得当前赛季 grant，super-admin 独立选择。它们使用公开、统一、可重置的 disposable fixture credential，不是安全边界；Vercel Deployment Protection 仍负责 Preview 访问控制。它们不是唯一允许登录的账号；正常 dev 注册、登录、重置和业务写入都可用。
 
 Vercel Preview 仅可配置 dev-scoped Supabase URL、anon/secret credential、独立 `ADMIN_SESSION_SECRET` 与必要的 dev/sandbox provider credential；`SUPABASE_SERVICE_ROLE_KEY` 仅作为尚未迁移环境的 fallback。privileged credential 可以存在，但其权限必须只限 `rivalhub-dev`；production credential 永远不得进入 Preview。

--- a/docs/operations/preview-mirror.md
+++ b/docs/operations/preview-mirror.md
@@ -6,7 +6,7 @@ RivalHub 的所有 Vercel Preview 固定连接 `rivalhub-dev`，不连接 produc
 
 - 每日定时、手动 dispatch，以及 Release 成功后的 `workflow_run` 都进入同一个不可并行的 refresh concurrency。
 - production job 只使用 production environment 的 `DATABASE_URL`/Supabase secret key；它不能写 production。公共 asset allowlist 在这一 job 生效。
-- dev job 只使用 staging environment 的 dev DB password、dev Supabase secret 和 persona password；它不能读取 production credential。
+- dev job 只使用 staging environment 的 dev DB password 和 dev Supabase secret；persona password 是仓库定义的公开 fixture，不需要 secret provisioning。它不能读取 production credential。
 - snapshot 只包含审查过的 public/domain projections。Auth identity、邮件、教育证据、邀请 token、审计、`recruitment_interests` 和 private bucket 不导出；公共 Team 招募 projection、team logo 与显式 allowlist 的赛事公共 asset 可以镜像。
 - `preview_mirror_state` 只记录 source tag/commit、refresh 时间和计数，供 Preview banner 诊断；它不是 availability 状态机。
 - refresh 先 reset 并应用 snapshot source migrations，再导入脱敏 production snapshot 和验证外键；manual dispatch 可随后把指定 ref 的当前 migration 应用到这份 production-derived 数据并再次验证，最后才 provision persona、公共 assets 与 mirror state。旧 Preview 因共享 schema/data 失效是可接受的 trade-off；daily/post-release refresh 始终用 `main`。
@@ -19,10 +19,24 @@ Vercel Preview environment 只配置 dev-scoped 值：
 - `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` 与 `SUPABASE_SECRET_KEY`：`rivalhub-dev` credential；`SUPABASE_SERVICE_ROLE_KEY` 只作为尚未迁移环境的临时 fallback；
 - 独立 Preview `ADMIN_SESSION_SECRET`，以及仅用于 dev/sandbox 的邮件、OCR 或其它 provider credential。
 
-Preview runtime 拒绝非 `rivalhub-dev` database/public Auth URL 与缺失的 server credential；production DB/Auth/Storage/provider credential 永远不得出现。正常的 dev 写入、Auth、Storage 和 sandbox provider 行为不受 Preview 专用限制；没有 sandbox provider credential 的单项能力应独立 fail closed。
+Preview runtime 拒绝非 `rivalhub-dev` database/public Auth URL 与缺失的 server credential；production DB/Auth/Storage/provider credential 永远不得出现。Vercel Deployment Protection 仍是 Preview 的访问边界；persona fixture credential 不是安全边界。正常的 dev 写入、Auth、Storage 和 sandbox provider 行为不受 Preview 专用限制；没有 sandbox provider credential 的单项能力应独立 fail closed。
+
+## Preview persona fixture credentials
+
+以下是 disposable Preview fixture credentials，供已经通过 Vercel Deployment Protection 的 developer/agent 直接进行角色态测试。它们不是安全 credential，也不应当用于 production 或其它不可牺牲环境；每次 refresh 都会把五个账号的密码重置为统一值。
+
+统一密码：`rivalhub-preview-persona-resettable`
+
+| Persona | Email |
+| --- | --- |
+| player | `preview-player@preview.invalid` |
+| invited | `preview-invited@preview.invalid` |
+| captain | `preview-captain@preview.invalid` |
+| season-admin | `preview-season-admin@preview.invalid` |
+| super-admin | `preview-super-admin@preview.invalid` |
 
 ## owner 一次性操作
 
-1. 在 GitHub `staging` environment 录入 `RIVALHUB_PREVIEW_DEV_SECRET_KEY`、`RIVALHUB_PREVIEW_PERSONA_PASSWORD` 与现有 `RIVALHUB_STAGING_DB_PASSWORD`。
+1. 在 GitHub `staging` environment 录入 `RIVALHUB_PREVIEW_DEV_SECRET_KEY` 与现有 `RIVALHUB_STAGING_DB_PASSWORD`；无需配置 persona password secret。
 2. 在 Vercel Preview environment 录入上述 dev-scoped 值，删除任何 production 或身份不明的同名值；保留 Deployment Protection。
 3. 手动运行 `Refresh Preview Data`，确认 job summary 的 source commit 和页面 smoke。artifact 保留一天，且不得下载到个人设备或把 secret 写入 PR。

--- a/scripts/db/preview/environment.ts
+++ b/scripts/db/preview/environment.ts
@@ -20,14 +20,10 @@ export function targetEnvironment(env: NodeJS.ProcessEnv = process.env) {
   if (env.RIVALHUB_PREVIEW_RESET_CONFIRM !== STAGING_PROJECT_REF) throw new Error("Explicit dev mirror reset confirmation required.");
   const databaseUrl = buildStagingEnvironment(env, { requiresWriteAuthorization: true }).DATABASE_URL!;
   const secretKey = env.RIVALHUB_PREVIEW_DEV_SECRET_KEY;
-  const personaPassword = env.RIVALHUB_PREVIEW_PERSONA_PASSWORD;
-  if (!secretKey || !personaPassword || personaPassword.length < 24) {
-    throw new Error("Mirror dev Auth and persona credentials must be provisioned first.");
-  }
+  if (!secretKey) throw new Error("Mirror dev Auth credential must be provisioned first.");
   return {
     databaseUrl,
     secretKey,
-    personaPassword,
     applyCurrentMigrations: env.RIVALHUB_PREVIEW_APPLY_CURRENT_MIGRATIONS === "true",
     supabaseUrl: `https://${STAGING_PROJECT_REF}.supabase.co`,
   };

--- a/scripts/db/preview/personas.ts
+++ b/scripts/db/preview/personas.ts
@@ -3,6 +3,9 @@ import { createHash } from "node:crypto";
 export const PREVIEW_PERSONAS = ["player", "invited", "captain", "season-admin", "super-admin"] as const;
 export type PreviewPersona = (typeof PREVIEW_PERSONAS)[number];
 
+/** Public, disposable fixture credential; never source it from protected environment config. */
+export const PREVIEW_PERSONA_PASSWORD = "rivalhub-preview-persona-resettable";
+
 export type PersonaCandidates = {
   currentSeasonId: string | null;
   playerUserId: string | null;

--- a/scripts/db/preview/refresh.ts
+++ b/scripts/db/preview/refresh.ts
@@ -10,7 +10,7 @@ import { verifyForeignKeys } from "../recovery/verify";
 import { targetEnvironment } from "./environment";
 import { readSnapshot, type MirrorSnapshot } from "./snapshot";
 import { quoteIdentifier } from "./policy";
-import { deterministicUserId, PREVIEW_PERSONAS, syntheticUserId, type PersonaBinding } from "./personas";
+import { deterministicUserId, PREVIEW_PERSONAS, PREVIEW_PERSONA_PASSWORD, syntheticUserId, type PersonaBinding } from "./personas";
 
 const MIRROR_STATE_TABLE = "preview_mirror_state";
 
@@ -100,8 +100,8 @@ async function provisionPersonas(snapshot: MirrorSnapshot, target: ReturnType<ty
     const email = `preview-${persona}@preview.invalid`;
     const existing = listing.data.users.find((user) => user.email === email);
     const result = existing
-      ? await auth.auth.admin.updateUserById(existing.id, { password: target.personaPassword, email_confirm: true })
-      : await auth.auth.admin.createUser({ email, password: target.personaPassword, email_confirm: true });
+      ? await auth.auth.admin.updateUserById(existing.id, { password: PREVIEW_PERSONA_PASSWORD, email_confirm: true })
+      : await auth.auth.admin.createUser({ email, password: PREVIEW_PERSONA_PASSWORD, email_confirm: true });
     if (result.error || !result.data.user) throw new Error(`Dev persona provisioning failed: ${persona}`);
     const row = snapshot.tables.users.find((user) => String(user.id) === id);
     if (!row) throw new Error("Persona source row disappeared during refresh.");

--- a/tests/unit/ci/preview-mirror-contract.test.mjs
+++ b/tests/unit/ci/preview-mirror-contract.test.mjs
@@ -2,6 +2,11 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const workflow = readFileSync(new URL("../../../.github/workflows/refresh-preview-data.yml", import.meta.url), "utf8");
+const environment = readFileSync(new URL("../../../scripts/db/preview/environment.ts", import.meta.url), "utf8");
+const personas = readFileSync(new URL("../../../scripts/db/preview/personas.ts", import.meta.url), "utf8");
+const refresh = readFileSync(new URL("../../../scripts/db/preview/refresh.ts", import.meta.url), "utf8");
+const runbook = readFileSync(new URL("../../../docs/operations/preview-mirror.md", import.meta.url), "utf8");
+const legacyPersonaPasswordEnv = ["RIVALHUB", "PREVIEW", "PERSONA", "PASSWORD"].join("_");
 
 describe("preview mirror workflow contract", () => {
   it("is protected, serialized, and split between production read and staging write", () => {
@@ -19,13 +24,30 @@ describe("preview mirror workflow contract", () => {
   });
 
   it("keeps the refresh implementation focused on reset/import rather than a read-only role", () => {
-    const refresh = readFileSync(new URL("../../../scripts/db/preview/refresh.ts", import.meta.url), "utf8");
     expect(refresh).toContain("DROP SCHEMA IF EXISTS public CASCADE");
     expect(refresh).toContain("TRUNCATE");
     expect(refresh).toContain("applyCurrentMigrations");
     expect(refresh).not.toContain("rivalhub_preview_ro");
     expect(workflow).toContain("RIVALHUB_PREVIEW_PUBLIC_ASSET_ALLOWLIST");
     expect(workflow).not.toContain("RIVALHUB_PREVIEW_RO_PASSWORD");
+  });
+
+  it("treats persona credentials as public disposable fixtures", () => {
+    expect(workflow).not.toContain(legacyPersonaPasswordEnv);
+    expect(environment).not.toContain(legacyPersonaPasswordEnv);
+    expect(environment).not.toContain("personaPassword");
+    expect(environment).not.toMatch(/length\s*<\s*24/);
+    expect(personas).toContain('export const PREVIEW_PERSONA_PASSWORD = "rivalhub-preview-persona-resettable";');
+    expect(refresh).toContain("password: PREVIEW_PERSONA_PASSWORD");
+    expect(runbook).toContain("disposable Preview fixture credentials");
+    for (const email of [
+      "preview-player@preview.invalid",
+      "preview-invited@preview.invalid",
+      "preview-captain@preview.invalid",
+      "preview-season-admin@preview.invalid",
+      "preview-super-admin@preview.invalid",
+    ]) expect(runbook).toContain(email);
+    expect(runbook).toContain("rivalhub-preview-persona-resettable");
   });
 
   it("defers the Preview mirror banner query until request time", () => {

--- a/tests/unit/db/preview-environment.test.ts
+++ b/tests/unit/db/preview-environment.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { targetEnvironment } from "../../../scripts/db/preview/environment";
+import { STAGING_PROJECT_REF } from "../../../scripts/db/staging-environment";
+
+const baseEnvironment: NodeJS.ProcessEnv = {
+  NODE_ENV: "test",
+  GITHUB_ACTIONS: "true",
+  GITHUB_REPOSITORY: "Starfie1d1272/RivalHub",
+  GITHUB_REF: "refs/heads/main",
+  GITHUB_WORKFLOW: "Refresh Preview Data",
+  GITHUB_EVENT_NAME: "workflow_dispatch",
+  RIVALHUB_PREVIEW_RESET_CONFIRM: STAGING_PROJECT_REF,
+  RIVALHUB_STAGING_PROJECT_CONFIRM: STAGING_PROJECT_REF,
+  RIVALHUB_STAGING_DB_HOST_CONFIRM: "aws-0-ap-northeast-1.pooler.supabase.com:6543",
+  RIVALHUB_ALLOW_REMOTE_DB_WRITE: "staging",
+  RIVALHUB_STAGING_DB_PASSWORD: "safe password",
+  RIVALHUB_PREVIEW_DEV_SECRET_KEY: "dev-secret-key",
+};
+
+describe("preview refresh target", () => {
+  it("accepts the target without a persona secret and returns only real dev credentials", () => {
+    const target = targetEnvironment(baseEnvironment);
+
+    expect(target).toMatchObject({
+      secretKey: "dev-secret-key",
+      supabaseUrl: `https://${STAGING_PROJECT_REF}.supabase.co`,
+      applyCurrentMigrations: false,
+    });
+    expect(target).not.toHaveProperty("personaPassword");
+  });
+
+  it("still requires the dev Auth privileged credential", () => {
+    expect(() => targetEnvironment({ ...baseEnvironment, RIVALHUB_PREVIEW_DEV_SECRET_KEY: undefined })).toThrow(/Auth credential/);
+  });
+});

--- a/tests/unit/db/preview-personas.test.ts
+++ b/tests/unit/db/preview-personas.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { deterministicUserId, syntheticUserId } from "../../../scripts/db/preview/personas";
+import { deterministicUserId, PREVIEW_PERSONA_PASSWORD, PREVIEW_PERSONAS, syntheticUserId } from "../../../scripts/db/preview/personas";
 import { selectPersonaCandidates } from "../../../scripts/db/preview/snapshot";
 
 describe("preview persona selection", () => {
   const users = [{ id: "00000000-0000-4000-8000-000000000001", status: "active" }, { id: "00000000-0000-4000-8000-000000000002", status: "active" }];
+
+  it("owns the public resettable fixture credential for all five personas", () => {
+    expect(PREVIEW_PERSONAS).toEqual(["player", "invited", "captain", "season-admin", "super-admin"]);
+    expect(PREVIEW_PERSONA_PASSWORD).toBe("rivalhub-preview-persona-resettable");
+  });
 
   it("prefers the current-event candidate and remains stable", () => {
     const candidates = { currentSeasonId: "season", playerUserId: users[1].id, invitedUserId: null, captainUserId: null, seasonAdminUserId: null, superAdminUserId: null };


### PR DESCRIPTION
移除 Preview persona protected secret/workflow dependency 与 24 字符 provisioning 校验；由 scripts/db/preview/personas.ts 统一使用公开固定密码 rivalhub-preview-persona-resettable，每次 refresh 重置五个 fixture 账号。Vercel Deployment Protection 保持访问边界，SUPABASE_SECRET_KEY、DB credentials、生产 Auth、snapshot/refresh 架构和 UI 不变。验证：pnpm test、type-check:scripts、type-check:tests、相关 ESLint。