### PR TITLE
fix(preview): 脱敏 Team membership 结束原因

### DIFF
--- a/scripts/db/preview/policy.ts
+++ b/scripts/db/preview/policy.ts
@@ -95,6 +95,7 @@ export function exportQuery(table: string): string {
   const expressions = columns.split(" ").map(quoteIdentifier);
   if (table === "users") expressions.push(`id::text || '@preview.invalid' AS email`, `'user' AS role`);
   if (table === "season_registrations") expressions.push(`ARRAY[]::text[] AS screenshot_urls`);
+  if (table === "team_memberships") expressions.push(`CASE WHEN "ended_at" IS NOT NULL THEN 'left'::team_membership_end_reason ELSE NULL END AS ended_reason`);
   if (table === "post_event_adjudications" || table === "tournament_honors") expressions.push(`id AS client_request_id`);
   if (table === "post_event_adjudications") expressions.push(`'预览已脱敏' AS reason`);
   // Only public, final facts; pending private review evidence is not a preview seed.

--- a/scripts/db/preview/snapshot.ts
+++ b/scripts/db/preview/snapshot.ts
@@ -149,6 +149,16 @@ function parsePublicStorageUrl(value: string): { bucket: MirrorAsset["bucket"]; 
   } catch { return null; }
 }
 
+function assertSanitizedTeamMembership(row: Record<string, unknown>): void {
+  if (!Object.hasOwn(row, "status") || !Object.hasOwn(row, "ended_at") || !Object.hasOwn(row, "ended_reason")) throw new Error("Invalid mirror team membership period.");
+  const ended = row.ended_at !== null;
+  const endedReason = row.ended_reason;
+  if (endedReason !== null && endedReason !== "left") throw new Error("Unsanitized mirror team membership end reason.");
+  const activeStatus = row.status === "active" || row.status === "benched";
+  if ((ended && (row.status !== "left" || endedReason !== "left"))
+    || (!ended && (!activeStatus || endedReason !== null))) throw new Error("Invalid mirror team membership period.");
+}
+
 export function readSnapshot(path: string): MirrorSnapshot {
   const snapshot = JSON.parse(readFileSync(path, "utf8")) as MirrorSnapshot;
   if (snapshot.format !== 2 || !/^[a-f0-9]{40}$/.test(snapshot.sourceCommit)
@@ -166,6 +176,7 @@ export function readSnapshot(path: string): MirrorSnapshot {
     const allowed = new Set(PREVIEW_COLUMNS[table].split(" "));
     if (table === "users") ["email", "role", "auth_id", "email_verified_at", "email_verification_source"].forEach((key) => allowed.add(key));
     if (table === "season_registrations") allowed.add("screenshot_urls");
+    if (table === "team_memberships") allowed.add("ended_reason");
     if (["post_event_adjudications", "tournament_honors"].includes(table)) allowed.add("client_request_id");
     if (table === "post_event_adjudications") allowed.add("reason");
     if (!Array.isArray(rows)) throw new Error("Invalid mirror rows.");
@@ -173,6 +184,7 @@ export function readSnapshot(path: string): MirrorSnapshot {
       if (!row || Object.keys(row).some((key) => !allowed.has(key))) throw new Error(`Unexpected mirror field: ${table}`);
       if (table === "users" && (row.email !== `${row.id}@preview.invalid` || row.role !== "user" || row.auth_id || row.email_verified_at)) throw new Error("Unsanitized mirror identity.");
       if (table === "season_registrations" && JSON.stringify(row.screenshot_urls) !== "[]") throw new Error("Private screenshot in mirror.");
+      if (table === "team_memberships") assertSanitizedTeamMembership(row);
       if (table === "community_groups" && row.qr_image_path && !String(row.qr_image_path).startsWith("public/")) throw new Error("Private group QR leaked into mirror.");
     }
   }

--- a/tests/integration/db/preview-mirror.test.ts
+++ b/tests/integration/db/preview-mirror.test.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { exportQuery } from "../../../scripts/db/preview/policy";
+import { createLocalPool } from "./harness/database";
+
+describe("preview mirror membership projection", () => {
+  it("redacts ended reasons and reimports active and ended memberships under the DB invariant", async () => {
+    const pool = createLocalPool({ max: 1 });
+    const client = await pool.connect();
+    const ids = { captain: randomUUID(), member: randomUUID(), team: randomUUID(), active: randomUUID(), ended: randomUUID() };
+    try {
+      await client.query("BEGIN");
+      await client.query("INSERT INTO users (id, email) VALUES ($1, $2), ($3, $4)", [ids.captain, `preview-membership-${ids.captain}@local.test`, ids.member, `preview-membership-${ids.member}@local.test`]);
+      await client.query("INSERT INTO teams (id, slug, name, creator_user_id, captain_user_id) VALUES ($1, $2, 'Preview membership team', $3, $3)", [ids.team, `preview-membership-${ids.team}`, ids.captain]);
+      await client.query(`INSERT INTO team_memberships (id, team_id, user_id, status, ended_at, ended_reason, invited_by_user_id)
+        VALUES ($1, $3, $4, 'active', NULL, NULL, $4), ($2, $3, $5, 'left', now(), 'kicked', $4)`, [ids.active, ids.ended, ids.team, ids.captain, ids.member]);
+
+      const membershipIds = new Set<string>([ids.active, ids.ended]);
+      const projected = (await client.query(exportQuery("team_memberships"))).rows
+        .filter((row) => membershipIds.has(String(row.id)));
+      const summarize = (rows: Array<Record<string, unknown>>) => rows.map((row) => ({ status: row.status, ended: row.ended_at !== null, ended_reason: row.ended_reason }))
+        .sort((a, b) => Number(a.ended) - Number(b.ended));
+      expect(summarize(projected)).toEqual([
+        { status: "active", ended: false, ended_reason: null },
+        { status: "left", ended: true, ended_reason: "left" },
+      ]);
+
+      await client.query("DELETE FROM team_memberships WHERE id = ANY($1::uuid[])", [[ids.active, ids.ended]]);
+      await client.query(`INSERT INTO public."team_memberships" ("id", "team_id", "user_id", "status", "started_at", "ended_at", "invited_by_user_id", "created_at", "updated_at", "ended_reason")
+        SELECT "id", "team_id", "user_id", "status", "started_at", "ended_at", "invited_by_user_id", "created_at", "updated_at", "ended_reason"
+        FROM jsonb_populate_recordset(NULL::public."team_memberships", $1::jsonb)`, [JSON.stringify(projected)]);
+      const imported = (await client.query("SELECT id, status, ended_at, ended_reason::text AS ended_reason FROM team_memberships WHERE id = ANY($1::uuid[]) ORDER BY id", [[ids.active, ids.ended]])).rows;
+      expect(summarize(imported)).toEqual([
+        { status: "active", ended: false, ended_reason: null },
+        { status: "left", ended: true, ended_reason: "left" },
+      ]);
+      await client.query("ROLLBACK");
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  });
+});

--- a/tests/unit/db/preview-policy.test.ts
+++ b/tests/unit/db/preview-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assertReviewedColumns, exportQuery, PREVIEW_COLUMNS } from "../../../scripts/db/preview/policy";
+import { assertReviewedColumns, exportQuery, OMITTED_COLUMNS, PREVIEW_COLUMNS } from "../../../scripts/db/preview/policy";
 
 describe("sanitized mirror policy", () => {
   it("keeps public community and Team recruitment information while excluding private interest records", () => {
@@ -9,6 +9,15 @@ describe("sanitized mirror policy", () => {
     expect(() => assertReviewedColumns("community_groups", PREVIEW_COLUMNS.community_groups.split(" "))).not.toThrow();
     expect(exportQuery("users")).not.toContain("auth_id");
     expect(exportQuery("users")).toContain("@preview.invalid");
+  });
+
+  it("projects a fixed end reason without selecting the private source field", () => {
+    const query = exportQuery("team_memberships");
+
+    expect(query).toContain(`CASE WHEN "ended_at" IS NOT NULL THEN 'left'::team_membership_end_reason ELSE NULL END AS ended_reason`);
+    expect(query).not.toContain('"ended_reason"');
+    expect(PREVIEW_COLUMNS.team_memberships).not.toContain("ended_reason");
+    expect(OMITTED_COLUMNS.team_memberships).toBe("ended_reason");
   });
 
   it("fails closed on an unknown source column or unreviewed table", () => {

--- a/tests/unit/db/preview-snapshot.test.ts
+++ b/tests/unit/db/preview-snapshot.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readExpectedMigrations } from "../../../scripts/db/production-preflight";
+import { PREVIEW_COLUMNS } from "../../../scripts/db/preview/policy";
+import { readSnapshot } from "../../../scripts/db/preview/snapshot";
+
+const BASE_MEMBERSHIP = {
+  id: "00000000-0000-4000-8000-000000000001",
+  team_id: "00000000-0000-4000-8000-000000000002",
+  user_id: "00000000-0000-4000-8000-000000000003",
+  started_at: "2026-01-01T00:00:00.000Z",
+  invited_by_user_id: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+function writeSnapshot(memberships: Record<string, unknown>[]): string {
+  const directory = mkdtempSync(join(tmpdir(), "rivalhub-preview-snapshot-"));
+  const path = join(directory, "mirror.json");
+  const tables = Object.fromEntries(Object.keys(PREVIEW_COLUMNS).map((table) => [table, [] as Record<string, unknown>[]]));
+  tables.team_memberships = memberships;
+  writeFileSync(path, JSON.stringify({
+    format: 2,
+    sourceCommit: "a".repeat(40),
+    sourceTag: "v2.9.0",
+    refreshedAt: "2026-09-12T00:00:00.000Z",
+    migrations: readExpectedMigrations(),
+    personaCandidates: {},
+    assets: [],
+    tables,
+  }));
+  return path;
+}
+
+function withSnapshot(memberships: Record<string, unknown>[], work: (path: string) => void): void {
+  const path = writeSnapshot(memberships);
+  const directory = dirname(path);
+  try {
+    work(path);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("preview mirror snapshot membership privacy", () => {
+  it("accepts active and ended memberships with the fixed placeholder", () => {
+    withSnapshot([
+      { ...BASE_MEMBERSHIP, status: "active", ended_at: null, ended_reason: null },
+      { ...BASE_MEMBERSHIP, id: "00000000-0000-4000-8000-000000000004", status: "left", ended_at: "2026-02-01T00:00:00.000Z", ended_reason: "left" },
+    ], (path) => {
+      const snapshot = readSnapshot(path);
+      expect(snapshot.tables.team_memberships.map((row) => ({ status: row.status, ended_at: row.ended_at, ended_reason: row.ended_reason }))).toEqual([
+        { status: "active", ended_at: null, ended_reason: null },
+        { status: "left", ended_at: "2026-02-01T00:00:00.000Z", ended_reason: "left" },
+      ]);
+    });
+  });
+
+  it.each(["kicked", "disbanded"]) ("rejects the real %s end reason", (endedReason) => {
+    withSnapshot([
+      { ...BASE_MEMBERSHIP, status: "left", ended_at: "2026-02-01T00:00:00.000Z", ended_reason: endedReason },
+    ], (path) => {
+      expect(() => readSnapshot(path)).toThrow("Unsanitized mirror team membership end reason.");
+    });
+  });
+});


### PR DESCRIPTION
## 摘要

- 在 Preview export projection 中保留 `team_memberships.ended_reason` 为私有 source field，并按 `ended_at` 输出固定的 `left` placeholder 或 `NULL`。
- `readSnapshot` 允许并严格校验该脱敏字段，拒绝 `kicked`、`disbanded` 等真实结束原因及不符合 membership period shape 的 artifact。
- 增加 active/ended membership 的 unit regression 与 real PostgreSQL projection/constraint regression。

## 范围

- 未修改 `team_memberships_period_shape_check`、migration、refresh 架构、environment 或 secrets。

## 本地验证

- `pnpm type-check:scripts`
- `pnpm type-check:tests`
- `pnpm exec vitest run --project unit-server-node`（70 files / 434 tests）
- `pnpm db:check`
- 本机未启动 Local Supabase；real PostgreSQL regression 由 PR postgres lane 执行。

Refs #612
