### PR TITLE
chore(tooling): 禁止 pnpm 检查命令隐式改写 lockfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Changeset/CHANGELOG 只描述 release-relevant 可观察影响，不复制 commi
 
 Node/pnpm contract 只由 `package.json` 的 `packageManager`、`devEngines.runtime`、`engines.node` 与 lockfile 共同声明。workflow、文档或个人脚本不要复制另一份版本常量；安装和 CI 使用仓库 manifest/lockfile 的 canonical runtime。
 
+未声明为项目依赖的一次性 CLI 使用 `pnpm dlx <package>@<version>`；`pnpm exec` 只用于已安装的项目 dependency binary。检查/查询命令不得隐式安装依赖或改写 lockfile。
+
 ## Documentation
 
 active docs 只保存当前稳定知识。改 architecture/domain/workflow/policy/shared UI contract 时同 PR 更新对应 canonical doc；优先**重写原段落为终态**，不要在旧说明后持续追加实施历史。实时工作状态留在 Issues/PRs，旧设计和已失效过程材料进入 `docs/archive/`。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+verifyDepsBeforeRun: error
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
## 背景

`pnpm run` / `pnpm exec` 在依赖状态不一致时默认可能自动执行 install，导致本应只读的检查命令改写 `pnpm-lock.yaml`，尤其会扰动 pnpm executable metadata。

## 改动

- 在 `pnpm-workspace.yaml` 设置 `verifyDepsBeforeRun: error`，依赖状态不一致时 fail closed，不再自动修复。
- 在 `CONTRIBUTING.md` 的 Runtime 规范中明确：未声明的一次性 CLI 使用固定版本的 `pnpm dlx`；`pnpm exec` 仅用于项目已安装 binary；检查/查询命令不得隐式安装依赖或改写 lockfile。

## 范围

纯开发工具与协作规范变更，不改变 shipped runtime / 用户行为，无 Changeset。

## 验证

- diff 仅包含 `pnpm-workspace.yaml` +1 行、`CONTRIBUTING.md` +2 行。
- 不修改 `package.json` 或 `pnpm-lock.yaml`。
