### PR TITLE
fix(preview): 补齐 team-logos bootstrap 与安全 phase 诊断

### DIFF
--- a/docs/operations/preview-mirror.md
+++ b/docs/operations/preview-mirror.md
@@ -7,9 +7,9 @@ RivalHub 的所有 Vercel Preview 固定连接 `rivalhub-dev`，不连接 produc
 - 每日定时、手动 dispatch，以及 Release 成功后的 `workflow_run` 都进入同一个不可并行的 refresh concurrency。
 - production job 只使用 production environment 的 `DATABASE_URL`/Supabase secret key；它不能写 production。公共 asset allowlist 在这一 job 生效。
 - dev job 只使用 staging environment 的 dev DB password 和 dev Supabase secret；persona password 是仓库定义的公开 fixture，不需要 secret provisioning。它不能读取 production credential。
-- snapshot 只包含审查过的 public/domain projections。Auth identity、邮件、教育证据、邀请 token、审计、`recruitment_interests` 和 private bucket 不导出；公共 Team 招募 projection、team logo 与显式 allowlist 的赛事公共 asset 可以镜像。
+- snapshot 只包含审查过的 public/domain projections。Auth identity、邮件、教育证据、邀请 token、审计、`recruitment_interests` 和 private bucket 不导出；公共 Team 招募 projection、team logo 与显式 allowlist 的赛事公共 asset 可以镜像。Preview 固定使用 dev `team-logos` public bucket，其 contract 为 1 MiB、`image/jpeg`/`image/png`/`image/webp`；refresh 只对这个固定 bucket 做幂等的 get/create/update bootstrap，不复制 production bucket 配置或对象。
 - `preview_mirror_state` 只记录 source tag/commit、refresh 时间和计数，供 Preview banner 诊断；它不是 availability 状态机。
-- refresh 先 reset 并应用 snapshot source migrations，再导入脱敏 production snapshot 和验证外键；manual dispatch 可随后把指定 ref 的当前 migration 应用到这份 production-derived 数据并再次验证，最后才 provision persona、公共 assets 与 mirror state。旧 Preview 因共享 schema/data 失效是可接受的 trade-off；daily/post-release refresh 始终用 `main`。
+- refresh 先完成 dev Storage preflight，再 reset 并应用 snapshot source migrations，导入脱敏 production snapshot 和验证外键；manual dispatch 可随后把指定 ref 的当前 migration 应用到这份 production-derived 数据并再次验证，最后才 provision persona、公共 assets 与 mirror state。命令只输出固定的 phase 名称和完成/失败状态，不输出 row value、asset path、credential 或 provider 原始错误。旧 Preview 因共享 schema/data 失效是可接受的 trade-off；daily/post-release refresh 始终用 `main`。
 
 ## Vercel Preview 必须配置
 
@@ -37,6 +37,7 @@ Preview runtime 拒绝非 `rivalhub-dev` database/public Auth URL 与缺失的 s
 
 ## owner 一次性操作
 
-1. 在 GitHub `staging` environment 录入 `RIVALHUB_PREVIEW_DEV_SECRET_KEY` 与现有 `RIVALHUB_STAGING_DB_PASSWORD`；无需配置 persona password secret。
-2. 在 Vercel Preview environment 录入上述 dev-scoped 值，删除任何 production 或身份不明的同名值；保留 Deployment Protection。
-3. 手动运行 `Refresh Preview Data`，确认 job summary 的 source commit 和页面 smoke。artifact 保留一天，且不得下载到个人设备或把 secret 写入 PR。
+1. 在 `rivalhub-dev` 的 Supabase Storage 确认 `team-logos` 为 public、1 MiB、且只允许 JPEG/PNG/WebP；`Refresh Preview Data` 会在 destructive DB reset 前对该固定 bucket 做幂等 bootstrap，provider 权限不足时必须先由 owner 补齐并 read back。
+2. 在 GitHub `staging` environment 录入 `RIVALHUB_PREVIEW_DEV_SECRET_KEY` 与现有 `RIVALHUB_STAGING_DB_PASSWORD`；无需配置 persona password secret。
+3. 在 Vercel Preview environment 录入上述 dev-scoped 值，删除任何 production 或身份不明的同名值；保留 Deployment Protection。
+4. 手动运行 `Refresh Preview Data`，确认 job summary 的 source commit、各 phase 结果和页面 smoke。artifact 保留一天，且不得下载到个人设备或把 secret 写入 PR。

--- a/scripts/db/preview/refresh.ts
+++ b/scripts/db/preview/refresh.ts
@@ -2,7 +2,7 @@ import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Pool, type PoolClient } from "pg";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { assertActiveChainPrefix, readExpectedMigrations } from "../production-preflight";
@@ -13,6 +13,59 @@ import { quoteIdentifier } from "./policy";
 import { deterministicUserId, PREVIEW_PERSONAS, PREVIEW_PERSONA_PASSWORD, syntheticUserId, type PersonaBinding } from "./personas";
 
 const MIRROR_STATE_TABLE = "preview_mirror_state";
+const PREVIEW_TEAM_LOGO_BUCKET = "team-logos";
+const PREVIEW_TEAM_LOGO_BUCKET_OPTIONS = {
+  public: true,
+  fileSizeLimit: 1_048_576,
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+};
+
+export type PreviewRefreshPhase =
+  | "dev storage preflight"
+  | "db reset"
+  | "db migrate"
+  | "db import"
+  | "db state setup"
+  | "persona auth"
+  | "persona db binding"
+  | "public asset upload"
+  | "mirror state commit";
+
+export class PreviewRefreshPhaseError extends Error {
+  constructor(readonly phase: PreviewRefreshPhase) {
+    super(`Preview mirror phase failed: ${phase}`);
+    this.name = "PreviewRefreshPhaseError";
+  }
+}
+
+export async function runPreviewRefreshPhase<T>(
+  phase: PreviewRefreshPhase,
+  operation: () => Promise<T>,
+  log: (message: string) => void = console.log,
+): Promise<T> {
+  log(`Preview mirror phase: ${phase}`);
+  try {
+    const result = await operation();
+    log(`Preview mirror phase complete: ${phase}`);
+    return result;
+  } catch {
+    throw new PreviewRefreshPhaseError(phase);
+  }
+}
+
+export async function ensurePreviewTeamLogoBucket(
+  storage: Pick<SupabaseClient["storage"], "getBucket" | "createBucket" | "updateBucket">,
+): Promise<void> {
+  const existing = await storage.getBucket(PREVIEW_TEAM_LOGO_BUCKET);
+  if (existing.error && !isMissingStorageBucketError(existing.error)) {
+    throw new Error("Preview team logo bucket preflight failed.");
+  }
+
+  const result = existing.data
+    ? await storage.updateBucket(PREVIEW_TEAM_LOGO_BUCKET, PREVIEW_TEAM_LOGO_BUCKET_OPTIONS)
+    : await storage.createBucket(PREVIEW_TEAM_LOGO_BUCKET, PREVIEW_TEAM_LOGO_BUCKET_OPTIONS);
+  if (result.error) throw new Error("Preview team logo bucket bootstrap failed.");
+}
 
 async function resetDevSchema(client: PoolClient): Promise<void> {
   await client.query("DROP SCHEMA IF EXISTS public CASCADE");
@@ -114,43 +167,58 @@ async function provisionPersonas(snapshot: MirrorSnapshot, target: ReturnType<ty
 export async function refreshMirror(path: string): Promise<void> {
   const target = targetEnvironment();
   const snapshot = readSnapshot(path);
+  const storage = createClient(target.supabaseUrl, target.secretKey, { auth: { persistSession: false, autoRefreshToken: false } }).storage;
+  await runPreviewRefreshPhase("dev storage preflight", () => ensurePreviewTeamLogoBucket(storage));
   const pool = new Pool({ connectionString: target.databaseUrl, ssl: { rejectUnauthorized: false }, max: 1 });
   const client = await pool.connect();
   try {
-    await resetDevSchema(client);
-    await migrateToSource(client, snapshot);
-    await importAndMigrateSnapshot(client, snapshot, target.applyCurrentMigrations);
-    await ensureMirrorState(client);
+    await runPreviewRefreshPhase("db reset", () => resetDevSchema(client));
+    await runPreviewRefreshPhase("db migrate", () => migrateToSource(client, snapshot));
+    await runPreviewRefreshPhase("db import", () => importAndMigrateSnapshot(client, snapshot, target.applyCurrentMigrations));
+    await runPreviewRefreshPhase("db state setup", () => ensureMirrorState(client));
 
-    const bindings = await provisionPersonas(snapshot, target);
-    await client.query("BEGIN");
-    for (const binding of bindings) {
-      const role = binding.persona === "super-admin" ? "super_admin" : "user";
-      // A sparse production snapshot may not contain five distinct active
-      // users. Synthetic persona rows are added after the bulk import, so
-      // insert the missing row before binding its deterministic Auth identity.
-      await client.query(
-        `INSERT INTO public.users (id, status, display_name, email, role)
-         VALUES ($1, 'active', $2, $3, $4)
-         ON CONFLICT (id) DO NOTHING`,
-        [binding.userId, `Preview ${binding.persona}`, binding.email, role],
-      );
-      await client.query("UPDATE public.users SET auth_id=$1, email=$2, email_verified_at=now(), email_verification_source='admin_migration', role=$3, updated_at=now() WHERE id=$4", [binding.authId, binding.email, binding.persona === "super-admin" ? "super_admin" : "user", binding.userId]);
-      await client.query(`INSERT INTO public.user_identities (user_id, kind, provider, provider_subject, normalized_value, verified_at, provenance, is_primary)
-        VALUES ($1, 'auth', 'supabase_auth', $2, $3, now(), 'admin_migration', true), ($1, 'email', 'email', $3, $3, now(), 'admin_migration', true) ON CONFLICT DO NOTHING`, [binding.userId, binding.authId, binding.email]);
-      if (binding.persona === "season-admin" && snapshot.personaCandidates.currentSeasonId) await client.query("INSERT INTO public.season_admin_grants (user_id, season_id) VALUES ($1, $2) ON CONFLICT DO NOTHING", [binding.userId, snapshot.personaCandidates.currentSeasonId]);
-    }
-    await uploadAssets(snapshot, target);
-    await client.query(`INSERT INTO public.${MIRROR_STATE_TABLE} (id, source_tag, source_commit, refreshed_at, persona_count, asset_count)
-      VALUES (true, $1, $2, now(), $3, $4)
-      ON CONFLICT (id) DO UPDATE SET source_tag=EXCLUDED.source_tag, source_commit=EXCLUDED.source_commit,
-      refreshed_at=EXCLUDED.refreshed_at, persona_count=EXCLUDED.persona_count, asset_count=EXCLUDED.asset_count`, [snapshot.sourceTag, snapshot.sourceCommit, bindings.length, snapshot.assets.length]);
-    await client.query("COMMIT");
+    const bindings = await runPreviewRefreshPhase("persona auth", () => provisionPersonas(snapshot, target));
+    await runPreviewRefreshPhase("persona db binding", async () => {
+      await client.query("BEGIN");
+      for (const binding of bindings) {
+        const role = binding.persona === "super-admin" ? "super_admin" : "user";
+        // A sparse production snapshot may not contain five distinct active
+        // users. Synthetic persona rows are added after the bulk import, so
+        // insert the missing row before binding its deterministic Auth identity.
+        await client.query(
+          `INSERT INTO public.users (id, status, display_name, email, role)
+           VALUES ($1, 'active', $2, $3, $4)
+           ON CONFLICT (id) DO NOTHING`,
+          [binding.userId, `Preview ${binding.persona}`, binding.email, role],
+        );
+        await client.query("UPDATE public.users SET auth_id=$1, email=$2, email_verified_at=now(), email_verification_source='admin_migration', role=$3, updated_at=now() WHERE id=$4", [binding.authId, binding.email, binding.persona === "super-admin" ? "super_admin" : "user", binding.userId]);
+        await client.query(`INSERT INTO public.user_identities (user_id, kind, provider, provider_subject, normalized_value, verified_at, provenance, is_primary)
+          VALUES ($1, 'auth', 'supabase_auth', $2, $3, now(), 'admin_migration', true), ($1, 'email', 'email', $3, $3, now(), 'admin_migration', true) ON CONFLICT DO NOTHING`, [binding.userId, binding.authId, binding.email]);
+        if (binding.persona === "season-admin" && snapshot.personaCandidates.currentSeasonId) await client.query("INSERT INTO public.season_admin_grants (user_id, season_id) VALUES ($1, $2) ON CONFLICT DO NOTHING", [binding.userId, snapshot.personaCandidates.currentSeasonId]);
+      }
+    });
+    await runPreviewRefreshPhase("public asset upload", () => uploadAssets(snapshot, target));
+    await runPreviewRefreshPhase("mirror state commit", async () => {
+      await client.query(`INSERT INTO public.${MIRROR_STATE_TABLE} (id, source_tag, source_commit, refreshed_at, persona_count, asset_count)
+        VALUES (true, $1, $2, now(), $3, $4)
+        ON CONFLICT (id) DO UPDATE SET source_tag=EXCLUDED.source_tag, source_commit=EXCLUDED.source_commit,
+        refreshed_at=EXCLUDED.refreshed_at, persona_count=EXCLUDED.persona_count, asset_count=EXCLUDED.asset_count`, [snapshot.sourceTag, snapshot.sourceCommit, bindings.length, snapshot.assets.length]);
+      await client.query("COMMIT");
+    });
     console.log(`Mirror refreshed: source=${snapshot.sourceTag} commit=${snapshot.sourceCommit} personas=${bindings.length} assets=${snapshot.assets.length}`);
   } catch (error) {
     await client.query("ROLLBACK").catch(() => {});
     throw error;
   } finally { client.release(); await pool.end(); }
+}
+
+function isMissingStorageBucketError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { status?: unknown; statusCode?: unknown; code?: unknown };
+  return candidate.status === 404
+    || candidate.statusCode === 404
+    || candidate.statusCode === "404"
+    || candidate.code === "NotFound";
 }
 
 async function uploadAssets(snapshot: MirrorSnapshot, target: ReturnType<typeof targetEnvironment>): Promise<void> {
@@ -162,4 +230,7 @@ async function uploadAssets(snapshot: MirrorSnapshot, target: ReturnType<typeof 
   }
 }
 
-if (process.argv[1]?.endsWith("preview/refresh.ts")) refreshMirror(process.argv[2]).catch(() => { console.error("Mirror refresh failed; provider errors and row values are not logged."); process.exitCode = 1; });
+if (process.argv[1]?.endsWith("preview/refresh.ts")) refreshMirror(process.argv[2]).catch((error: unknown) => {
+  console.error(error instanceof PreviewRefreshPhaseError ? `${error.message}; provider errors and row values are not logged.` : "Mirror refresh failed; provider errors and row values are not logged.");
+  process.exitCode = 1;
+});

--- a/tests/unit/db/preview-refresh.test.ts
+++ b/tests/unit/db/preview-refresh.test.ts
@@ -1,6 +1,11 @@
 import type { PoolClient } from "pg";
-import { describe, expect, it } from "vitest";
-import { importAndMigrateSnapshot } from "../../../scripts/db/preview/refresh";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ensurePreviewTeamLogoBucket,
+  importAndMigrateSnapshot,
+  PreviewRefreshPhaseError,
+  runPreviewRefreshPhase,
+} from "../../../scripts/db/preview/refresh";
 import type { MirrorSnapshot } from "../../../scripts/db/preview/snapshot";
 
 describe("preview mirror refresh", () => {
@@ -24,5 +29,48 @@ describe("preview mirror refresh", () => {
       "migrate",
       "verify:current-migration",
     ]);
+  });
+
+  it("bootstraps the fixed dev team logo bucket when it is missing", async () => {
+    const getBucket = vi.fn().mockResolvedValue({ data: null, error: { status: 404 } });
+    const createBucket = vi.fn().mockResolvedValue({ data: null, error: null });
+    const updateBucket = vi.fn();
+
+    await ensurePreviewTeamLogoBucket({ getBucket, createBucket, updateBucket });
+
+    expect(createBucket).toHaveBeenCalledWith("team-logos", {
+      public: true,
+      fileSizeLimit: 1_048_576,
+      allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+    });
+    expect(updateBucket).not.toHaveBeenCalled();
+  });
+
+  it("reconciles only the fixed dev team logo bucket contract when it exists", async () => {
+    const getBucket = vi.fn().mockResolvedValue({ data: { id: "team-logos" }, error: null });
+    const createBucket = vi.fn();
+    const updateBucket = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    await ensurePreviewTeamLogoBucket({ getBucket, createBucket, updateBucket });
+
+    expect(updateBucket).toHaveBeenCalledWith("team-logos", {
+      public: true,
+      fileSizeLimit: 1_048_576,
+      allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+    });
+    expect(createBucket).not.toHaveBeenCalled();
+  });
+
+  it("reports a safe phase without exposing the provider error", async () => {
+    const logs: string[] = [];
+    await expect(runPreviewRefreshPhase(
+      "public asset upload",
+      async () => { throw new Error("raw provider error"); },
+      (message) => logs.push(message),
+    )).rejects.toMatchObject({
+      phase: "public asset upload",
+      message: "Preview mirror phase failed: public asset upload",
+    } satisfies Partial<PreviewRefreshPhaseError>);
+    expect(logs).toEqual(["Preview mirror phase: public asset upload"]);
   });
 });


### PR DESCRIPTION
## 变更

- 在 destructive DB reset 前，对固定的 dev `team-logos` bucket 执行安全幂等 bootstrap：public、1 MiB、JPEG/PNG/WebP。
- 为 reset/migrate/import、persona Auth、persona DB binding、public asset upload、mirror state commit 增加只输出固定 phase 名称的诊断；底层 provider error、row value、asset path 和 credential 不进入日志。
- 更新 Preview mirror owner bootstrap runbook，并补充 bucket/phase regression。

## 验证

- `pnpm exec vitest run --project unit-server-node`（70 files / 437 tests）
- `pnpm type-check:scripts`
- `pnpm type-check:tests`
- `pnpm exec eslint scripts/db/preview/refresh.ts tests/unit/db/preview-refresh.test.ts`
- `pnpm architecture:check`
- `pnpm db:check`

不修改 schema、migration、refresh 顺序或 secrets。

Refs #612
