### PR TITLE
fix(release): 传递回滚部署身份

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,7 @@ jobs:
             and .readyState == "READY"
           ' <<<"$PREVIOUS_DEPLOYMENT_INFO" >/dev/null
           PREVIOUS_DEPLOYMENT_ID="$(jq -er '.id | strings | select(startswith("dpl_"))' <<<"$PREVIOUS_DEPLOYMENT_INFO")"
+          echo "previous_deployment_id=$PREVIOUS_DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
           echo "Previous canonical deployment resolved for rollback."
 
           wait_for_alias_job() {
@@ -311,6 +312,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           PREVIOUS_TAG: ${{ steps.promote.outputs.previous_tag }}
           PREVIOUS_COMMIT: ${{ steps.promote.outputs.previous_commit }}
+          PREVIOUS_DEPLOYMENT_ID: ${{ steps.promote.outputs.previous_deployment_id }}
         run: |
           set -euo pipefail
           CANONICAL_START="$(date +%s%3N)"


### PR DESCRIPTION
## 摘要

- 将 Promote 步骤解析出的 previous deployment ID 写入 step output
- 将该 output 传入 canonical smoke，以保证 smoke 失败时 rollback 分支不会因 `set -u` 触发二次失败

## 背景

`v2.9.3` 首次受保护 Release 已完成 backup、migration、candidate smoke 和 promotion；canonical smoke 失败后，workflow 因未传递 `PREVIOUS_DEPLOYMENT_ID` 无法执行 rollback。当前线上 identity 已稳定为 `v2.9.3 / 8d19e8111d1052ca12f5a04898fa2e727f8b8e17`。

这是 release workflow 修复，不改变 shipped application behavior，不新增 Changeset。合并后用同一个 immutable `v2.9.3` tag 重试，不移动 tag。